### PR TITLE
refactor(sync): one inventory-completeness gate for all deletions

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -675,28 +675,15 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 		e.logger.Debug("pulled resource", "uid", uid, "path", res.Path, "etag", res.ETag)
 	}
 
-	// Detect deletions by UID. Local rows with no remote_url have never been
-	// pushed and must be left alone — they're still pending upload.
-	for _, local := range localResources {
-		if local.RemoteUrl == "" {
-			continue
-		}
-		if remoteUIDs[local.Uid] {
-			continue
-		}
-		e.logger.Debug("resource deleted on server", "uid", local.Uid, "remote_url", local.RemoteUrl)
-		if err := e.deleteLocalResourceByUID(ctx, local.OwnerType, local.Uid); err != nil {
-			e.logger.Error("delete local resource", "uid", local.Uid, "owner_type", local.OwnerType, "error", err)
-			continue
-		}
-		if err := e.q.DeleteSyncResource(ctx, storage.DeleteSyncResourceParams{
-			CalendarID: calendarID,
-			Uid:        local.Uid,
-		}); err != nil {
-			e.logger.Error("delete sync resource", "uid", local.Uid, "error", err)
-		}
-		result.deleted++
-	}
+	// Deletions go through the same chokepoint as the sync-collection path.
+	// QueryAll downloads the entire collection or returns an error (handled
+	// above), so by construction the inventory is complete — but routing
+	// through inferFromAbsence keeps the invariant uniform, so a future
+	// partial-fetch optimization here cannot silently start deleting against
+	// a partial view without flipping the complete flag.
+	deletions := newPendingDeletions(e.logger)
+	deletions.inferFromAbsence(calendarID, localResources, remoteUIDs, true, "complete (QueryAll)")
+	result.deleted += deletions.apply(ctx, e, calendarID)
 
 	return result, nil
 }
@@ -705,6 +692,101 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 // Servers (notably Google) reject very large multigets; 50 is the conservative
 // number used by other clients and keeps response sizes manageable.
 const multigetBatchSize = 50
+
+// pendingDeletions is the single chokepoint for the sync engine's most
+// dangerous operation: removing local rows because the server no longer has
+// them. Three production data-loss incidents — multiget 404s, href rewrites,
+// and RFC 6578 §3.6 truncation — all share one root cause: a local row was
+// deleted because it was ABSENT from a remote view that turned out to be
+// incomplete. The two recorders below encode the only safe rule. Explicit
+// deletions carry positive evidence (the server returned 404 for a specific
+// href) and are always sound; absence-inferred deletions require a provably
+// complete inventory and are withheld otherwise. Every deletion the pull
+// performs goes through apply(), so a new "this looks deleted" code path
+// cannot reach the executor without choosing one of these two doors.
+type pendingDeletions struct {
+	logger *slog.Logger
+	owner  map[string]string // uid -> ownerType, deduped across both sources
+}
+
+func newPendingDeletions(logger *slog.Logger) *pendingDeletions {
+	return &pendingDeletions{logger: logger, owner: make(map[string]string)}
+}
+
+// markExplicit records a deletion backed by positive evidence: the server
+// returned 404 for this resource's specific href. Sound regardless of
+// inventory completeness.
+func (p *pendingDeletions) markExplicit(r storage.SyncResource) {
+	if r.Uid != "" {
+		p.owner[r.Uid] = r.OwnerType
+	}
+}
+
+// inferFromAbsence records a deletion for every local resource missing from
+// the remote inventory (`seen`) — but ONLY when complete is true. When the
+// inventory is partial it withholds the entire sweep (logging the count and
+// reason) so a partial view can never drive deletions; the rows are
+// re-evaluated on the next clean sync. complete MUST be computed by the
+// caller as "every resource the server has was observed this pull." Local
+// rows with no remote_url are skipped — they were never pushed.
+func (p *pendingDeletions) inferFromAbsence(calendarID int64, locals []storage.SyncResource, seen map[string]bool, complete bool, reason string) {
+	var candidates []storage.SyncResource
+	for _, local := range locals {
+		if local.RemoteUrl == "" {
+			continue
+		}
+		if seen[local.Uid] || p.owner[local.Uid] != "" {
+			continue
+		}
+		candidates = append(candidates, local)
+	}
+	if len(candidates) == 0 {
+		return
+	}
+	if !complete {
+		p.logger.Warn("withholding absence-inferred deletions: incomplete inventory",
+			"calendar_id", calendarID, "withheld", len(candidates), "reason", reason)
+		return
+	}
+	for _, c := range candidates {
+		p.owner[c.Uid] = c.OwnerType
+	}
+}
+
+// apply executes the accumulated deletions: soft-delete each local owner row
+// and drop its sync_resource. Returns the count actually deleted.
+func (p *pendingDeletions) apply(ctx context.Context, e *Engine, calendarID int64) int {
+	deleted := 0
+	for uid, ownerType := range p.owner {
+		if err := e.deleteLocalResourceByUID(ctx, ownerType, uid); err != nil {
+			e.logger.Error("delete local resource", "uid", uid, "owner_type", ownerType, "error", err)
+			continue
+		}
+		if err := e.q.DeleteSyncResource(ctx, storage.DeleteSyncResourceParams{
+			CalendarID: calendarID,
+			Uid:        uid,
+		}); err != nil {
+			e.logger.Error("delete sync resource", "uid", uid, "error", err)
+		}
+		deleted++
+	}
+	return deleted
+}
+
+// absenceWithholdReason describes why an absence sweep was (or wasn't) safe,
+// for the withhold log line.
+func absenceWithholdReason(truncated bool, multigetMisses int) string {
+	switch {
+	case truncated && multigetMisses > 0:
+		return fmt.Sprintf("response truncated and %d multiget miss(es)", multigetMisses)
+	case truncated:
+		return "response truncated (RFC 6578 §3.6)"
+	case multigetMisses > 0:
+		return fmt.Sprintf("%d multiget miss(es)", multigetMisses)
+	default:
+		return "complete"
+	}
+}
 
 // applySyncCollection consumes the change list from a sync-collection REPORT,
 // fetches bodies for changed resources via calendar-multiget, persists them,
@@ -872,63 +954,42 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 		}
 	}
 
-	deletedUIDs := make(map[string]bool)
-	for _, p := range deletedPaths {
-		local, exists := localByPath[p]
-		if !exists {
+	// All deletions funnel through one chokepoint (see pendingDeletions).
+	// The inventory is "complete" only when nothing limited our view of the
+	// server's resources: the response wasn't truncated and every changed
+	// body was fetched.
+	inventoryComplete := !syncResult.Truncated && multigetMisses == 0
+	deletions := newPendingDeletions(e.logger)
+
+	// Explicit deletions: the server returned a top-level 404 for these
+	// hrefs. Positive evidence — sound even if the inventory is incomplete.
+	// Exception: an href rewrite (Cosmo/GMX) shows the same UID 404'd at the
+	// old path but present at a new one within the same response; the fetch
+	// loop already re-upserted it, so a seen UID is not a deletion.
+	for _, pth := range deletedPaths {
+		local, exists := localByPath[pth]
+		if !exists || seenUIDs[local.Uid] {
 			continue
 		}
-		if seenUIDs[local.Uid] {
-			// Server reported a 404 on the old path but the same UID showed
-			// up at a new path within the same response — this is an href
-			// rewrite (Cosmo/GMX), not a real deletion. The fetch loop
-			// already upserted the new path; skip.
-			continue
-		}
-		deletedUIDs[local.Uid] = true
+		deletions.markExplicit(local)
 	}
 
-	// Initial-snapshot pulls (empty stored token) only see ADDITIONS in the
-	// change list, never deletions. So any locally-tracked UID missing from
-	// the snapshot is gone on the server. This also handles upgrades from
-	// QueryAll-based deployments where calendars carry sync resources but
-	// no sync-token yet.
-	//
-	// HARD GUARD: never run this sweep on a truncated change list. pull()
-	// paginates until complete, so Truncated is false here on every normal
-	// path — but a partial inventory driving deletions is exactly the bug
-	// that mass-deleted local events, so the invariant is enforced where
-	// the damage would happen, not just where the data is fetched.
-	if initialSnapshot && !syncResult.Truncated {
-		for _, local := range localResources {
-			if local.RemoteUrl == "" {
-				continue
-			}
-			if seenUIDs[local.Uid] || deletedUIDs[local.Uid] {
-				continue
-			}
-			deletedUIDs[local.Uid] = true
-		}
+	// Absence-inferred deletions: an initial snapshot lists only additions,
+	// so a locally-tracked UID missing from it is gone on the server — but
+	// only when the inventory is complete. Incremental pulls carry deletions
+	// explicitly (above), so absence inference applies to initial snapshots
+	// only. The gate withholds the sweep on a partial inventory; pull()
+	// paginates so the common path is complete, but the invariant is
+	// enforced here, where the deletion happens, not only where data is
+	// fetched.
+	if initialSnapshot {
+		deletions.inferFromAbsence(calendarID, localResources, seenUIDs,
+			inventoryComplete, absenceWithholdReason(syncResult.Truncated, multigetMisses))
 	}
 
-	for _, local := range localResources {
-		if !deletedUIDs[local.Uid] {
-			continue
-		}
-		if err := e.deleteLocalResourceByUID(ctx, local.OwnerType, local.Uid); err != nil {
-			e.logger.Error("delete local resource", "uid", local.Uid, "owner_type", local.OwnerType, "error", err)
-			continue
-		}
-		if err := e.q.DeleteSyncResource(ctx, storage.DeleteSyncResourceParams{
-			CalendarID: calendarID,
-			Uid:        local.Uid,
-		}); err != nil {
-			e.logger.Error("delete sync resource", "uid", local.Uid, "error", err)
-		}
-		result.deleted++
-	}
+	result.deleted += deletions.apply(ctx, e, calendarID)
 
-	if syncResult.SyncToken != "" && multigetMisses == 0 && !syncResult.Truncated {
+	if syncResult.SyncToken != "" && inventoryComplete {
 		token := syncResult.SyncToken
 		if err := e.q.UpdateCalendarSyncState(ctx, storage.UpdateCalendarSyncStateParams{
 			ID:        calendarID,

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
@@ -1766,5 +1767,158 @@ func TestSummarizeSyncError(t *testing.T) {
 				t.Errorf("summarizeSyncError = %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+// discardLogger returns a logger that drops everything, for pure-function
+// tests of the deletion chokepoint.
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func uidSet(rs map[string]string) map[string]bool {
+	out := make(map[string]bool, len(rs))
+	for uid := range rs {
+		out[uid] = true
+	}
+	return out
+}
+
+// TestPendingDeletions_AbsenceGate is the core invariant: absence-inferred
+// deletions are withheld unless the inventory is complete. This is the single
+// guard that three production data-loss bugs would now hit.
+func TestPendingDeletions_AbsenceGate(t *testing.T) {
+	t.Parallel()
+	locals := []storage.SyncResource{
+		{Uid: "a", OwnerType: "event", RemoteUrl: "/a.ics"},
+		{Uid: "b", OwnerType: "event", RemoteUrl: "/b.ics"},
+		{Uid: "never-pushed", OwnerType: "event", RemoteUrl: ""}, // must never delete
+	}
+	seen := map[string]bool{"a": true} // server still has "a"; "b" is absent
+
+	t.Run("incomplete inventory withholds all", func(t *testing.T) {
+		p := newPendingDeletions(discardLogger())
+		p.inferFromAbsence(1, locals, seen, false, "truncated")
+		if got := uidSet(p.owner); len(got) != 0 {
+			t.Errorf("incomplete inventory must withhold; got %v", got)
+		}
+	})
+
+	t.Run("complete inventory deletes only the absent, pushed row", func(t *testing.T) {
+		p := newPendingDeletions(discardLogger())
+		p.inferFromAbsence(1, locals, seen, true, "complete")
+		got := uidSet(p.owner)
+		if !got["b"] {
+			t.Error("absent pushed row b should be marked for deletion")
+		}
+		if got["a"] {
+			t.Error("seen row a must not be deleted")
+		}
+		if got["never-pushed"] {
+			t.Error("never-pushed row (empty remote_url) must never be deleted")
+		}
+	})
+}
+
+// TestPendingDeletions_ExplicitAlwaysDeletes confirms explicit (server-404)
+// deletions are sound regardless of completeness, and dedupe with absence.
+func TestPendingDeletions_ExplicitAlwaysDeletes(t *testing.T) {
+	t.Parallel()
+	p := newPendingDeletions(discardLogger())
+	p.markExplicit(storage.SyncResource{Uid: "gone", OwnerType: "event"})
+	p.markExplicit(storage.SyncResource{Uid: "", OwnerType: "event"}) // empty UID ignored
+	// An incomplete inventory must not erase an explicit deletion.
+	p.inferFromAbsence(1, []storage.SyncResource{{Uid: "x", OwnerType: "event", RemoteUrl: "/x.ics"}},
+		map[string]bool{}, false, "truncated")
+	got := uidSet(p.owner)
+	if !got["gone"] {
+		t.Error("explicit deletion should always be marked")
+	}
+	if got[""] {
+		t.Error("empty UID must be ignored")
+	}
+	if got["x"] {
+		t.Error("absence deletion must stay withheld under incomplete inventory")
+	}
+}
+
+// TestEnginePullMultigetMissWithholdsAbsenceDeletions pins the stricter
+// behavior the chokepoint enforces: if even one body 404s on multiget during
+// an initial snapshot, the inventory is incomplete, so NO absence-inferred
+// deletion runs that round — not just the missed path. A locally-tracked row
+// absent from the snapshot must survive until a clean sync confirms it.
+func TestEnginePullMultigetMissWithholdsAbsenceDeletions(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	// "absent" is tracked locally but will NOT appear in the snapshot at all
+	// (a genuine candidate for absence-deletion). "racey" appears in the
+	// change list but 404s on multiget (the incompleteness trigger).
+	insertTestEvent(t, db, calendarID, "absent")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID: calendarID, Uid: "absent", OwnerType: "event",
+		RemoteUrl: "/calendar/absent.ics", Etag: "e1", Dirty: 0, SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource absent: %v", err)
+	}
+	insertTestEvent(t, db, calendarID, "racey")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID: calendarID, Uid: "racey", OwnerType: "event",
+		RemoteUrl: "/calendar/racey.ics", Etag: "old", Dirty: 0, SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource racey: %v", err)
+	}
+
+	// Initial snapshot (empty token): lists only "racey" (changed), which
+	// then 404s on multiget. "absent" is not listed at all.
+	const syncBody = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/calendar/racey.ics</d:href>
+    <d:propstat><d:prop><d:getetag>&quot;new&quot;</d:getetag></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:sync-token>https://example.com/sync/t1</d:sync-token>
+</d:multistatus>`
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		raw, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(raw), "calendar-multiget") {
+			return &http.Response{StatusCode: http.StatusMultiStatus, Status: "207 Multi-Status",
+				Header: http.Header{"Content-Type": []string{"application/xml"}},
+				Body:   io.NopCloser(strings.NewReader(syncBody)), Request: r}, nil
+		}
+		// racey.ics 404s on multiget.
+		multigetBody := `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response><d:href>/calendar/racey.ics</d:href><d:status>HTTP/1.1 404 Not Found</d:status></d:response>
+</d:multistatus>`
+		return &http.Response{StatusCode: http.StatusMultiStatus, Status: "207 Multi-Status",
+			Header: http.Header{"Content-Type": []string{"application/xml"}},
+			Body:   io.NopCloser(strings.NewReader(multigetBody)), Request: r}, nil
+	})
+
+	result, err := engine.pull(ctx, client, calendarID, "/calendar/")
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if result.deleted != 0 {
+		t.Fatalf("deleted = %d, want 0 (incomplete inventory must withhold ALL absence deletions)", result.deleted)
+	}
+	// Both rows must still exist — neither the missed one nor the absent one.
+	if _, err := q.GetEventByUID(ctx, "absent"); err != nil {
+		t.Errorf("absent row was wrongly deleted against a partial inventory: %v", err)
+	}
+	if _, err := q.GetEventByUID(ctx, "racey"); err != nil {
+		t.Errorf("racey row (multiget miss) was wrongly deleted: %v", err)
+	}
+	// Token must not advance on an incomplete pull.
+	calRow, _ := q.GetCalendar(ctx, calendarID)
+	if tok := storage.NullableToString(calRow.SyncToken); tok != "" {
+		t.Errorf("sync_token = %q, want empty (held back on incomplete pull)", tok)
 	}
 }

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1840,6 +1840,21 @@ func TestPendingDeletions_ExplicitAlwaysDeletes(t *testing.T) {
 	}
 }
 
+// TestPendingDeletions_DedupExplicitAndAbsence exercises the dedup branch
+// (owner already set) when a UID is both explicitly deleted and absent from a
+// COMPLETE inventory — it must appear exactly once, not double-counted.
+func TestPendingDeletions_DedupExplicitAndAbsence(t *testing.T) {
+	t.Parallel()
+	p := newPendingDeletions(discardLogger())
+	p.markExplicit(storage.SyncResource{Uid: "dup", OwnerType: "event"})
+	p.inferFromAbsence(1,
+		[]storage.SyncResource{{Uid: "dup", OwnerType: "event", RemoteUrl: "/dup.ics"}},
+		map[string]bool{}, true, "complete")
+	if got := uidSet(p.owner); len(got) != 1 || !got["dup"] {
+		t.Errorf("dup should be present exactly once, got %v", got)
+	}
+}
+
 // TestEnginePullMultigetMissWithholdsAbsenceDeletions pins the stricter
 // behavior the chokepoint enforces: if even one body 404s on multiget during
 // an initial snapshot, the inventory is incomplete, so NO absence-inferred
@@ -1920,5 +1935,99 @@ func TestEnginePullMultigetMissWithholdsAbsenceDeletions(t *testing.T) {
 	calRow, _ := q.GetCalendar(ctx, calendarID)
 	if tok := storage.NullableToString(calRow.SyncToken); tok != "" {
 		t.Errorf("sync_token = %q, want empty (held back on incomplete pull)", tok)
+	}
+}
+
+// TestEnginePullFullSnapshotDeletesAbsent covers the legacy QueryAll fallback
+// (servers without RFC 6578 sync-collection, e.g. GMX) now that its deletions
+// route through the pendingDeletions chokepoint. A sync-collection REPORT that
+// returns "unsupported" makes pull() fall back to pullFullSnapshot; a local
+// pushed row absent from the QueryAll result must be deleted, while a
+// never-pushed row (empty remote_url) must survive.
+func TestEnginePullFullSnapshotDeletesAbsent(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	insertTestEvent(t, db, calendarID, "gone-uid")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID: calendarID, Uid: "gone-uid", OwnerType: "event",
+		RemoteUrl: "/calendar/gone.ics", Etag: "e1", Dirty: 0, SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource gone: %v", err)
+	}
+	insertTestEvent(t, db, calendarID, "local-only")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID: calendarID, Uid: "local-only", OwnerType: "event",
+		RemoteUrl: "", Etag: "", Dirty: 1, SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource local-only: %v", err)
+	}
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		raw, _ := io.ReadAll(r.Body)
+		body := string(raw)
+		// sync-collection REPORT -> reply 422 so the engine falls back to QueryAll.
+		if strings.Contains(body, "sync-collection") {
+			return &http.Response{
+				StatusCode: http.StatusUnprocessableEntity,
+				Status:     "422 Unprocessable Entity",
+				Header:     http.Header{"Content-Type": []string{"application/xml"}},
+				Body:       io.NopCloser(strings.NewReader(`<?xml version="1.0"?><error xmlns="DAV:"/>`)),
+				Request:    r,
+			}, nil
+		}
+		// calendar-query REPORT (QueryAll): return an inventory WITHOUT gone.ics.
+		queryBody := `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/calendar/survivor.ics</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>&quot;s1&quot;</d:getetag>
+        <cal:calendar-data>BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//chroncal//tests//EN
+BEGIN:VEVENT
+UID:survivor-uid
+DTSTAMP:20260606T120000Z
+DTSTART:20260606T120000Z
+DTEND:20260606T130000Z
+SUMMARY:Survivor
+END:VEVENT
+END:VCALENDAR
+</cal:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+		return &http.Response{
+			StatusCode: http.StatusMultiStatus,
+			Status:     "207 Multi-Status",
+			Header:     http.Header{"Content-Type": []string{"application/xml"}},
+			Body:       io.NopCloser(strings.NewReader(queryBody)),
+			Request:    r,
+		}, nil
+	})
+
+	result, err := engine.pull(ctx, client, calendarID, "/calendar/")
+	if err != nil {
+		t.Fatalf("pull (fullsnapshot): %v", err)
+	}
+	if result.deleted != 1 {
+		t.Fatalf("deleted = %d, want 1 (gone-uid absent from QueryAll)", result.deleted)
+	}
+	if _, err := q.GetEventByUID(ctx, "gone-uid"); err == nil {
+		t.Error("gone-uid should be deleted (absent from complete QueryAll inventory)")
+	}
+	if _, err := q.GetEventByUID(ctx, "local-only"); err != nil {
+		t.Errorf("never-pushed local-only row must survive: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Hardens the sync engine's deletion path — the single function behind three
production data-loss incidents — so "never delete against an incomplete
inventory" is a structural guarantee instead of scattered ad-hoc checks.

The deletion logic now funnels through one chokepoint, `pendingDeletions`,
with exactly two doors:
- **`markExplicit`** — deletions backed by positive evidence (the server
  returned a top-level 404 for a specific href). Sound regardless of
  inventory completeness; preserves the href-rewrite guard.
- **`inferFromAbsence`** — deletions inferred from "it's missing, so remove
  it." Withheld in full unless the caller proves the inventory is complete;
  the withheld count + reason are logged, and the rows are re-evaluated on
  the next clean sync.

Both pull paths (`applySyncCollection` and the legacy `pullFullSnapshot`)
route their deletions and the shared executor through it. Completeness on
the sync-collection path is now one flag — `!Truncated && multigetMisses == 0`
— reused for the sync-token advance, so a token can't move past a view we
didn't fully see. A future "this looks deleted" edit can't reach the delete
loop without picking one of the two doors.

**Why this matters:** the three incidents (multiget 404s mistaken for
deletions, href-rewrite false positives, RFC 6578 §3.6 truncation) were the
same root cause each time. This makes a fourth variant structurally hard.

**Behavior change:** a single multiget miss during an initial snapshot now
withholds the *whole* absence sweep for that round (previously only the
missed path was protected; other absent rows could still be deleted).
Stricter and safer — withheld deletions are re-detected next clean sync.

## Test Coverage

- `pendingDeletions` gate unit tests: absence withheld when incomplete,
  explicit always deleted, never-pushed (empty remote_url) and seen rows
  protected, explicit+absence dedup under a complete inventory.
- Integration: initial-snapshot multiget miss withholds the entire absence
  sweep and holds the token.
- Integration: legacy `pullFullSnapshot` (QueryAll fallback) routes deletions
  through the chokepoint — absent pushed row deleted, never-pushed row
  survives. (This path had no test before — pre-existing coverage debt, now
  closed.)
- All pre-existing sync tests (truncation pagination, multiget tolerance,
  href-rewrite preservation, remote-delete) still pass under `-race`.
- Known gap: `apply()`'s partial-failure path (a soft-delete erroring
  mid-loop) needs a delete-injection seam — low value, noted as follow-up.

## Pre-Landing Review

5 informational findings, 0 critical, across testing + maintainability
specialists:
- **[testing, conf 8]** legacy `pullFullSnapshot` deletion routing untested
  → **fixed** (end-to-end test added this PR).
- **[testing, conf 5]** dedup-under-complete branch untested → **fixed**.
- **[testing, conf 4]** `apply()` executor error path → accepted as
  low-value follow-up (needs injection).
- **[maintainability, conf 5]** `absenceWithholdReason` eagerly evaluated
  and returns a "complete" sentinel → accepted (cosmetic; logic
  adversarially verified).

## Adversarial Review

Three independent passes, all clear:
- **Claude adversarial** — verified every guard survives the refactor, the
  completeness gate covers every absence deletion, token advance can't
  outrun a withheld sweep. Verdict: "net-safer than the code it replaces,
  LAND."
- **Codex adversarial** + **Codex structured (P1 gate)** — no introduced
  data-loss or correctness issue. GATE: PASS.

## Plan Completion

No design doc — this is proactive architectural hardening surfaced by the
weekly retro (the deletion sweep's three-incident pattern).

## Test plan
- [x] `make check` green (vet, lint 0 issues, govulncheck clean, `-race`)
- [x] Claude + Codex adversarial + Codex structured P1 gate all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
