### PR TITLE
test(auth): fix macOS keyring migration test (platform-correct config dir)

### DIFF
--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -227,9 +227,20 @@ func TestNewCredentialStore_PrefersKeyringWhenAvailable(t *testing.T) {
 
 func TestNewCredentialStore_MigratesLegacyPlaintextCredentials(t *testing.T) {
 	dir := t.TempDir()
+	// Redirect the config dir the way each platform actually resolves it:
+	// credentialDir honors XDG_CONFIG_HOME only on Linux; macOS uses
+	// os.UserConfigDir ($HOME/Library/Application Support). Set both, then
+	// derive the legacy dir from credentialDir itself so the test seeds the
+	// legacy credential exactly where NewCredentialStore's internal plaintext
+	// store looks for it — on any platform. (Hardcoding the Linux XDG layout
+	// is what made this test fail on the macOS CI runner.)
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
 
-	legacyDir := filepath.Join(dir, "chroncal", "credentials")
+	legacyDir, err := credentialDir()
+	if err != nil {
+		t.Fatalf("credentialDir: %v", err)
+	}
 	legacyStore := &PlaintextFileStore{dir: legacyDir}
 	legacyCred := Credential{
 		AccountID: 99,


### PR DESCRIPTION
## Summary

`TestNewCredentialStore_MigratesLegacyPlaintextCredentials` has been failing
on the `Test (Go 1.26, macos-latest)` CI job — red on `master` for the whole
recent series — while Linux CI and local `make check` (Linux) stayed green.
That red has been masking the macOS signal on every PR merge.

**Root cause (test bug, not flake):** the test set `XDG_CONFIG_HOME` and
hardcoded the legacy credential at the Linux XDG layout
(`$dir/chroncal/credentials`). But `credentialDir()` honors
`XDG_CONFIG_HOME` only on Linux — macOS resolves to `os.UserConfigDir()`
(`$HOME/Library/Application Support`). On the macOS runner the test wrote the
legacy cred to the tempdir, but `NewCredentialStore`'s internal plaintext
store looked under `~/Library/...`, found nothing, and the migration returned
`secret not found in keyring`.

**Fix (test-only, zero production risk):** derive the legacy dir from
`credentialDir()` itself, and set `HOME` as well as `XDG_CONFIG_HOME`, so the
test seeds the legacy credential exactly where production resolves it on any
platform. The keyring is already mocked via `overrideKeyringForTest`, so no
real Keychain is touched.

## Why it matters

A green macOS job is what makes the *next* macOS failure meaningful. Until
now, merges rode over a permanently-red required check; a real macOS
regression could have landed under the noise.

## Test plan
- [x] `go test ./internal/auth/` green on Linux
- [x] `make check` green (vet, lint, vulncheck, -race) on Linux
- [x] macOS CI job — can't run locally; the fix aligns the legacy path with
      `credentialDir()` by construction, so the macos-latest job should now
      pass (this PR's own CI is the verification)

Note: the same Linux-only `XDG_*` divergence exists in `userDataDir()`
(DB path) — not exercised by a failing test today, noted for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)