### PR TITLE
chore(test): add Radicale CalDAV server for local integration testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,28 @@ Always use `-count=1` to bypass Go's test cache.
 - Integration tests end with `_integration_test.go`
 - Use `context.Background()` for test contexts
 
+### CalDAV integration tests (Radicale)
+
+The CalDAV round-trip tests in `internal/ical/radicale_test.go` exercise a
+real server — covering VEVENT, VTODO, and VJOURNAL. They **skip
+automatically** when no server is reachable, so `make test` stays
+hermetic. To run them, start the bundled [Radicale](https://radicale.org/)
+server (anonymous, wide-open rights, on `localhost:5232`):
+
+```bash
+# Start (requires Docker)
+docker compose -f tools/radicale/docker-compose.yml up -d
+
+# Run the CalDAV round-trip tests against it
+RADICALE_URL=http://localhost:5232 go test ./internal/ical -run Radicale -v -count=1
+
+# Stop (add -v to also wipe the stored collections)
+docker compose -f tools/radicale/docker-compose.yml down
+```
+
+`RADICALE_URL` overrides the default endpoint if you run a server
+elsewhere. See `tools/radicale/README.md` for configuration details.
+
 ## Database changes
 
 ### Adding a migration

--- a/tools/radicale/README.md
+++ b/tools/radicale/README.md
@@ -1,0 +1,52 @@
+# Radicale — local CalDAV test server
+
+A throwaway [Radicale](https://radicale.org/) server for exercising
+chroncal's CalDAV sync and iCal round-trip against a real server. It
+supports **VEVENT**, **VTODO**, and **VJOURNAL**, which makes it the
+target for the integration tests in
+[`internal/ical/radicale_test.go`](../../internal/ical/radicale_test.go).
+
+## Usage
+
+```bash
+# Start (detached). Requires Docker + the compose plugin.
+docker compose -f tools/radicale/docker-compose.yml up -d
+
+# It serves at http://localhost:5232 with NO authentication.
+
+# Stop, keeping stored collections in the named volume:
+docker compose -f tools/radicale/docker-compose.yml down
+
+# Stop and wipe all stored collections:
+docker compose -f tools/radicale/docker-compose.yml down -v
+```
+
+## Configuration
+
+| File                 | Purpose                                                        |
+| -------------------- | -------------------------------------------------------------- |
+| `docker-compose.yml` | Runs `tomsquest/docker-radicale` on port 5232, persistent vol. |
+| `config`             | `auth = none`, filesystem storage, `rights = from_file`.       |
+| `rights`             | Grants every (anonymous) user full read/write to all paths.    |
+
+This matches what the integration tests expect: anonymous `MKCOL` /
+`MKCALENDAR` / `PUT` on `localhost:5232`, no credentials.
+
+> ⚠️ **Local testing only.** Authentication is disabled and every
+> collection is world-writable. Never expose this to a network.
+
+## Using it from chroncal
+
+Point a calendar's remote link at a collection on this server (create one
+first with `MKCALENDAR`, or let a sync push create it), e.g.
+`http://localhost:5232/qauser/qa/`. Because auth is disabled, any
+username works and no password is required.
+
+## Running the integration tests
+
+```bash
+RADICALE_URL=http://localhost:5232 go test ./internal/ical -run Radicale -v -count=1
+```
+
+`RADICALE_URL` defaults to `http://localhost:5232`; set it to target a
+server running elsewhere.

--- a/tools/radicale/config
+++ b/tools/radicale/config
@@ -1,0 +1,16 @@
+[server]
+hosts = 0.0.0.0:5232
+
+# Local-testing config only: no authentication, wide-open rights.
+# Matches the anonymous access the integration tests expect at
+# http://localhost:5232 (see internal/ical/radicale_test.go).
+# DO NOT use this anywhere reachable from the network.
+[auth]
+type = none
+
+[storage]
+filesystem_folder = /data/collections
+
+[rights]
+type = from_file
+file = /config/rights

--- a/tools/radicale/docker-compose.yml
+++ b/tools/radicale/docker-compose.yml
@@ -1,0 +1,31 @@
+# Radicale CalDAV server for local testing.
+#
+# Supports VEVENT, VTODO, and VJOURNAL. Listens on http://localhost:5232
+# with NO authentication and wide-open rights, matching what the
+# integration tests in internal/ical/radicale_test.go expect.
+#
+# Usage:
+#   docker compose -f tools/radicale/docker-compose.yml up -d
+#   docker compose -f tools/radicale/docker-compose.yml down
+#
+# Data persists in the named volume `radicale-data`. To wipe state:
+#   docker compose -f tools/radicale/docker-compose.yml down -v
+services:
+  radicale:
+    image: tomsquest/docker-radicale:latest
+    container_name: chroncal-radicale
+    ports:
+      - "5232:5232"
+    volumes:
+      - ./config:/config/config:ro
+      - ./rights:/config/rights:ro
+      - radicale-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5232/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  radicale-data:

--- a/tools/radicale/rights
+++ b/tools/radicale/rights
@@ -1,0 +1,6 @@
+# Local-testing rights: every (anonymous) user gets full read/write to
+# every collection, so MKCOL / MKCALENDAR / PUT all succeed without auth.
+[allow-everything]
+user = .*
+collection = .*
+permissions = RrWw


### PR DESCRIPTION
## What

Adds a bundled [Radicale](https://radicale.org/) CalDAV server for local
integration testing under `tools/radicale/`, plus documentation.

The server supports **VEVENT, VTODO, and VJOURNAL** and listens anonymously
on `localhost:5232` — exactly the endpoint the existing round-trip tests in
`internal/ical/radicale_test.go` already target (they skip when no server is
reachable, so `make test` stays hermetic).

## Why

This is groundwork for #30 (bringing VTODO and VJOURNAL to the TUI). To build
and validate todo/journal management in the TUI, we need a real CalDAV server
that speaks all three component types to sync against. Radicale is the
lightest server that does, and it's already the integration-test target.

## Changes

- `tools/radicale/docker-compose.yml` — runs `tomsquest/docker-radicale` on
  port 5232 with a persistent named volume.
- `tools/radicale/config` — `auth = none`, filesystem storage,
  `rights = from_file`.
- `tools/radicale/rights` — grants every (anonymous) user full read/write
  (local-testing only; never expose to a network).
- `tools/radicale/README.md` — usage + configuration reference.
- `CONTRIBUTING.md` — new "CalDAV integration tests (Radicale)" section.

## How to use

```bash
docker compose -f tools/radicale/docker-compose.yml up -d
RADICALE_URL=http://localhost:5232 go test ./internal/ical -run Radicale -v -count=1
docker compose -f tools/radicale/docker-compose.yml down   # -v to wipe data
```

## Verification

- `MKCOL` / `MKCALENDAR` / `PUT` of a VEVENT, VTODO, and VJOURNAL all return
  201 anonymously and read back intact.
- The full `internal/ical` Radicale integration suite (VEVENT/VTODO/VJOURNAL,
  recurrence, timezones, attendees, categories, VALARM) passes against the
  live server.

## Status

Draft — opened to track the groundwork alongside #30. The TUI work itself is
proposed in that issue and will land in follow-up PRs.

Relates to #30
