### PR TITLE
fix(tui): keep form dialog actions visible

### DIFF
--- a/internal/tui/calendar_dialog.go
+++ b/internal/tui/calendar_dialog.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 )
@@ -200,6 +201,7 @@ type CalendarDialogModel struct {
 	linked       bool
 	dialog       Dialog
 	form         Form
+	body         viewport.Model
 	help         help.Model
 	testStatus   string
 	theme        Theme
@@ -419,6 +421,7 @@ func NewCalendarDialogModel(params CalendarDialogParams, theme Theme) CalendarDi
 		linked:          params.RemoteLinked,
 		dialog:          dialog,
 		form:            form,
+		body:            viewport.New(),
 		help:            newThemedHelp(theme),
 		theme:           theme,
 		accentColor:     theme.Selected,
@@ -427,6 +430,7 @@ func NewCalendarDialogModel(params CalendarDialogParams, theme Theme) CalendarDi
 		saveMakeDefault: saveMakeDefault,
 		contentWidth:    contentWidth,
 	}
+	m.body.MouseWheelEnabled = true
 
 	// Edit mode, not yet default: surface "Set as Default" so the user
 	// can reach the action without backing out into the manage-calendars
@@ -864,7 +868,78 @@ func (m CalendarDialogModel) SetSize(w, h int) CalendarDialogModel {
 	if m.contentWidth != nil {
 		*m.contentWidth = m.dialog.ContentWidth()
 	}
+	m.syncBodyViewport()
 	return m
+}
+
+func (m CalendarDialogModel) formViewportHeight() int {
+	const chromeLines = 2 + // top + bottom border
+		1 + // top padding (PaddingY)
+		2 + // dialog title + blank line
+		2 // blank line + help footer
+	extra := 0
+	if m.testStatus != "" {
+		extra = 1
+	}
+	actionLines := 1 + max(lipgloss.Height(m.form.ButtonRowView()), 1) // separator + buttons
+	return max(m.dialog.height-chromeLines-actionLines-extra, 1)
+}
+
+func (m *CalendarDialogModel) syncBodyViewport() {
+	cw := m.dialog.ContentWidth()
+	if cw <= 0 || m.dialog.height <= 0 {
+		return
+	}
+	bodyLines := strings.Split(m.form.BodyView(), "\n")
+	m.body.SetWidth(cw)
+	m.body.SetHeight(min(len(bodyLines), m.formViewportHeight()))
+	m.body.SetContentLines(bodyLines)
+	m.keepFocusedFieldVisible()
+}
+
+func (m *CalendarDialogModel) keepFocusedFieldVisible() {
+	if m.body.Height() <= 0 {
+		return
+	}
+	line := m.form.FocusedLine()
+	if line < m.body.YOffset() {
+		m.body.ScrollUp(m.body.YOffset() - line)
+		return
+	}
+	bottom := m.body.YOffset() + m.body.Height() - 1
+	if line > bottom {
+		m.body.ScrollDown(line - bottom)
+	}
+}
+
+func (m CalendarDialogModel) bodyOverflows() bool {
+	return m.body.TotalLineCount() > m.body.VisibleLineCount()
+}
+
+func (m CalendarDialogModel) scrollHint() string {
+	if !m.bodyOverflows() {
+		return ""
+	}
+	switch {
+	case m.body.AtTop():
+		return "↓ more"
+	case m.body.AtBottom():
+		return "↑ more"
+	default:
+		return "↑↓ more"
+	}
+}
+
+func (m CalendarDialogModel) actionsSeparator(w int) string {
+	faint := lipgloss.NewStyle().Faint(true)
+	hint := m.scrollHint()
+	hw := lipgloss.Width(hint)
+	if hint == "" || w <= hw+2 {
+		return faint.Render(strings.Repeat("─", w))
+	}
+	left := (w - hw - 2) / 2
+	right := w - hw - 2 - left
+	return faint.Render(strings.Repeat("─", left)) + " " + faint.Render(hint) + " " + faint.Render(strings.Repeat("─", right))
 }
 
 func (m CalendarDialogModel) BoxSize() (int, int) {
@@ -877,7 +952,9 @@ func (m CalendarDialogModel) Update(msg tea.Msg) (CalendarDialogModel, tea.Cmd) 
 	}
 
 	if _, ok := msg.(testConnectionPressedMsg); ok {
-		return m.handleTestPressed()
+		m, cmd := m.handleTestPressed()
+		m.syncBodyViewport()
+		return m, cmd
 	}
 
 	if _, ok := msg.(calendarSavePromotePressedMsg); ok {
@@ -897,6 +974,7 @@ func (m CalendarDialogModel) Update(msg tea.Msg) (CalendarDialogModel, tea.Cmd) 
 			m.testStatus = lipgloss.NewStyle().Foreground(m.theme.Error).
 				Render("✗ " + tr.Message)
 		}
+		m.syncBodyViewport()
 		return m, nil
 	}
 
@@ -923,9 +1001,16 @@ func (m CalendarDialogModel) Update(msg tea.Msg) (CalendarDialogModel, tea.Cmd) 
 		}
 		return m, nil
 	}
+	if mw, ok := msg.(tea.MouseWheelMsg); ok {
+		var cmd tea.Cmd
+		m.syncBodyViewport()
+		m.body, cmd = m.body.Update(mw)
+		return m, cmd
+	}
 
 	var cmd tea.Cmd
 	m.form, cmd = m.form.Update(msg)
+	m.syncBodyViewport()
 	return m, cmd
 }
 
@@ -936,10 +1021,14 @@ func (m CalendarDialogModel) View() string {
 		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel")),
 	}
 	m.dialog.SetFooter(m.help.ShortHelpView(helpKeys))
-	body := m.form.View()
+	m.syncBodyViewport()
+	cw := m.dialog.ContentWidth()
+	parts := []string{m.body.View()}
 	if m.testStatus != "" {
-		body += "\n" + m.testStatus
+		parts = append(parts, truncateTo(m.testStatus, cw))
 	}
+	parts = append(parts, m.actionsSeparator(cw), m.form.ButtonRowView())
+	body := strings.Join(parts, "\n")
 	content := mouseSweep(m.dialog.Box(body))
 	return content
 }

--- a/internal/tui/calendar_dialog.go
+++ b/internal/tui/calendar_dialog.go
@@ -868,7 +868,7 @@ func (m CalendarDialogModel) SetSize(w, h int) CalendarDialogModel {
 	if m.contentWidth != nil {
 		*m.contentWidth = m.dialog.ContentWidth()
 	}
-	m.syncBodyViewport()
+	m.syncBodyViewport(true)
 	return m
 }
 
@@ -885,7 +885,7 @@ func (m CalendarDialogModel) formViewportHeight() int {
 	return max(m.dialog.height-chromeLines-actionLines-extra, 1)
 }
 
-func (m *CalendarDialogModel) syncBodyViewport() {
+func (m *CalendarDialogModel) syncBodyViewport(keepFocusVisible bool) {
 	cw := m.dialog.ContentWidth()
 	if cw <= 0 || m.dialog.height <= 0 {
 		return
@@ -894,7 +894,9 @@ func (m *CalendarDialogModel) syncBodyViewport() {
 	m.body.SetWidth(cw)
 	m.body.SetHeight(min(len(bodyLines), m.formViewportHeight()))
 	m.body.SetContentLines(bodyLines)
-	m.keepFocusedFieldVisible()
+	if keepFocusVisible {
+		m.keepFocusedFieldVisible()
+	}
 }
 
 func (m *CalendarDialogModel) keepFocusedFieldVisible() {
@@ -953,7 +955,7 @@ func (m CalendarDialogModel) Update(msg tea.Msg) (CalendarDialogModel, tea.Cmd) 
 
 	if _, ok := msg.(testConnectionPressedMsg); ok {
 		m, cmd := m.handleTestPressed()
-		m.syncBodyViewport()
+		m.syncBodyViewport(true)
 		return m, cmd
 	}
 
@@ -974,7 +976,7 @@ func (m CalendarDialogModel) Update(msg tea.Msg) (CalendarDialogModel, tea.Cmd) 
 			m.testStatus = lipgloss.NewStyle().Foreground(m.theme.Error).
 				Render("✗ " + tr.Message)
 		}
-		m.syncBodyViewport()
+		m.syncBodyViewport(true)
 		return m, nil
 	}
 
@@ -1003,14 +1005,14 @@ func (m CalendarDialogModel) Update(msg tea.Msg) (CalendarDialogModel, tea.Cmd) 
 	}
 	if mw, ok := msg.(tea.MouseWheelMsg); ok {
 		var cmd tea.Cmd
-		m.syncBodyViewport()
+		m.syncBodyViewport(false)
 		m.body, cmd = m.body.Update(mw)
 		return m, cmd
 	}
 
 	var cmd tea.Cmd
 	m.form, cmd = m.form.Update(msg)
-	m.syncBodyViewport()
+	m.syncBodyViewport(true)
 	return m, cmd
 }
 
@@ -1021,7 +1023,7 @@ func (m CalendarDialogModel) View() string {
 		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel")),
 	}
 	m.dialog.SetFooter(m.help.ShortHelpView(helpKeys))
-	m.syncBodyViewport()
+	m.syncBodyViewport(false)
 	cw := m.dialog.ContentWidth()
 	parts := []string{m.body.View()}
 	if m.testStatus != "" {

--- a/internal/tui/calendar_dialog_oauth_test.go
+++ b/internal/tui/calendar_dialog_oauth_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 )
 
@@ -62,6 +63,32 @@ func TestCalendarDialog_OAuthLayoutFitsSmallTerminal(t *testing.T) {
 	}
 	if !strings.Contains(out, "more") {
 		t.Fatalf("scroll hint should render when body overflows, got %q", out)
+	}
+}
+
+func TestCalendarDialog_MouseWheelScrollSurvivesRender(t *testing.T) {
+	m := oauthDialogFixture(t, "oauth2").SetSize(120, 15)
+	if !m.bodyOverflows() {
+		t.Fatal("test precondition: calendar form body should overflow")
+	}
+
+	for range 30 {
+		var cmd tea.Cmd
+		m, cmd = m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+		if cmd != nil {
+			t.Fatalf("mouse wheel returned unexpected command %T", cmd)
+		}
+	}
+	if !m.body.AtBottom() {
+		t.Fatal("mouse wheel should scroll the body to the bottom")
+	}
+
+	out := m.View()
+	if !strings.Contains(out, "Client secret") {
+		t.Fatalf("rendering must preserve the wheel-scrolled viewport, got %q", out)
+	}
+	if !strings.Contains(out, "↑ more") {
+		t.Fatalf("bottom scroll hint should render after wheel scrolling, got %q", out)
 	}
 }
 

--- a/internal/tui/calendar_dialog_oauth_test.go
+++ b/internal/tui/calendar_dialog_oauth_test.go
@@ -46,6 +46,25 @@ func TestCalendarDialog_OAuthLayoutSwapsRows(t *testing.T) {
 	}
 }
 
+func TestCalendarDialog_OAuthLayoutFitsSmallTerminal(t *testing.T) {
+	m := oauthDialogFixture(t, "oauth2").SetSize(120, 15)
+
+	_, bh := lipgloss.Size(m.View())
+	if bh > 15 {
+		t.Fatalf("rendered calendar dialog height = %d, want <= 15", bh)
+	}
+	if !m.bodyOverflows() {
+		t.Fatal("test precondition: calendar form body should overflow")
+	}
+	out := m.View()
+	if !strings.Contains(out, "New calendar") || !strings.Contains(out, "Save") || !strings.Contains(out, "Cancel") {
+		t.Fatalf("title and actions should stay visible in small terminal, got %q", out)
+	}
+	if !strings.Contains(out, "more") {
+		t.Fatalf("scroll hint should render when body overflows, got %q", out)
+	}
+}
+
 func TestCalendarDialog_OAuthLayoutSwitchPreservesValues(t *testing.T) {
 	m := oauthDialogFixture(t, "basic")
 	rebuild := func() {

--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -786,7 +786,7 @@ func (m EventFormModel) SetSize(w, h int) EventFormModel {
 	m.height = h
 	m.dialog = m.dialog.Update(tea.WindowSizeMsg{Width: w, Height: h})
 	m.form.SetWidth(m.dialog.ContentWidth())
-	m.syncBodyViewport()
+	m.syncBodyViewport(true)
 	return m
 }
 
@@ -799,7 +799,7 @@ func (m EventFormModel) formViewportHeight() int {
 	return max(m.height-chromeLines-actionLines, 1)
 }
 
-func (m *EventFormModel) syncBodyViewport() {
+func (m *EventFormModel) syncBodyViewport(keepFocusVisible bool) {
 	if m.width <= 0 || m.height <= 0 {
 		return
 	}
@@ -811,7 +811,9 @@ func (m *EventFormModel) syncBodyViewport() {
 	m.body.SetWidth(cw)
 	m.body.SetHeight(min(len(bodyLines), m.formViewportHeight()))
 	m.body.SetContentLines(bodyLines)
-	m.keepFocusedFieldVisible()
+	if keepFocusVisible {
+		m.keepFocusedFieldVisible()
+	}
 }
 
 func (m *EventFormModel) keepFocusedFieldVisible() {
@@ -938,14 +940,14 @@ func (m EventFormModel) Update(msg tea.Msg) (EventFormModel, tea.Cmd) {
 	}
 	if mw, ok := msg.(tea.MouseWheelMsg); ok {
 		var cmd tea.Cmd
-		m.syncBodyViewport()
+		m.syncBodyViewport(false)
 		m.body, cmd = m.body.Update(mw)
 		return m, cmd
 	}
 
 	var cmd tea.Cmd
 	m.form, cmd = m.form.Update(msg)
-	m.syncBodyViewport()
+	m.syncBodyViewport(true)
 	return m, cmd
 }
 
@@ -1530,7 +1532,7 @@ func (m EventFormModel) View() string {
 		m.keys.Close,
 	}
 	m.dialog.SetFooter(m.help.ShortHelpView(helpKeys))
-	m.syncBodyViewport()
+	m.syncBodyViewport(false)
 	cw := m.dialog.ContentWidth()
 	body := strings.Join([]string{
 		m.body.View(),

--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 
@@ -181,6 +182,7 @@ type EventFormModel struct {
 	// Dialog + Form
 	dialog Dialog
 	form   Form
+	body   viewport.Model
 	// fieldKeys maps form item index → field key for OnFieldEnter
 	fieldKeys []string
 
@@ -574,6 +576,8 @@ func (m *EventFormModel) buildDialogAndForm() {
 	m.form.OnRebuild(func(f *Form) {
 		m.syncFromForm()
 	})
+	m.body = viewport.New()
+	m.body.MouseWheelEnabled = true
 }
 
 func (m *EventFormModel) rebuildDialog() {
@@ -782,7 +786,77 @@ func (m EventFormModel) SetSize(w, h int) EventFormModel {
 	m.height = h
 	m.dialog = m.dialog.Update(tea.WindowSizeMsg{Width: w, Height: h})
 	m.form.SetWidth(m.dialog.ContentWidth())
+	m.syncBodyViewport()
 	return m
+}
+
+func (m EventFormModel) formViewportHeight() int {
+	const chromeLines = 2 + // top + bottom border
+		1 + // top padding (PaddingY)
+		2 + // dialog title + blank line
+		2 // blank line + help footer
+	actionLines := 1 + max(lipgloss.Height(m.form.ButtonRowView()), 1) // separator + buttons
+	return max(m.height-chromeLines-actionLines, 1)
+}
+
+func (m *EventFormModel) syncBodyViewport() {
+	if m.width <= 0 || m.height <= 0 {
+		return
+	}
+	cw := m.dialog.ContentWidth()
+	if cw <= 0 {
+		return
+	}
+	bodyLines := strings.Split(m.form.BodyView(), "\n")
+	m.body.SetWidth(cw)
+	m.body.SetHeight(min(len(bodyLines), m.formViewportHeight()))
+	m.body.SetContentLines(bodyLines)
+	m.keepFocusedFieldVisible()
+}
+
+func (m *EventFormModel) keepFocusedFieldVisible() {
+	if m.body.Height() <= 0 {
+		return
+	}
+	line := m.form.FocusedLine()
+	if line < m.body.YOffset() {
+		m.body.ScrollUp(m.body.YOffset() - line)
+		return
+	}
+	bottom := m.body.YOffset() + m.body.Height() - 1
+	if line > bottom {
+		m.body.ScrollDown(line - bottom)
+	}
+}
+
+func (m EventFormModel) bodyOverflows() bool {
+	return m.body.TotalLineCount() > m.body.VisibleLineCount()
+}
+
+func (m EventFormModel) scrollHint() string {
+	if !m.bodyOverflows() {
+		return ""
+	}
+	switch {
+	case m.body.AtTop():
+		return "↓ more"
+	case m.body.AtBottom():
+		return "↑ more"
+	default:
+		return "↑↓ more"
+	}
+}
+
+func (m EventFormModel) actionsSeparator(w int) string {
+	faint := lipgloss.NewStyle().Faint(true)
+	hint := m.scrollHint()
+	hw := lipgloss.Width(hint)
+	if hint == "" || w <= hw+2 {
+		return faint.Render(strings.Repeat("─", w))
+	}
+	left := (w - hw - 2) / 2
+	right := w - hw - 2 - left
+	return faint.Render(strings.Repeat("─", left)) + " " + faint.Render(hint) + " " + faint.Render(strings.Repeat("─", right))
 }
 
 // BoxSize returns the outer dimensions of the form dialog.
@@ -862,9 +936,16 @@ func (m EventFormModel) Update(msg tea.Msg) (EventFormModel, tea.Cmd) {
 		}
 		return m, nil
 	}
+	if mw, ok := msg.(tea.MouseWheelMsg); ok {
+		var cmd tea.Cmd
+		m.syncBodyViewport()
+		m.body, cmd = m.body.Update(mw)
+		return m, cmd
+	}
 
 	var cmd tea.Cmd
 	m.form, cmd = m.form.Update(msg)
+	m.syncBodyViewport()
 	return m, cmd
 }
 
@@ -1449,7 +1530,14 @@ func (m EventFormModel) View() string {
 		m.keys.Close,
 	}
 	m.dialog.SetFooter(m.help.ShortHelpView(helpKeys))
-	content := mouseSweep(m.dialog.Box(m.form.View()))
+	m.syncBodyViewport()
+	cw := m.dialog.ContentWidth()
+	body := strings.Join([]string{
+		m.body.View(),
+		m.actionsSeparator(cw),
+		m.form.ButtonRowView(),
+	}, "\n")
+	content := mouseSweep(m.dialog.Box(body))
 	return content
 }
 

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/stretchr/testify/assert"
@@ -252,6 +253,29 @@ func TestEventForm_EditDialogFitsSmallTerminal(t *testing.T) {
 	assert.Contains(t, out, "Save")
 	assert.Contains(t, out, "Cancel")
 	assert.Contains(t, out, "more")
+}
+
+func TestEventForm_MouseWheelScrollSurvivesRender(t *testing.T) {
+	m, _ := NewEventFormModelForEdit(event.Event{
+		ID:         42,
+		Title:      "Very detailed planning session",
+		StartTime:  time.Date(2026, 4, 22, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 22, 15, 0, 0, 0, time.UTC),
+		CalendarID: 1,
+	}, testEventFormCalendars(), Theme{})
+	m = m.SetSize(120, 15)
+	require.True(t, m.bodyOverflows(), "test precondition: form body should overflow")
+
+	for range 30 {
+		var cmd tea.Cmd
+		m, cmd = m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+		require.Nil(t, cmd)
+	}
+	require.True(t, m.body.AtBottom(), "mouse wheel should scroll the body to the bottom")
+
+	out := m.View()
+	assert.Contains(t, out, "Alarms", "rendering must preserve the wheel-scrolled viewport")
+	assert.Contains(t, out, "↑ more")
 }
 
 func TestEventForm_SaveIncludesShowAsAndVisibility(t *testing.T) {

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -230,6 +230,30 @@ func TestEventForm_EditModeRetainsEditID(t *testing.T) {
 	require.True(t, ok, "OnSubmit must emit eventFormSubmitNowMsg")
 }
 
+func TestEventForm_EditDialogFitsSmallTerminal(t *testing.T) {
+	m, _ := NewEventFormModelForEdit(event.Event{
+		ID:          42,
+		Title:       "Very detailed planning session",
+		Description: strings.Repeat("Long notes that make the form tall.\n", 30),
+		StartTime:   time.Date(2026, 4, 22, 14, 0, 0, 0, time.UTC),
+		EndTime:     time.Date(2026, 4, 22, 15, 0, 0, 0, time.UTC),
+		CalendarID:  1,
+		Categories:  "planning, review",
+	}, testEventFormCalendars(), Theme{})
+	const termH = 15
+	m = m.SetSize(120, termH)
+
+	_, bh := m.BoxSize()
+	require.LessOrEqual(t, bh, termH, "rendered edit form must fit inside the terminal")
+	require.True(t, m.bodyOverflows(), "test precondition: form body should overflow")
+
+	out := m.View()
+	assert.Contains(t, out, "Edit Event")
+	assert.Contains(t, out, "Save")
+	assert.Contains(t, out, "Cancel")
+	assert.Contains(t, out, "more")
+}
+
 func TestEventForm_SaveIncludesShowAsAndVisibility(t *testing.T) {
 	m, _ := NewEventFormModel(time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), testEventFormCalendars(), Theme{})
 	m.titleField.SetValue("Planning")

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -1806,7 +1806,7 @@ func (f Form) Update(msg tea.Msg) (Form, tea.Cmd) {
 	return f, nil
 }
 
-func (f Form) View() string {
+func (f Form) fieldParts() []string {
 	var parts []string
 
 	// Compute the widest label among inline items so all inline labels
@@ -1885,6 +1885,10 @@ func (f Form) View() string {
 		}
 	}
 
+	return parts
+}
+
+func (f Form) buttonRow() string {
 	bs := f.styles.Buttons
 	leadParts := make([]string, 0, len(f.actionButtons))
 	rightParts := make([]string, 0, len(f.actionButtons)+2)
@@ -1907,10 +1911,7 @@ func (f Form) View() string {
 	// Use the form's width (typically set from Dialog.ContentWidth()) so
 	// buttons align relative to the container, not the field rows. Fall
 	// back to the natural content width when no explicit width is set.
-	alignWidth := f.width
-	if alignWidth <= 0 {
-		alignWidth = lipgloss.Width(lipgloss.JoinVertical(lipgloss.Left, parts...))
-	}
+	alignWidth := f.buttonAlignWidth()
 
 	var buttons string
 	if len(leadParts) > 0 {
@@ -1948,16 +1949,67 @@ func (f Form) View() string {
 		}
 	}
 
+	return buttons
+}
+
+func (f Form) buttonAlignWidth() int {
+	alignWidth := f.width
+	if alignWidth <= 0 {
+		alignWidth = lipgloss.Width(lipgloss.JoinVertical(lipgloss.Left, f.fieldParts()...))
+	}
+	return alignWidth
+}
+
+func (f Form) buttonParts() []string {
+	buttons := f.buttonRow()
 	if f.styles.ButtonRule {
-		ruleWidth := alignWidth
+		ruleWidth := f.buttonAlignWidth()
 		if ruleWidth <= 0 {
 			ruleWidth = lipgloss.Width(buttons)
 		}
 		rule := strings.Repeat(Glyphs["separator.horizontal"], ruleWidth)
-		parts = append(parts, "", lipgloss.NewStyle().Faint(true).Render(rule), buttons)
-	} else {
-		parts = append(parts, "", buttons)
+		return []string{lipgloss.NewStyle().Faint(true).Render(rule), buttons}
 	}
+	return []string{buttons}
+}
+
+// BodyView renders only the form fields, excluding the bottom action row.
+// Dialogs with constrained height can put this body in a viewport while
+// keeping Save/Cancel pinned below it.
+func (f Form) BodyView() string {
+	return lipgloss.JoinVertical(lipgloss.Left, f.fieldParts()...)
+}
+
+// ActionsView renders the form action separator and buttons without the
+// leading blank line used by the full form view.
+func (f Form) ActionsView() string {
+	return lipgloss.JoinVertical(lipgloss.Left, f.buttonParts()...)
+}
+
+// ButtonRowView renders only the form buttons. Scrollable dialogs use this
+// with their own separator so they can include scroll state in the rule.
+func (f Form) ButtonRowView() string {
+	return f.buttonRow()
+}
+
+// FocusedLine returns the first rendered body line for the focused item.
+// It is used by scrollable dialogs to keep the active field visible.
+func (f Form) FocusedLine() int {
+	parts := f.fieldParts()
+	line := 0
+	for i, part := range parts {
+		if i == f.focused {
+			return line
+		}
+		line += max(lipgloss.Height(part), 1)
+	}
+	return 0
+}
+
+func (f Form) View() string {
+	parts := f.fieldParts()
+	parts = append(parts, "")
+	parts = append(parts, f.buttonParts()...)
 
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }


### PR DESCRIPTION
## Summary
- Split shared form rendering into scrollable body and reusable pinned button row
- Constrain event create/edit forms to terminal height while keeping title, help, and Save/Cancel visible
- Apply the same constrained form body to calendar dialogs, including OAuth/sync layouts

## Tests
- go test ./...
