### PR TITLE
ci: build via the Nix flake on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,20 @@ jobs:
       - name: Build
         run: go build -o chroncal ./cmd/chroncal
 
+  flake:
+    name: Nix flake build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+
+      # Build via the flake, exactly as the release does. This catches a stale
+      # vendorHash — e.g. a dependency bump that changed go.sum but not
+      # flake.nix — on the PR instead of failing the release after tagging.
+      - name: Build via the flake
+        run: nix build .#chroncal --no-link --print-build-logs
+
   release-config:
     name: Release config
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The Nix flake build only runs in the **release** workflow. So a dependency bump that changes `go.sum` without updating `flake.nix`'s `vendorHash` (exactly what happened with the `golang.org/x/net 0.56.0` dependabot bump) sails through CI and only fails **after** a tag is pushed — turning a release into a fire drill.

## What

Add a `Nix flake build` job to `ci.yml` that runs the same `nix build .#chroncal` the release does, on every push/PR to `master`. A stale `vendorHash` now fails on the PR, where it's cheap to fix, instead of at release time.

This PR's own CI run exercises the new job.