### PR TITLE
feat(calendar): user-configurable sidebar ordering

### DIFF
--- a/db/migrations/032_calendar_display_order.sql
+++ b/db/migrations/032_calendar_display_order.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE calendars ADD COLUMN display_order INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill: rank existing calendars by name so the persisted starting order
+-- matches the alphabetical order the sidebar showed before this column
+-- existed. Names are UNIQUE, so the correlated count yields a stable, gap-free
+-- 0-based rank with no ties.
+UPDATE calendars SET display_order = (
+    SELECT COUNT(*) FROM calendars c2 WHERE c2.name < calendars.name
+);
+
+-- +goose Down
+ALTER TABLE calendars DROP COLUMN display_order;

--- a/db/queries/calendars.sql
+++ b/db/queries/calendars.sql
@@ -1,11 +1,15 @@
 -- name: ListCalendars :many
-SELECT * FROM calendars ORDER BY name;
+SELECT * FROM calendars ORDER BY display_order, name;
 
 -- name: GetCalendar :one
 SELECT * FROM calendars WHERE id = ?;
 
 -- name: CreateCalendar :one
-INSERT INTO calendars (name, color, description) VALUES (?, ?, ?) RETURNING *;
+-- display_order is computed as MAX+1 (0 for the first calendar) so new
+-- calendars append to the bottom of the sidebar instead of all colliding at 0.
+INSERT INTO calendars (name, color, description, display_order)
+VALUES (?, ?, ?, (SELECT COALESCE(MAX(display_order), -1) + 1 FROM calendars))
+RETURNING *;
 
 -- name: UpdateCalendar :one
 UPDATE calendars SET name = ?, color = ?, description = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ? RETURNING *;
@@ -17,7 +21,13 @@ SELECT COUNT(*) FROM calendars;
 DELETE FROM calendars WHERE id = ?;
 
 -- name: ListCalendarsByAccount :many
-SELECT * FROM calendars WHERE account_id = ? ORDER BY name;
+SELECT * FROM calendars WHERE account_id = ? ORDER BY display_order, name;
+
+-- name: SetCalendarDisplayOrder :exec
+UPDATE calendars SET
+    display_order = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE id = ?;
 
 -- name: UpdateCalendarSyncState :exec
 UPDATE calendars SET

--- a/internal/calendar/model.go
+++ b/internal/calendar/model.go
@@ -13,6 +13,8 @@ type Calendar struct {
 
 	OwnerEmail string // Email of the calendar owner (for RSVP matching)
 
+	DisplayOrder int64 // Sidebar sort position; lower sorts first
+
 	// Sync fields — populated when calendar is linked to a remote account
 	AccountID           int64  // 0 = local-only calendar
 	RemoteURL           string // CalDAV calendar URL (href)

--- a/internal/calendar/service.go
+++ b/internal/calendar/service.go
@@ -48,6 +48,31 @@ func (s *Service) List(ctx context.Context) ([]Calendar, error) {
 	return cals, nil
 }
 
+// SetOrder persists the given calendar IDs as display order 0..n-1 in a single
+// transaction, so the sidebar (and manage-calendars dialog) render in this
+// order. The caller passes the full ordered ID list — typically the sidebar's
+// current row order after a move — making the operation idempotent and
+// self-healing against any drift. IDs not present in the slice are left
+// untouched.
+func (s *Service) SetOrder(ctx context.Context, ids []int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	qtx := s.q.WithTx(tx)
+	for i, id := range ids {
+		if err := qtx.SetCalendarDisplayOrder(ctx, storage.SetCalendarDisplayOrderParams{
+			DisplayOrder: int64(i),
+			ID:           id,
+		}); err != nil {
+			return fmt.Errorf("set display order: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
 func (s *Service) Get(ctx context.Context, id int64) (Calendar, error) {
 	r, err := s.q.GetCalendar(ctx, id)
 	if err != nil {
@@ -306,6 +331,7 @@ func fromStorage(r storage.Calendar) Calendar {
 		Color:               r.Color,
 		Description:         storage.NullableToString(r.Description),
 		OwnerEmail:          r.OwnerEmail,
+		DisplayOrder:        r.DisplayOrder,
 		CreatedAt:           timeutil.ParseDateTime(r.CreatedAt),
 		UpdatedAt:           timeutil.ParseDateTime(r.UpdatedAt),
 		AccountID:           accountID,

--- a/internal/calendar/service_test.go
+++ b/internal/calendar/service_test.go
@@ -63,6 +63,37 @@ func TestCalendarService_Create(t *testing.T) {
 	}
 }
 
+func TestCalendarService_CreateAppendsDisplayOrder(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	// The seed "Personal" calendar holds the lowest display_order; newly
+	// created calendars must append after it (MAX+1) rather than collide at 0.
+	seed, _ := svc.List(ctx)
+	first, err := svc.Create(ctx, "Aardvark", "#111", "")
+	if err != nil {
+		t.Fatalf("Create error: %v", err)
+	}
+	second, err := svc.Create(ctx, "Beaver", "#222", "")
+	if err != nil {
+		t.Fatalf("Create error: %v", err)
+	}
+
+	if first.DisplayOrder != seed[0].DisplayOrder+1 {
+		t.Errorf("first created DisplayOrder = %d, want %d", first.DisplayOrder, seed[0].DisplayOrder+1)
+	}
+	if second.DisplayOrder != first.DisplayOrder+1 {
+		t.Errorf("second created DisplayOrder = %d, want %d", second.DisplayOrder, first.DisplayOrder+1)
+	}
+
+	// List orders by display_order, so the newest calendar lands at the bottom
+	// even though "Beaver" would sort before some existing names alphabetically.
+	cals, _ := svc.List(ctx)
+	if cals[len(cals)-1].Name != "Beaver" {
+		t.Errorf("last calendar = %q, want %q (newest appends to bottom)", cals[len(cals)-1].Name, "Beaver")
+	}
+}
+
 func TestCalendarService_Get(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/internal/storage/calendars.sql.go
+++ b/internal/storage/calendars.sql.go
@@ -62,7 +62,9 @@ func (q *Queries) CountDefaultCalendars(ctx context.Context) (int64, error) {
 }
 
 const createCalendar = `-- name: CreateCalendar :one
-INSERT INTO calendars (name, color, description) VALUES (?, ?, ?) RETURNING id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default
+INSERT INTO calendars (name, color, description, display_order)
+VALUES (?, ?, ?, (SELECT COALESCE(MAX(display_order), -1) + 1 FROM calendars))
+RETURNING id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default, display_order
 `
 
 type CreateCalendarParams struct {
@@ -71,6 +73,8 @@ type CreateCalendarParams struct {
 	Description *string
 }
 
+// display_order is computed as MAX+1 (0 for the first calendar) so new
+// calendars append to the bottom of the sidebar instead of all colliding at 0.
 func (q *Queries) CreateCalendar(ctx context.Context, arg CreateCalendarParams) (Calendar, error) {
 	row := q.db.QueryRowContext(ctx, createCalendar, arg.Name, arg.Color, arg.Description)
 	var i Calendar
@@ -92,6 +96,7 @@ func (q *Queries) CreateCalendar(ctx context.Context, arg CreateCalendarParams) 
 		&i.ColorDirty,
 		&i.OwnerEmail,
 		&i.IsDefault,
+		&i.DisplayOrder,
 	)
 	return i, err
 }
@@ -106,7 +111,7 @@ func (q *Queries) DeleteCalendar(ctx context.Context, id int64) error {
 }
 
 const getCalendar = `-- name: GetCalendar :one
-SELECT id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default FROM calendars WHERE id = ?
+SELECT id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default, display_order FROM calendars WHERE id = ?
 `
 
 func (q *Queries) GetCalendar(ctx context.Context, id int64) (Calendar, error) {
@@ -130,12 +135,13 @@ func (q *Queries) GetCalendar(ctx context.Context, id int64) (Calendar, error) {
 		&i.ColorDirty,
 		&i.OwnerEmail,
 		&i.IsDefault,
+		&i.DisplayOrder,
 	)
 	return i, err
 }
 
 const getDefaultCalendar = `-- name: GetDefaultCalendar :one
-SELECT id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default FROM calendars WHERE is_default = 1 LIMIT 1
+SELECT id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default, display_order FROM calendars WHERE is_default = 1 LIMIT 1
 `
 
 func (q *Queries) GetDefaultCalendar(ctx context.Context) (Calendar, error) {
@@ -159,6 +165,7 @@ func (q *Queries) GetDefaultCalendar(ctx context.Context) (Calendar, error) {
 		&i.ColorDirty,
 		&i.OwnerEmail,
 		&i.IsDefault,
+		&i.DisplayOrder,
 	)
 	return i, err
 }
@@ -183,7 +190,7 @@ func (q *Queries) LinkCalendarToAccount(ctx context.Context, arg LinkCalendarToA
 }
 
 const listCalendars = `-- name: ListCalendars :many
-SELECT id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default FROM calendars ORDER BY name
+SELECT id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default, display_order FROM calendars ORDER BY display_order, name
 `
 
 func (q *Queries) ListCalendars(ctx context.Context) ([]Calendar, error) {
@@ -213,6 +220,7 @@ func (q *Queries) ListCalendars(ctx context.Context) ([]Calendar, error) {
 			&i.ColorDirty,
 			&i.OwnerEmail,
 			&i.IsDefault,
+			&i.DisplayOrder,
 		); err != nil {
 			return nil, err
 		}
@@ -228,7 +236,7 @@ func (q *Queries) ListCalendars(ctx context.Context) ([]Calendar, error) {
 }
 
 const listCalendarsByAccount = `-- name: ListCalendarsByAccount :many
-SELECT id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default FROM calendars WHERE account_id = ? ORDER BY name
+SELECT id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default, display_order FROM calendars WHERE account_id = ? ORDER BY display_order, name
 `
 
 func (q *Queries) ListCalendarsByAccount(ctx context.Context, accountID *int64) ([]Calendar, error) {
@@ -258,6 +266,7 @@ func (q *Queries) ListCalendarsByAccount(ctx context.Context, accountID *int64) 
 			&i.ColorDirty,
 			&i.OwnerEmail,
 			&i.IsDefault,
+			&i.DisplayOrder,
 		); err != nil {
 			return nil, err
 		}
@@ -296,8 +305,25 @@ func (q *Queries) SetCalendarAsDefault(ctx context.Context, id int64) error {
 	return err
 }
 
+const setCalendarDisplayOrder = `-- name: SetCalendarDisplayOrder :exec
+UPDATE calendars SET
+    display_order = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE id = ?
+`
+
+type SetCalendarDisplayOrderParams struct {
+	DisplayOrder int64
+	ID           int64
+}
+
+func (q *Queries) SetCalendarDisplayOrder(ctx context.Context, arg SetCalendarDisplayOrderParams) error {
+	_, err := q.db.ExecContext(ctx, setCalendarDisplayOrder, arg.DisplayOrder, arg.ID)
+	return err
+}
+
 const updateCalendar = `-- name: UpdateCalendar :one
-UPDATE calendars SET name = ?, color = ?, description = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ? RETURNING id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default
+UPDATE calendars SET name = ?, color = ?, description = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ? RETURNING id, name, color, description, created_at, updated_at, account_id, remote_url, ctag, sync_token, last_sync_at, last_sync_attempted_at, last_sync_error, remote_color, color_dirty, owner_email, is_default, display_order
 `
 
 type UpdateCalendarParams struct {
@@ -333,6 +359,7 @@ func (q *Queries) UpdateCalendar(ctx context.Context, arg UpdateCalendarParams) 
 		&i.ColorDirty,
 		&i.OwnerEmail,
 		&i.IsDefault,
+		&i.DisplayOrder,
 	)
 	return i, err
 }

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -42,6 +42,7 @@ type Calendar struct {
 	ColorDirty          int64
 	OwnerEmail          string
 	IsDefault           int64
+	DisplayOrder        int64
 }
 
 type Event struct {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -126,6 +126,15 @@ type eventCreatedMsg struct {
 
 type calendarMutationDoneMsg struct{ err error }
 
+// calendarOrderSavedMsg reports the result of persisting a sidebar reorder.
+// Success is silent (the list already shows the new order); failure surfaces
+// as a toast. ids carries the order that was written so the handler can clear
+// the matching pendingOrder entries without discarding a newer reorder.
+type calendarOrderSavedMsg struct {
+	ids []int64
+	err error
+}
+
 type calendarDeleteCountMsg struct {
 	id         int64
 	name       string
@@ -343,7 +352,13 @@ type Model struct {
 	loadedFrom     time.Time
 	loadedTo       time.Time
 	calendars      map[int64]CalendarInfo
-	dialog         EventDialogModel
+	// pendingOrder holds an optimistic sidebar order (calendar ID → position)
+	// for a reorder whose async SetOrder has not yet confirmed. It is overlaid
+	// onto reloads so an interleaved loadCalendars (e.g. a sync finishing
+	// mid-save) can't snap calendars back to the stale DB order, and cleared
+	// once calendarOrderSavedMsg confirms the write.
+	pendingOrder map[int64]int64
+	dialog       EventDialogModel
 	dialogOpen     bool
 	viewDialog     EventViewDialogModel
 	viewDialogOpen bool
@@ -880,6 +895,7 @@ func (m Model) loadCalendars() tea.Cmd {
 				OwnerEmail:          c.OwnerEmail,
 				Description:         c.Description,
 				EventCount:          count,
+				DisplayOrder:        c.DisplayOrder,
 				Synced:              c.AccountID != 0,
 				AccountServerURL:    accountServerURLs[c.AccountID],
 				LastSyncAt:          c.LastSyncAt,
@@ -1666,11 +1682,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case calendarsLoadedMsg:
 		if msg.err == nil {
 			m.calendars = msg.calendars
+			// Overlay any unconfirmed reorder so a reload that races an
+			// in-flight SetOrder reflects the user's move instead of the stale
+			// DB order. Applied to m.calendars itself so the sidebar items and
+			// the manage dialog (both built below from m.calendars) agree.
+			for id, pos := range m.pendingOrder {
+				if c, ok := m.calendars[id]; ok {
+					c.DisplayOrder = pos
+					m.calendars[id] = c
+				}
+			}
 			items := make([]CalendarListItem, 0, len(m.calendars))
 			for id, c := range m.calendars {
-				items = append(items, CalendarListItem{ID: id, Name: c.Name, Color: c.Color, Health: syncHealthFor(c)})
+				items = append(items, CalendarListItem{ID: id, Name: c.Name, Color: c.Color, Health: syncHealthFor(c), Order: c.DisplayOrder})
 			}
-			slices.SortFunc(items, func(a, b CalendarListItem) int { return strings.Compare(a.Name, b.Name) })
+			// Honor the user's persisted sidebar order; fall back to name for
+			// any ties (e.g. rows that share a backfilled default).
+			slices.SortFunc(items, func(a, b CalendarListItem) int {
+				return compareCalendarOrder(a.Order, a.Name, b.Order, b.Name)
+			})
 			m.sidebar = m.sidebar.SetList(m.sidebar.List().SetItems(items))
 			// Prune stale hidden IDs after CalendarListModel has done its pruning.
 			m.hiddenCalendars = m.sidebar.List().HiddenSet()
@@ -2138,6 +2168,43 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.dialogOpen {
 			dayEvents := eventsOn(filterVisibleEvents(m.events, m.hiddenCalendars), m.dialog.day)
 			m.dialog = m.dialog.SetEvents(dayEvents)
+		}
+		return m, nil
+
+	case CalendarReorderedMsg:
+		// The sidebar list already reflects the new order locally; mirror it
+		// into m.calendars so any later reload-from-cache (e.g. the manage
+		// dialog) stays coherent, and record it as pending so a reload that
+		// races the async SetOrder below doesn't revert to the stale DB order.
+		ids := msg.IDs
+		if m.pendingOrder == nil {
+			m.pendingOrder = make(map[int64]int64, len(ids))
+		}
+		for i, id := range ids {
+			m.pendingOrder[id] = int64(i)
+			if info, ok := m.calendars[id]; ok {
+				info.DisplayOrder = int64(i)
+				m.calendars[id] = info
+			}
+		}
+		if m.calendarListDialogOpen {
+			m.calendarListDialog = m.calendarListDialog.SetCalendars(m.calendars, m.hiddenCalendars)
+		}
+		return m, func() tea.Msg {
+			return calendarOrderSavedMsg{ids: ids, err: m.app.Calendars.SetOrder(context.Background(), ids)}
+		}
+
+	case calendarOrderSavedMsg:
+		if msg.err != nil {
+			return m, m.toast.Failed(msg.err.Error())
+		}
+		// Clear only the positions this save confirmed: a newer reorder may
+		// have updated m.pendingOrder while this write was in flight, and that
+		// one stays pending until its own save lands.
+		for i, id := range msg.ids {
+			if m.pendingOrder[id] == int64(i) {
+				delete(m.pendingOrder, id)
+			}
 		}
 		return m, nil
 

--- a/internal/tui/app_calendar_reorder_test.go
+++ b/internal/tui/app_calendar_reorder_test.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+// sidebarOrderIDs returns the calendar IDs in the order the sidebar list
+// currently renders them.
+func sidebarOrderIDs(m Model) []int64 {
+	items := m.sidebar.List().items
+	ids := make([]int64, len(items))
+	for i, it := range items {
+		ids[i] = it.ID
+	}
+	return ids
+}
+
+// TestCalendarReorder_PendingOrderSurvivesStaleReload locks in the fix for the
+// optimistic-reorder race: a calendar reload that lands while the async
+// SetOrder is still in flight (e.g. a sync finishing mid-save) returns the
+// stale DB order, and must NOT snap the just-moved calendar back. The pending
+// order is overlaid until the save confirms, then released.
+func TestCalendarReorder_PendingOrderSurvivesStaleReload(t *testing.T) {
+	// Redirect the UI-state write the reload handler performs to a temp dir.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+	items := []CalendarListItem{
+		{ID: 1, Name: "Alpha", Color: "#111", Order: 0},
+		{ID: 2, Name: "Bravo", Color: "#222", Order: 1},
+	}
+	m := Model{
+		sidebar: NewSidebarModel(NewMiniMonthModel(now), NewCalendarListModel(items, nil)),
+		calendars: map[int64]CalendarInfo{
+			1: {Name: "Alpha", Color: "#111", DisplayOrder: 0},
+			2: {Name: "Bravo", Color: "#222", DisplayOrder: 1},
+		},
+	}
+
+	// User moves Bravo (id 2) above Alpha (id 1).
+	updated, _ := m.Update(CalendarReorderedMsg{IDs: []int64{2, 1}})
+	m = updated.(Model)
+	if m.pendingOrder[2] != 0 || m.pendingOrder[1] != 1 {
+		t.Fatalf("pendingOrder not recorded: %v", m.pendingOrder)
+	}
+
+	// A reload races the unsaved write and returns the OLD DB order.
+	stale := map[int64]CalendarInfo{
+		1: {Name: "Alpha", Color: "#111", DisplayOrder: 0},
+		2: {Name: "Bravo", Color: "#222", DisplayOrder: 1},
+	}
+	updated, _ = m.Update(calendarsLoadedMsg{calendars: stale})
+	m = updated.(Model)
+	if got := sidebarOrderIDs(m); !slices.Equal(got, []int64{2, 1}) {
+		t.Fatalf("stale reload reverted reorder: got %v want [2 1]", got)
+	}
+
+	// The save confirms; the matching pending entries clear.
+	updated, _ = m.Update(calendarOrderSavedMsg{ids: []int64{2, 1}})
+	m = updated.(Model)
+	if len(m.pendingOrder) != 0 {
+		t.Fatalf("pendingOrder not cleared after save: %v", m.pendingOrder)
+	}
+
+	// A later reload carrying the now-persisted order keeps Bravo first.
+	fresh := map[int64]CalendarInfo{
+		1: {Name: "Alpha", Color: "#111", DisplayOrder: 1},
+		2: {Name: "Bravo", Color: "#222", DisplayOrder: 0},
+	}
+	updated, _ = m.Update(calendarsLoadedMsg{calendars: fresh})
+	m = updated.(Model)
+	if got := sidebarOrderIDs(m); !slices.Equal(got, []int64{2, 1}) {
+		t.Fatalf("post-save reload wrong order: got %v want [2 1]", got)
+	}
+}
+
+// TestCalendarReorder_StaleSaveDoesNotClearNewerReorder verifies that when a
+// second reorder happens while the first save is still in flight, the late
+// confirmation of the first save does not drop the newer pending order.
+func TestCalendarReorder_StaleSaveDoesNotClearNewerReorder(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+	items := []CalendarListItem{
+		{ID: 1, Name: "Alpha", Color: "#111", Order: 0},
+		{ID: 2, Name: "Bravo", Color: "#222", Order: 1},
+	}
+	m := Model{
+		sidebar: NewSidebarModel(NewMiniMonthModel(now), NewCalendarListModel(items, nil)),
+		calendars: map[int64]CalendarInfo{
+			1: {Name: "Alpha", DisplayOrder: 0},
+			2: {Name: "Bravo", DisplayOrder: 1},
+		},
+	}
+
+	// First reorder: [2, 1]. Second reorder (before the first save lands): [1, 2].
+	updated, _ := m.Update(CalendarReorderedMsg{IDs: []int64{2, 1}})
+	m = updated.(Model)
+	updated, _ = m.Update(CalendarReorderedMsg{IDs: []int64{1, 2}})
+	m = updated.(Model)
+
+	// The first save confirms late. It must not clear the newer pending order,
+	// whose positions differ from what the first save wrote.
+	updated, _ = m.Update(calendarOrderSavedMsg{ids: []int64{2, 1}})
+	m = updated.(Model)
+	if m.pendingOrder[1] != 0 || m.pendingOrder[2] != 1 {
+		t.Fatalf("newer pending order dropped by stale save: %v", m.pendingOrder)
+	}
+}

--- a/internal/tui/calendar_list_dialog.go
+++ b/internal/tui/calendar_list_dialog.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"cmp"
 	"fmt"
 	"image/color"
 	"slices"
@@ -57,7 +58,8 @@ type CalendarListDialogModel struct {
 }
 
 // NewCalendarListDialogModel builds a dialog populated from the given calendar
-// map and hidden set. Calendars are sorted by name for a stable list order.
+// map and hidden set. Calendars follow the persisted sidebar display order
+// (name as a tiebreak) so this dialog matches the sidebar.
 func NewCalendarListDialogModel(calendars map[int64]CalendarInfo, hidden map[int64]bool, h help.Model) CalendarListDialogModel {
 	newAction := ListDialogAction{
 		Label:   "+ Add Calendar",
@@ -84,10 +86,10 @@ type calendarPromotionCandidate struct {
 	name string
 }
 
-// defaultPromotionCandidates returns every calendar other than excludeID,
-// sorted by name so the picker's first option is the alphabetical default.
-// Lives next to the dialog so the row label and the picker share their
-// sort rule via sortedCalendarIDs.
+// defaultPromotionCandidates returns every calendar other than excludeID, in
+// the persisted sidebar display order so the picker matches the list. Lives
+// next to the dialog so the row label and the picker share their sort rule
+// via sortedCalendarIDs.
 func defaultPromotionCandidates(calendars map[int64]CalendarInfo, excludeID int64) []calendarPromotionCandidate {
 	ids := sortedCalendarIDs(calendars)
 	out := make([]calendarPromotionCandidate, 0, len(ids))
@@ -100,13 +102,20 @@ func defaultPromotionCandidates(calendars map[int64]CalendarInfo, excludeID int6
 	return out
 }
 
+// compareCalendarOrder orders calendars by their persisted sidebar position,
+// falling back to name for ties. Shared by the sidebar list and the
+// manage-calendars dialog so both render calendars in the same order.
+func compareCalendarOrder(aOrder int64, aName string, bOrder int64, bName string) int {
+	return cmp.Or(cmp.Compare(aOrder, bOrder), strings.Compare(aName, bName))
+}
+
 func sortedCalendarIDs(calendars map[int64]CalendarInfo) []int64 {
 	ids := make([]int64, 0, len(calendars))
 	for id := range calendars {
 		ids = append(ids, id)
 	}
 	slices.SortFunc(ids, func(a, b int64) int {
-		return strings.Compare(calendars[a].Name, calendars[b].Name)
+		return compareCalendarOrder(calendars[a].DisplayOrder, calendars[a].Name, calendars[b].DisplayOrder, calendars[b].Name)
 	})
 	return ids
 }

--- a/internal/tui/calendar_list_model.go
+++ b/internal/tui/calendar_list_model.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"image/color"
 	"maps"
+	"slices"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -47,10 +48,17 @@ type CalendarListItem struct {
 	Name   string
 	Color  string // hex like "#a6e3a1"
 	Health SyncHealth
+	Order  int64 // persisted sidebar sort position (lower sorts first)
 }
+
+// CalendarReorderedMsg is emitted when the user moves a calendar in the list.
+// IDs is the full row order, top to bottom, so the parent can persist
+// display_order = index for each.
+type CalendarReorderedMsg struct{ IDs []int64 }
 
 type calendarListKeyMap struct {
 	Up, Down, Tab, ShiftTab key.Binding
+	MoveUp, MoveDown        key.Binding
 	Toggle                  key.Binding
 	Open                    key.Binding
 }
@@ -61,6 +69,8 @@ func defaultCalendarListKeys() calendarListKeyMap {
 		Down:     key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
 		Tab:      key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next")),
 		ShiftTab: key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "prev")),
+		MoveUp:   key.NewBinding(key.WithKeys("shift+up", "K"), key.WithHelp("shift+↑/K", "move up")),
+		MoveDown: key.NewBinding(key.WithKeys("shift+down", "J"), key.WithHelp("shift+↓/J", "move down")),
 		Toggle:   key.NewBinding(key.WithKeys("space"), key.WithHelp("space", "toggle visibility")),
 		Open:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "open")),
 	}
@@ -152,6 +162,30 @@ func (m CalendarListModel) moveCursor(delta int) CalendarListModel {
 	return m
 }
 
+// moveCurrent swaps the item under the cursor with its neighbour delta rows
+// away (±1), keeping the cursor on the moved item so repeated presses keep
+// dragging the same calendar. Returns a command emitting CalendarReorderedMsg
+// with the new top-to-bottom ID order, or nil if the move would fall off the
+// list's edge.
+func (m CalendarListModel) moveCurrent(delta int) (CalendarListModel, tea.Cmd) {
+	j := m.cursor + delta
+	if m.cursor < 0 || m.cursor >= len(m.items) || j < 0 || j >= len(m.items) {
+		return m, nil
+	}
+	// Copy the slice before mutating: the value receiver shares the backing
+	// array with whatever the parent stored, so an in-place swap would also
+	// reorder that aliased view before the new model is committed.
+	items := slices.Clone(m.items)
+	items[m.cursor], items[j] = items[j], items[m.cursor]
+	m.items = items
+	m.cursor = j
+	ids := make([]int64, len(items))
+	for i, it := range items {
+		ids[i] = it.ID
+	}
+	return m, func() tea.Msg { return CalendarReorderedMsg{IDs: ids} }
+}
+
 // toggleCurrent flips the hidden state of the item under the cursor and
 // returns the new model plus a command that emits
 // CalendarVisibilityToggledMsg.
@@ -187,6 +221,10 @@ func (m CalendarListModel) Update(msg tea.Msg) (CalendarListModel, tea.Cmd) {
 		return m, nil
 	}
 	switch {
+	case key.Matches(kp, m.keys.MoveUp):
+		return m.moveCurrent(-1)
+	case key.Matches(kp, m.keys.MoveDown):
+		return m.moveCurrent(1)
 	case key.Matches(kp, m.keys.Up), key.Matches(kp, m.keys.ShiftTab):
 		return m.moveCursor(-1), nil
 	case key.Matches(kp, m.keys.Down), key.Matches(kp, m.keys.Tab):

--- a/internal/tui/calendar_list_model_test.go
+++ b/internal/tui/calendar_list_model_test.go
@@ -57,6 +57,51 @@ func TestCalendarList_MoveCursorClampsAtEdges(t *testing.T) {
 	}
 }
 
+func TestCalendarList_MoveCurrentSwapsAndEmitsOrder(t *testing.T) {
+	m := makeListFixture().Focus()
+	m.cursor = 0 // Default (ID 1)
+	nextM, cmd := m.moveCurrent(1)
+	if cmd == nil {
+		t.Fatal("expected a reorder command")
+	}
+	msg, ok := cmd().(CalendarReorderedMsg)
+	if !ok {
+		t.Fatalf("expected CalendarReorderedMsg, got %T", cmd())
+	}
+	if want := []int64{2, 1}; len(msg.IDs) != 2 || msg.IDs[0] != want[0] || msg.IDs[1] != want[1] {
+		t.Errorf("reordered IDs got %v want %v", msg.IDs, want)
+	}
+	if nextM.cursor != 1 {
+		t.Errorf("cursor should follow the moved item: got %d want 1", nextM.cursor)
+	}
+	if nextM.items[1].ID != 1 {
+		t.Errorf("moved item not at new position: %+v", nextM.items)
+	}
+}
+
+func TestCalendarList_MoveCurrentAtEdgesIsNoop(t *testing.T) {
+	m := makeListFixture().Focus()
+	m.cursor = 0
+	if _, cmd := m.moveCurrent(-1); cmd != nil {
+		t.Error("moveCurrent(-1) at top should be a no-op")
+	}
+	m.cursor = m.RowCount() - 1
+	if _, cmd := m.moveCurrent(1); cmd != nil {
+		t.Error("moveCurrent(+1) at bottom should be a no-op")
+	}
+}
+
+func TestCalendarList_MoveCurrentDoesNotMutateOriginal(t *testing.T) {
+	m := makeListFixture().Focus()
+	m.cursor = 0
+	_, _ = m.moveCurrent(1)
+	// The receiver's backing array must be untouched: the parent still holds
+	// this slice until it commits the returned model.
+	if m.items[0].ID != 1 || m.items[1].ID != 2 {
+		t.Errorf("original items mutated by moveCurrent: %+v", m.items)
+	}
+}
+
 func TestCalendarList_HandleClickTogglesItem(t *testing.T) {
 	m := makeListFixture().Focus()
 	m.cursor = 0

--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -82,6 +82,8 @@ type CalendarInfo struct {
 	OwnerEmail  string
 	Description string
 	EventCount  int64
+	// DisplayOrder is the persisted sidebar sort position (lower sorts first).
+	DisplayOrder int64
 	// Synced reports whether the calendar is linked to a CalDAV account.
 	// Drives opportunistic save-time push: local-only calendars skip it.
 	Synced bool

--- a/internal/tui/help_dialog.go
+++ b/internal/tui/help_dialog.go
@@ -185,6 +185,7 @@ func (m HelpDialogModel) sections() []helpSection {
 				{"s", "sync all"},
 				{"enter (sidebar)", "open calendar"},
 				{"space (sidebar)", "toggle visibility"},
+				{"shift+↑/↓ (sidebar)", "reorder calendar"},
 				{"*", "set as default"},
 			},
 		},


### PR DESCRIPTION
## What

Lets users set the order calendars appear in the sidebar, instead of always alphabetically.

- **schema**: migration 032 adds `display_order`, backfilled by name rank so the upgrade preserves the previous alphabetical order
- **queries**: list by `display_order, name`; `CreateCalendar` appends via `MAX+1` so new calendars land at the bottom rather than colliding at 0
- **service**: `SetOrder` persists a full ordered ID list in one transaction (idempotent, self-healing against drift)
- **tui**: reorder in place from the sidebar with `shift+↑/↓` (or `K`/`J`); a shared `compareCalendarOrder` keeps the sidebar and manage-calendars dialog consistent
- **tui**: a `pendingOrder` overlay guards the optimistic move against a calendar reload that races the async save (e.g. a sync finishing mid-write), so the just-moved calendar isn't snapped back to the stale DB order

## How it was chosen

Reorder lives in the sidebar (move keys) rather than as a numeric field in the calendar dialog — the dialog edits one calendar blind to the others, whereas in-place reordering gives live feedback.

## Tests

- service: `SetOrder` / `Create` append behavior
- list model: move/swap, edge no-ops, non-mutation
- app: stale-reload race regression (`pendingOrder` overlay) + stale-save-doesn't-clear-newer-reorder

`go vet ./...` clean; full suite green.