### PR TITLE
feat(calendar): reorder calendars from the manage dialog

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -910,6 +910,21 @@ func (m Model) loadCalendars() tea.Cmd {
 	}
 }
 
+// sortedCalendarListItems builds the sidebar's calendar rows from the calendar
+// map and sorts them by the user's persisted display order (name as a tiebreak,
+// e.g. rows that share a backfilled default). Shared by the reload handler and
+// the reorder handler so both produce identical row order.
+func sortedCalendarListItems(calendars map[int64]CalendarInfo) []CalendarListItem {
+	items := make([]CalendarListItem, 0, len(calendars))
+	for id, c := range calendars {
+		items = append(items, CalendarListItem{ID: id, Name: c.Name, Color: c.Color, Health: syncHealthFor(c), Order: c.DisplayOrder})
+	}
+	slices.SortFunc(items, func(a, b CalendarListItem) int {
+		return compareCalendarOrder(a.Order, a.Name, b.Order, b.Name)
+	})
+	return items
+}
+
 // syncHealthFor derives the sidebar health marker state from a calendar's
 // persisted sync fields. Local-only calendars (not Synced) get no marker;
 // a recorded last_sync_error is the only loud (SyncHealthError) state. Because
@@ -1692,16 +1707,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.calendars[id] = c
 				}
 			}
-			items := make([]CalendarListItem, 0, len(m.calendars))
-			for id, c := range m.calendars {
-				items = append(items, CalendarListItem{ID: id, Name: c.Name, Color: c.Color, Health: syncHealthFor(c), Order: c.DisplayOrder})
-			}
-			// Honor the user's persisted sidebar order; fall back to name for
-			// any ties (e.g. rows that share a backfilled default).
-			slices.SortFunc(items, func(a, b CalendarListItem) int {
-				return compareCalendarOrder(a.Order, a.Name, b.Order, b.Name)
-			})
-			m.sidebar = m.sidebar.SetList(m.sidebar.List().SetItems(items))
+			m.sidebar = m.sidebar.SetList(m.sidebar.List().SetItems(sortedCalendarListItems(m.calendars)))
 			// Prune stale hidden IDs after CalendarListModel has done its pruning.
 			m.hiddenCalendars = m.sidebar.List().HiddenSet()
 			m.saveUIState()
@@ -2172,10 +2178,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case CalendarReorderedMsg:
-		// The sidebar list already reflects the new order locally; mirror it
-		// into m.calendars so any later reload-from-cache (e.g. the manage
-		// dialog) stays coherent, and record it as pending so a reload that
-		// races the async SetOrder below doesn't revert to the stale DB order.
+		// A reorder can originate from either the sidebar list or the manage
+		// dialog; mirror it into m.calendars so both views (and any later
+		// reload-from-cache) stay coherent, and record it as pending so a
+		// reload racing the async SetOrder below doesn't revert to the stale DB
+		// order.
 		ids := msg.IDs
 		if m.pendingOrder == nil {
 			m.pendingOrder = make(map[int64]int64, len(ids))
@@ -2187,6 +2194,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.calendars[id] = info
 			}
 		}
+		// Re-sort the sidebar from the updated order. This is what makes a
+		// dialog-originated reorder show up behind the dialog; for a
+		// sidebar-originated one it just re-applies the order the list already
+		// swapped to, keeping the cursor on the moved calendar.
+		m.sidebar = m.sidebar.SetList(m.sidebar.List().SetItems(sortedCalendarListItems(m.calendars)))
 		if m.calendarListDialogOpen {
 			m.calendarListDialog = m.calendarListDialog.SetCalendars(m.calendars, m.hiddenCalendars)
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2202,8 +2202,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Re-sort the sidebar from the updated order. This is what makes a
 		// dialog-originated reorder show up behind the dialog; for a
 		// sidebar-originated one it just re-applies the order the list already
-		// swapped to, keeping the cursor on the moved calendar.
-		m.sidebar = m.sidebar.SetList(m.sidebar.List().SetItems(sortedCalendarListItems(m.calendars)))
+		// swapped to. Preserve the cursor by calendar identity so a reorder
+		// (from either surface) never leaves the sidebar highlight on a
+		// different calendar than before.
+		m.sidebar = m.sidebar.SetList(m.sidebar.List().SetItemsPreservingCursor(sortedCalendarListItems(m.calendars)))
 		if m.calendarListDialogOpen {
 			m.calendarListDialog = m.calendarListDialog.SetCalendars(m.calendars, m.hiddenCalendars)
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1705,6 +1705,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if c, ok := m.calendars[id]; ok {
 					c.DisplayOrder = pos
 					m.calendars[id] = c
+				} else {
+					// Gone from a full reload (deleted) — drop the stale pending
+					// entry so the map can't grow without bound across
+					// reorder+delete cycles.
+					delete(m.pendingOrder, id)
 				}
 			}
 			m.sidebar = m.sidebar.SetList(m.sidebar.List().SetItems(sortedCalendarListItems(m.calendars)))

--- a/internal/tui/app_calendar_reorder_test.go
+++ b/internal/tui/app_calendar_reorder_test.go
@@ -116,6 +116,48 @@ func TestCalendarReorder_DialogOriginatedSyncsSidebarAndDialog(t *testing.T) {
 	}
 }
 
+// TestCalendarReorder_DialogReorderKeepsSidebarCursorOnSameCalendar verifies a
+// dialog-originated reorder that shifts rows keeps the sidebar cursor on the
+// same calendar (by identity), so the next sidebar keystroke doesn't act on the
+// wrong one.
+func TestCalendarReorder_DialogReorderKeepsSidebarCursorOnSameCalendar(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+	items := []CalendarListItem{
+		{ID: 1, Name: "Alpha", Order: 0},
+		{ID: 2, Name: "Bravo", Order: 1},
+		{ID: 3, Name: "Charlie", Order: 2},
+	}
+	cl := NewCalendarListModel(items, nil)
+	cl.cursor = 1 // sidebar highlight on Bravo (id 2)
+	cals := map[int64]CalendarInfo{
+		1: {Name: "Alpha", DisplayOrder: 0},
+		2: {Name: "Bravo", DisplayOrder: 1},
+		3: {Name: "Charlie", DisplayOrder: 2},
+	}
+	m := Model{
+		sidebar:   NewSidebarModel(NewMiniMonthModel(now), cl),
+		calendars: cals,
+	}
+
+	// Dialog moves Charlie to the top: [3,1,2]. Bravo shifts index 1 → 2.
+	updated, _ := m.Update(CalendarReorderedMsg{IDs: []int64{3, 1, 2}})
+	m = updated.(Model)
+
+	order := sidebarOrderIDs(m)
+	if !slices.Equal(order, []int64{3, 1, 2}) {
+		t.Fatalf("sidebar order = %v want [3 1 2]", order)
+	}
+	cur := m.sidebar.List().Cursor()
+	if cur < 0 || cur >= len(order) {
+		t.Fatalf("cursor out of range: %d", cur)
+	}
+	if order[cur] != 2 {
+		t.Errorf("sidebar cursor on calendar %d, want 2 (Bravo) — cursor did not follow the calendar", order[cur])
+	}
+}
+
 // TestCalendarReorder_StaleSaveDoesNotClearNewerReorder verifies that when a
 // second reorder happens while the first save is still in flight, the late
 // confirmation of the first save does not drop the newer pending order.

--- a/internal/tui/app_calendar_reorder_test.go
+++ b/internal/tui/app_calendar_reorder_test.go
@@ -4,6 +4,8 @@ import (
 	"slices"
 	"testing"
 	"time"
+
+	"charm.land/bubbles/v2/help"
 )
 
 // sidebarOrderIDs returns the calendar IDs in the order the sidebar list
@@ -73,6 +75,44 @@ func TestCalendarReorder_PendingOrderSurvivesStaleReload(t *testing.T) {
 	m = updated.(Model)
 	if got := sidebarOrderIDs(m); !slices.Equal(got, []int64{2, 1}) {
 		t.Fatalf("post-save reload wrong order: got %v want [2 1]", got)
+	}
+}
+
+// TestCalendarReorder_DialogOriginatedSyncsSidebarAndDialog verifies a reorder
+// emitted by the manage dialog (where the sidebar list was NOT pre-swapped)
+// re-sorts the background sidebar from m.calendars and keeps the open dialog in
+// sync — the two branches the dialog feature added to the handler.
+func TestCalendarReorder_DialogOriginatedSyncsSidebarAndDialog(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+	items := []CalendarListItem{
+		{ID: 1, Name: "Alpha", Order: 0},
+		{ID: 2, Name: "Bravo", Order: 1},
+		{ID: 3, Name: "Charlie", Order: 2},
+	}
+	cals := map[int64]CalendarInfo{
+		1: {Name: "Alpha", DisplayOrder: 0},
+		2: {Name: "Bravo", DisplayOrder: 1},
+		3: {Name: "Charlie", DisplayOrder: 2},
+	}
+	m := Model{
+		sidebar:                NewSidebarModel(NewMiniMonthModel(now), NewCalendarListModel(items, nil)),
+		calendars:              cals,
+		calendarListDialogOpen: true,
+		calendarListDialog:     NewCalendarListDialogModel(cals, nil, help.New()),
+	}
+
+	// Dialog moved Bravo above Alpha; only the dialog swapped locally, so the
+	// sidebar must be re-sorted by the handler, not by a prior list swap.
+	updated, _ := m.Update(CalendarReorderedMsg{IDs: []int64{2, 1, 3}})
+	m = updated.(Model)
+
+	if got := sidebarOrderIDs(m); !slices.Equal(got, []int64{2, 1, 3}) {
+		t.Fatalf("sidebar not synced to dialog reorder: got %v want [2 1 3]", got)
+	}
+	if got := m.calendarListDialog.order; !slices.Equal(got, []int64{2, 1, 3}) {
+		t.Fatalf("open dialog not synced to reorder: got %v want [2 1 3]", got)
 	}
 }
 

--- a/internal/tui/calendar_list_dialog.go
+++ b/internal/tui/calendar_list_dialog.go
@@ -29,10 +29,11 @@ type CalendarSetDefaultRequestedMsg struct {
 }
 
 type calendarListDialogKeyMap struct {
-	Edit       key.Binding
-	Delete     key.Binding
-	New        key.Binding
-	SetDefault key.Binding
+	Edit             key.Binding
+	Delete           key.Binding
+	New              key.Binding
+	SetDefault       key.Binding
+	MoveUp, MoveDown key.Binding
 }
 
 func defaultCalendarListDialogKeys() calendarListDialogKeyMap {
@@ -41,6 +42,8 @@ func defaultCalendarListDialogKeys() calendarListDialogKeyMap {
 		Delete:     key.NewBinding(key.WithKeys("x", "delete"), key.WithHelp("x", "delete")),
 		New:        key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add")),
 		SetDefault: key.NewBinding(key.WithKeys("*"), key.WithHelp("*", "set default")),
+		MoveUp:     key.NewBinding(key.WithKeys("shift+up", "K"), key.WithHelp("shift+↑/K", "move up")),
+		MoveDown:   key.NewBinding(key.WithKeys("shift+down", "J"), key.WithHelp("shift+↓/J", "move down")),
 	}
 }
 
@@ -227,7 +230,11 @@ func (m CalendarListDialogModel) shortHelp() []key.Binding {
 		key.WithKeys("up", "down", "k", "j"),
 		key.WithHelp("↑↓", "navigate"),
 	)
-	return []key.Binding{nav, sk.Tab, m.keys.New, m.keys.Edit, m.keys.SetDefault, m.keys.Delete, sk.Close}
+	reorder := key.NewBinding(
+		key.WithKeys("shift+up", "shift+down", "K", "J"),
+		key.WithHelp("shift+↑↓", "reorder"),
+	)
+	return []key.Binding{nav, reorder, sk.Tab, m.keys.New, m.keys.Edit, m.keys.SetDefault, m.keys.Delete, sk.Close}
 }
 
 // detailWidth returns the width of the detail column for the current shell
@@ -304,11 +311,33 @@ func (m CalendarListDialogModel) handleKey(msg tea.KeyPressMsg) (CalendarListDia
 			return m, func() tea.Msg { return CalendarSetDefaultRequestedMsg{ID: id, Name: info.Name} }
 		}
 		return m, nil
+	case key.Matches(msg, m.keys.MoveUp):
+		return m.moveSelected(-1)
+	case key.Matches(msg, m.keys.MoveDown):
+		return m.moveSelected(1)
 	}
 
 	shell, cmd, _ := m.shell.HandleKey(msg, func() tea.Msg { return CalendarListDialogClosedMsg{} })
 	m.shell = shell
 	return m.refresh(), cmd
+}
+
+// moveSelected swaps the selected calendar with its neighbour delta rows away
+// (±1), keeps the selection on the moved calendar, and emits
+// CalendarReorderedMsg with the new top-to-bottom ID order so the app persists
+// it and keeps the sidebar in sync. The local swap mirrors the sidebar list's
+// optimistic behavior so the dialog updates without waiting for the round-trip.
+func (m CalendarListDialogModel) moveSelected(delta int) (CalendarListDialogModel, tea.Cmd) {
+	i := m.shell.Selected()
+	j := i + delta
+	if i < 0 || i >= len(m.order) || j < 0 || j >= len(m.order) {
+		return m, nil
+	}
+	order := slices.Clone(m.order)
+	order[i], order[j] = order[j], order[i]
+	m.order = order
+	m.shell = m.shell.SetSelected(j)
+	return m.refresh(), func() tea.Msg { return CalendarReorderedMsg{IDs: order} }
 }
 
 func (m CalendarListDialogModel) handleMouse(msg tea.MouseClickMsg) (CalendarListDialogModel, tea.Cmd) {

--- a/internal/tui/calendar_list_dialog.go
+++ b/internal/tui/calendar_list_dialog.go
@@ -231,7 +231,7 @@ func (m CalendarListDialogModel) shortHelp() []key.Binding {
 		key.WithHelp("↑↓", "navigate"),
 	)
 	reorder := key.NewBinding(
-		key.WithKeys("shift+up", "shift+down", "K", "J"),
+		key.WithKeys(append(m.keys.MoveUp.Keys(), m.keys.MoveDown.Keys()...)...),
 		key.WithHelp("shift+↑↓", "reorder"),
 	)
 	return []key.Binding{nav, reorder, sk.Tab, m.keys.New, m.keys.Edit, m.keys.SetDefault, m.keys.Delete, sk.Close}
@@ -311,9 +311,12 @@ func (m CalendarListDialogModel) handleKey(msg tea.KeyPressMsg) (CalendarListDia
 			return m, func() tea.Msg { return CalendarSetDefaultRequestedMsg{ID: id, Name: info.Name} }
 		}
 		return m, nil
-	case key.Matches(msg, m.keys.MoveUp):
+	// Reorder only when the list itself owns focus; when the user has Tabbed
+	// to the action buttons or the title action, fall through so shift+↑/↓ and
+	// K/J don't silently reorder (and persist) a row the user isn't looking at.
+	case m.shell.FocusZone() == ListZoneList && key.Matches(msg, m.keys.MoveUp):
 		return m.moveSelected(-1)
-	case key.Matches(msg, m.keys.MoveDown):
+	case m.shell.FocusZone() == ListZoneList && key.Matches(msg, m.keys.MoveDown):
 		return m.moveSelected(1)
 	}
 

--- a/internal/tui/calendar_list_dialog_test.go
+++ b/internal/tui/calendar_list_dialog_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"slices"
+	"testing"
+
+	"charm.land/bubbles/v2/help"
+)
+
+func makeCalListDialogFixture() CalendarListDialogModel {
+	cals := map[int64]CalendarInfo{
+		1: {Name: "Alpha", DisplayOrder: 0},
+		2: {Name: "Bravo", DisplayOrder: 1},
+		3: {Name: "Charlie", DisplayOrder: 2},
+	}
+	return NewCalendarListDialogModel(cals, nil, help.New())
+}
+
+// TestCalendarListDialog_MoveSelectedReordersAndEmits verifies the manage
+// dialog reorders the selected calendar, keeps the selection on it, and emits
+// the full new order for the app to persist.
+func TestCalendarListDialog_MoveSelectedReordersAndEmits(t *testing.T) {
+	m := makeCalListDialogFixture()
+	m.shell = m.shell.SetSelected(0) // Alpha (id 1)
+
+	m2, cmd := m.moveSelected(1) // move Alpha down
+	if cmd == nil {
+		t.Fatal("expected a reorder command")
+	}
+	msg, ok := cmd().(CalendarReorderedMsg)
+	if !ok {
+		t.Fatalf("expected CalendarReorderedMsg, got %T", cmd())
+	}
+	if want := []int64{2, 1, 3}; !slices.Equal(msg.IDs, want) {
+		t.Fatalf("reordered IDs = %v, want %v", msg.IDs, want)
+	}
+	if id, ok := m2.selectedID(); !ok || id != 1 {
+		t.Errorf("selection should follow the moved calendar: got %d (ok=%v), want 1", id, ok)
+	}
+}
+
+// TestCalendarListDialog_MoveSelectedEdgesAreNoops verifies moving past either
+// end of the list does nothing and emits no command.
+func TestCalendarListDialog_MoveSelectedEdgesAreNoops(t *testing.T) {
+	m := makeCalListDialogFixture()
+
+	m.shell = m.shell.SetSelected(0)
+	if _, cmd := m.moveSelected(-1); cmd != nil {
+		t.Error("moveSelected(-1) at top should be a no-op")
+	}
+	m.shell = m.shell.SetSelected(2)
+	if _, cmd := m.moveSelected(1); cmd != nil {
+		t.Error("moveSelected(+1) at bottom should be a no-op")
+	}
+}
+
+// TestCalendarListDialog_MoveSelectedDoesNotMutateOriginalOrder guards against
+// the value receiver aliasing the parent's order slice via an in-place swap.
+func TestCalendarListDialog_MoveSelectedDoesNotMutateOriginalOrder(t *testing.T) {
+	m := makeCalListDialogFixture()
+	m.shell = m.shell.SetSelected(0)
+	_, _ = m.moveSelected(1)
+	if want := []int64{1, 2, 3}; !slices.Equal(m.order, want) {
+		t.Errorf("original order mutated by moveSelected: got %v, want %v", m.order, want)
+	}
+}

--- a/internal/tui/calendar_list_dialog_test.go
+++ b/internal/tui/calendar_list_dialog_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/help"
+	tea "charm.land/bubbletea/v2"
 )
 
 func makeCalListDialogFixture() CalendarListDialogModel {
@@ -62,5 +63,42 @@ func TestCalendarListDialog_MoveSelectedDoesNotMutateOriginalOrder(t *testing.T)
 	_, _ = m.moveSelected(1)
 	if want := []int64{1, 2, 3}; !slices.Equal(m.order, want) {
 		t.Errorf("original order mutated by moveSelected: got %v, want %v", m.order, want)
+	}
+}
+
+// TestCalendarListDialog_ReorderIgnoredWhenActionsFocused locks in the
+// focus-zone guard: a move key pressed while the action buttons (not the list)
+// own focus must not reorder or persist anything.
+func TestCalendarListDialog_ReorderIgnoredWhenActionsFocused(t *testing.T) {
+	m := makeCalListDialogFixture()
+	m.shell = m.shell.SetSelected(0)
+	m.shell = m.shell.SetFocusZone(ListZoneActions)
+
+	m2, cmd := m.handleKey(tea.KeyPressMsg{Code: 'J', Text: "J"}) // move-down key
+	if !slices.Equal(m2.order, []int64{1, 2, 3}) {
+		t.Errorf("order changed while actions zone focused: got %v", m2.order)
+	}
+	if cmd != nil {
+		if _, ok := cmd().(CalendarReorderedMsg); ok {
+			t.Error("reorder emitted while actions zone focused")
+		}
+	}
+}
+
+// TestCalendarListDialog_MoveSelectedSingleAndEmpty covers the bounds-guard
+// edge cases the 3-item fixture can't reach.
+func TestCalendarListDialog_MoveSelectedSingleAndEmpty(t *testing.T) {
+	single := NewCalendarListDialogModel(map[int64]CalendarInfo{1: {Name: "Solo"}}, nil, help.New())
+	single.shell = single.shell.SetSelected(0)
+	if _, cmd := single.moveSelected(1); cmd != nil {
+		t.Error("single-item move down should be a no-op")
+	}
+	if _, cmd := single.moveSelected(-1); cmd != nil {
+		t.Error("single-item move up should be a no-op")
+	}
+
+	empty := NewCalendarListDialogModel(map[int64]CalendarInfo{}, nil, help.New())
+	if _, cmd := empty.moveSelected(1); cmd != nil {
+		t.Error("empty-list move should be a no-op")
 	}
 }

--- a/internal/tui/calendar_list_model.go
+++ b/internal/tui/calendar_list_model.go
@@ -149,12 +149,13 @@ func (m CalendarListModel) SetItems(items []CalendarListItem) CalendarListModel 
 // calendar — which would make the next keystroke act on the wrong one. Falls
 // back to SetItems' clamp when the current calendar is gone.
 func (m CalendarListModel) SetItemsPreservingCursor(items []CalendarListItem) CalendarListModel {
-	curID := int64(-1)
-	if m.cursor >= 0 && m.cursor < len(m.items) {
+	var curID int64
+	hasCursor := m.cursor >= 0 && m.cursor < len(m.items)
+	if hasCursor {
 		curID = m.items[m.cursor].ID
 	}
 	m = m.SetItems(items)
-	if curID >= 0 {
+	if hasCursor {
 		for i, it := range items {
 			if it.ID == curID {
 				m.cursor = i

--- a/internal/tui/calendar_list_model.go
+++ b/internal/tui/calendar_list_model.go
@@ -143,6 +143,28 @@ func (m CalendarListModel) SetItems(items []CalendarListItem) CalendarListModel 
 	return m
 }
 
+// SetItemsPreservingCursor replaces the items but keeps the cursor on whatever
+// calendar it currently points at (by ID) rather than by raw index, so a
+// reorder or reload that shifts rows doesn't leave the highlight on a different
+// calendar — which would make the next keystroke act on the wrong one. Falls
+// back to SetItems' clamp when the current calendar is gone.
+func (m CalendarListModel) SetItemsPreservingCursor(items []CalendarListItem) CalendarListModel {
+	curID := int64(-1)
+	if m.cursor >= 0 && m.cursor < len(m.items) {
+		curID = m.items[m.cursor].ID
+	}
+	m = m.SetItems(items)
+	if curID >= 0 {
+		for i, it := range items {
+			if it.ID == curID {
+				m.cursor = i
+				break
+			}
+		}
+	}
+	return m
+}
+
 // HiddenSet returns a copy of the current hidden set.
 func (m CalendarListModel) HiddenSet() map[int64]bool {
 	out := make(map[int64]bool, len(m.hidden))

--- a/internal/tui/help_dialog.go
+++ b/internal/tui/help_dialog.go
@@ -185,7 +185,7 @@ func (m HelpDialogModel) sections() []helpSection {
 				{"s", "sync all"},
 				{"enter (sidebar)", "open calendar"},
 				{"space (sidebar)", "toggle visibility"},
-				{"shift+↑/↓ (sidebar)", "reorder calendar"},
+				{"shift+↑/↓ · K/J", "reorder calendar (sidebar or manage dialog)"},
 				{"*", "set as default"},
 			},
 		},


### PR DESCRIPTION
## What

Brings the calendar-reordering feature (shipped for the sidebar in v0.4.0) into the manage-calendars dialog (`shift+c`), so calendars can be reordered from either place.

- **dialog:** `shift+↑/↓` (or `K`/`J`) moves the selected calendar — optimistic local swap, selection follows the moved calendar, emits the existing `CalendarReorderedMsg` for persistence.
- **app:** extracted `sortedCalendarListItems` (shared by the reload + reorder handlers); the reorder handler re-sorts the sidebar so a dialog-originated move keeps the background sidebar in sync.
- **help:** documented in the dialog footer and the help dialog (now noted as working in both the sidebar and the manage dialog).

## Review findings fixed (in this branch)

Found and fixed during `/review` + `/code-review`:
- **Focus-zone guard:** reorder no longer fires while focus is on the action buttons/title action (it was silently reordering + persisting the wrong row).
- **Sidebar cursor:** `SetItemsPreservingCursor` keeps the sidebar highlight on the same calendar across a reorder re-sort (was landing on the wrong calendar by index).
- Pruned unbounded `pendingOrder` entries for deleted calendars; built the help binding from the existing keys; dropped a magic `-1` sentinel.

## Tests

Dialog reorder + selection, focus-zone guard regression, single/empty edge cases, dialog-originated sidebar+dialog sync, and cursor-follows-calendar. `go vet ./...` clean; full suite green.