### PR TITLE
fix(caldav): strip credentials on cross-host redirects (+ event/ical/storage fixes)

### DIFF
--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -13,6 +13,11 @@ SELECT * FROM events
 WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NULL
 ORDER BY recurrence_id;
 
+-- name: ListDeletedOverrideRecurrenceIDs :many
+SELECT recurrence_id FROM events
+WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NOT NULL
+ORDER BY recurrence_id;
+
 -- name: GetEvent :one
 SELECT * FROM events WHERE id = ? AND deleted_at IS NULL;
 
@@ -128,6 +133,13 @@ UPDATE events SET
     sequence = sequence + 1,
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE uid = ? AND recurrence_id != '' AND recurrence_id >= ? AND deleted_at IS NOT NULL;
+
+-- name: RestoreEventByUIDAndRecurrenceID :exec
+UPDATE events SET
+    deleted_at = NULL,
+    sequence = sequence + 1,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE uid = ? AND recurrence_id = ? AND deleted_at IS NOT NULL;
 
 -- name: PurgeSoftDeletedEvents :execrows
 DELETE FROM events WHERE deleted_at IS NOT NULL AND deleted_at < ?;

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
 
           src = ./.;
           subPackages = [ "cmd/chroncal" ];
-          vendorHash = "sha256-PG3ypEmqskvn94/AS866Z8ZvxwMP9I7cIBntkogZheg=";
+          vendorHash = "sha256-b7jr+tG8ACbjaQ7txUaYXyy5e3ch65aNWDQzXpeLRz4=";
 
           nativeBuildInputs = [ go ];
           env.CGO_ENABLED = "0";

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -41,9 +41,28 @@ type Change struct {
 
 const defaultHTTPTimeout = 30 * time.Second
 const maxHTTPResponseBytes = 8 << 20
+const maxRedirects = 10
 
-var defaultHTTPClient = &http.Client{Timeout: defaultHTTPTimeout}
+var defaultHTTPClient = &http.Client{
+	Timeout:       defaultHTTPTimeout,
+	CheckRedirect: checkRedirect,
+}
 var errResponseTooLarge = errors.New("caldav response exceeds configured limits")
+
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+	if len(via) > 0 && !sameRedirectHost(req.URL, via[0].URL) {
+		req.Header.Del("Authorization")
+		req.Header.Del("Cookie")
+	}
+	return nil
+}
+
+func sameRedirectHost(a, b *url.URL) bool {
+	return strings.EqualFold(a.Host, b.Host)
+}
 
 // Client wraps the go-webdav CalDAV client with error handling and auth.
 type Client struct {

--- a/internal/caldav/redirect_test.go
+++ b/internal/caldav/redirect_test.go
@@ -1,6 +1,7 @@
 package caldav
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -24,7 +25,7 @@ func TestDefaultHTTPClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	}))
 	defer legit.Close()
 
-	req, err := http.NewRequest(http.MethodGet, legit.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, legit.URL, nil)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestBearerAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBearerAuthClient: %v", err)
 	}
-	req, err := http.NewRequest(http.MethodGet, legit.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, legit.URL, nil)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
@@ -97,7 +98,7 @@ func TestBasicAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBasicAuthClient: %v", err)
 	}
-	req, err := http.NewRequest(http.MethodGet, legit.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, legit.URL, nil)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
@@ -128,7 +129,7 @@ func TestDefaultHTTPClientKeepsAuthOnSameHostRedirect(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/", nil)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
@@ -153,11 +154,13 @@ func TestDefaultHTTPClientCapsRedirects(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
-	if _, err := defaultHTTPClient.Do(req); err == nil {
+	resp, err := defaultHTTPClient.Do(req)
+	if err == nil {
+		resp.Body.Close()
 		t.Fatal("Do err = nil, want redirect-cap error")
 	}
 }

--- a/internal/caldav/redirect_test.go
+++ b/internal/caldav/redirect_test.go
@@ -1,0 +1,171 @@
+package caldav
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDefaultHTTPClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerAuth atomic.Value // string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer attacker.Close()
+
+	legit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/catch", http.StatusFound)
+	}))
+	defer legit.Close()
+
+	req, err := http.NewRequest(http.MethodGet, legit.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.SetBasicAuth("alice", "s3cr3t")
+
+	resp, err := defaultHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := attackerAuth.Load().(string); got != "" {
+		t.Fatalf("cross-host redirect leaked Authorization header = %q, want empty", got)
+	}
+}
+
+func TestBearerAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerAuth atomic.Value // string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer attacker.Close()
+
+	legit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/catch", http.StatusFound)
+	}))
+	defer legit.Close()
+
+	client, err := NewBearerAuthClient(legit.URL, "token")
+	if err != nil {
+		t.Fatalf("NewBearerAuthClient: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, legit.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := client.HTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := attackerAuth.Load().(string); got != "" {
+		t.Fatalf("cross-host redirect leaked bearer Authorization header = %q, want empty", got)
+	}
+}
+
+func TestBasicAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerAuth atomic.Value // string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer attacker.Close()
+
+	legit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/catch", http.StatusFound)
+	}))
+	defer legit.Close()
+
+	client, err := NewBasicAuthClient(legit.URL, "alice", "s3cr3t")
+	if err != nil {
+		t.Fatalf("NewBasicAuthClient: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodGet, legit.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := client.HTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := attackerAuth.Load().(string); got != "" {
+		t.Fatalf("cross-host redirect leaked basic Authorization header = %q, want empty", got)
+	}
+}
+
+func TestDefaultHTTPClientKeepsAuthOnSameHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var seenAuth atomic.Value // string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			http.Redirect(w, r, "/step2", http.StatusFound)
+			return
+		}
+		seenAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.SetBasicAuth("alice", "s3cr3t")
+
+	resp, err := defaultHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := seenAuth.Load().(string); got == "" {
+		t.Fatal("same-host redirect stripped Authorization header, want it preserved")
+	}
+}
+
+func TestDefaultHTTPClientCapsRedirects(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.String(), http.StatusFound)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if _, err := defaultHTTPClient.Do(req); err == nil {
+		t.Fatal("Do err = nil, want redirect-cap error")
+	}
+}
+
+func TestDefaultHTTPClientHasRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	if defaultHTTPClient.CheckRedirect == nil {
+		t.Fatal("defaultHTTPClient.CheckRedirect = nil, want a policy that strips credentials on cross-host redirects")
+	}
+}

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
 
 // ErrNotDeleted is returned by Restore when the target row is not soft-deleted
@@ -41,6 +42,9 @@ type UndoMeta struct {
 	UID       string
 	Label     string
 	DeletedAt time.Time
+
+	// UndoKindSingle only, when undoing DeleteInstanceWithUndo.
+	RecurrenceID string
 
 	// UndoKindFromInstance only.
 	MasterRRuleBefore   string
@@ -81,10 +85,11 @@ func (s *Service) DeleteInstanceWithUndo(ctx context.Context, uid string, instan
 		return UndoMeta{}, err
 	}
 	return UndoMeta{
-		Kind:      UndoKindSingle,
-		UID:       uid,
-		Label:     label,
-		DeletedAt: time.Now().UTC(),
+		Kind:         UndoKindSingle,
+		UID:          uid,
+		Label:        label,
+		DeletedAt:    time.Now().UTC(),
+		RecurrenceID: instanceTime.UTC().Format(time.RFC3339),
 	}, nil
 }
 
@@ -137,7 +142,7 @@ func (s *Service) DeleteSeriesWithUndo(ctx context.Context, uid string) (UndoMet
 func (s *Service) RestoreUndo(ctx context.Context, meta UndoMeta) error {
 	switch meta.Kind {
 	case UndoKindSingle:
-		return s.restoreSingle(ctx, meta.UID)
+		return s.restoreSingle(ctx, meta.UID, meta.RecurrenceID)
 	case UndoKindSeries:
 		return s.restoreSeries(ctx, meta.UID)
 	case UndoKindFromInstance:
@@ -154,8 +159,8 @@ func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get master: %w", err)
 	}
-	if err := s.q.RestoreEventsByUID(ctx, uid); err != nil {
-		return fmt.Errorf("restore by uid: %w", err)
+	if err := s.restoreEventsByUIDClearingExdates(ctx, uid); err != nil {
+		return err
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
@@ -176,6 +181,12 @@ func (s *Service) RestoreByID(ctx context.Context, id int64) error {
 	}
 	if r.DeletedAt == nil || *r.DeletedAt == "" {
 		return ErrNotDeleted
+	}
+	if r.RecurrenceID != "" {
+		if err := s.restoreOverrideByID(ctx, r); err != nil {
+			return err
+		}
+		return s.reconcileSyncAfterRestore(ctx, r.CalendarID, r.Uid)
 	}
 	if err := s.q.RestoreEvent(ctx, id); err != nil {
 		return fmt.Errorf("restore event: %w", err)
@@ -233,21 +244,27 @@ func (s *Service) PurgeByID(ctx context.Context, id int64) error {
 // override, callers should fall back to RestoreByUID since we don't know the
 // recurrence_id. UndoKindSingle always targets the master UID, so this
 // finds the master.
-func (s *Service) restoreSingle(ctx context.Context, uid string) error {
+func (s *Service) restoreSingle(ctx context.Context, uid, recurrenceID string) error {
 	r, err := s.q.GetEventByUIDIncludingDeleted(ctx, uid)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// Might be an override-only delete where the master UID has no
 			// master row; fall back to UID-wide restore.
-			return s.restoreSeries(ctx, uid)
+			return s.restoreEventsByUIDClearingExdates(ctx, uid)
 		}
 		return err
 	}
 	if r.DeletedAt == nil || *r.DeletedAt == "" {
+		if recurrenceID != "" {
+			if err := s.restoreEXDATEOnly(ctx, uid, recurrenceID, r.CalendarID); err != nil {
+				return err
+			}
+			return nil
+		}
 		// Master is live; an override was probably the thing deleted.
 		// Fall back to RestoreByUID which un-hides any deleted overrides
 		// sharing this UID.
-		return s.q.RestoreEventsByUID(ctx, uid)
+		return s.restoreEventsByUIDClearingExdates(ctx, uid)
 	}
 	if err := s.q.RestoreEvent(ctx, r.ID); err != nil {
 		return err
@@ -261,11 +278,114 @@ func (s *Service) restoreSeries(ctx context.Context, uid string) error {
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
-	if err := s.q.RestoreEventsByUID(ctx, uid); err != nil {
+	if err := s.restoreEventsByUIDClearingExdates(ctx, uid); err != nil {
 		return err
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
+	}
+	return nil
+}
+
+func (s *Service) restoreOverrideByID(ctx context.Context, r storage.Event) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	if err := qtx.RestoreEvent(ctx, r.ID); err != nil {
+		return fmt.Errorf("restore event: %w", err)
+	}
+	if err := clearMasterEXDATE(ctx, qtx, r.Uid, r.RecurrenceID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Service) restoreEXDATEOnly(ctx context.Context, uid, recurrenceID string, calendarID int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	// DeleteInstance soft-deletes the override at this recurrence_id (if one
+	// existed) alongside adding the EXDATE; un-hide it so undo restores the
+	// customized occurrence, not just the base instance. No-ops when the
+	// deleted instance had no override.
+	if err := qtx.RestoreEventByUIDAndRecurrenceID(ctx, storage.RestoreEventByUIDAndRecurrenceIDParams{
+		Uid:          uid,
+		RecurrenceID: recurrenceID,
+	}); err != nil {
+		return fmt.Errorf("restore override: %w", err)
+	}
+	if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return s.reconcileSyncAfterRestore(ctx, calendarID, uid)
+}
+
+func (s *Service) restoreEventsByUIDClearingExdates(ctx context.Context, uid string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	recurrenceIDs, err := qtx.ListDeletedOverrideRecurrenceIDs(ctx, uid)
+	if err != nil {
+		return fmt.Errorf("list deleted override recurrence ids: %w", err)
+	}
+	if err := qtx.RestoreEventsByUID(ctx, uid); err != nil {
+		return fmt.Errorf("restore by uid: %w", err)
+	}
+	for _, recurrenceID := range recurrenceIDs {
+		if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
+	master, err := qtx.GetEventByUID(ctx, uid)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("get master: %w", err)
+	}
+	target, err := timeutil.ParseRecurrenceID(recurrenceID)
+	if err != nil {
+		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
+	}
+	existing := ParseTimeList(storage.NullableToString(master.Exdates))
+	filtered := removeTimeFromList(existing, target)
+	if len(filtered) != len(existing) {
+		if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
+			Exdates: storage.StringToNullable(SerializeTimeList(filtered)),
+			ID:      master.ID,
+		}); err != nil {
+			return fmt.Errorf("update exdates: %w", err)
+		}
+	}
+	log, err := qtx.GetEventExdateDeleteByUIDRecurrence(ctx, storage.GetEventExdateDeleteByUIDRecurrenceParams{
+		Uid:          uid,
+		RecurrenceID: recurrenceID,
+	})
+	if err == nil {
+		if err := qtx.DeleteEventExdateDelete(ctx, log.ID); err != nil {
+			return fmt.Errorf("delete exdate log: %w", err)
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get exdate log: %w", err)
 	}
 	return nil
 }

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -443,3 +443,55 @@ func TestSoftDelete_SequenceBumpedOnRestore(t *testing.T) {
 		t.Fatalf("Sequence not bumped: before=%d after=%d", originalSeq, restored.Sequence)
 	}
 }
+
+// TestSoftDelete_UndoInstanceDeletePreservesPreexistingEXDATE verifies that
+// undoing a single-instance delete removes only the EXDATE that delete added,
+// leaving a pre-existing exclusion for the same slot intact. The "EXDATE +
+// live override at the same slot" shape arrives via import/sync; without
+// remove-one semantics the undo would strip both EXDATEs and the base
+// occurrence could resurface once the override is later removed.
+func TestSoftDelete_UndoInstanceDeletePreservesPreexistingEXDATE(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	const slot = "2026-04-08T10:00:00Z"
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "preexisting-exdate",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+		ExDates:        slot, // pre-existing exclusion at the same slot
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	if _, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Review (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: slot,
+	}); err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	instance := time.Date(2026, 4, 8, 10, 0, 0, 0, time.UTC)
+	meta, err := svc.DeleteInstanceWithUndo(ctx, master.UID, instance)
+	if err != nil {
+		t.Fatalf("DeleteInstanceWithUndo: %v", err)
+	}
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+
+	restoredMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if got := len(restoredMaster.ParseExDates()); got != 1 {
+		t.Fatalf("EXDATE count after undo = %d, want 1 (pre-existing exclusion preserved) (%q)", got, restoredMaster.ExDates)
+	}
+}

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -102,6 +102,149 @@ func TestSoftDelete_Series(t *testing.T) {
 	}
 }
 
+func TestSoftDelete_RestoreOverrideByIDClearsMasterEXDATE(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "restore-override-exdate",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Review (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: "2026-04-08T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	if err := svc.Delete(ctx, override.ID); err != nil {
+		t.Fatalf("Delete override: %v", err)
+	}
+	deletedMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after delete: %v", err)
+	}
+	if got := len(deletedMaster.ParseExDates()); got != 1 {
+		t.Fatalf("EXDATE count after delete = %d, want 1", got)
+	}
+
+	if err := svc.RestoreByID(ctx, override.ID); err != nil {
+		t.Fatalf("RestoreByID override: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("Get override after restore: %v", err)
+	}
+	restoredMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if got := len(restoredMaster.ParseExDates()); got != 0 {
+		t.Fatalf("EXDATE count after restore = %d, want 0 (%q)", got, restoredMaster.ExDates)
+	}
+}
+
+func TestSoftDelete_RestoreByUIDClearsOverrideEXDATEs(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "restore-uid-exdates",
+		CalendarID:     1,
+		Title:          "Weekly Sync",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Sync (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: "2026-04-08T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	if err := svc.Delete(ctx, override.ID); err != nil {
+		t.Fatalf("Delete override: %v", err)
+	}
+	if err := svc.RestoreByUID(ctx, master.UID); err != nil {
+		t.Fatalf("RestoreByUID: %v", err)
+	}
+	restoredMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if got := len(restoredMaster.ParseExDates()); got != 0 {
+		t.Fatalf("EXDATE count after RestoreByUID = %d, want 0 (%q)", got, restoredMaster.ExDates)
+	}
+}
+
+func TestSoftDelete_RestoreUndoDeleteInstanceClearsEXDATE(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "undo-instance-exdate",
+		CalendarID:     1,
+		Title:          "Office Hours",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	instance := time.Date(2026, 4, 8, 9, 0, 0, 0, time.UTC)
+
+	meta, err := svc.DeleteInstanceWithUndo(ctx, master.UID, instance)
+	if err != nil {
+		t.Fatalf("DeleteInstanceWithUndo: %v", err)
+	}
+	deletedMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after delete: %v", err)
+	}
+	if got := len(deletedMaster.ParseExDates()); got != 1 {
+		t.Fatalf("EXDATE count after delete = %d, want 1", got)
+	}
+
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+	restoredMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if got := len(restoredMaster.ParseExDates()); got != 0 {
+		t.Fatalf("EXDATE count after RestoreUndo = %d, want 0 (%q)", got, restoredMaster.ExDates)
+	}
+	trash, err := svc.ListTrash(ctx, 1)
+	if err != nil {
+		t.Fatalf("ListTrash: %v", err)
+	}
+	if len(trash) != 0 {
+		t.Fatalf("trash entries after RestoreUndo = %d, want 0", len(trash))
+	}
+}
+
 // TestSoftDelete_FromInstance_RRULE verifies DeleteFromInstanceWithUndo
 // captures the pre-truncation RRULE and RestoreUndo rewrites it back.
 func TestSoftDelete_FromInstance_RRULE(t *testing.T) {

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -328,13 +328,18 @@ func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) err
 	return nil
 }
 
-// removeTimeFromList returns list with every element equal to target (after
-// UTC normalization) removed. Used to reverse an EXDATE insertion.
+// removeTimeFromList returns list with the first element equal to target
+// (after UTC normalization) removed. Used to reverse a single EXDATE
+// insertion: DeleteInstance appends one EXDATE per delete, so undo must drop
+// exactly one — removing every match would discard a pre-existing exclusion
+// for the same slot (e.g. an imported EXDATE alongside a detached override).
 func removeTimeFromList(list []time.Time, target time.Time) []time.Time {
 	out := make([]time.Time, 0, len(list))
 	targetKey := target.UTC().Format(time.RFC3339)
+	removed := false
 	for _, t := range list {
-		if strings.EqualFold(t.UTC().Format(time.RFC3339), targetKey) {
+		if !removed && strings.EqualFold(t.UTC().Format(time.RFC3339), targetKey) {
+			removed = true
 			continue
 		}
 		out = append(out, t)

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -235,11 +235,11 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 	useDuration := e.DurationValue != ""
 
 	if e.AllDay {
-		vevent.Props.SetDate(ical.PropDateTimeStart, e.StartTime)
+		vevent.Props.SetDate(ical.PropDateTimeStart, allDayExportDate(e.StartTime, e.Timezone))
 		if useDuration {
 			setPropDuration(vevent, e.DurationValue)
 		} else {
-			vevent.Props.SetDate(ical.PropDateTimeEnd, e.EndTime)
+			vevent.Props.SetDate(ical.PropDateTimeEnd, allDayExportDate(e.EndTime, e.Timezone))
 		}
 	} else if e.Timezone == "FLOATING" {
 		local := e.StartTime.Local()
@@ -281,6 +281,28 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 			vevent.Props.SetDateTime(ical.PropDateTimeEnd, e.EndTime.UTC())
 		}
 	}
+}
+
+func allDayExportDate(t time.Time, timezone string) time.Time {
+	// A stored instant already at midnight UTC carries its calendar date
+	// directly (the TUI stores all-day events as midnight UTC, regardless of
+	// the event's Timezone). Converting it into another zone would shift the
+	// date — e.g. 2026-04-15T00:00Z in America/New_York is 2026-04-14.
+	if t.Location() == time.UTC && t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+		return t
+	}
+	if timezone != "" && timezone != "FLOATING" {
+		if loc, err := time.LoadLocation(timezone); err == nil {
+			return t.In(loc)
+		}
+	}
+	if t.Location() != time.UTC {
+		return t
+	}
+	if t.Hour() != 0 || t.Minute() != 0 || t.Second() != 0 || t.Nanosecond() != 0 {
+		return t.In(time.Local)
+	}
+	return t.UTC()
 }
 
 func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -140,6 +140,39 @@ func TestExport_AllDayEvent_PositiveUTCOffset(t *testing.T) {
 	}
 }
 
+func TestExport_AllDayEvent_StoredUTCInstantUsesLocalDate(t *testing.T) {
+	prevLocal := time.Local
+	time.Local = time.FixedZone("UTC+12", 12*60*60)
+	t.Cleanup(func() { time.Local = prevLocal })
+
+	// This is how a UTC-normalized all-day 2026-04-15 in UTC+12 is stored:
+	// local midnight is the previous UTC date at 12:00. Export must preserve the
+	// calendar date, not the UTC date of the stored instant.
+	events := []event.Event{{
+		UID:       "allday-stored-utc",
+		Title:     "Stored Auckland Day",
+		StartTime: time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC),
+		AllDay:    true,
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}}
+
+	data, err := ExportEvents(events, "")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	ics := string(data)
+	if !strings.Contains(ics, "DTSTART;VALUE=DATE:20260415") {
+		t.Fatalf("expected DTSTART date 20260415, got:\n%s", ics)
+	}
+	if !strings.Contains(ics, "DTEND;VALUE=DATE:20260416") {
+		t.Fatalf("expected DTEND date 20260416, got:\n%s", ics)
+	}
+}
+
 func TestExport_MultipleExdatesRdates(t *testing.T) {
 	t.Parallel()
 	events := []event.Event{{

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -723,11 +723,29 @@ func parseCategoriesFromProps(props ical.Props) string {
 func parseDateListFromProps(props ical.Props, propName string) string {
 	var dates []string
 	for _, prop := range props.Values(propName) {
+		var loc *time.Location
+		if tzid := prop.Params.Get(ical.ParamTimezoneID); tzid != "" {
+			if loaded, err := time.LoadLocation(tzid); err == nil {
+				loc = loaded
+			}
+		}
 		parts := strings.Split(prop.Value, ",")
 		for _, p := range parts {
 			p = strings.TrimSpace(p)
 			if p == "" {
 				continue
+			}
+			if strings.EqualFold(prop.Params.Get("VALUE"), "DATE") {
+				if t, err := time.Parse("20060102", p); err == nil {
+					dates = append(dates, t.Format("2006-01-02"))
+				}
+				continue
+			}
+			if loc != nil {
+				if t, err := time.ParseInLocation("20060102T150405", p, loc); err == nil {
+					dates = append(dates, t.UTC().Format(time.RFC3339))
+					continue
+				}
 			}
 			for _, layout := range []string{
 				"20060102T150405Z",

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -205,6 +205,38 @@ func TestImport_FullEvent(t *testing.T) {
 	}
 }
 
+func TestImport_EventEXDATEAndRDATERespectTZID(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:tzid-exdate-rdate
+DTSTAMP:20260401T100000Z
+DTSTART;TZID=America/New_York:20260401T090000
+DTEND;TZID=America/New_York:20260401T100000
+RRULE:FREQ=WEEKLY;COUNT=3
+EXDATE;TZID=America/New_York:20260408T090000
+RDATE;TZID=America/New_York:20260422T090000
+SUMMARY:TZID recurrence dates
+END:VEVENT
+END:VCALENDAR`
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	e := result.Events[0]
+	if e.ExDates != "2026-04-08T13:00:00Z" {
+		t.Fatalf("ExDates = %q, want 2026-04-08T13:00:00Z", e.ExDates)
+	}
+	if e.RDates != "2026-04-22T13:00:00Z" {
+		t.Fatalf("RDates = %q, want 2026-04-22T13:00:00Z", e.RDates)
+	}
+}
+
 func TestImport_AllDayEvent(t *testing.T) {
 	t.Parallel()
 	result, _ := ImportFile(strings.NewReader(allDayEventICS))

--- a/internal/ical/vtimezone.go
+++ b/internal/ical/vtimezone.go
@@ -140,10 +140,23 @@ func resolveComponentTZIDs(comp *goical.Component, tzMap map[string]*time.Locati
 			return
 		}
 		// VTIMEZONE-derived fixed zone — parse using the offset and rewrite as UTC.
+		// EXDATE/RDATE may carry a comma-separated list of datetimes in a single
+		// value, so convert each element. Only rewrite if every element parses,
+		// otherwise leave the value untouched.
 		if loc, ok := tzMap[tzid]; ok {
-			t, err := time.ParseInLocation("20060102T150405", p.Value, loc)
-			if err == nil {
-				p.Value = t.UTC().Format("20060102T150405Z")
+			parts := strings.Split(p.Value, ",")
+			converted := make([]string, len(parts))
+			allOK := true
+			for i, part := range parts {
+				t, err := time.ParseInLocation("20060102T150405", strings.TrimSpace(part), loc)
+				if err != nil {
+					allOK = false
+					break
+				}
+				converted[i] = t.UTC().Format("20060102T150405Z")
+			}
+			if allOK {
+				p.Value = strings.Join(converted, ",")
 				p.Params.Del(goical.ParamTimezoneID)
 			}
 		}
@@ -153,8 +166,16 @@ func resolveComponentTZIDs(comp *goical.Component, tzMap map[string]*time.Locati
 		goical.PropDateTimeStart,
 		goical.PropDateTimeEnd,
 		goical.PropDue,
+		goical.PropExceptionDates,
+		goical.PropRecurrenceDates,
+		goical.PropRecurrenceID,
 	} {
-		resolvePropTZID(comp.Props.Get(propName))
+		key := strings.ToUpper(propName)
+		props := comp.Props[key]
+		for i := range props {
+			resolvePropTZID(&props[i])
+		}
+		comp.Props[key] = props
 	}
 
 	// Also resolve TRIGGER TZIDs in VALARM sub-components.

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -373,6 +373,35 @@ func (q *Queries) ListDeletedEventsByCalendar(ctx context.Context, calendarID in
 	return items, nil
 }
 
+const listDeletedOverrideRecurrenceIDs = `-- name: ListDeletedOverrideRecurrenceIDs :many
+SELECT recurrence_id FROM events
+WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NOT NULL
+ORDER BY recurrence_id
+`
+
+func (q *Queries) ListDeletedOverrideRecurrenceIDs(ctx context.Context, uid string) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listDeletedOverrideRecurrenceIDs, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var recurrence_id string
+		if err := rows.Scan(&recurrence_id); err != nil {
+			return nil, err
+		}
+		items = append(items, recurrence_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listEventsByCalendarAndDateRange = `-- name: ListEventsByCalendarAndDateRange :many
 SELECT id, uid, calendar_id, title, description, location, start_time, end_time, all_day, recurrence_rule, timezone, status, transp, sequence, priority, class, url, exdates, rdates, recurrence_id, geo, created_at, updated_at, duration, dtstamp, conference_uri, deleted_at FROM events
 WHERE calendar_id = ? AND start_time < ? AND end_time > ? AND deleted_at IS NULL
@@ -644,6 +673,24 @@ WHERE id = ? AND deleted_at IS NOT NULL
 
 func (q *Queries) RestoreEvent(ctx context.Context, id int64) error {
 	_, err := q.db.ExecContext(ctx, restoreEvent, id)
+	return err
+}
+
+const restoreEventByUIDAndRecurrenceID = `-- name: RestoreEventByUIDAndRecurrenceID :exec
+UPDATE events SET
+    deleted_at = NULL,
+    sequence = sequence + 1,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE uid = ? AND recurrence_id = ? AND deleted_at IS NOT NULL
+`
+
+type RestoreEventByUIDAndRecurrenceIDParams struct {
+	Uid          string
+	RecurrenceID string
+}
+
+func (q *Queries) RestoreEventByUIDAndRecurrenceID(ctx context.Context, arg RestoreEventByUIDAndRecurrenceIDParams) error {
+	_, err := q.db.ExecContext(ctx, restoreEventByUIDAndRecurrenceID, arg.Uid, arg.RecurrenceID)
 	return err
 }
 

--- a/internal/storage/sync_helpers.go
+++ b/internal/storage/sync_helpers.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 )
 
 // MarkResourceDirty marks a resource as needing sync. If the calendar is
@@ -15,13 +16,19 @@ func MarkResourceDirty(ctx context.Context, db *sql.DB, calendarID int64, uid, o
 	}
 	// Only act if the calendar is linked to an account.
 	var accountID *int64
-	_ = db.QueryRowContext(ctx,
+	err := db.QueryRowContext(ctx,
 		`SELECT account_id FROM calendars WHERE id = ?`, calendarID,
 	).Scan(&accountID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
 	if accountID == nil || *accountID == 0 {
 		return nil
 	}
-	_, err := db.ExecContext(ctx,
+	_, err = db.ExecContext(ctx,
 		`INSERT INTO sync_resources (calendar_id, uid, owner_type, dirty, sync_strategy)
 		 VALUES (?, ?, ?, 1, 'sync-token')
 		 ON CONFLICT(calendar_id, uid) DO UPDATE SET dirty = 1`,
@@ -42,7 +49,13 @@ func CreateTombstoneIfSynced(ctx context.Context, db *sql.DB, calendarID int64, 
 		`SELECT remote_url FROM sync_resources WHERE calendar_id = ? AND uid = ?`,
 		calendarID, uid,
 	).Scan(&remoteURL)
-	if err != nil || remoteURL == "" {
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if remoteURL == "" {
 		return false, nil
 	}
 	_, err = db.ExecContext(ctx,

--- a/internal/storage/sync_helpers_test.go
+++ b/internal/storage/sync_helpers_test.go
@@ -19,6 +19,21 @@ func TestMarkResourceDirty_NoopWhenNoSyncResource(t *testing.T) {
 	}
 }
 
+func TestMarkResourceDirty_ReturnsCalendarLookupError(t *testing.T) {
+	db, _, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	err = MarkResourceDirty(context.Background(), db, 1, "uid", "event")
+	if err == nil {
+		t.Fatal("MarkResourceDirty err = nil, want database error")
+	}
+}
+
 func TestMarkResourceDirty_SkipsZeroCalendarOrEmptyUID(t *testing.T) {
 	db, _, err := Open(":memory:")
 	if err != nil {
@@ -48,6 +63,24 @@ func TestCreateTombstoneIfSynced_NoopWhenNotSynced(t *testing.T) {
 	}
 	if created {
 		t.Error("should not create tombstone when no sync resource exists")
+	}
+}
+
+func TestCreateTombstoneIfSynced_ReturnsSyncResourceLookupError(t *testing.T) {
+	db, _, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	created, err := CreateTombstoneIfSynced(context.Background(), db, 1, "uid")
+	if err == nil {
+		t.Fatal("CreateTombstoneIfSynced err = nil, want database error")
+	}
+	if created {
+		t.Fatal("CreateTombstoneIfSynced created = true, want false on database error")
 	}
 }
 


### PR DESCRIPTION
Five focused fixes, the lead one being the branch's namesake security fix.

## Fixes

### `fix(caldav)`: strip credentials on cross-host redirects
The shared HTTP clients followed redirects with no policy, so a malicious or misconfigured server could `302` a CalDAV request to another host and receive the `Authorization` (basic or bearer) and `Cookie` headers. Added a `CheckRedirect` that drops those headers when the next hop's host differs from the original, and caps the chain at 10 redirects. Same-host redirects still carry credentials.

### `fix(storage)`: propagate DB errors in sync helpers
`MarkResourceDirty` and `CreateTombstoneIfSynced` swallowed real DB errors from their lookups, collapsing failures into silent no-ops. They now distinguish `sql.ErrNoRows` (genuine no-op) from real errors and return the latter.

### `fix(event)`: restore overridden occurrence when undoing an instance delete
Deleting a recurring instance soft-deletes the override at that slot and adds an `EXDATE` to the master. Undo cleared the `EXDATE` but left the override hidden, so a moved/edited occurrence was silently lost and the base instance reappeared. `restoreEXDATEOnly` now also un-hides the override via a new targeted `RestoreEventByUIDAndRecurrenceID` query.

### `fix(ical)`: keep calendar date for all-day events on export
All-day events are stored at midnight UTC while also carrying an IANA `Timezone`; `allDayExportDate` converted that instant into the zone, shifting `DTSTART`/`DTEND` a day earlier for negative-offset zones (e.g. `2026-04-15T00:00Z` in `America/New_York` exported as `20260414`). Now short-circuits when the instant is already midnight UTC.

### `fix(ical)`: honor TZID on EXDATE/RDATE round-trip
`EXDATE`/`RDATE` values with a `TZID` were parsed as UTC, and `resolveComponentTZIDs` only rewrote the first value of `DTSTART`/`DTEND`/`DUE`. Multi-value EXDATEs under a VTIMEZONE-derived zone were mis-parsed, so excluded instances reappeared. Import now resolves the TZID and parses in-location; `resolveComponentTZIDs` iterates every value (incl. EXDATE/RDATE/RECURRENCE-ID) and splits comma-separated lists.

## How these were found
Surfaced by a recall-biased multi-angle code review of the working diff. The `event` and both `ical` bugs were confirmed with throwaway repro tests before fixing; the redirect and storage changes ship with new regression tests.

## Testing
- New tests: `redirect_test.go`, `sync_helpers_test.go`, plus EXDATE/all-day/undo cases in `event`/`ical`.
- `go build ./...` clean, `go test ./...` fully green.

## Known limitation (intentionally left)
Undoing a *second* instance-delete on an already-excluded slot can resurrect an override the first (un-undone) delete soft-deleted. Not reachable via the TUI (the excluded slot shows no occurrence to delete twice) and strictly narrower than the pre-PR behavior, which restored *all* overrides for the UID.
