### PR TITLE
chore(nix): update vendorHash after sqlite 1.53.0 bump

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
 
           src = ./.;
           subPackages = [ "cmd/chroncal" ];
-          vendorHash = "sha256-PG3ypEmqskvn94/AS866Z8ZvxwMP9I7cIBntkogZheg=";
+          vendorHash = "sha256-b7jr+tG8ACbjaQ7txUaYXyy5e3ch65aNWDQzXpeLRz4=";
 
           nativeBuildInputs = [ go ];
           env.CGO_ENABLED = "0";


### PR DESCRIPTION
The Dependabot bump of `modernc.org/sqlite` 1.52.0 → 1.53.0 (`9a1b26d`) changed `go.sum` without updating the flake's `vendorHash`, so the **Nix flake build on master is currently failing** with a go-modules hash mismatch.

Updates `vendorHash` to the value Nix computes for the new `go.sum` (`sha256-b7jr…`).

This unblocks the Nix check for master and all open PRs. Recommend landing first.