### PR TITLE
fix(caldav): strip credentials on cross-host redirects

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -41,9 +41,28 @@ type Change struct {
 
 const defaultHTTPTimeout = 30 * time.Second
 const maxHTTPResponseBytes = 8 << 20
+const maxRedirects = 10
 
-var defaultHTTPClient = &http.Client{Timeout: defaultHTTPTimeout}
+var defaultHTTPClient = &http.Client{
+	Timeout:       defaultHTTPTimeout,
+	CheckRedirect: checkRedirect,
+}
 var errResponseTooLarge = errors.New("caldav response exceeds configured limits")
+
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+	if len(via) > 0 && !sameRedirectHost(req.URL, via[0].URL) {
+		req.Header.Del("Authorization")
+		req.Header.Del("Cookie")
+	}
+	return nil
+}
+
+func sameRedirectHost(a, b *url.URL) bool {
+	return strings.EqualFold(a.Host, b.Host)
+}
 
 // Client wraps the go-webdav CalDAV client with error handling and auth.
 type Client struct {

--- a/internal/caldav/redirect_test.go
+++ b/internal/caldav/redirect_test.go
@@ -1,0 +1,174 @@
+package caldav
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDefaultHTTPClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerAuth atomic.Value // string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer attacker.Close()
+
+	legit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/catch", http.StatusFound)
+	}))
+	defer legit.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, legit.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.SetBasicAuth("alice", "s3cr3t")
+
+	resp, err := defaultHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := attackerAuth.Load().(string); got != "" {
+		t.Fatalf("cross-host redirect leaked Authorization header = %q, want empty", got)
+	}
+}
+
+func TestBearerAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerAuth atomic.Value // string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer attacker.Close()
+
+	legit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/catch", http.StatusFound)
+	}))
+	defer legit.Close()
+
+	client, err := NewBearerAuthClient(legit.URL, "token")
+	if err != nil {
+		t.Fatalf("NewBearerAuthClient: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, legit.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := client.HTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := attackerAuth.Load().(string); got != "" {
+		t.Fatalf("cross-host redirect leaked bearer Authorization header = %q, want empty", got)
+	}
+}
+
+func TestBasicAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var attackerAuth atomic.Value // string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer attacker.Close()
+
+	legit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/catch", http.StatusFound)
+	}))
+	defer legit.Close()
+
+	client, err := NewBasicAuthClient(legit.URL, "alice", "s3cr3t")
+	if err != nil {
+		t.Fatalf("NewBasicAuthClient: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, legit.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := client.HTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := attackerAuth.Load().(string); got != "" {
+		t.Fatalf("cross-host redirect leaked basic Authorization header = %q, want empty", got)
+	}
+}
+
+func TestDefaultHTTPClientKeepsAuthOnSameHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var seenAuth atomic.Value // string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			http.Redirect(w, r, "/step2", http.StatusFound)
+			return
+		}
+		seenAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.SetBasicAuth("alice", "s3cr3t")
+
+	resp, err := defaultHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := seenAuth.Load().(string); got == "" {
+		t.Fatal("same-host redirect stripped Authorization header, want it preserved")
+	}
+}
+
+func TestDefaultHTTPClientCapsRedirects(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.String(), http.StatusFound)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := defaultHTTPClient.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("Do err = nil, want redirect-cap error")
+	}
+}
+
+func TestDefaultHTTPClientHasRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	if defaultHTTPClient.CheckRedirect == nil {
+		t.Fatal("defaultHTTPClient.CheckRedirect = nil, want a policy that strips credentials on cross-host redirects")
+	}
+}


### PR DESCRIPTION
## Security fix

The shared CalDAV HTTP clients followed redirects with no policy, so a malicious or misconfigured server could `302` a request to another host and receive the `Authorization` (basic or bearer) and `Cookie` headers.

Installs a `CheckRedirect` that drops `Authorization` and `Cookie` when the next hop's host differs from the original, and caps the redirect chain at 10. Same-host redirects still carry credentials.

New regression tests cover basic/bearer/default clients on cross-host redirects, same-host preservation, and the redirect cap.

_Split out of #49 (one independent fix per PR). Nix check will go green once #50 lands._