### PR TITLE
fix(storage): propagate DB errors in sync helpers

### DIFF
--- a/internal/storage/sync_helpers.go
+++ b/internal/storage/sync_helpers.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 )
 
 // MarkResourceDirty marks a resource as needing sync. If the calendar is
@@ -15,13 +16,19 @@ func MarkResourceDirty(ctx context.Context, db *sql.DB, calendarID int64, uid, o
 	}
 	// Only act if the calendar is linked to an account.
 	var accountID *int64
-	_ = db.QueryRowContext(ctx,
+	err := db.QueryRowContext(ctx,
 		`SELECT account_id FROM calendars WHERE id = ?`, calendarID,
 	).Scan(&accountID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
 	if accountID == nil || *accountID == 0 {
 		return nil
 	}
-	_, err := db.ExecContext(ctx,
+	_, err = db.ExecContext(ctx,
 		`INSERT INTO sync_resources (calendar_id, uid, owner_type, dirty, sync_strategy)
 		 VALUES (?, ?, ?, 1, 'sync-token')
 		 ON CONFLICT(calendar_id, uid) DO UPDATE SET dirty = 1`,
@@ -42,7 +49,13 @@ func CreateTombstoneIfSynced(ctx context.Context, db *sql.DB, calendarID int64, 
 		`SELECT remote_url FROM sync_resources WHERE calendar_id = ? AND uid = ?`,
 		calendarID, uid,
 	).Scan(&remoteURL)
-	if err != nil || remoteURL == "" {
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if remoteURL == "" {
 		return false, nil
 	}
 	_, err = db.ExecContext(ctx,

--- a/internal/storage/sync_helpers_test.go
+++ b/internal/storage/sync_helpers_test.go
@@ -19,6 +19,21 @@ func TestMarkResourceDirty_NoopWhenNoSyncResource(t *testing.T) {
 	}
 }
 
+func TestMarkResourceDirty_ReturnsCalendarLookupError(t *testing.T) {
+	db, _, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	err = MarkResourceDirty(context.Background(), db, 1, "uid", "event")
+	if err == nil {
+		t.Fatal("MarkResourceDirty err = nil, want database error")
+	}
+}
+
 func TestMarkResourceDirty_SkipsZeroCalendarOrEmptyUID(t *testing.T) {
 	db, _, err := Open(":memory:")
 	if err != nil {
@@ -48,6 +63,24 @@ func TestCreateTombstoneIfSynced_NoopWhenNotSynced(t *testing.T) {
 	}
 	if created {
 		t.Error("should not create tombstone when no sync resource exists")
+	}
+}
+
+func TestCreateTombstoneIfSynced_ReturnsSyncResourceLookupError(t *testing.T) {
+	db, _, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	created, err := CreateTombstoneIfSynced(context.Background(), db, 1, "uid")
+	if err == nil {
+		t.Fatal("CreateTombstoneIfSynced err = nil, want database error")
+	}
+	if created {
+		t.Fatal("CreateTombstoneIfSynced created = true, want false on database error")
 	}
 }
 


### PR DESCRIPTION
`MarkResourceDirty` swallowed the `calendars` lookup error and `CreateTombstoneIfSynced` swallowed every error from the `sync_resources` lookup, both collapsing real DB failures into a silent no-op. Now they distinguish `sql.ErrNoRows` (genuine no-op) from real errors and return the latter so callers can surface them.

New tests assert both helpers return an error on a closed DB.

_Split out of #49. Nix check will go green once #50 lands._