### PR TITLE
fix(event): restore overridden occurrence when undoing instance delete

### DIFF
--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -13,6 +13,11 @@ SELECT * FROM events
 WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NULL
 ORDER BY recurrence_id;
 
+-- name: ListDeletedOverrideRecurrenceIDs :many
+SELECT recurrence_id FROM events
+WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NOT NULL
+ORDER BY recurrence_id;
+
 -- name: GetEvent :one
 SELECT * FROM events WHERE id = ? AND deleted_at IS NULL;
 
@@ -128,6 +133,13 @@ UPDATE events SET
     sequence = sequence + 1,
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE uid = ? AND recurrence_id != '' AND recurrence_id >= ? AND deleted_at IS NOT NULL;
+
+-- name: RestoreEventByUIDAndRecurrenceID :exec
+UPDATE events SET
+    deleted_at = NULL,
+    sequence = sequence + 1,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE uid = ? AND recurrence_id = ? AND deleted_at IS NOT NULL;
 
 -- name: PurgeSoftDeletedEvents :execrows
 DELETE FROM events WHERE deleted_at IS NOT NULL AND deleted_at < ?;

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
 
 // ErrNotDeleted is returned by Restore when the target row is not soft-deleted
@@ -41,6 +42,9 @@ type UndoMeta struct {
 	UID       string
 	Label     string
 	DeletedAt time.Time
+
+	// UndoKindSingle only, when undoing DeleteInstanceWithUndo.
+	RecurrenceID string
 
 	// UndoKindFromInstance only.
 	MasterRRuleBefore   string
@@ -81,10 +85,11 @@ func (s *Service) DeleteInstanceWithUndo(ctx context.Context, uid string, instan
 		return UndoMeta{}, err
 	}
 	return UndoMeta{
-		Kind:      UndoKindSingle,
-		UID:       uid,
-		Label:     label,
-		DeletedAt: time.Now().UTC(),
+		Kind:         UndoKindSingle,
+		UID:          uid,
+		Label:        label,
+		DeletedAt:    time.Now().UTC(),
+		RecurrenceID: instanceTime.UTC().Format(time.RFC3339),
 	}, nil
 }
 
@@ -137,7 +142,7 @@ func (s *Service) DeleteSeriesWithUndo(ctx context.Context, uid string) (UndoMet
 func (s *Service) RestoreUndo(ctx context.Context, meta UndoMeta) error {
 	switch meta.Kind {
 	case UndoKindSingle:
-		return s.restoreSingle(ctx, meta.UID)
+		return s.restoreSingle(ctx, meta.UID, meta.RecurrenceID)
 	case UndoKindSeries:
 		return s.restoreSeries(ctx, meta.UID)
 	case UndoKindFromInstance:
@@ -154,8 +159,8 @@ func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get master: %w", err)
 	}
-	if err := s.q.RestoreEventsByUID(ctx, uid); err != nil {
-		return fmt.Errorf("restore by uid: %w", err)
+	if err := s.restoreEventsByUIDClearingExdates(ctx, uid); err != nil {
+		return err
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
@@ -176,6 +181,12 @@ func (s *Service) RestoreByID(ctx context.Context, id int64) error {
 	}
 	if r.DeletedAt == nil || *r.DeletedAt == "" {
 		return ErrNotDeleted
+	}
+	if r.RecurrenceID != "" {
+		if err := s.restoreOverrideByID(ctx, r); err != nil {
+			return err
+		}
+		return s.reconcileSyncAfterRestore(ctx, r.CalendarID, r.Uid)
 	}
 	if err := s.q.RestoreEvent(ctx, id); err != nil {
 		return fmt.Errorf("restore event: %w", err)
@@ -233,21 +244,27 @@ func (s *Service) PurgeByID(ctx context.Context, id int64) error {
 // override, callers should fall back to RestoreByUID since we don't know the
 // recurrence_id. UndoKindSingle always targets the master UID, so this
 // finds the master.
-func (s *Service) restoreSingle(ctx context.Context, uid string) error {
+func (s *Service) restoreSingle(ctx context.Context, uid, recurrenceID string) error {
 	r, err := s.q.GetEventByUIDIncludingDeleted(ctx, uid)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// Might be an override-only delete where the master UID has no
 			// master row; fall back to UID-wide restore.
-			return s.restoreSeries(ctx, uid)
+			return s.restoreEventsByUIDClearingExdates(ctx, uid)
 		}
 		return err
 	}
 	if r.DeletedAt == nil || *r.DeletedAt == "" {
+		if recurrenceID != "" {
+			if err := s.restoreEXDATEOnly(ctx, uid, recurrenceID, r.CalendarID); err != nil {
+				return err
+			}
+			return nil
+		}
 		// Master is live; an override was probably the thing deleted.
 		// Fall back to RestoreByUID which un-hides any deleted overrides
 		// sharing this UID.
-		return s.q.RestoreEventsByUID(ctx, uid)
+		return s.restoreEventsByUIDClearingExdates(ctx, uid)
 	}
 	if err := s.q.RestoreEvent(ctx, r.ID); err != nil {
 		return err
@@ -261,11 +278,114 @@ func (s *Service) restoreSeries(ctx context.Context, uid string) error {
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
-	if err := s.q.RestoreEventsByUID(ctx, uid); err != nil {
+	if err := s.restoreEventsByUIDClearingExdates(ctx, uid); err != nil {
 		return err
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
+	}
+	return nil
+}
+
+func (s *Service) restoreOverrideByID(ctx context.Context, r storage.Event) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	if err := qtx.RestoreEvent(ctx, r.ID); err != nil {
+		return fmt.Errorf("restore event: %w", err)
+	}
+	if err := clearMasterEXDATE(ctx, qtx, r.Uid, r.RecurrenceID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Service) restoreEXDATEOnly(ctx context.Context, uid, recurrenceID string, calendarID int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	// DeleteInstance soft-deletes the override at this recurrence_id (if one
+	// existed) alongside adding the EXDATE; un-hide it so undo restores the
+	// customized occurrence, not just the base instance. No-ops when the
+	// deleted instance had no override.
+	if err := qtx.RestoreEventByUIDAndRecurrenceID(ctx, storage.RestoreEventByUIDAndRecurrenceIDParams{
+		Uid:          uid,
+		RecurrenceID: recurrenceID,
+	}); err != nil {
+		return fmt.Errorf("restore override: %w", err)
+	}
+	if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return s.reconcileSyncAfterRestore(ctx, calendarID, uid)
+}
+
+func (s *Service) restoreEventsByUIDClearingExdates(ctx context.Context, uid string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	recurrenceIDs, err := qtx.ListDeletedOverrideRecurrenceIDs(ctx, uid)
+	if err != nil {
+		return fmt.Errorf("list deleted override recurrence ids: %w", err)
+	}
+	if err := qtx.RestoreEventsByUID(ctx, uid); err != nil {
+		return fmt.Errorf("restore by uid: %w", err)
+	}
+	for _, recurrenceID := range recurrenceIDs {
+		if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
+	master, err := qtx.GetEventByUID(ctx, uid)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("get master: %w", err)
+	}
+	target, err := timeutil.ParseRecurrenceID(recurrenceID)
+	if err != nil {
+		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
+	}
+	existing := ParseTimeList(storage.NullableToString(master.Exdates))
+	filtered := removeTimeFromList(existing, target)
+	if len(filtered) != len(existing) {
+		if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
+			Exdates: storage.StringToNullable(SerializeTimeList(filtered)),
+			ID:      master.ID,
+		}); err != nil {
+			return fmt.Errorf("update exdates: %w", err)
+		}
+	}
+	log, err := qtx.GetEventExdateDeleteByUIDRecurrence(ctx, storage.GetEventExdateDeleteByUIDRecurrenceParams{
+		Uid:          uid,
+		RecurrenceID: recurrenceID,
+	})
+	if err == nil {
+		if err := qtx.DeleteEventExdateDelete(ctx, log.ID); err != nil {
+			return fmt.Errorf("delete exdate log: %w", err)
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get exdate log: %w", err)
 	}
 	return nil
 }

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -102,6 +102,149 @@ func TestSoftDelete_Series(t *testing.T) {
 	}
 }
 
+func TestSoftDelete_RestoreOverrideByIDClearsMasterEXDATE(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "restore-override-exdate",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Review (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: "2026-04-08T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	if err := svc.Delete(ctx, override.ID); err != nil {
+		t.Fatalf("Delete override: %v", err)
+	}
+	deletedMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after delete: %v", err)
+	}
+	if got := len(deletedMaster.ParseExDates()); got != 1 {
+		t.Fatalf("EXDATE count after delete = %d, want 1", got)
+	}
+
+	if err := svc.RestoreByID(ctx, override.ID); err != nil {
+		t.Fatalf("RestoreByID override: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("Get override after restore: %v", err)
+	}
+	restoredMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if got := len(restoredMaster.ParseExDates()); got != 0 {
+		t.Fatalf("EXDATE count after restore = %d, want 0 (%q)", got, restoredMaster.ExDates)
+	}
+}
+
+func TestSoftDelete_RestoreByUIDClearsOverrideEXDATEs(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "restore-uid-exdates",
+		CalendarID:     1,
+		Title:          "Weekly Sync",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Sync (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: "2026-04-08T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	if err := svc.Delete(ctx, override.ID); err != nil {
+		t.Fatalf("Delete override: %v", err)
+	}
+	if err := svc.RestoreByUID(ctx, master.UID); err != nil {
+		t.Fatalf("RestoreByUID: %v", err)
+	}
+	restoredMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if got := len(restoredMaster.ParseExDates()); got != 0 {
+		t.Fatalf("EXDATE count after RestoreByUID = %d, want 0 (%q)", got, restoredMaster.ExDates)
+	}
+}
+
+func TestSoftDelete_RestoreUndoDeleteInstanceClearsEXDATE(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "undo-instance-exdate",
+		CalendarID:     1,
+		Title:          "Office Hours",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	instance := time.Date(2026, 4, 8, 9, 0, 0, 0, time.UTC)
+
+	meta, err := svc.DeleteInstanceWithUndo(ctx, master.UID, instance)
+	if err != nil {
+		t.Fatalf("DeleteInstanceWithUndo: %v", err)
+	}
+	deletedMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after delete: %v", err)
+	}
+	if got := len(deletedMaster.ParseExDates()); got != 1 {
+		t.Fatalf("EXDATE count after delete = %d, want 1", got)
+	}
+
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+	restoredMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if got := len(restoredMaster.ParseExDates()); got != 0 {
+		t.Fatalf("EXDATE count after RestoreUndo = %d, want 0 (%q)", got, restoredMaster.ExDates)
+	}
+	trash, err := svc.ListTrash(ctx, 1)
+	if err != nil {
+		t.Fatalf("ListTrash: %v", err)
+	}
+	if len(trash) != 0 {
+		t.Fatalf("trash entries after RestoreUndo = %d, want 0", len(trash))
+	}
+}
+
 // TestSoftDelete_FromInstance_RRULE verifies DeleteFromInstanceWithUndo
 // captures the pre-truncation RRULE and RestoreUndo rewrites it back.
 func TestSoftDelete_FromInstance_RRULE(t *testing.T) {
@@ -298,5 +441,57 @@ func TestSoftDelete_SequenceBumpedOnRestore(t *testing.T) {
 	}
 	if restored.Sequence <= originalSeq {
 		t.Fatalf("Sequence not bumped: before=%d after=%d", originalSeq, restored.Sequence)
+	}
+}
+
+// TestSoftDelete_UndoInstanceDeletePreservesPreexistingEXDATE verifies that
+// undoing a single-instance delete removes only the EXDATE that delete added,
+// leaving a pre-existing exclusion for the same slot intact. The "EXDATE +
+// live override at the same slot" shape arrives via import/sync; without
+// remove-one semantics the undo would strip both EXDATEs and the base
+// occurrence could resurface once the override is later removed.
+func TestSoftDelete_UndoInstanceDeletePreservesPreexistingEXDATE(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	const slot = "2026-04-08T10:00:00Z"
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "preexisting-exdate",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+		ExDates:        slot, // pre-existing exclusion at the same slot
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	if _, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Review (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: slot,
+	}); err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	instance := time.Date(2026, 4, 8, 10, 0, 0, 0, time.UTC)
+	meta, err := svc.DeleteInstanceWithUndo(ctx, master.UID, instance)
+	if err != nil {
+		t.Fatalf("DeleteInstanceWithUndo: %v", err)
+	}
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+
+	restoredMaster, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if got := len(restoredMaster.ParseExDates()); got != 1 {
+		t.Fatalf("EXDATE count after undo = %d, want 1 (pre-existing exclusion preserved) (%q)", got, restoredMaster.ExDates)
 	}
 }

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -328,13 +328,18 @@ func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) err
 	return nil
 }
 
-// removeTimeFromList returns list with every element equal to target (after
-// UTC normalization) removed. Used to reverse an EXDATE insertion.
+// removeTimeFromList returns list with the first element equal to target
+// (after UTC normalization) removed. Used to reverse a single EXDATE
+// insertion: DeleteInstance appends one EXDATE per delete, so undo must drop
+// exactly one — removing every match would discard a pre-existing exclusion
+// for the same slot (e.g. an imported EXDATE alongside a detached override).
 func removeTimeFromList(list []time.Time, target time.Time) []time.Time {
 	out := make([]time.Time, 0, len(list))
 	targetKey := target.UTC().Format(time.RFC3339)
+	removed := false
 	for _, t := range list {
-		if strings.EqualFold(t.UTC().Format(time.RFC3339), targetKey) {
+		if !removed && strings.EqualFold(t.UTC().Format(time.RFC3339), targetKey) {
+			removed = true
 			continue
 		}
 		out = append(out, t)

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -373,6 +373,35 @@ func (q *Queries) ListDeletedEventsByCalendar(ctx context.Context, calendarID in
 	return items, nil
 }
 
+const listDeletedOverrideRecurrenceIDs = `-- name: ListDeletedOverrideRecurrenceIDs :many
+SELECT recurrence_id FROM events
+WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NOT NULL
+ORDER BY recurrence_id
+`
+
+func (q *Queries) ListDeletedOverrideRecurrenceIDs(ctx context.Context, uid string) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listDeletedOverrideRecurrenceIDs, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var recurrence_id string
+		if err := rows.Scan(&recurrence_id); err != nil {
+			return nil, err
+		}
+		items = append(items, recurrence_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listEventsByCalendarAndDateRange = `-- name: ListEventsByCalendarAndDateRange :many
 SELECT id, uid, calendar_id, title, description, location, start_time, end_time, all_day, recurrence_rule, timezone, status, transp, sequence, priority, class, url, exdates, rdates, recurrence_id, geo, created_at, updated_at, duration, dtstamp, conference_uri, deleted_at FROM events
 WHERE calendar_id = ? AND start_time < ? AND end_time > ? AND deleted_at IS NULL
@@ -644,6 +673,24 @@ WHERE id = ? AND deleted_at IS NOT NULL
 
 func (q *Queries) RestoreEvent(ctx context.Context, id int64) error {
 	_, err := q.db.ExecContext(ctx, restoreEvent, id)
+	return err
+}
+
+const restoreEventByUIDAndRecurrenceID = `-- name: RestoreEventByUIDAndRecurrenceID :exec
+UPDATE events SET
+    deleted_at = NULL,
+    sequence = sequence + 1,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE uid = ? AND recurrence_id = ? AND deleted_at IS NOT NULL
+`
+
+type RestoreEventByUIDAndRecurrenceIDParams struct {
+	Uid          string
+	RecurrenceID string
+}
+
+func (q *Queries) RestoreEventByUIDAndRecurrenceID(ctx context.Context, arg RestoreEventByUIDAndRecurrenceIDParams) error {
+	_, err := q.db.ExecContext(ctx, restoreEventByUIDAndRecurrenceID, arg.Uid, arg.RecurrenceID)
 	return err
 }
 


### PR DESCRIPTION
Deleting a recurring instance soft-deletes the override at that slot and adds an `EXDATE` to the master. Undo cleared the `EXDATE` but left the override hidden, so a moved/edited occurrence was **silently lost** and the base instance reappeared. `restoreEXDATEOnly` now also un-hides the override at `(uid, recurrence_id)` via a new targeted `RestoreEventByUIDAndRecurrenceID` query.

Also fixes `removeTimeFromList` to drop only the **first** matching `EXDATE`: `DeleteInstance` appends exactly one per delete, so undo must remove one, not every match — otherwise a pre-existing exclusion for the same slot (imported `EXDATE` alongside a detached override) would be lost and the base occurrence could resurface after sync.

New tests cover override restoration on undo, RestoreByUID/RestoreByID EXDATE clearing, and the pre-existing-EXDATE preservation case.

_Split out of #49. Nix check will go green once #50 lands._