### PR TITLE
fix(ical): keep calendar date for all-day events on export

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -235,11 +235,11 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 	useDuration := e.DurationValue != ""
 
 	if e.AllDay {
-		vevent.Props.SetDate(ical.PropDateTimeStart, e.StartTime)
+		vevent.Props.SetDate(ical.PropDateTimeStart, allDayExportDate(e.StartTime, e.Timezone))
 		if useDuration {
 			setPropDuration(vevent, e.DurationValue)
 		} else {
-			vevent.Props.SetDate(ical.PropDateTimeEnd, e.EndTime)
+			vevent.Props.SetDate(ical.PropDateTimeEnd, allDayExportDate(e.EndTime, e.Timezone))
 		}
 	} else if e.Timezone == "FLOATING" {
 		local := e.StartTime.Local()
@@ -281,6 +281,28 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 			vevent.Props.SetDateTime(ical.PropDateTimeEnd, e.EndTime.UTC())
 		}
 	}
+}
+
+func allDayExportDate(t time.Time, timezone string) time.Time {
+	// A stored instant already at midnight UTC carries its calendar date
+	// directly (the TUI stores all-day events as midnight UTC, regardless of
+	// the event's Timezone). Converting it into another zone would shift the
+	// date — e.g. 2026-04-15T00:00Z in America/New_York is 2026-04-14.
+	if t.Location() == time.UTC && t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+		return t
+	}
+	if timezone != "" && timezone != "FLOATING" {
+		if loc, err := time.LoadLocation(timezone); err == nil {
+			return t.In(loc)
+		}
+	}
+	if t.Location() != time.UTC {
+		return t
+	}
+	if t.Hour() != 0 || t.Minute() != 0 || t.Second() != 0 || t.Nanosecond() != 0 {
+		return t.In(time.Local)
+	}
+	return t.UTC()
 }
 
 func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -140,6 +140,39 @@ func TestExport_AllDayEvent_PositiveUTCOffset(t *testing.T) {
 	}
 }
 
+func TestExport_AllDayEvent_StoredUTCInstantUsesLocalDate(t *testing.T) {
+	prevLocal := time.Local
+	time.Local = time.FixedZone("UTC+12", 12*60*60)
+	t.Cleanup(func() { time.Local = prevLocal })
+
+	// This is how a UTC-normalized all-day 2026-04-15 in UTC+12 is stored:
+	// local midnight is the previous UTC date at 12:00. Export must preserve the
+	// calendar date, not the UTC date of the stored instant.
+	events := []event.Event{{
+		UID:       "allday-stored-utc",
+		Title:     "Stored Auckland Day",
+		StartTime: time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC),
+		AllDay:    true,
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}}
+
+	data, err := ExportEvents(events, "")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	ics := string(data)
+	if !strings.Contains(ics, "DTSTART;VALUE=DATE:20260415") {
+		t.Fatalf("expected DTSTART date 20260415, got:\n%s", ics)
+	}
+	if !strings.Contains(ics, "DTEND;VALUE=DATE:20260416") {
+		t.Fatalf("expected DTEND date 20260416, got:\n%s", ics)
+	}
+}
+
 func TestExport_MultipleExdatesRdates(t *testing.T) {
 	t.Parallel()
 	events := []event.Event{{


### PR DESCRIPTION
All-day events created in the TUI are stored at midnight UTC while also carrying an IANA `Timezone`. `allDayExportDate` converted that instant into the zone, shifting `DTSTART`/`DTEND` a day earlier for negative-offset zones (e.g. `2026-04-15T00:00Z` in `America/New_York` exported as `20260414`).

Short-circuits when the stored instant is already midnight UTC and emits its calendar date directly. The UTC-equivalent-of-local-midnight path is unchanged. New test covers the IANA-timezone all-day case.

_Split out of #49. Nix check will go green once #50 lands._