### PR TITLE
fix(ical): honor TZID on EXDATE/RDATE round-trip

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -723,11 +723,29 @@ func parseCategoriesFromProps(props ical.Props) string {
 func parseDateListFromProps(props ical.Props, propName string) string {
 	var dates []string
 	for _, prop := range props.Values(propName) {
+		var loc *time.Location
+		if tzid := prop.Params.Get(ical.ParamTimezoneID); tzid != "" {
+			if loaded, err := time.LoadLocation(tzid); err == nil {
+				loc = loaded
+			}
+		}
 		parts := strings.Split(prop.Value, ",")
 		for _, p := range parts {
 			p = strings.TrimSpace(p)
 			if p == "" {
 				continue
+			}
+			if strings.EqualFold(prop.Params.Get("VALUE"), "DATE") {
+				if t, err := time.Parse("20060102", p); err == nil {
+					dates = append(dates, t.Format("2006-01-02"))
+				}
+				continue
+			}
+			if loc != nil {
+				if t, err := time.ParseInLocation("20060102T150405", p, loc); err == nil {
+					dates = append(dates, t.UTC().Format(time.RFC3339))
+					continue
+				}
 			}
 			for _, layout := range []string{
 				"20060102T150405Z",

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -205,6 +205,38 @@ func TestImport_FullEvent(t *testing.T) {
 	}
 }
 
+func TestImport_EventEXDATEAndRDATERespectTZID(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:tzid-exdate-rdate
+DTSTAMP:20260401T100000Z
+DTSTART;TZID=America/New_York:20260401T090000
+DTEND;TZID=America/New_York:20260401T100000
+RRULE:FREQ=WEEKLY;COUNT=3
+EXDATE;TZID=America/New_York:20260408T090000
+RDATE;TZID=America/New_York:20260422T090000
+SUMMARY:TZID recurrence dates
+END:VEVENT
+END:VCALENDAR`
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	e := result.Events[0]
+	if e.ExDates != "2026-04-08T13:00:00Z" {
+		t.Fatalf("ExDates = %q, want 2026-04-08T13:00:00Z", e.ExDates)
+	}
+	if e.RDates != "2026-04-22T13:00:00Z" {
+		t.Fatalf("RDates = %q, want 2026-04-22T13:00:00Z", e.RDates)
+	}
+}
+
 func TestImport_AllDayEvent(t *testing.T) {
 	t.Parallel()
 	result, _ := ImportFile(strings.NewReader(allDayEventICS))

--- a/internal/ical/vtimezone.go
+++ b/internal/ical/vtimezone.go
@@ -140,10 +140,23 @@ func resolveComponentTZIDs(comp *goical.Component, tzMap map[string]*time.Locati
 			return
 		}
 		// VTIMEZONE-derived fixed zone — parse using the offset and rewrite as UTC.
+		// EXDATE/RDATE may carry a comma-separated list of datetimes in a single
+		// value, so convert each element. Only rewrite if every element parses,
+		// otherwise leave the value untouched.
 		if loc, ok := tzMap[tzid]; ok {
-			t, err := time.ParseInLocation("20060102T150405", p.Value, loc)
-			if err == nil {
-				p.Value = t.UTC().Format("20060102T150405Z")
+			parts := strings.Split(p.Value, ",")
+			converted := make([]string, len(parts))
+			allOK := true
+			for i, part := range parts {
+				t, err := time.ParseInLocation("20060102T150405", strings.TrimSpace(part), loc)
+				if err != nil {
+					allOK = false
+					break
+				}
+				converted[i] = t.UTC().Format("20060102T150405Z")
+			}
+			if allOK {
+				p.Value = strings.Join(converted, ",")
 				p.Params.Del(goical.ParamTimezoneID)
 			}
 		}
@@ -153,8 +166,16 @@ func resolveComponentTZIDs(comp *goical.Component, tzMap map[string]*time.Locati
 		goical.PropDateTimeStart,
 		goical.PropDateTimeEnd,
 		goical.PropDue,
+		goical.PropExceptionDates,
+		goical.PropRecurrenceDates,
+		goical.PropRecurrenceID,
 	} {
-		resolvePropTZID(comp.Props.Get(propName))
+		key := strings.ToUpper(propName)
+		props := comp.Props[key]
+		for i := range props {
+			resolvePropTZID(&props[i])
+		}
+		comp.Props[key] = props
 	}
 
 	// Also resolve TRIGGER TZIDs in VALARM sub-components.


### PR DESCRIPTION
`EXDATE`/`RDATE` values carrying a `TZID` were parsed as UTC on import, and `resolveComponentTZIDs` only rewrote the first value of `DTSTART`/`DTEND`/`DUE`, ignoring `EXDATE`, `RDATE` and `RECURRENCE-ID`. A VTIMEZONE-derived zone with a comma-separated multi-value `EXDATE` was left mis-parsed, so excluded instances reappeared.

`parseDateListFromProps` now resolves the `TZID` and parses in that location; `resolveComponentTZIDs` iterates every value (and the expanded prop set) and splits comma-separated lists, converting each element to UTC. New test covers TZID-qualified EXDATE/RDATE import.

_Split out of #49. Nix check will go green once #50 lands._