### PR TITLE
feat(tui): make event Where field clickable when it holds a link

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -349,16 +349,16 @@ type Model struct {
 	// by m.events so agenda expansion can query only the newly-added
 	// slice instead of re-querying the whole window each time. Zero values
 	// mean "no prior load" and force a full refresh.
-	loadedFrom     time.Time
-	loadedTo       time.Time
-	calendars      map[int64]CalendarInfo
+	loadedFrom time.Time
+	loadedTo   time.Time
+	calendars  map[int64]CalendarInfo
 	// pendingOrder holds an optimistic sidebar order (calendar ID → position)
 	// for a reorder whose async SetOrder has not yet confirmed. It is overlaid
 	// onto reloads so an interleaved loadCalendars (e.g. a sync finishing
 	// mid-save) can't snap calendars back to the stale DB order, and cleared
 	// once calendarOrderSavedMsg confirms the write.
-	pendingOrder map[int64]int64
-	dialog       EventDialogModel
+	pendingOrder   map[int64]int64
+	dialog         EventDialogModel
 	dialogOpen     bool
 	viewDialog     EventViewDialogModel
 	viewDialogOpen bool

--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -786,8 +786,8 @@ func eventDetailLines(ev event.Event, cal CalendarInfo, w, labelWidth int, rsvpL
 }
 
 func detailLine(labelStyle lipgloss.Style, label, value string, lw, w int) string {
-	padded := strings.Repeat(" ", max(lw-len(label), 0)) + label
-	return truncateTo(labelStyle.Render(padded)+"  "+value, w)
+	prefix, _ := detailLabelPrefix(labelStyle, label, lw, w)
+	return truncateTo(prefix+value, w)
 }
 
 // labelColWidth returns the on-screen cell width consumed by the label column

--- a/internal/tui/event_view_dialog.go
+++ b/internal/tui/event_view_dialog.go
@@ -393,15 +393,50 @@ func (m EventViewDialogModel) handleMouse(msg tea.MouseClickMsg) (EventViewDialo
 	return m, nil
 }
 
+// detailLabelPrefix renders the right-aligned label column plus its two-space
+// gap and returns the rendered prefix together with the cell width left for
+// the value. Shared by the link detail-line helpers so the column math lives
+// in one place.
+func detailLabelPrefix(labelStyle lipgloss.Style, label string, lw, w int) (prefix string, available int) {
+	padded := strings.Repeat(" ", max(lw-len(label), 0)) + label
+	return labelStyle.Render(padded) + "  ", w - labelColWidth(label, lw)
+}
+
 // detailLinkLine is detailLine for values that should be rendered as a
 // clickable link. The visible URL text is sized to the available column
 // width while the OSC 8 target and mouse-zone payload stay the full URL —
 // or its rewriter output when the calendar has one (e.g., Google authuser).
 func detailLinkLine(labelStyle lipgloss.Style, label, url string, lw, w int, rw urlRewriter) string {
-	padded := strings.Repeat(" ", max(lw-len(label), 0)) + label
-	prefix := labelStyle.Render(padded) + "  "
-	available := w - labelColWidth(label, lw)
+	prefix, available := detailLabelPrefix(labelStyle, label, lw, w)
 	return prefix + renderLinkValue(url, available, rw)
+}
+
+// detailLinkifiedLine is detailLine for a free-text value that may contain a
+// URL somewhere inside it (e.g., "Room 4 — join at https://…"). The plain
+// value is truncated to the column width *first*, then linkified, so the OSC 8
+// and mouse-zone escapes are always emitted complete. (truncateTo cuts on the
+// stripped plain text and stripANSI does not understand OSC 8, so linkifying
+// before truncating would slice a hyperlink mid-sequence and leave it
+// unterminated — corrupting the rest of the dialog.)
+func detailLinkifiedLine(labelStyle lipgloss.Style, label, value string, lw, w int, rw urlRewriter) string {
+	prefix, available := detailLabelPrefix(labelStyle, label, lw, w)
+	return prefix + linkifyText(truncateTo(value, available), rw)
+}
+
+// isBareURL reports whether s is a single http/https URL with no surrounding
+// text. Such a value is best rendered via detailLinkLine, which keeps the full
+// URL as the click target while truncating only the visible text — truncating
+// it as free text would corrupt the click target. The check reuses urlPattern
+// (the package's canonical URL grammar) so "bare" means the same thing here as
+// it does in linkifyText: the whole trimmed value is one URL with no interior
+// whitespace or excluded characters.
+func isBareURL(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	loc := urlPattern.FindStringIndex(s)
+	return loc != nil && loc[0] == 0 && loc[1] == len(s)
 }
 
 // linkRewriter returns the URL rewriter to apply to clickable links in this
@@ -553,10 +588,14 @@ func (m EventViewDialogModel) buildBodyLines(w int) []string {
 		}
 		lines = append(lines, detailLine(faint, "Calendar", dot+" "+m.calendar.Name, eventViewLabelWidth, w))
 	}
-	if ev.Location != "" {
-		lines = append(lines, detailLine(faint, "Where", ev.Location, eventViewLabelWidth, w))
-	}
 	rw := m.linkRewriter()
+	if ev.Location != "" {
+		if isBareURL(ev.Location) {
+			lines = append(lines, detailLinkLine(faint, "Where", strings.TrimSpace(ev.Location), eventViewLabelWidth, w, rw))
+		} else {
+			lines = append(lines, detailLinkifiedLine(faint, "Where", ev.Location, eventViewLabelWidth, w, rw))
+		}
+	}
 	if ev.ConferenceURI != "" {
 		lines = append(lines, detailLinkLine(faint, "Conference", ev.ConferenceURI, eventViewLabelWidth, w, rw))
 	}

--- a/internal/tui/event_view_dialog.go
+++ b/internal/tui/event_view_dialog.go
@@ -412,31 +412,13 @@ func detailLinkLine(labelStyle lipgloss.Style, label, url string, lw, w int, rw 
 }
 
 // detailLinkifiedLine is detailLine for a free-text value that may contain a
-// URL somewhere inside it (e.g., "Room 4 — join at https://…"). The plain
-// value is truncated to the column width *first*, then linkified, so the OSC 8
-// and mouse-zone escapes are always emitted complete. (truncateTo cuts on the
-// stripped plain text and stripANSI does not understand OSC 8, so linkifying
-// before truncating would slice a hyperlink mid-sequence and leave it
-// unterminated — corrupting the rest of the dialog.)
+// URL somewhere inside it (e.g., "Room 4 — join at https://…") or be a bare
+// URL. renderLinkifiedValue makes each URL clickable while keeping its full
+// address as the click target, so the rendering is correct whether the value
+// is plain text, a bare URL, or text with an embedded link.
 func detailLinkifiedLine(labelStyle lipgloss.Style, label, value string, lw, w int, rw urlRewriter) string {
 	prefix, available := detailLabelPrefix(labelStyle, label, lw, w)
-	return prefix + linkifyText(truncateTo(value, available), rw)
-}
-
-// isBareURL reports whether s is a single http/https URL with no surrounding
-// text. Such a value is best rendered via detailLinkLine, which keeps the full
-// URL as the click target while truncating only the visible text — truncating
-// it as free text would corrupt the click target. The check reuses urlPattern
-// (the package's canonical URL grammar) so "bare" means the same thing here as
-// it does in linkifyText: the whole trimmed value is one URL with no interior
-// whitespace or excluded characters.
-func isBareURL(s string) bool {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return false
-	}
-	loc := urlPattern.FindStringIndex(s)
-	return loc != nil && loc[0] == 0 && loc[1] == len(s)
+	return prefix + renderLinkifiedValue(value, available, rw)
 }
 
 // linkRewriter returns the URL rewriter to apply to clickable links in this
@@ -590,11 +572,7 @@ func (m EventViewDialogModel) buildBodyLines(w int) []string {
 	}
 	rw := m.linkRewriter()
 	if ev.Location != "" {
-		if isBareURL(ev.Location) {
-			lines = append(lines, detailLinkLine(faint, "Where", strings.TrimSpace(ev.Location), eventViewLabelWidth, w, rw))
-		} else {
-			lines = append(lines, detailLinkifiedLine(faint, "Where", ev.Location, eventViewLabelWidth, w, rw))
-		}
+		lines = append(lines, detailLinkifiedLine(faint, "Where", ev.Location, eventViewLabelWidth, w, rw))
 	}
 	if ev.ConferenceURI != "" {
 		lines = append(lines, detailLinkLine(faint, "Conference", ev.ConferenceURI, eventViewLabelWidth, w, rw))

--- a/internal/tui/event_view_dialog_test.go
+++ b/internal/tui/event_view_dialog_test.go
@@ -104,6 +104,24 @@ func TestEventViewDialog_OverflowingLinkifiedLocationStaysTerminated(t *testing.
 		"OSC 8 hyperlink sequences must stay balanced after truncation")
 }
 
+func TestEventViewDialog_OverflowingEmbeddedURLKeepsFullClickTarget(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	ev := testViewEvent()
+	fullURL := "https://meet.example.com/" + strings.Repeat("abcdef", 12)
+	ev.Location = "Room 4: " + fullURL
+	cal := CalendarInfo{Name: "Work"}
+
+	// Narrow enough to ellipsize the visible URL text.
+	m := NewEventViewDialogModel(ev, cal, Theme{}).SetSize(60, 40)
+	out := m.View()
+
+	// Visible text is truncated, but the click target (OSC 8 + mouse zone)
+	// must stay the full URL — clicking an ellipsized link still opens the
+	// right place.
+	assert.Contains(t, out, "\x1b]8;;"+fullURL)
+	assert.True(t, hasMouseZone(defaultMouseTracker, linkZonePrefix+fullURL))
+}
+
 // hasMouseZone reports whether the render registered a clickable zone with the
 // given name. mouseSweep (run inside View) moves marked regions into zones.
 func hasMouseZone(mt *mouseTracker, name string) bool {

--- a/internal/tui/event_view_dialog_test.go
+++ b/internal/tui/event_view_dialog_test.go
@@ -43,6 +43,78 @@ func TestEventViewDialog_RendersCoreFields(t *testing.T) {
 	assert.Contains(t, out, "esc close")
 }
 
+func TestEventViewDialog_BareURLLocationIsClickable(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	ev := testViewEvent()
+	ev.Location = "https://zoom.us/j/123456789"
+	cal := CalendarInfo{Name: "Work"}
+
+	m := NewEventViewDialogModel(ev, cal, Theme{}).SetSize(120, 40)
+	out := m.View()
+
+	// OSC 8 hyperlink target carries the full URL (survives the render sweep).
+	assert.Contains(t, out, "\x1b]8;;"+ev.Location)
+	// The render registered a clickable mouse zone for the URL.
+	assert.True(t, hasMouseZone(defaultMouseTracker, linkZonePrefix+ev.Location))
+}
+
+func TestEventViewDialog_URLInsideLocationIsClickable(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	ev := testViewEvent()
+	ev.Location = "Room 4: https://meet.example.com/abc"
+	cal := CalendarInfo{Name: "Work"}
+
+	m := NewEventViewDialogModel(ev, cal, Theme{}).SetSize(160, 40)
+	out := m.View()
+
+	assert.Contains(t, out, "Room 4")
+	// The embedded URL is the OSC 8 / click target; surrounding text is plain.
+	assert.Contains(t, out, "\x1b]8;;https://meet.example.com/abc")
+	assert.True(t, hasMouseZone(defaultMouseTracker, linkZonePrefix+"https://meet.example.com/abc"))
+}
+
+func TestEventViewDialog_PlainTextLocationHasNoLink(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	ev := testViewEvent()
+	ev.Location = "Conference Room B"
+	cal := CalendarInfo{Name: "Work"}
+
+	m := NewEventViewDialogModel(ev, cal, Theme{}).SetSize(120, 40)
+	out := m.View()
+
+	assert.Contains(t, out, "Conference Room B")
+	assert.NotContains(t, out, "\x1b]8;;")
+}
+
+func TestEventViewDialog_OverflowingLinkifiedLocationStaysTerminated(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	ev := testViewEvent()
+	// A text+URL Location far wider than the dialog column, forcing truncation
+	// inside detailLinkifiedLine.
+	ev.Location = "Room 4: https://meet.example.com/" + strings.Repeat("abcdef", 12)
+	cal := CalendarInfo{Name: "Work"}
+
+	m := NewEventViewDialogModel(ev, cal, Theme{}).SetSize(60, 40)
+	out := m.View()
+
+	// Every OSC 8 sequence (open and close) starts with this introducer; a
+	// balanced (even) count means no hyperlink was sliced mid-sequence and
+	// left unterminated to corrupt the rest of the dialog.
+	assert.Equal(t, 0, strings.Count(out, "\x1b]8;;")%2,
+		"OSC 8 hyperlink sequences must stay balanced after truncation")
+}
+
+// hasMouseZone reports whether the render registered a clickable zone with the
+// given name. mouseSweep (run inside View) moves marked regions into zones.
+func hasMouseZone(mt *mouseTracker, name string) bool {
+	for _, z := range mt.zones {
+		if z.name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func TestEventViewDialog_ShowsRSVPForAttendee(t *testing.T) {
 	ev := testViewEvent()
 	ev.Attendees = []model.Attendee{

--- a/internal/tui/links.go
+++ b/internal/tui/links.go
@@ -136,6 +136,57 @@ func renderLinkValue(raw string, available int, rw urlRewriter) string {
 	return mouseMark(linkZonePrefix+target, hyperlink(target, visible))
 }
 
+// renderLinkifiedValue renders a free-text value that may contain URLs, sized
+// to `available` cells. The value is truncated to width first, so the OSC 8 /
+// mouse-zone escapes it emits are always complete (truncateTo cuts the plain
+// text and stripANSI does not understand OSC 8, so linkifying before
+// truncating could leave a hyperlink unterminated). Each URL keeps its FULL
+// address as the click target even when its visible text is ellipsized by the
+// truncation — so an overflowing embedded link still opens the right place,
+// the same full-target guarantee renderLinkValue gives bare-URL fields. The
+// optional rewriter transforms the click target only.
+func renderLinkifiedValue(value string, available int, rw urlRewriter) string {
+	if available <= 0 {
+		return ""
+	}
+	visible := truncateTo(value, available)
+	fullMatches := urlPattern.FindAllString(value, -1)
+	idxs := urlPattern.FindAllStringIndex(visible, -1)
+	if len(fullMatches) == 0 || len(idxs) == 0 {
+		return visible
+	}
+	var b strings.Builder
+	b.Grow(len(visible) + 64*len(idxs))
+	last := 0
+	for i, m := range idxs {
+		start, end := m[0], m[1]
+		seen := visible[start:end]
+		b.WriteString(visible[last:start])
+		last = end
+		// trimURLTail leaves a truncation ellipsis in place but strips
+		// over-captured punctuation, mirroring linkifyText.
+		vis := trimURLTail(seen)
+		if vis == "" {
+			b.WriteString(seen)
+			continue
+		}
+		// The i-th visible URL aligns with the i-th URL in the full value
+		// (truncation only removes a suffix), so its full address is the
+		// click target even when vis is an ellipsized prefix.
+		target := vis
+		if i < len(fullMatches) {
+			if full := trimURLTail(fullMatches[i]); full != "" {
+				target = full
+			}
+		}
+		target = rw.rewrite(target)
+		b.WriteString(mouseMark(linkZonePrefix+target, hyperlink(target, vis)))
+		b.WriteString(seen[len(vis):]) // over-captured tail stays plain text
+	}
+	b.WriteString(visible[last:])
+	return b.String()
+}
+
 // googleAuthuserRewriter returns a urlRewriter that appends authuser=<email>
 // to URLs on Google services that honor it (Meet, Calendar, Docs, Drive,
 // Mail). Returns nil when email is empty so callers can pass it through to


### PR DESCRIPTION
## Summary

The event-view dialog rendered the **Where** (Location) field as plain text. It now renders as a clickable link, reusing the OSC 8 + mouse-zone infrastructure that already powers the Conference and URL fields. Terminals that honor OSC 8 make it directly clickable; the TUI also registers a mouse zone so clicks open the URL via the platform handler (`xdg-open`/`open`/`start`, http/https only).

Three cases are handled:
- **Bare-URL location** (e.g. `https://zoom.us/j/123`) → rendered via `detailLinkLine`, keeping the *full* URL as the click target while truncating only the visible text.
- **Free text with an embedded URL** (e.g. `Room 4: https://meet.example.com/abc`) → linkified in place via the new `detailLinkifiedLine`; surrounding text stays plain.
- **Plain text** (e.g. `Conference Room B`) → unchanged, no link.

## Correctness note

`detailLinkifiedLine` truncates the plain text to the column width **before** linkifying. `truncateTo`/`stripANSI` strip CSI escapes but not OSC 8 hyperlinks, so linkifying first would slice a hyperlink mid-sequence and emit an **unterminated** OSC 8 escape that corrupts the rest of the dialog. Truncating first guarantees every emitted hyperlink sequence is complete. `isBareURL` reuses the package's canonical `urlPattern`, so "bare" means the same thing here as in `linkifyText` and interior whitespace (newline/CR) can't misclassify a value.

## Cleanup

Shared label-column math extracted into `detailLabelPrefix`, now used by `detailLine`, `detailLinkLine`, and `detailLinkifiedLine`.

## Tests

Added to `event_view_dialog_test.go`:
- bare-URL location is clickable (OSC 8 target + mouse zone)
- embedded URL in free text is clickable, surrounding text plain
- plain text has no link
- overflowing linkified location stays OSC-8-balanced (regression guard for the truncation-order bug)

`go build ./...`, `go vet ./internal/tui/`, `gofmt`, and the full `go test ./...` suite pass.