### PR TITLE
refactor(tui): extract linkifySegment from link helpers

### DIFF
--- a/internal/tui/links.go
+++ b/internal/tui/links.go
@@ -75,51 +75,69 @@ func linkifyText(s string, rw urlRewriter) string {
 	return linkifyTextZoned(s, rw, true)
 }
 
+// linkifySegment renders `visible` (already width-constrained when needed), using
+// `full` when click targets must survive suffix truncation.
+func linkifySegment(visible, full string, rw urlRewriter, zones bool) string {
+	if visible == "" || !strings.Contains(visible, "http") {
+		return visible
+	}
+	idxs := urlPattern.FindAllStringIndex(visible, -1)
+	if len(idxs) == 0 {
+		return visible
+	}
+	fullMatches := urlPattern.FindAllString(full, -1)
+	var b strings.Builder
+	b.Grow(len(visible) + 64*len(idxs))
+	last := 0
+	for i, m := range idxs {
+		start, end := m[0], m[1]
+		seen := visible[start:end]
+		b.WriteString(visible[last:start])
+		last = end
+		// trimURLTail keeps truncation ellipses but strips over-captured
+		// punctuation, mirroring linkifyText behavior.
+		vis := trimURLTail(seen)
+		if vis == "" {
+			b.WriteString(seen)
+			continue
+		}
+		// The i-th visible URL aligns with the i-th full URL because visible is
+		// either identical to full or a suffix-truncated prefix of full.
+		target := vis
+		if i < len(fullMatches) {
+			if full := trimURLTail(fullMatches[i]); full != "" {
+				target = full
+			}
+		}
+		target = rw.rewrite(target)
+		link := hyperlink(target, vis)
+		if zones {
+			link = mouseMark(linkZonePrefix+target, link)
+		}
+		b.WriteString(link)
+		b.WriteString(seen[len(vis):]) // over-captured tail stays plain text
+	}
+	b.WriteString(visible[last:])
+	return b.String()
+}
+
 // linkifyTextZoned is linkifyText with control over mouse zones. When zones is
 // false it emits OSC 8 hyperlinks only — clickable in terminals that honor
 // OSC 8 — without the mouseMark markers, which would leak on surfaces that
 // don't sweep them (the day and trash dialogs).
 func linkifyTextZoned(s string, rw urlRewriter, zones bool) string {
-	if s == "" || !strings.Contains(s, "http") {
-		return s
-	}
-	idxs := urlPattern.FindAllStringIndex(s, -1)
-	if len(idxs) == 0 {
-		return s
-	}
-	var b strings.Builder
-	b.Grow(len(s) + 64*len(idxs))
-	last := 0
-	for _, m := range idxs {
-		start, end := m[0], m[1]
-		raw := s[start:end]
-		trimmed := trimURLTail(raw)
-		if trimmed == "" {
-			b.WriteString(s[last:end])
-			last = end
-			continue
-		}
-		tailLen := len(raw) - len(trimmed)
-		target := rw.rewrite(trimmed)
-		b.WriteString(s[last:start])
-		link := hyperlink(target, trimmed)
-		if zones {
-			link = mouseMark(linkZonePrefix+target, link)
-		}
-		b.WriteString(link)
-		if tailLen > 0 {
-			b.WriteString(raw[len(trimmed):])
-		}
-		last = end
-	}
-	b.WriteString(s[last:])
-	return b.String()
+	return linkifySegment(s, s, rw, zones)
 }
 
 // renderLinkValue wraps a known URL value (e.g., ev.URL or ev.ConferenceURI)
-// as a clickable link. The visible text is truncated to fit available width
-// while the click/OSC 8 target stays the full URL. The optional rewriter
-// rewrites the click target only — what the user sees stays the original.
+// as a clickable link. The whole value is the click target — it is NOT run
+// through the prose linkifier, so the exact stored URI survives verbatim:
+// trailing sub-delimiters (a "...&x=1!" query, a Wikipedia "(disambiguation)"
+// link) are kept rather than trimmed, and non-http schemes (mailto:,
+// zoommtg:) still get wrapped. The visible text is truncated to fit the
+// available width while the click/OSC 8 target stays the full URL. The
+// optional rewriter rewrites the click target only — what the user sees
+// stays the original.
 func renderLinkValue(raw string, available int, rw urlRewriter) string {
 	if raw == "" {
 		return ""
@@ -150,41 +168,7 @@ func renderLinkifiedValue(value string, available int, rw urlRewriter) string {
 		return ""
 	}
 	visible := truncateTo(value, available)
-	fullMatches := urlPattern.FindAllString(value, -1)
-	idxs := urlPattern.FindAllStringIndex(visible, -1)
-	if len(fullMatches) == 0 || len(idxs) == 0 {
-		return visible
-	}
-	var b strings.Builder
-	b.Grow(len(visible) + 64*len(idxs))
-	last := 0
-	for i, m := range idxs {
-		start, end := m[0], m[1]
-		seen := visible[start:end]
-		b.WriteString(visible[last:start])
-		last = end
-		// trimURLTail leaves a truncation ellipsis in place but strips
-		// over-captured punctuation, mirroring linkifyText.
-		vis := trimURLTail(seen)
-		if vis == "" {
-			b.WriteString(seen)
-			continue
-		}
-		// The i-th visible URL aligns with the i-th URL in the full value
-		// (truncation only removes a suffix), so its full address is the
-		// click target even when vis is an ellipsized prefix.
-		target := vis
-		if i < len(fullMatches) {
-			if full := trimURLTail(fullMatches[i]); full != "" {
-				target = full
-			}
-		}
-		target = rw.rewrite(target)
-		b.WriteString(mouseMark(linkZonePrefix+target, hyperlink(target, vis)))
-		b.WriteString(seen[len(vis):]) // over-captured tail stays plain text
-	}
-	b.WriteString(visible[last:])
-	return b.String()
+	return linkifySegment(visible, value, rw, true)
 }
 
 // googleAuthuserRewriter returns a urlRewriter that appends authuser=<email>

--- a/internal/tui/links_test.go
+++ b/internal/tui/links_test.go
@@ -132,6 +132,34 @@ func TestRenderLinkValue_AppliesRewriterToTargetNotVisibleText(t *testing.T) {
 	assert.Equal(t, "link:https://meet.google.com/abc?authuser=me%40example.com", target)
 }
 
+func TestRenderLinkValue_KeepsExactTargetForTrailingSubDelimiter(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	// A structured URL field whose value legitimately ends in a URL
+	// sub-delimiter must keep that character in the click target — the prose
+	// trimURLTail behavior would wrongly drop it.
+	raw := "https://example.com/confirm!"
+	out := renderLinkValue(raw, 80, nil)
+
+	assert.Contains(t, out, "\x1b]8;;"+raw+"\x1b\\", "OSC 8 target must keep the trailing '!'")
+
+	_ = mouseSweep(out)
+	assert.Equal(t, "link:"+raw, mouseResolve(0, 0), "mouse target must keep the trailing '!'")
+}
+
+func TestRenderLinkValue_WrapsNonHTTPScheme(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	// Known URI fields may hold non-http schemes (an imported CONFERENCE
+	// zoommtg:// link, a mailto: URL). renderLinkValue wraps the whole value
+	// regardless of scheme rather than regressing to plain text.
+	raw := "zoommtg://zoom.us/join?confno=123"
+	out := renderLinkValue(raw, 80, nil)
+
+	assert.Contains(t, out, "\x1b]8;;"+raw+"\x1b\\", "non-http URI must still get an OSC 8 link")
+
+	_ = mouseSweep(out)
+	assert.Equal(t, "link:"+raw, mouseResolve(0, 0))
+}
+
 func TestOpenURLCmd_RejectsNonHTTP(t *testing.T) {
 	assert.Nil(t, openURLCmd("javascript:alert(1)"))
 	assert.Nil(t, openURLCmd("file:///etc/passwd"))


### PR DESCRIPTION
## Summary
- Extract internal `linkifySegment(visible, full, rw, zones)` in `links.go` as the single URL-wrapping primitive.
- Refactor `linkifyTextZoned` and `renderLinkifiedValue` to delegate to it.
- Foundation PR for the stacked TUI link-refactor series (thermo-nuclear code quality review).

## Test plan
- [x] `go test ./internal/tui/...`
