### PR TITLE
refactor(tui): colocate detailLabelPrefix with detailLine

### DIFF
--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -785,6 +785,14 @@ func eventDetailLines(ev event.Event, cal CalendarInfo, w, labelWidth int, rsvpL
 	return lines, rsvpIdx
 }
 
+// detailLabelPrefix renders the right-aligned label column plus its two-space
+// gap and returns the rendered prefix together with the cell width left for
+// the value.
+func detailLabelPrefix(labelStyle lipgloss.Style, label string, lw, w int) (prefix string, available int) {
+	padded := strings.Repeat(" ", max(lw-len(label), 0)) + label
+	return labelStyle.Render(padded) + "  ", w - labelColWidth(label, lw)
+}
+
 func detailLine(labelStyle lipgloss.Style, label, value string, lw, w int) string {
 	prefix, _ := detailLabelPrefix(labelStyle, label, lw, w)
 	return truncateTo(prefix+value, w)

--- a/internal/tui/event_view_dialog.go
+++ b/internal/tui/event_view_dialog.go
@@ -393,15 +393,6 @@ func (m EventViewDialogModel) handleMouse(msg tea.MouseClickMsg) (EventViewDialo
 	return m, nil
 }
 
-// detailLabelPrefix renders the right-aligned label column plus its two-space
-// gap and returns the rendered prefix together with the cell width left for
-// the value. Shared by the link detail-line helpers so the column math lives
-// in one place.
-func detailLabelPrefix(labelStyle lipgloss.Style, label string, lw, w int) (prefix string, available int) {
-	padded := strings.Repeat(" ", max(lw-len(label), 0)) + label
-	return labelStyle.Render(padded) + "  ", w - labelColWidth(label, lw)
-}
-
 // detailLinkLine is detailLine for values that should be rendered as a
 // clickable link. The visible URL text is sized to the available column
 // width while the OSC 8 target and mouse-zone payload stay the full URL —


### PR DESCRIPTION
## Summary
- Move `detailLabelPrefix` from `event_view_dialog.go` to `event_dialog.go` next to `detailLine` and `labelColWidth`.
- Independent of the link-helper stack; can merge in any order before the shared metadata PR.

## Test plan
- [x] `go test ./internal/tui/...`