### PR TITLE
refactor(tui): extract shared event metadata detail lines

### DIFF
--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -305,12 +305,13 @@ func (m EventDialogModel) refresh() EventDialogModel {
 	w := m.detailWidth()
 	if ev, ok := m.selectedEvent(); ok {
 		cal := m.calendars[ev.CalendarID]
+		rw := eventMetaURLRewriter(cal)
 		rsvpLine := ""
 		if rsvp := m.rsvpActions(); len(rsvp) > 0 {
 			att, _ := m.userAttendee()
 			rsvpLine = m.renderRSVPLine(att, rsvp, w)
 		}
-		lines, _ := eventDetailLines(ev, cal, w, m.labelWidth(), rsvpLine)
+		lines, _ := eventDetailLines(ev, cal, w, m.labelWidth(), rsvpLine, rw)
 		m.shell = m.shell.SetDetailTitle(ev.Title).SetDetailLines(lines)
 	} else {
 		m.shell = m.shell.SetDetailTitle("").SetDetailLines(nil)
@@ -636,9 +637,10 @@ func (m EventDialogModel) hitRSVPBtn(x, y int) (int, tea.Cmd, bool) {
 		return 0, nil, false
 	}
 	cal := m.calendars[ev.CalendarID]
+	rw := eventMetaURLRewriter(cal)
 	att, _ := m.userAttendee()
 	rsvpLine := m.renderRSVPLine(att, rsvp, m.detailWidth())
-	_, rowIdx := eventDetailLines(ev, cal, m.detailWidth(), m.labelWidth(), rsvpLine)
+	_, rowIdx := eventDetailLines(ev, cal, m.detailWidth(), m.labelWidth(), rsvpLine, rw)
 	if rowIdx < 0 {
 		return 0, nil, false
 	}
@@ -718,10 +720,103 @@ func rsvpButtonLabel(baseLabel, rsvpStatus string) string {
 	return baseLabel
 }
 
+type eventMetaDetailLinesOptions struct {
+	labelStyle  lipgloss.Style
+	width       int
+	labelWidth  int
+	urlRewriter urlRewriter
+	// interactive enables mouse-zone markers on the linkified URL rows. Only
+	// set it on surfaces that MouseSweep their own output (the full event
+	// view). The list-pane and trash detail panes composite plain shell.View()
+	// output after the app's single MouseSweep, so their markers would never
+	// be stripped — they leave it false and emit OSC 8 links only.
+	interactive bool
+
+	calendar   CalendarInfo
+	location   string
+	conference string
+	url        string
+	status     string
+	tags       string
+	repeat     string
+	showAs     string
+	visibility string
+}
+
+// eventMetaURLRewriter returns a link rewriter for event metadata rows. It
+// rewrites supported Google URLs to include authuser when possible; otherwise
+// it returns an identity rewriter so URL fields are still clickable.
+func eventMetaURLRewriter(cal CalendarInfo) urlRewriter {
+	if isGoogleAccountServer(cal.AccountServerURL) {
+		if rw := googleAuthuserRewriter(cal.OwnerEmail); rw != nil {
+			return rw
+		}
+	}
+	return func(raw string) string { return raw }
+}
+
+// eventMetaDetailLines renders shared metadata rows used by list-pane detail,
+// full event view, and trash details.
+func eventMetaDetailLines(opts eventMetaDetailLinesOptions) []string {
+	lines := make([]string, 0, 9)
+	add := func(label, value string) {
+		if value == "" {
+			return
+		}
+		lines = append(lines, detailLine(opts.labelStyle, label, value, opts.labelWidth, opts.width))
+	}
+	// addLinkified renders a free-text field (Where) that may merely *contain*
+	// a URL. addURL renders a known URL-valued field (Conference, URL) whose
+	// whole value is a single URI, kept exact and scheme-agnostic. Both fall
+	// back to plain text when there is no rewriter and only emit mouse zones
+	// on interactive (swept) surfaces.
+	addLinkified := func(label, value string) {
+		if value == "" {
+			return
+		}
+		if opts.urlRewriter == nil {
+			add(label, value)
+			return
+		}
+		lines = append(lines, detailLinkifiedLine(opts.labelStyle, label, value, opts.labelWidth, opts.width, opts.urlRewriter, opts.interactive))
+	}
+	addURL := func(label, value string) {
+		if value == "" {
+			return
+		}
+		if opts.urlRewriter == nil {
+			add(label, value)
+			return
+		}
+		lines = append(lines, detailURLField(opts.labelStyle, label, value, opts.labelWidth, opts.width, opts.urlRewriter, opts.interactive))
+	}
+
+	if opts.calendar.Name != "" {
+		dot := "●"
+		if opts.calendar.Color != "" {
+			dot = lipgloss.NewStyle().Foreground(lipgloss.Color(opts.calendar.Color)).Render("●")
+		}
+		add("Calendar", dot+" "+opts.calendar.Name)
+	}
+
+	addLinkified("Where", opts.location)
+	addURL("Conference", opts.conference)
+	addURL("URL", opts.url)
+	if opts.status != "" {
+		add("Status", statusBadge(opts.status))
+	}
+	add("Tags", opts.tags)
+	add("Repeat", opts.repeat)
+	add("Show as", opts.showAs)
+	add("Visibility", opts.visibility)
+
+	return lines
+}
+
 // eventDetailLines returns detail lines and the index of the RSVP row (-1 if none).
 // The event title is pinned by the shell via SetDetailTitle, so callers must
 // not prepend it here — these lines scroll, the title does not.
-func eventDetailLines(ev event.Event, cal CalendarInfo, w, labelWidth int, rsvpLine string) ([]string, int) {
+func eventDetailLines(ev event.Event, cal CalendarInfo, w, labelWidth int, rsvpLine string, rw urlRewriter) ([]string, int) {
 	faint := lipgloss.NewStyle().Faint(true)
 
 	var lines []string
@@ -732,29 +827,18 @@ func eventDetailLines(ev event.Event, cal CalendarInfo, w, labelWidth int, rsvpL
 		lines = append(lines, detailLine(faint, "Duration", dur, labelWidth, w))
 	}
 
-	if cal.Name != "" {
-		dot := "●"
-		if cal.Color != "" {
-			dot = lipgloss.NewStyle().Foreground(lipgloss.Color(cal.Color)).Render("●")
-		}
-		lines = append(lines, detailLine(faint, "Calendar", dot+" "+cal.Name, labelWidth, w))
-	}
-
-	if ev.Location != "" {
-		lines = append(lines, detailLine(faint, "Where", ev.Location, labelWidth, w))
-	}
-	if ev.Status != "" {
-		lines = append(lines, detailLine(faint, "Status", statusBadge(ev.Status), labelWidth, w))
-	}
-	if ev.Categories != "" {
-		lines = append(lines, detailLine(faint, "Tags", ev.Categories, labelWidth, w))
-	}
-	if ev.URL != "" {
-		lines = append(lines, detailLine(faint, "URL", ev.URL, labelWidth, w))
-	}
-	if ev.ConferenceURI != "" {
-		lines = append(lines, detailLine(faint, "Conference", ev.ConferenceURI, labelWidth, w))
-	}
+	lines = append(lines, eventMetaDetailLines(eventMetaDetailLinesOptions{
+		labelStyle:  faint,
+		width:       w,
+		labelWidth:  labelWidth,
+		urlRewriter: rw,
+		calendar:    cal,
+		location:    ev.Location,
+		conference:  ev.ConferenceURI,
+		url:         ev.URL,
+		status:      ev.Status,
+		tags:        ev.Categories,
+	})...)
 	rsvpIdx := -1
 	if rsvpLine != "" {
 		rsvpIdx = len(lines)

--- a/internal/tui/event_meta_detail_lines_test.go
+++ b/internal/tui/event_meta_detail_lines_test.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// mouseZoneMarker matches the private CSI marker mouseMark emits (ESC[<id>z).
+// These are only meaningful on surfaces that MouseSweep their own output.
+var mouseZoneMarker = regexp.MustCompile(`\x1b\[\d+z`)
+
+func metaOptsWithURLs(interactive bool) eventMetaDetailLinesOptions {
+	return eventMetaDetailLinesOptions{
+		labelStyle:  lipgloss.NewStyle(),
+		width:       80,
+		labelWidth:  12,
+		urlRewriter: func(s string) string { return s },
+		interactive: interactive,
+		location:    "Join at https://meet.example.com/room",
+		conference:  "zoommtg://zoom.us/join?confno=1",
+		url:         "https://example.com/event",
+	}
+}
+
+// The list-pane and trash detail panes render plain shell.View() output that is
+// composited AFTER the app's single MouseSweep, so any mouse-zone markers would
+// leak as raw escapes. Non-interactive rows must emit OSC 8 links only.
+func TestEventMetaDetailLines_NonInteractiveEmitsNoMouseZones(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	out := strings.Join(eventMetaDetailLines(metaOptsWithURLs(false)), "\n")
+
+	assert.Contains(t, out, "\x1b]8;;", "non-interactive rows should still carry OSC 8 links")
+	assert.NotRegexp(t, mouseZoneMarker, out, "non-interactive rows must not emit mouse-zone markers")
+}
+
+// The full event view sweeps its own output, so it opts into clickable zones.
+func TestEventMetaDetailLines_InteractiveEmitsMouseZones(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	out := strings.Join(eventMetaDetailLines(metaOptsWithURLs(true)), "\n")
+
+	assert.Regexp(t, mouseZoneMarker, out, "interactive rows should emit mouse-zone markers")
+}
+
+// The Conference field holds a whole URI (here a non-http scheme): it must be
+// wrapped as an OSC 8 link verbatim rather than regressing to plain text.
+func TestEventMetaDetailLines_ConferenceNonHTTPStaysLinked(t *testing.T) {
+	defaultMouseTracker = &mouseTracker{}
+	out := strings.Join(eventMetaDetailLines(metaOptsWithURLs(false)), "\n")
+
+	assert.Contains(t, out, "\x1b]8;;zoommtg://zoom.us/join?confno=1\x1b\\",
+		"a non-http Conference URI must still get an OSC 8 link")
+}

--- a/internal/tui/event_view_dialog.go
+++ b/internal/tui/event_view_dialog.go
@@ -398,31 +398,28 @@ func (m EventViewDialogModel) handleMouse(msg tea.MouseClickMsg) (EventViewDialo
 // wraps the whole value as the click target — exact and scheme-agnostic, so
 // trailing sub-delimiters survive and non-http schemes (mailto:, zoommtg:)
 // still link. Use detailLinkifiedLine instead for free-text fields that merely
-// *contain* a URL.
-func detailURLField(labelStyle lipgloss.Style, label, value string, lw, w int, rw urlRewriter) string {
+// *contain* a URL. zones controls whether clickable mouse-zone markers are
+// emitted (only safe on surfaces that MouseSweep their output).
+func detailURLField(labelStyle lipgloss.Style, label, value string, lw, w int, rw urlRewriter, zones bool) string {
 	prefix, available := detailLabelPrefix(labelStyle, label, lw, w)
-	return prefix + renderLinkValue(value, available, rw)
+	return prefix + renderLinkValue(value, available, rw, zones)
 }
 
 // detailLinkifiedLine is detailLine for a free-text value that may contain a
 // URL somewhere inside it (e.g., "Room 4 — join at https://…") or be a bare
 // URL. renderLinkifiedValue makes each embedded URL clickable while keeping its
 // full address as the click target, so the rendering is correct whether the
-// value is plain text, a bare URL, or text with an embedded link.
-func detailLinkifiedLine(labelStyle lipgloss.Style, label, value string, lw, w int, rw urlRewriter) string {
+// value is plain text, a bare URL, or text with an embedded link. zones
+// controls whether clickable mouse-zone markers are emitted (only safe on
+// surfaces that MouseSweep their output).
+func detailLinkifiedLine(labelStyle lipgloss.Style, label, value string, lw, w int, rw urlRewriter, zones bool) string {
 	prefix, available := detailLabelPrefix(labelStyle, label, lw, w)
-	return prefix + renderLinkifiedValue(value, available, rw)
+	return prefix + renderLinkifiedValue(value, available, rw, zones)
 }
 
-// linkRewriter returns the URL rewriter to apply to clickable links in this
-// event. Currently produces a Google authuser hint when the calendar is
-// linked to a Google account and we know the user's email. Returns nil
-// otherwise so links open unchanged.
+// linkRewriter returns the metadata-row URL rewriter for this event.
 func (m EventViewDialogModel) linkRewriter() urlRewriter {
-	if !isGoogleAccountServer(m.calendar.AccountServerURL) {
-		return nil
-	}
-	return googleAuthuserRewriter(m.calendar.OwnerEmail)
+	return eventMetaURLRewriter(m.calendar)
 }
 
 func (m EventViewDialogModel) renderRSVPRow(w int) string {
@@ -546,44 +543,26 @@ func (m EventViewDialogModel) buildBodyLines(w int) []string {
 	if ev.Timezone != "" {
 		lines = append(lines, detailLine(faint, "Timezone", ev.Timezone, eventViewLabelWidth, w))
 	}
-	if rep := describeRecurrence(ev.RecurrenceRule); rep != "" {
-		lines = append(lines, detailLine(faint, "Repeat", rep, eventViewLabelWidth, w))
-	}
-
-	hasMeta := m.calendar.Name != "" || ev.Location != "" || ev.ConferenceURI != "" ||
-		ev.URL != "" || ev.Status != "" || ev.Categories != "" ||
-		ev.Transp != "" || ev.Class != ""
-	if hasMeta {
-		lines = append(lines, "")
-	}
-	if m.calendar.Name != "" {
-		dot := Glyphs["dot"]
-		if m.calendar.Color != "" {
-			dot = lipgloss.NewStyle().Foreground(lipgloss.Color(m.calendar.Color)).Render(Glyphs["dot"])
-		}
-		lines = append(lines, detailLine(faint, "Calendar", dot+" "+m.calendar.Name, eventViewLabelWidth, w))
-	}
 	rw := m.linkRewriter()
-	if ev.Location != "" {
-		lines = append(lines, detailLinkifiedLine(faint, "Where", ev.Location, eventViewLabelWidth, w, rw))
-	}
-	if ev.ConferenceURI != "" {
-		lines = append(lines, detailURLField(faint, "Conference", ev.ConferenceURI, eventViewLabelWidth, w, rw))
-	}
-	if ev.URL != "" {
-		lines = append(lines, detailURLField(faint, "URL", ev.URL, eventViewLabelWidth, w, rw))
-	}
-	if ev.Status != "" {
-		lines = append(lines, detailLine(faint, "Status", statusBadge(ev.Status), eventViewLabelWidth, w))
-	}
-	if ev.Categories != "" {
-		lines = append(lines, detailLine(faint, "Tags", ev.Categories, eventViewLabelWidth, w))
-	}
-	if v := formatShowAs(ev.Transp); v != "" {
-		lines = append(lines, detailLine(faint, "Show as", v, eventViewLabelWidth, w))
-	}
-	if v := formatVisibility(ev.Class); v != "" {
-		lines = append(lines, detailLine(faint, "Visibility", v, eventViewLabelWidth, w))
+	metaLines := eventMetaDetailLines(eventMetaDetailLinesOptions{
+		labelStyle:  faint,
+		width:       w,
+		labelWidth:  eventViewLabelWidth,
+		urlRewriter: rw,
+		interactive: true,
+		calendar:    m.calendar,
+		location:    ev.Location,
+		conference:  ev.ConferenceURI,
+		url:         ev.URL,
+		status:      ev.Status,
+		tags:        ev.Categories,
+		repeat:      describeRecurrence(ev.RecurrenceRule),
+		showAs:      formatShowAs(ev.Transp),
+		visibility:  formatVisibility(ev.Class),
+	})
+	if len(metaLines) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, metaLines...)
 	}
 
 	if rsvpLine := m.renderRSVPRow(w); rsvpLine != "" {

--- a/internal/tui/links.go
+++ b/internal/tui/links.go
@@ -137,14 +137,19 @@ func linkifyTextZoned(s string, rw urlRewriter, zones bool) string {
 // zoommtg:) still get wrapped. The visible text is truncated to fit the
 // available width while the click/OSC 8 target stays the full URL. The
 // optional rewriter rewrites the click target only — what the user sees
-// stays the original.
-func renderLinkValue(raw string, available int, rw urlRewriter) string {
+// stays the original. When zones is false the OSC 8 hyperlink is emitted
+// without the mouseMark zone marker, for surfaces that don't MouseSweep.
+func renderLinkValue(raw string, available int, rw urlRewriter, zones bool) string {
 	if raw == "" {
 		return ""
 	}
 	visible := truncateTo(raw, available)
 	target := rw.rewrite(raw)
-	return mouseMark(linkZonePrefix+target, hyperlink(target, visible))
+	link := hyperlink(target, visible)
+	if zones {
+		link = mouseMark(linkZonePrefix+target, link)
+	}
+	return link
 }
 
 // renderLinkifiedValue renders a free-text value that may contain URLs, sized
@@ -155,13 +160,15 @@ func renderLinkValue(raw string, available int, rw urlRewriter) string {
 // address as the click target even when its visible text is ellipsized by the
 // truncation — so an overflowing embedded link still opens the right place,
 // the same full-target guarantee renderLinkValue gives bare-URL fields. The
-// optional rewriter transforms the click target only.
-func renderLinkifiedValue(value string, available int, rw urlRewriter) string {
+// optional rewriter transforms the click target only. When zones is false the
+// OSC 8 hyperlinks are emitted without mouseMark zone markers, for surfaces
+// that don't MouseSweep.
+func renderLinkifiedValue(value string, available int, rw urlRewriter, zones bool) string {
 	if available <= 0 {
 		return ""
 	}
 	visible := truncateTo(value, available)
-	return linkifySegment(visible, value, rw, true)
+	return linkifySegment(visible, value, rw, zones)
 }
 
 // googleAuthuserRewriter returns a urlRewriter that appends authuser=<email>

--- a/internal/tui/links_test.go
+++ b/internal/tui/links_test.go
@@ -116,7 +116,7 @@ func TestIsGoogleAccountServer(t *testing.T) {
 func TestRenderLinkValue_AppliesRewriterToTargetNotVisibleText(t *testing.T) {
 	defaultMouseTracker = &mouseTracker{}
 	rw := googleAuthuserRewriter("me@example.com")
-	out := renderLinkValue("https://meet.google.com/abc", 80, rw)
+	out := renderLinkValue("https://meet.google.com/abc", 80, rw, true)
 
 	// OSC 8 target carries the rewritten URL so modifier-click in honoring
 	// terminals opens the right account.
@@ -138,7 +138,7 @@ func TestRenderLinkValue_KeepsExactTargetForTrailingSubDelimiter(t *testing.T) {
 	// sub-delimiter must keep that character in the click target — the prose
 	// trimURLTail behavior would wrongly drop it.
 	raw := "https://example.com/confirm!"
-	out := renderLinkValue(raw, 80, nil)
+	out := renderLinkValue(raw, 80, nil, true)
 
 	assert.Contains(t, out, "\x1b]8;;"+raw+"\x1b\\", "OSC 8 target must keep the trailing '!'")
 
@@ -152,7 +152,7 @@ func TestRenderLinkValue_WrapsNonHTTPScheme(t *testing.T) {
 	// zoommtg:// link, a mailto: URL). renderLinkValue wraps the whole value
 	// regardless of scheme rather than regressing to plain text.
 	raw := "zoommtg://zoom.us/join?confno=123"
-	out := renderLinkValue(raw, 80, nil)
+	out := renderLinkValue(raw, 80, nil, true)
 
 	assert.Contains(t, out, "\x1b]8;;"+raw+"\x1b\\", "non-http URI must still get an OSC 8 link")
 

--- a/internal/tui/trash_model.go
+++ b/internal/tui/trash_model.go
@@ -282,11 +282,12 @@ func (m TrashModel) refresh() TrashModel {
 
 	if e, ok := m.selectedEntry(); ok {
 		cal := m.calendars[e.CalendarID]
+		rw := eventMetaURLRewriter(cal)
 		title := e.Title
 		if title == "" {
 			title = "(untitled)"
 		}
-		lines := trashDetailLines(e, cal, m.detailWidth(), m.labelWidth())
+		lines := trashDetailLines(e, cal, m.detailWidth(), m.labelWidth(), rw)
 		m.shell = m.shell.SetDetailTitle(title).SetDetailLines(lines)
 	} else {
 		m.shell = m.shell.SetDetailTitle("").SetDetailLines(nil)
@@ -452,7 +453,7 @@ func formatTrashRowLabel(e trash.Entry) string {
 // Kind so todos show due-date/status/progress and journals show a start
 // date where events would show a time range. The entry title is pinned
 // by the shell via SetDetailTitle and must not be prepended here.
-func trashDetailLines(e trash.Entry, cal CalendarInfo, w, labelWidth int) []string {
+func trashDetailLines(e trash.Entry, cal CalendarInfo, w, labelWidth int, rw urlRewriter) []string {
 	faint := lipgloss.NewStyle().Faint(true)
 
 	var lines []string
@@ -498,25 +499,21 @@ func trashDetailLines(e trash.Entry, cal CalendarInfo, w, labelWidth int) []stri
 		}
 	}
 
-	if cal.Name != "" {
-		dot := "●"
-		if cal.Color != "" {
-			dot = lipgloss.NewStyle().Foreground(lipgloss.Color(cal.Color)).Render("●")
-		}
-		lines = append(lines, detailLine(faint, "Calendar", dot+" "+cal.Name, labelWidth, w))
+	repeat := ""
+	if e.Kind == trash.KindEventSeriesTail {
+		repeat = e.PreviousRRule
 	}
-	if e.Location != "" {
-		lines = append(lines, detailLine(faint, "Where", e.Location, labelWidth, w))
-	}
-	if e.Status != "" {
-		lines = append(lines, detailLine(faint, "Status", statusBadge(e.Status), labelWidth, w))
-	}
-	if e.Categories != "" {
-		lines = append(lines, detailLine(faint, "Tags", e.Categories, labelWidth, w))
-	}
-	if e.Kind == trash.KindEventSeriesTail && e.PreviousRRule != "" {
-		lines = append(lines, detailLine(faint, "Repeat", e.PreviousRRule, labelWidth, w))
-	}
+	lines = append(lines, eventMetaDetailLines(eventMetaDetailLinesOptions{
+		labelStyle:  faint,
+		width:       w,
+		labelWidth:  labelWidth,
+		urlRewriter: rw,
+		calendar:    cal,
+		location:    e.Location,
+		status:      e.Status,
+		tags:        e.Categories,
+		repeat:      repeat,
+	})...)
 
 	if e.Description != "" {
 		lines = append(lines, "")


### PR DESCRIPTION
## Summary
- Extract `eventMetaDetailLines` + `eventMetaURLRewriter` in `event_dialog.go`.
- Reuse across list-pane detail (`eventDetailLines`), full view (`buildBodyLines`), and trash detail.
- Wire clickable Where/URL/Conference consistently via calendar-derived rewriters on all surfaces.
- Incorporates `detailLabelPrefix` colocation from #60 (merged into this branch).
- Stacks on #61; merge #60 first or this branch already includes that move.

## Test plan
- [x] `go test ./internal/tui/...`