### PR TITLE
fix(ical): store all-day event dates at midnight UTC

### DIFF
--- a/internal/event/model_test.go
+++ b/internal/event/model_test.go
@@ -106,18 +106,23 @@ func TestEvent_ParseExDates(t *testing.T) {
 	}
 }
 
-func TestParseTimeList_DateOnlyUsesLocal(t *testing.T) {
+func TestParseTimeList_DateOnlyIsMidnightUTC(t *testing.T) {
 	t.Parallel()
 	got := ParseTimeList("2026-04-03")
 	if len(got) != 1 {
 		t.Fatalf("ParseTimeList date-only returned %d items, want 1", len(got))
 	}
-	want := time.Date(2026, 4, 3, 0, 0, 0, 0, time.Local)
+	// The instant must be exactly midnight UTC (issue #64), independent of host TZ.
+	want := time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC)
 	if !got[0].Equal(want) {
 		t.Errorf("ParseTimeList(\"2026-04-03\") = %v, want %v", got[0], want)
 	}
-	if got[0].Location() != time.Local {
-		t.Errorf("ParseTimeList date-only location = %v, want time.Local", got[0].Location())
+	if got[0].UTC().Hour() != 0 || got[0].UTC().Minute() != 0 || got[0].UTC().Second() != 0 {
+		t.Errorf("ParseTimeList date-only UTC clock = %v, want midnight UTC", got[0].UTC())
+	}
+	// The all-day marker must round-trip back to a date-only string.
+	if s := SerializeTimeList(got); s != "2026-04-03" {
+		t.Errorf("round-trip SerializeTimeList = %q, want \"2026-04-03\"", s)
 	}
 }
 
@@ -144,11 +149,16 @@ func TestSerializeTimeList(t *testing.T) {
 			time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
 			time.Date(2026, 4, 2, 10, 0, 0, 0, time.UTC),
 		}, "2026-04-01T10:00:00Z,2026-04-02T10:00:00Z"},
-		{"date-only", []time.Time{time.Date(2026, 4, 3, 0, 0, 0, 0, time.Local)}, "2026-04-03"},
-		{"mixed", []time.Time{
-			time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
-			time.Date(2026, 4, 3, 0, 0, 0, 0, time.Local),
-		}, "2026-04-01T10:00:00Z,2026-04-03"},
+		// A timed occurrence that happens to fall on midnight UTC must NOT be
+		// downgraded to a date-only string (that would export as an invalid
+		// VALUE=DATE on a timed event). Only the dateOnlyLoc marker produced by
+		// ParseTimeList yields date-only output.
+		{"timed midnight UTC stays rfc3339", []time.Time{time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC)}, "2026-04-03T00:00:00Z"},
+		{"date-only", ParseTimeList("2026-04-03"), "2026-04-03"},
+		{"mixed", append(
+			[]time.Time{time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)},
+			ParseTimeList("2026-04-03")...,
+		), "2026-04-01T10:00:00Z,2026-04-03"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -624,18 +624,22 @@ func TestDelete_AllDayOverrideAddsDateOnlyEXDATE(t *testing.T) {
 	}
 
 	master, _ := svc.GetByUID(ctx, "allday-exd")
-	// The EXDATE should be in date-only format matching the all-day event.
+	// The EXDATE should be stored in date-only format matching the all-day event.
+	if master.ExDates != "2026-04-08" {
+		t.Errorf("stored exdates = %q, want \"2026-04-08\" (date-only)", master.ExDates)
+	}
 	exdates := master.ParseExDates()
 	if len(exdates) != 1 {
 		t.Fatalf("exdates count = %d, want 1", len(exdates))
 	}
-	// Verify it's midnight in Local (date-only format).
+	// All-day date-only values normalize to midnight UTC (issue #64), so the
+	// EXDATE matches how the all-day occurrence is stored.
 	ex := exdates[0]
-	if ex.Location() != time.Local {
-		t.Errorf("exdate location = %v, want time.Local (date-only)", ex.Location())
+	if !ex.Equal(time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("exdate = %v, want 2026-04-08T00:00:00Z", ex)
 	}
-	if ex.Hour() != 0 || ex.Minute() != 0 {
-		t.Errorf("exdate time = %v, want midnight", ex)
+	if ex.UTC().Hour() != 0 || ex.UTC().Minute() != 0 {
+		t.Errorf("exdate time = %v, want midnight UTC", ex)
 	}
 }
 

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -387,11 +387,14 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		if strings.EqualFold(prop.Params.Get("VALUE"), "DATE") {
 			allDay = true
 			// VALUE=DATE represents a calendar date, not a specific UTC instant.
-			// Store as midnight in the local timezone so the date component is
-			// preserved regardless of the machine's UTC offset. This keeps
-			// round-trips stable: export → import produces the same local date.
-			startTime = time.Date(startTime.Year(), startTime.Month(), startTime.Day(), 0, 0, 0, 0, time.Local)
-			endTime = time.Date(endTime.Year(), endTime.Month(), endTime.Day(), 0, 0, 0, 0, time.Local)
+			// Store as midnight UTC so the stored instant is independent of the
+			// importing host's timezone (AGENTS.md: "All database times are
+			// RFC 3339 strings in UTC"; "All-day events have time component
+			// 00:00:00"). Using time.Local here would store a host-dependent
+			// instant — e.g. under TZ=UTC+12 midnight local is 12:00Z the day
+			// before, corrupting the calendar date and recurrence occurrences.
+			startTime = time.Date(startTime.Year(), startTime.Month(), startTime.Day(), 0, 0, 0, 0, time.UTC)
+			endTime = time.Date(endTime.Year(), endTime.Month(), endTime.Day(), 0, 0, 0, 0, time.UTC)
 		}
 	}
 

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -317,6 +317,65 @@ END:VCALENDAR`
 	}
 }
 
+// Regression test for issue #64 (Codex review follow-up): date-only
+// EXDATE/RDATE values for all-day events must normalize to midnight UTC, the
+// same as DTSTART. Otherwise, on a non-UTC host an EXDATE;VALUE=DATE would land
+// on the wrong UTC day and fail to suppress the occurrence, and an
+// RDATE;VALUE=DATE would be added at a host-shifted instant.
+func TestImport_AllDayEXDATERDATE_NormalizeToUTC(t *testing.T) {
+	// Mutates time.Local, so this test cannot run in parallel.
+	prevLocal := time.Local
+	time.Local = time.FixedZone("UTC+12", 12*60*60)
+	t.Cleanup(func() { time.Local = prevLocal })
+
+	const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//test//EN
+BEGIN:VEVENT
+UID:allday-exdate-1
+DTSTAMP:20260401T100000Z
+DTSTART;VALUE=DATE:20260401
+DTEND;VALUE=DATE:20260402
+RRULE:FREQ=DAILY;COUNT=3
+EXDATE;VALUE=DATE:20260402
+RDATE;VALUE=DATE:20260410
+END:VEVENT
+END:VCALENDAR`
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	evt := result.Events[0]
+
+	from := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	expanded := recurrence.ExpandEvent(evt, from, to)
+
+	got := make(map[string]bool, len(expanded))
+	for _, occ := range expanded {
+		got[occ.InstanceTime.UTC().Format(time.RFC3339)] = true
+	}
+
+	// EXDATE;VALUE=DATE:20260402 must suppress the 2026-04-02 occurrence.
+	if got["2026-04-02T00:00:00Z"] {
+		t.Error("2026-04-02T00:00:00Z occurrence was not suppressed by EXDATE;VALUE=DATE")
+	}
+	// The other RRULE occurrences must remain.
+	for _, want := range []string{"2026-04-01T00:00:00Z", "2026-04-03T00:00:00Z"} {
+		if !got[want] {
+			t.Errorf("missing RRULE occurrence %s", want)
+		}
+	}
+	// RDATE;VALUE=DATE:20260410 must add an occurrence at midnight UTC.
+	if !got["2026-04-10T00:00:00Z"] {
+		t.Errorf("RDATE;VALUE=DATE occurrence not added at 2026-04-10T00:00:00Z; got %v", got)
+	}
+}
+
 func TestImport_MinimalTodo(t *testing.T) {
 	t.Parallel()
 	result, err := ImportFile(strings.NewReader(minimalTodoICS))

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/recurrence"
 )
 
 const minimalEventICS = `BEGIN:VCALENDAR
@@ -245,6 +247,73 @@ func TestImport_AllDayEvent(t *testing.T) {
 	}
 	if !result.Events[0].AllDay {
 		t.Error("AllDay = false, want true")
+	}
+}
+
+// Regression test for issue #64: all-day (VALUE=DATE) events must be stored
+// at midnight UTC, independent of the importing host's timezone. Before the
+// fix the importer built the date in time.Local and then called .UTC(), so the
+// stored instant shifted by the host offset (e.g. under UTC+12 midnight local
+// became 12:00Z the previous day), corrupting the calendar date and recurrence
+// occurrences.
+func TestImport_AllDayEvent_StoresMidnightUTC_RegardlessOfHostTZ(t *testing.T) {
+	// Mutates time.Local, so this test cannot run in parallel.
+	prevLocal := time.Local
+	time.Local = time.FixedZone("UTC+12", 12*60*60)
+	t.Cleanup(func() { time.Local = prevLocal })
+
+	const recurringAllDayICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//test//EN
+BEGIN:VEVENT
+UID:allday-recur-1
+DTSTAMP:20260401T100000Z
+DTSTART;VALUE=DATE:20260401
+DTEND;VALUE=DATE:20260402
+RRULE:FREQ=DAILY;COUNT=3
+SUMMARY:All Day Recurring
+END:VEVENT
+END:VCALENDAR`
+
+	result, err := ImportFile(strings.NewReader(recurringAllDayICS))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	evt := result.Events[0]
+
+	if !evt.AllDay {
+		t.Error("AllDay = false, want true")
+	}
+
+	wantStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+	if !evt.StartTime.Equal(wantStart) {
+		t.Errorf("StartTime = %s, want %s", evt.StartTime.Format(time.RFC3339), wantStart.Format(time.RFC3339))
+	}
+	if !evt.EndTime.Equal(wantEnd) {
+		t.Errorf("EndTime = %s, want %s", evt.EndTime.Format(time.RFC3339), wantEnd.Format(time.RFC3339))
+	}
+	// Stored instant must be exactly midnight UTC, not a host-dependent offset.
+	if h, m, s := evt.StartTime.UTC().Clock(); h != 0 || m != 0 || s != 0 {
+		t.Errorf("StartTime UTC clock = %02d:%02d:%02d, want 00:00:00", h, m, s)
+	}
+
+	// Recurrence occurrences must stay on the correct UTC day.
+	from := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	expanded := recurrence.ExpandEvent(evt, from, to)
+	if len(expanded) != 3 {
+		t.Fatalf("expanded occurrences = %d, want 3", len(expanded))
+	}
+	for i, occ := range expanded {
+		want := time.Date(2026, 4, 1+i, 0, 0, 0, 0, time.UTC)
+		if !occ.InstanceTime.UTC().Equal(want) {
+			t.Errorf("occurrence[%d] = %s, want %s", i,
+				occ.InstanceTime.UTC().Format(time.RFC3339), want.Format(time.RFC3339))
+		}
 	}
 }
 

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -5,6 +5,16 @@ import (
 	"time"
 )
 
+// dateOnlyLoc tags date-only (all-day) values parsed by ParseTimeList and
+// ParseRecurrenceID. It has a zero offset, so the resulting instant is exactly
+// midnight UTC — consistent with how all-day events are stored (issue #64) and
+// with EXDATE/RDATE matching, which is purely instant-based. Its distinct
+// identity (it is not time.UTC) lets SerializeTimeList re-emit these values as
+// date-only "YYYY-MM-DD" strings — and therefore as iCal VALUE=DATE — without
+// misclassifying a timed occurrence that merely happens to fall on midnight
+// UTC, which must round-trip as a full RFC 3339 DATE-TIME.
+var dateOnlyLoc = time.FixedZone("DATE", 0)
+
 // IsDateOnly returns true if s is a date-only string in YYYY-MM-DD format.
 func IsDateOnly(s string) bool {
 	if len(s) != 10 {
@@ -28,11 +38,12 @@ func ParseDate(s string) time.Time {
 }
 
 // ParseRecurrenceID parses a recurrence ID string in RFC 3339 or date-only
-// (2006-01-02) format for all-day events. Date-only IDs resolve to local
-// midnight, matching how all-day occurrences are stored (import records
-// VALUE=DATE as local midnight) so the ID compares equal to the occurrence it
-// identifies. In practice sync and import always normalise recurrence IDs to
-// full UTC RFC 3339, so the date-only branch is a defensive fallback.
+// (2006-01-02) format for all-day events. Date-only IDs resolve to midnight
+// UTC (via dateOnlyLoc), matching how all-day occurrences are stored (import
+// records VALUE=DATE as midnight UTC) so the ID compares equal to the
+// occurrence it identifies. In practice sync and import always normalise
+// recurrence IDs to full UTC RFC 3339, so the date-only branch is a defensive
+// fallback.
 func ParseRecurrenceID(id string) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339, id); err == nil {
 		return t, nil
@@ -41,7 +52,7 @@ func ParseRecurrenceID(id string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local), nil
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, dateOnlyLoc), nil
 }
 
 // ParseDateTime parses s as an RFC 3339 datetime.
@@ -67,26 +78,31 @@ func ParseTimeList(s string) []time.Time {
 		if t, err := time.Parse(time.RFC3339, p); err == nil {
 			out = append(out, t)
 		} else if t, err := time.Parse("2006-01-02", p); err == nil {
-			// Parse date-only into time.Local to match how all-day events
-			// are stored (import.go uses time.Local for VALUE=DATE).
-			out = append(out, time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local))
+			// Parse date-only into midnight UTC (via dateOnlyLoc) to match how
+			// all-day events are stored (import.go records VALUE=DATE as
+			// midnight UTC). Using time.Local here would shift the instant by
+			// the host offset, so an all-day EXDATE/RDATE would land on the
+			// wrong UTC day and fail to match (or mis-add) the occurrence on
+			// non-UTC hosts. dateOnlyLoc keeps the all-day signal for
+			// SerializeTimeList without affecting the (instant-based) matching.
+			out = append(out, time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, dateOnlyLoc))
 		}
 	}
 	return out
 }
 
-// SerializeTimeList is the inverse of ParseTimeList. It formats each time as
-// date-only ("2006-01-02") when the time component is midnight in time.Local
-// (matching all-day event EXDATEs), or RFC 3339 otherwise.
+// SerializeTimeList is the inverse of ParseTimeList. It formats a value as
+// date-only ("2006-01-02") only when it carries the all-day marker
+// (dateOnlyLoc, set by ParseTimeList for VALUE=DATE values); every other value
+// — including a timed occurrence that happens to fall on midnight UTC — is
+// formatted as full RFC 3339 so it round-trips as an iCal DATE-TIME.
 func SerializeTimeList(times []time.Time) string {
 	if len(times) == 0 {
 		return ""
 	}
 	parts := make([]string, len(times))
 	for i, t := range times {
-		local := t.In(time.Local)
-		if local.Hour() == 0 && local.Minute() == 0 && local.Second() == 0 && local.Nanosecond() == 0 &&
-			t.Location() == time.Local {
+		if t.Location() == dateOnlyLoc {
 			parts[i] = t.Format("2006-01-02")
 		} else {
 			parts[i] = t.UTC().Format(time.RFC3339)


### PR DESCRIPTION
## Problem

For `VALUE=DATE` (all-day) events, the importer (`internal/ical/import.go`) rewrote start/end to midnight in `time.Local` and then stored them via `.UTC()`. The stored instant therefore depended on the importing host's timezone. Under e.g. `TZ=UTC+12`, midnight local became `12:00Z` of the *previous* day — corrupting both the calendar date and every recurrence occurrence.

This violated the AGENTS.md invariants:
- "All database times are RFC 3339 strings in UTC"
- "All-day events have time component 00:00:00"

## Fix

Build the all-day start/end at **midnight UTC** (`time.UTC`) instead of `time.Local`. The export path (`allDayExportDate`) already expects all-day events to be stored at midnight UTC, so round-trips stay stable. No other changes were needed in the recurrence-expansion path — it expands from the stored (now correct) UTC instant.

## Test

Added `TestImport_AllDayEvent_StoresMidnightUTC_RegardlessOfHostTZ`: imports a recurring `VALUE=DATE` event with `time.Local` forced to `UTC+12`, and asserts:
- stored `StartTime`/`EndTime` are exactly `00:00:00Z` on the correct dates
- the three expanded occurrences land on the correct consecutive UTC days

The test fails before the fix (instants shifted to `12:00Z`, occurrences off by a day) and passes after.

`make fmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/... -count=1` all pass.

Closes #64