### PR TITLE
fix(event): correct stale-master guard in truncation undo

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -499,9 +499,20 @@ func (s *Service) DeleteInstance(ctx context.Context, uid string, instanceTime t
 // any overrides at or after the cutoff, and records the pre-truncation
 // RRULE in event_truncate_deletes so the trash view can restore it atomically.
 func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTime time.Time) error {
+	_, err := s.deleteFromInstance(ctx, uid, instanceTime)
+	return err
+}
+
+// deleteFromInstance performs the truncation and returns the master's
+// updated_at as written by this operation, read back inside the same
+// transaction. Returning the in-tx value (rather than a post-commit read)
+// closes a TOCTOU window: a concurrent writer editing the master after our
+// commit but before a separate read would otherwise have its updated_at
+// captured as the undo baseline, letting RestoreUndo clobber that edit.
+func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTime time.Time) (string, error) {
 	master, err := s.q.GetEventByUID(ctx, uid)
 	if err != nil {
-		return fmt.Errorf("get master: %w", err)
+		return "", fmt.Errorf("get master: %w", err)
 	}
 
 	prevRRule := storage.NullableToString(master.RecurrenceRule)
@@ -510,7 +521,7 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return "", fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
@@ -519,7 +530,7 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 		RecurrenceRule: storage.StringToNullable(rule),
 		ID:             master.ID,
 	}); err != nil {
-		return fmt.Errorf("update rrule: %w", err)
+		return "", fmt.Errorf("update rrule: %w", err)
 	}
 
 	cutoff := instanceTime.UTC().Format(time.RFC3339)
@@ -527,7 +538,7 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 		Uid:          uid,
 		RecurrenceID: cutoff,
 	}); err != nil {
-		return fmt.Errorf("soft-delete future overrides: %w", err)
+		return "", fmt.Errorf("soft-delete future overrides: %w", err)
 	}
 
 	if err := qtx.RecordEventTruncateDelete(ctx, storage.RecordEventTruncateDeleteParams{
@@ -536,14 +547,23 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 		CutoffTime:    cutoff,
 		PreviousRrule: prevRRule,
 	}); err != nil {
-		return fmt.Errorf("record truncate: %w", err)
+		return "", fmt.Errorf("record truncate: %w", err)
 	}
 
+	// Read the master's updated_at back inside the transaction so the value we
+	// return reflects exactly this truncation's write, with no chance of an
+	// interleaved external edit in between.
+	truncated, err := qtx.GetEventByUID(ctx, uid)
+	if err != nil {
+		return "", fmt.Errorf("read back master: %w", err)
+	}
+	postUpdated := truncated.UpdatedAt
+
 	if err := tx.Commit(); err != nil {
-		return err
+		return "", err
 	}
 	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
-	return nil
+	return postUpdated, nil
 }
 
 // UpdateInstance creates or updates a per-occurrence override of a recurring

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -102,18 +102,30 @@ func (s *Service) DeleteFromInstanceWithUndo(ctx context.Context, uid string, in
 		return UndoMeta{}, fmt.Errorf("get master: %w", err)
 	}
 	prevRRule := storage.NullableToString(master.RecurrenceRule)
-	prevUpdated := master.UpdatedAt
 
 	if err := s.DeleteFromInstance(ctx, uid, instanceTime); err != nil {
 		return UndoMeta{}, err
 	}
+
+	// DeleteFromInstance bumps the master's updated_at (UpdateEventRecurrenceRule
+	// sets updated_at=now). The stale-master guard in restoreFromInstance must
+	// expect that post-truncation value, not the pre-truncation one — otherwise
+	// the truncation's own write looks like a concurrent external edit and Undo
+	// always fails. Re-read the master to capture the timestamp the guard should
+	// legitimately tolerate; only edits that advance updated_at *past* this point
+	// (i.e. genuine concurrent writes) trip the guard.
+	postUpdated := master.UpdatedAt
+	if truncated, err := s.q.GetEventByUID(ctx, uid); err == nil {
+		postUpdated = truncated.UpdatedAt
+	}
+
 	return UndoMeta{
 		Kind:                UndoKindFromInstance,
 		UID:                 uid,
 		Label:               master.Title,
 		DeletedAt:           time.Now().UTC(),
 		MasterRRuleBefore:   prevRRule,
-		MasterUpdatedBefore: parseStorageTime(prevUpdated),
+		MasterUpdatedBefore: parseStorageTime(postUpdated),
 	}, nil
 }
 

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -103,20 +103,18 @@ func (s *Service) DeleteFromInstanceWithUndo(ctx context.Context, uid string, in
 	}
 	prevRRule := storage.NullableToString(master.RecurrenceRule)
 
-	if err := s.DeleteFromInstance(ctx, uid, instanceTime); err != nil {
+	// deleteFromInstance bumps the master's updated_at (UpdateEventRecurrenceRule
+	// sets updated_at=now) and returns that post-truncation value, read back
+	// inside the truncation transaction. The stale-master guard in
+	// restoreFromInstance must expect this value, not the pre-truncation one —
+	// otherwise the truncation's own write looks like a concurrent external edit
+	// and Undo always fails. Capturing it in-tx (rather than via a separate read
+	// after commit) also prevents a concurrent external edit landing between
+	// commit and read from being mistaken for the baseline. Only edits that
+	// advance updated_at *past* this point trip the guard.
+	postUpdated, err := s.deleteFromInstance(ctx, uid, instanceTime)
+	if err != nil {
 		return UndoMeta{}, err
-	}
-
-	// DeleteFromInstance bumps the master's updated_at (UpdateEventRecurrenceRule
-	// sets updated_at=now). The stale-master guard in restoreFromInstance must
-	// expect that post-truncation value, not the pre-truncation one — otherwise
-	// the truncation's own write looks like a concurrent external edit and Undo
-	// always fails. Re-read the master to capture the timestamp the guard should
-	// legitimately tolerate; only edits that advance updated_at *past* this point
-	// (i.e. genuine concurrent writes) trip the guard.
-	postUpdated := master.UpdatedAt
-	if truncated, err := s.q.GetEventByUID(ctx, uid); err == nil {
-		postUpdated = truncated.UpdatedAt
 	}
 
 	return UndoMeta{

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -319,6 +319,73 @@ func TestSoftDelete_FromInstance_RRULE(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_FromInstance_UndoAfterGap reproduces issue #66: when the
+// master's last real edit predates the truncation by more than one second,
+// the stale-master guard used to mistake the truncation's own updated_at bump
+// for a concurrent external edit and reject the Undo. The guard must compare
+// against the master's POST-truncation updated_at, so Undo succeeds here while
+// still detecting genuine later edits.
+func TestSoftDelete_FromInstance_UndoAfterGap(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "gap-review-uid",
+		CalendarID:     1,
+		Title:          "Sprint Review",
+		StartTime:      time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=10",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	originalRRULE := master.RecurrenceRule
+
+	// Backdate the master's updated_at well into the past so its last real edit
+	// is more than one second before the truncation — the production scenario
+	// the old guard failed on.
+	pastEdit := time.Now().UTC().Add(-1 * time.Hour).Format(storageTimeFormat)
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET updated_at = ? WHERE id = ?", pastEdit, master.ID); err != nil {
+		t.Fatalf("backdate updated_at: %v", err)
+	}
+
+	cutoff := time.Date(2026, 4, 22, 14, 0, 0, 0, time.UTC)
+	meta, err := svc.DeleteFromInstanceWithUndo(ctx, master.UID, cutoff)
+	if err != nil {
+		t.Fatalf("DeleteFromInstanceWithUndo: %v", err)
+	}
+
+	// Undo must succeed even though the master's prior edit was >1s ago.
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo after gap: %v", err)
+	}
+	restored, err := svc.Get(ctx, master.ID)
+	if err != nil {
+		t.Fatalf("Get master after restore: %v", err)
+	}
+	if restored.RecurrenceRule != originalRRULE {
+		t.Fatalf("RRULE not restored: got %q, want %q", restored.RecurrenceRule, originalRRULE)
+	}
+
+	// The guard must still catch a genuine concurrent edit. Re-truncate to get
+	// fresh undo meta, then advance updated_at past the captured post-truncation
+	// value to simulate an external write, and confirm Undo is rejected.
+	meta2, err := svc.DeleteFromInstanceWithUndo(ctx, master.UID, cutoff)
+	if err != nil {
+		t.Fatalf("DeleteFromInstanceWithUndo (2): %v", err)
+	}
+	future := time.Now().UTC().Add(1 * time.Hour).Format(storageTimeFormat)
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET updated_at = ? WHERE id = ?", future, master.ID); err != nil {
+		t.Fatalf("simulate concurrent edit: %v", err)
+	}
+	if err := svc.RestoreUndo(ctx, meta2); err == nil {
+		t.Fatal("RestoreUndo should reject a master edited after truncation")
+	}
+}
+
 // TestSoftDelete_PurgeDeleted drops rows past the retention window and
 // leaves fresh soft-deletes alone.
 func TestSoftDelete_PurgeDeleted(t *testing.T) {

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -357,6 +357,21 @@ func TestSoftDelete_FromInstance_UndoAfterGap(t *testing.T) {
 		t.Fatalf("DeleteFromInstanceWithUndo: %v", err)
 	}
 
+	// The captured baseline must be the truncation's own write (not the stale
+	// pre-truncation value), so it equals the master's current updated_at.
+	var dbUpdated string
+	if err := svc.db.QueryRowContext(ctx,
+		"SELECT updated_at FROM events WHERE id = ?", master.ID).Scan(&dbUpdated); err != nil {
+		t.Fatalf("read updated_at: %v", err)
+	}
+	if got := meta.MasterUpdatedBefore; !got.Equal(parseStorageTime(dbUpdated)) {
+		t.Fatalf("MasterUpdatedBefore = %s, want %s (the truncation's own write)",
+			got.Format(time.RFC3339), dbUpdated)
+	}
+	if !meta.MasterUpdatedBefore.After(parseStorageTime(pastEdit)) {
+		t.Fatal("MasterUpdatedBefore did not advance past the backdated edit")
+	}
+
 	// Undo must succeed even though the master's prior edit was >1s ago.
 	if err := svc.RestoreUndo(ctx, meta); err != nil {
 		t.Fatalf("RestoreUndo after gap: %v", err)


### PR DESCRIPTION
## Problem

Recurring-event truncation "Undo" always failed in production. The
stale-master guard in `restoreFromInstance` compared the master's
current `updated_at` against the **pre-truncation** value captured in
`UndoMeta.MasterUpdatedBefore`. But `DeleteFromInstance` itself bumps
`updated_at` (`UpdateEventRecurrenceRule` sets `updated_at = now`), so
the guard mistook the truncation's own write for a concurrent external
edit whenever the master's last real edit was more than one second
before the truncate — essentially always in real use.

The existing `TestSoftDelete_FromInstance_RRULE` passed only because
create + truncate + restore all happen within one wall-clock second.

## Fix

`DeleteFromInstanceWithUndo` now re-reads the master after the
truncation write and stores that **post-truncation** `updated_at` as
`MasterUpdatedBefore` — the value the guard should legitimately expect.
Genuine concurrent edits that advance `updated_at` past that point are
still detected and still block the Undo.

## Test

`TestSoftDelete_FromInstance_UndoAfterGap` backdates the master's
`updated_at` by an hour before truncating (the >1s gap), asserts Undo
succeeds, then simulates a real post-truncation edit and asserts Undo is
rejected. Fails before the fix, passes after.

`make fmt`, `go vet ./...`, `go build ./...`, and
`go test ./internal/... -count=1` all pass.

Closes #66
