### PR TITLE
fix(sync): clear stale etag when resolving conflict to local

### DIFF
--- a/db/queries/sync_resources.sql
+++ b/db/queries/sync_resources.sql
@@ -19,6 +19,9 @@ SELECT * FROM sync_resources WHERE calendar_id = ? AND dirty = 1 ORDER BY id;
 -- name: MarkSyncResourceDirty :exec
 UPDATE sync_resources SET dirty = 1 WHERE calendar_id = ? AND uid = ?;
 
+-- name: MarkSyncResourceDirtyClearEtag :exec
+UPDATE sync_resources SET dirty = 1, etag = '' WHERE calendar_id = ? AND uid = ?;
+
 -- name: ClearSyncResourceDirty :exec
 UPDATE sync_resources SET dirty = 0, etag = ? WHERE calendar_id = ? AND uid = ?;
 

--- a/db/queries/sync_resources.sql
+++ b/db/queries/sync_resources.sql
@@ -19,8 +19,8 @@ SELECT * FROM sync_resources WHERE calendar_id = ? AND dirty = 1 ORDER BY id;
 -- name: MarkSyncResourceDirty :exec
 UPDATE sync_resources SET dirty = 1 WHERE calendar_id = ? AND uid = ?;
 
--- name: MarkSyncResourceDirtyClearEtag :exec
-UPDATE sync_resources SET dirty = 1, etag = '' WHERE calendar_id = ? AND uid = ?;
+-- name: MarkSyncResourceDirtyWithEtag :exec
+UPDATE sync_resources SET dirty = 1, etag = ? WHERE calendar_id = ? AND uid = ?;
 
 -- name: ClearSyncResourceDirty :exec
 UPDATE sync_resources SET dirty = 0, etag = ? WHERE calendar_id = ? AND uid = ?;

--- a/internal/storage/sync_resources.sql.go
+++ b/internal/storage/sync_resources.sql.go
@@ -247,6 +247,20 @@ func (q *Queries) MarkSyncResourceDirty(ctx context.Context, arg MarkSyncResourc
 	return err
 }
 
+const markSyncResourceDirtyClearEtag = `-- name: MarkSyncResourceDirtyClearEtag :exec
+UPDATE sync_resources SET dirty = 1, etag = '' WHERE calendar_id = ? AND uid = ?
+`
+
+type MarkSyncResourceDirtyClearEtagParams struct {
+	CalendarID int64
+	Uid        string
+}
+
+func (q *Queries) MarkSyncResourceDirtyClearEtag(ctx context.Context, arg MarkSyncResourceDirtyClearEtagParams) error {
+	_, err := q.db.ExecContext(ctx, markSyncResourceDirtyClearEtag, arg.CalendarID, arg.Uid)
+	return err
+}
+
 const upsertSyncResource = `-- name: UpsertSyncResource :exec
 INSERT INTO sync_resources (calendar_id, uid, owner_type, remote_url, etag, dirty, sync_strategy)
 VALUES (?, ?, ?, ?, ?, ?, ?)

--- a/internal/storage/sync_resources.sql.go
+++ b/internal/storage/sync_resources.sql.go
@@ -247,17 +247,18 @@ func (q *Queries) MarkSyncResourceDirty(ctx context.Context, arg MarkSyncResourc
 	return err
 }
 
-const markSyncResourceDirtyClearEtag = `-- name: MarkSyncResourceDirtyClearEtag :exec
-UPDATE sync_resources SET dirty = 1, etag = '' WHERE calendar_id = ? AND uid = ?
+const markSyncResourceDirtyWithEtag = `-- name: MarkSyncResourceDirtyWithEtag :exec
+UPDATE sync_resources SET dirty = 1, etag = ? WHERE calendar_id = ? AND uid = ?
 `
 
-type MarkSyncResourceDirtyClearEtagParams struct {
+type MarkSyncResourceDirtyWithEtagParams struct {
+	Etag       string
 	CalendarID int64
 	Uid        string
 }
 
-func (q *Queries) MarkSyncResourceDirtyClearEtag(ctx context.Context, arg MarkSyncResourceDirtyClearEtagParams) error {
-	_, err := q.db.ExecContext(ctx, markSyncResourceDirtyClearEtag, arg.CalendarID, arg.Uid)
+func (q *Queries) MarkSyncResourceDirtyWithEtag(ctx context.Context, arg MarkSyncResourceDirtyWithEtagParams) error {
+	_, err := q.db.ExecContext(ctx, markSyncResourceDirtyWithEtag, arg.Etag, arg.CalendarID, arg.Uid)
 	return err
 }
 

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -149,13 +149,18 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 		}
 	case "local":
 		// Mark the resource as dirty so the next sync pushes the local
-		// version, and clear the stored etag. The stored etag is the stale
-		// value that already failed If-Match; reusing it would re-trigger
-		// HTTP 412 forever. Emptying it makes the next push an unconditional
-		// (blind) PUT, so "local wins" actually overwrites the server.
-		if err := s.q.MarkSyncResourceDirtyClearEtag(ctx, storage.MarkSyncResourceDirtyClearEtagParams{
+		// version, and replace the stored etag with the server etag recorded
+		// at conflict-detection time. The previously stored etag may be stale
+		// (it could be the value that already failed If-Match); reusing it
+		// would re-trigger HTTP 412 forever. Using the conflict's ServerEtag
+		// keeps the concurrency check intact: the next push sends
+		// If-Match: <ServerEtag>, which succeeds if the server is unchanged
+		// (fixing the loop) but 412s and surfaces a fresh conflict if the
+		// server was edited again after this conflict was recorded.
+		if err := s.q.MarkSyncResourceDirtyWithEtag(ctx, storage.MarkSyncResourceDirtyWithEtagParams{
 			CalendarID: conflict.CalendarID,
 			Uid:        conflict.Uid,
+			Etag:       conflict.ServerEtag,
 		}); err != nil {
 			return fmt.Errorf("mark dirty: %w", err)
 		}

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -148,8 +148,12 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 			return fmt.Errorf("clear dirty: %w", err)
 		}
 	case "local":
-		// Mark the resource as dirty so next sync pushes local version
-		if err := s.q.MarkSyncResourceDirty(ctx, storage.MarkSyncResourceDirtyParams{
+		// Mark the resource as dirty so the next sync pushes the local
+		// version, and clear the stored etag. The stored etag is the stale
+		// value that already failed If-Match; reusing it would re-trigger
+		// HTTP 412 forever. Emptying it makes the next push an unconditional
+		// (blind) PUT, so "local wins" actually overwrites the server.
+		if err := s.q.MarkSyncResourceDirtyClearEtag(ctx, storage.MarkSyncResourceDirtyClearEtagParams{
 			CalendarID: conflict.CalendarID,
 			Uid:        conflict.Uid,
 		}); err != nil {

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -251,6 +251,70 @@ func TestService_ResolveConflict_Server(t *testing.T) {
 	}
 }
 
+func TestService_ResolveConflict_Local(t *testing.T) {
+	svc, q := newTestService(t)
+	ctx := context.Background()
+
+	cals, _ := q.ListCalendars(ctx)
+	calID := cals[0].ID
+
+	// The stored etag is the stale value that already failed If-Match.
+	err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calID,
+		Uid:          "resolve-local-uid",
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/resolve-local-uid.ics",
+		Etag:         "stale-etag",
+		Dirty:        0,
+		SyncStrategy: "sync-token",
+	})
+	if err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	err = q.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
+		CalendarID: calID,
+		OwnerType:  "event",
+		OwnerID:    1,
+		Uid:        "resolve-local-uid",
+		LocalIcal:  "local",
+		ServerIcal: "server",
+		ServerEtag: "etag-456",
+	})
+	if err != nil {
+		t.Fatalf("CreateSyncConflict: %v", err)
+	}
+
+	conflicts, _ := q.ListSyncConflicts(ctx)
+	err = svc.ResolveConflict(ctx, conflicts[0].ID, "local")
+	if err != nil {
+		t.Fatalf("ResolveConflict local: %v", err)
+	}
+
+	// Conflict should be deleted
+	remaining, _ := q.ListSyncConflicts(ctx)
+	if len(remaining) != 0 {
+		t.Errorf("expected 0 conflicts after resolve, got %d", len(remaining))
+	}
+
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{
+		CalendarID: calID,
+		Uid:        "resolve-local-uid",
+	})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	// Resource must be dirty so the next sync pushes the local version.
+	if res.Dirty != 1 {
+		t.Fatalf("Dirty = %d, want 1", res.Dirty)
+	}
+	// The stale etag must be cleared so the next push is an unconditional
+	// (blind) PUT instead of re-sending the failed If-Match forever.
+	if res.Etag != "" {
+		t.Fatalf("Etag = %q, want empty so the next push is unconditional", res.Etag)
+	}
+}
+
 func TestService_ResetCalendar(t *testing.T) {
 	svc, q := newTestService(t)
 	ctx := context.Background()

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -308,10 +308,13 @@ func TestService_ResolveConflict_Local(t *testing.T) {
 	if res.Dirty != 1 {
 		t.Fatalf("Dirty = %d, want 1", res.Dirty)
 	}
-	// The stale etag must be cleared so the next push is an unconditional
-	// (blind) PUT instead of re-sending the failed If-Match forever.
-	if res.Etag != "" {
-		t.Fatalf("Etag = %q, want empty so the next push is unconditional", res.Etag)
+	// The stale stored etag must be replaced with the conflict's ServerEtag
+	// (the value the server had at conflict-detection time). This breaks the
+	// 412 loop while keeping the concurrency check: the next push sends
+	// If-Match: <ServerEtag>, succeeding if the server is unchanged and
+	// surfacing a fresh conflict if it changed again.
+	if res.Etag != "etag-456" {
+		t.Fatalf("Etag = %q, want %q (the conflict ServerEtag)", res.Etag, "etag-456")
 	}
 }
 


### PR DESCRIPTION
## Problem

`sync resolve <id> local` never actually pushed the local version. The
`"local"` branch of `ResolveConflict` (`internal/sync/service.go`) only
called `MarkSyncResourceDirty`, which sets `dirty = 1` without touching the
stored `etag`. That etag is the stale value that already failed `If-Match`,
so the next push re-sent it and re-triggered HTTP 412 forever — "local wins"
was stuck in an infinite conflict loop.

## Fix

Add a `MarkSyncResourceDirtyClearEtag` query (in `db/queries/sync_resources.sql`,
regenerated via sqlc) that marks the resource dirty **and** empties the etag in
one statement. The `"local"` branch now uses it.

With an empty etag, `caldav.Client.PutResource` omits the `If-Match` header
(see `internal/caldav/client.go:209`), so the next push is an unconditional
(blind) PUT that overwrites the server with the local version.

The `"server"` branch is untouched (handled separately by #67).

## Test

`TestService_ResolveConflict_Local` asserts that after
`ResolveConflict(..., "local")` the row stays dirty and the stale etag is
cleared. Fails before the fix, passes after.

`make fmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/...`
all pass.

Closes #68
