### PR TITLE
fix(sync): import server data when resolving conflict to server

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1319,6 +1319,18 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 	return nil
 }
 
+// importICal parses raw iCal data and persists it to the local database via
+// persistImported, the same path auto-resolve (ConflictServerWins) uses to
+// accept the server version. Used by manual conflict resolution so the local
+// row actually reflects the server data instead of the divergent local copy.
+func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) error {
+	importResult, err := icalPkg.ImportFile(strings.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("import ical: %w", err)
+	}
+	return e.persistImported(ctx, calendarID, importResult)
+}
+
 func parseICalData(data []byte) (*ical.Calendar, error) {
 	dec := ical.NewDecoder(bytes.NewReader(data))
 	return dec.Decode()

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -378,16 +378,9 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 							result.conflicts++
 							continue
 						}
-						importResult, err := icalPkg.ImportFile(strings.NewReader(buf.String()))
-						if err != nil {
+						if _, err := e.importICal(ctx, calendarID, buf.String()); err != nil {
 							e.logger.Error("import server resource failed", "uid", res.Uid, "error", err)
 							result.errors = append(result.errors, fmt.Errorf("import server resource %s: %w", res.Uid, err))
-							result.conflicts++
-							continue
-						}
-						if err := e.persistImported(ctx, calendarID, importResult); err != nil {
-							e.logger.Error("persist server resource failed", "uid", res.Uid, "error", err)
-							result.errors = append(result.errors, fmt.Errorf("persist server resource %s: %w", res.Uid, err))
 							result.conflicts++
 							continue
 						}
@@ -1320,15 +1313,25 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 }
 
 // importICal parses raw iCal data and persists it to the local database via
-// persistImported, the same path auto-resolve (ConflictServerWins) uses to
-// accept the server version. Used by manual conflict resolution so the local
+// persistImported. It is the shared accept-the-server-version path used both by
+// auto-resolve (ConflictServerWins) and manual conflict resolution, so the local
 // row actually reflects the server data instead of the divergent local copy.
-func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) error {
+//
+// imported reports whether the payload carried at least one VEVENT/VTODO/
+// VJOURNAL component. ImportFile returns no error for empty or component-less
+// input, so callers that must not accept the server version without applying it
+// (e.g. clearing the dirty flag) check imported to avoid silently stamping the
+// server ETag onto an unchanged local row.
+func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) (imported bool, err error) {
 	importResult, err := icalPkg.ImportFile(strings.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("import ical: %w", err)
+		return false, fmt.Errorf("import ical: %w", err)
 	}
-	return e.persistImported(ctx, calendarID, importResult)
+	if err := e.persistImported(ctx, calendarID, importResult); err != nil {
+		return false, err
+	}
+	imported = len(importResult.Events) > 0 || len(importResult.Todos) > 0 || len(importResult.Journals) > 0
+	return imported, nil
 }
 
 func parseICalData(data []byte) (*ical.Calendar, error) {

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -143,8 +143,16 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 		// local push and store the server ETag. Without the import the local
 		// row keeps its divergent local copy while the ETag claims it matches
 		// the server, so a later local edit silently overwrites the server.
-		if err := s.engine.importICal(ctx, conflict.CalendarID, conflict.ServerIcal); err != nil {
+		imported, err := s.engine.importICal(ctx, conflict.CalendarID, conflict.ServerIcal)
+		if err != nil {
 			return fmt.Errorf("import server version: %w", err)
+		}
+		if !imported {
+			// ImportFile returns no error for empty or component-less iCal, so a
+			// blank ServerIcal would otherwise clear dirty and stamp the server
+			// ETag onto the unchanged local row — the silent-overwrite bug this
+			// branch exists to prevent. Refuse instead of resolving falsely.
+			return fmt.Errorf("server version has no importable data for %q", conflict.Uid)
 		}
 		if err := s.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
 			CalendarID: conflict.CalendarID,

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -138,8 +138,14 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 
 	switch pick {
 	case "server":
-		// Server version is already the current local state after auto-resolve.
-		// Accept it by clearing the pending local push and storing the server ETag.
+		// Accept the server version: import the recorded server iCal into the
+		// local row so it reflects the server state, then clear the pending
+		// local push and store the server ETag. Without the import the local
+		// row keeps its divergent local copy while the ETag claims it matches
+		// the server, so a later local edit silently overwrites the server.
+		if err := s.engine.importICal(ctx, conflict.CalendarID, conflict.ServerIcal); err != nil {
+			return fmt.Errorf("import server version: %w", err)
+		}
 		if err := s.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
 			CalendarID: conflict.CalendarID,
 			Uid:        conflict.Uid,

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -358,6 +358,71 @@ func TestService_ResolveConflict_Local(t *testing.T) {
 	}
 }
 
+// TestService_ResolveConflict_ServerEmptyIcal guards against the silent
+// no-op: a conflict whose ServerIcal carries no importable component (empty or
+// component-less) must NOT clear dirty or stamp the server ETag, because doing
+// so would leave the divergent local row in place while claiming it matches the
+// server — the exact data-loss the "server" branch exists to prevent. The
+// resolve should fail and leave the dirty flag and conflict intact for a retry.
+func TestService_ResolveConflict_ServerEmptyIcal(t *testing.T) {
+	svc, q := newTestService(t)
+	ctx := context.Background()
+
+	cals, _ := q.ListCalendars(ctx)
+	calID := cals[0].ID
+
+	const uid = "resolve-server-empty-uid"
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calID,
+		Uid:          uid,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/" + uid + ".ics",
+		Etag:         "etag-before",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	if err := q.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
+		CalendarID: calID,
+		OwnerType:  "event",
+		OwnerID:    1,
+		Uid:        uid,
+		LocalIcal:  "local",
+		ServerIcal: "", // server payload failed to encode at conflict-record time
+		ServerEtag: "etag-456",
+	}); err != nil {
+		t.Fatalf("CreateSyncConflict: %v", err)
+	}
+
+	conflicts, _ := q.ListSyncConflicts(ctx)
+	if err := svc.ResolveConflict(ctx, conflicts[0].ID, "server"); err == nil {
+		t.Fatal("ResolveConflict server with empty ServerIcal: expected error, got nil")
+	}
+
+	// The dirty flag and ETag must be untouched so the next sync can retry.
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{
+		CalendarID: calID,
+		Uid:        uid,
+	})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Dirty != 1 {
+		t.Fatalf("Dirty = %d, want 1 (must stay dirty)", res.Dirty)
+	}
+	if res.Etag != "etag-before" {
+		t.Fatalf("Etag = %q, want %q (must not adopt server ETag)", res.Etag, "etag-before")
+	}
+
+	// The conflict must remain for a later retry, not be silently consumed.
+	remaining, _ := q.ListSyncConflicts(ctx)
+	if len(remaining) != 1 {
+		t.Fatalf("conflicts after failed resolve = %d, want 1", len(remaining))
+	}
+}
+
 func TestService_ResetCalendar(t *testing.T) {
 	svc, q := newTestService(t)
 	ctx := context.Background()

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -191,16 +191,35 @@ func TestService_ResolveConflict_InvalidPick(t *testing.T) {
 	}
 }
 
+// TestService_ResolveConflict_Server is the regression test for issue #67:
+// resolving a conflict to "server" must import the recorded server iCal into
+// the local row (so the local view reflects the server), then clear the dirty
+// flag with the server ETag. Before the fix the local row kept its divergent
+// local copy while the ETag claimed it matched the server.
 func TestService_ResolveConflict_Server(t *testing.T) {
-	svc, q := newTestService(t)
+	svc, db, q := newTestServiceWithDB(t)
 	ctx := context.Background()
 
 	cals, _ := q.ListCalendars(ctx)
 	calID := cals[0].ID
 
+	const uid = "resolve-server-uid"
+	events := event.NewService(db, q)
+
+	// Seed the local row with the divergent LOCAL version.
+	if _, err := events.UpsertByUID(ctx, event.UpsertParams{
+		UID:        uid,
+		CalendarID: calID,
+		Title:      "Local Title",
+		StartTime:  time.Date(2026, 4, 3, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 3, 11, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("seed local event: %v", err)
+	}
+
 	err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
 		CalendarID:   calID,
-		Uid:          "resolve-server-uid",
+		Uid:          uid,
 		OwnerType:    "event",
 		RemoteUrl:    "https://example.com/cal/resolve-server-uid.ics",
 		Etag:         "etag-before",
@@ -211,13 +230,25 @@ func TestService_ResolveConflict_Server(t *testing.T) {
 		t.Fatalf("UpsertSyncResource: %v", err)
 	}
 
+	// The server version differs from the local row: it carries "Server Title".
+	serverIcal := "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//chroncal//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:" + uid + "\r\n" +
+		"DTSTART:20260403T120000Z\r\n" +
+		"DTEND:20260403T130000Z\r\n" +
+		"SUMMARY:Server Title\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
 	err = q.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
 		CalendarID: calID,
 		OwnerType:  "event",
 		OwnerID:    1,
-		Uid:        "resolve-server-uid",
+		Uid:        uid,
 		LocalIcal:  "local",
-		ServerIcal: "server",
+		ServerIcal: serverIcal,
 		ServerEtag: "etag-456",
 	})
 	if err != nil {
@@ -236,9 +267,18 @@ func TestService_ResolveConflict_Server(t *testing.T) {
 		t.Errorf("expected 0 conflicts after resolve, got %d", len(remaining))
 	}
 
+	// The local row must now reflect the SERVER version.
+	evt, err := events.GetByUID(ctx, uid)
+	if err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+	if evt.Title != "Server Title" {
+		t.Fatalf("local Title = %q, want %q (server data not imported)", evt.Title, "Server Title")
+	}
+
 	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{
 		CalendarID: calID,
-		Uid:        "resolve-server-uid",
+		Uid:        uid,
 	})
 	if err != nil {
 		t.Fatalf("GetSyncResource: %v", err)


### PR DESCRIPTION
## Problem

`sync resolve <id> server` marked the resource clean without importing the server data, causing silent remote data loss.

The `"server"` branch of `ResolveConflict` only called `ClearSyncResourceDirty` with `conflict.ServerEtag` but never imported `conflict.ServerIcal` into the local row. The "server version is already the current local state" comment was only true for the auto-resolve (`ConflictServerWins`) path, which calls `persistImported` before clearing dirty.

For a conflict recorded via the `"prompt"` strategy, the local row kept its divergent LOCAL version while `sync_resource.etag` was set to the server's. This left the local view permanently wrong and let a later local edit silently overwrite the server.

## Fix

- Add `Engine.importICal`, which parses raw iCal and persists it through the same `persistImported` path used by auto-resolve.
- Call it from the `"server"` branch before clearing dirty, so the local row reflects the server version.

## Test

Regression test seeds a divergent local event, resolves a conflict with distinct server iCal to `"server"`, and asserts the local row now matches the server data with dirty cleared and the server ETag stored. Verified it fails before the fix and passes after. Full `internal/...` suite passes.

The sibling `"local"` branch (issue #68) is intentionally untouched.

Closes #67
