### PR TITLE
fix(sync): propagate server-side child-collection removals on pull

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1248,30 +1248,18 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		if err != nil {
 			return fmt.Errorf("upsert event %q: %w", ev.UID, err)
 		}
-		if len(ev.Alarms) > 0 {
-			_ = e.events.ReplaceAlarms(ctx, saved.ID, ev.Alarms)
-		}
-		if len(ev.Attendees) > 0 {
-			_ = e.events.ReplaceAttendees(ctx, saved.ID, ev.Attendees)
-		}
-		if len(ev.Attachments) > 0 {
-			_ = e.events.ReplaceAttachments(ctx, saved.ID, ev.Attachments)
-		}
-		if len(ev.Comments) > 0 {
-			_ = e.events.ReplaceComments(ctx, saved.ID, ev.Comments)
-		}
-		if len(ev.Contacts) > 0 {
-			_ = e.events.ReplaceContacts(ctx, saved.ID, ev.Contacts)
-		}
-		if len(ev.Resources) > 0 {
-			_ = e.events.ReplaceResources(ctx, saved.ID, ev.Resources)
-		}
-		if len(ev.Relations) > 0 {
-			_ = e.events.ReplaceRelations(ctx, saved.ID, ev.Relations)
-		}
-		if len(ev.XProperties) > 0 {
-			_ = e.events.ReplaceXProperties(ctx, saved.ID, ev.XProperties)
-		}
+		// Replace child collections unconditionally so server-side removals
+		// (an empty list) are propagated, mirroring how Categories are handled
+		// via UpsertByUID. A full CalDAV pull sends the complete component, so
+		// the absence of a property means "cleared", not "unknown".
+		_ = e.events.ReplaceAlarms(ctx, saved.ID, ev.Alarms)
+		_ = e.events.ReplaceAttendees(ctx, saved.ID, ev.Attendees)
+		_ = e.events.ReplaceAttachments(ctx, saved.ID, ev.Attachments)
+		_ = e.events.ReplaceComments(ctx, saved.ID, ev.Comments)
+		_ = e.events.ReplaceContacts(ctx, saved.ID, ev.Contacts)
+		_ = e.events.ReplaceResources(ctx, saved.ID, ev.Resources)
+		_ = e.events.ReplaceRelations(ctx, saved.ID, ev.Relations)
+		_ = e.events.ReplaceXProperties(ctx, saved.ID, ev.XProperties)
 	}
 
 	// Import todos
@@ -1291,30 +1279,16 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		if err != nil {
 			return fmt.Errorf("upsert todo %q: %w", t.UID, err)
 		}
-		if len(t.Alarms) > 0 {
-			_ = e.todos.ReplaceAlarms(ctx, saved.ID, t.Alarms)
-		}
-		if len(t.Attendees) > 0 {
-			_ = e.todos.ReplaceAttendees(ctx, saved.ID, t.Attendees)
-		}
-		if len(t.Attachments) > 0 {
-			_ = e.todos.ReplaceAttachments(ctx, saved.ID, t.Attachments)
-		}
-		if len(t.Comments) > 0 {
-			_ = e.todos.ReplaceComments(ctx, saved.ID, t.Comments)
-		}
-		if len(t.Contacts) > 0 {
-			_ = e.todos.ReplaceContacts(ctx, saved.ID, t.Contacts)
-		}
-		if len(t.Resources) > 0 {
-			_ = e.todos.ReplaceResources(ctx, saved.ID, t.Resources)
-		}
-		if len(t.Relations) > 0 {
-			_ = e.todos.ReplaceRelations(ctx, saved.ID, t.Relations)
-		}
-		if len(t.XProperties) > 0 {
-			_ = e.todos.ReplaceXProperties(ctx, saved.ID, t.XProperties)
-		}
+		// Replace child collections unconditionally so server-side removals
+		// (an empty list) are propagated. See the event loop above.
+		_ = e.todos.ReplaceAlarms(ctx, saved.ID, t.Alarms)
+		_ = e.todos.ReplaceAttendees(ctx, saved.ID, t.Attendees)
+		_ = e.todos.ReplaceAttachments(ctx, saved.ID, t.Attachments)
+		_ = e.todos.ReplaceComments(ctx, saved.ID, t.Comments)
+		_ = e.todos.ReplaceContacts(ctx, saved.ID, t.Contacts)
+		_ = e.todos.ReplaceResources(ctx, saved.ID, t.Resources)
+		_ = e.todos.ReplaceRelations(ctx, saved.ID, t.Relations)
+		_ = e.todos.ReplaceXProperties(ctx, saved.ID, t.XProperties)
 	}
 
 	// Import journals
@@ -1332,24 +1306,14 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		if err != nil {
 			return fmt.Errorf("upsert journal %q: %w", j.UID, err)
 		}
-		if len(j.Attendees) > 0 {
-			_ = e.journals.ReplaceAttendees(ctx, saved.ID, j.Attendees)
-		}
-		if len(j.Attachments) > 0 {
-			_ = e.journals.ReplaceAttachments(ctx, saved.ID, j.Attachments)
-		}
-		if len(j.Comments) > 0 {
-			_ = e.journals.ReplaceComments(ctx, saved.ID, j.Comments)
-		}
-		if len(j.Contacts) > 0 {
-			_ = e.journals.ReplaceContacts(ctx, saved.ID, j.Contacts)
-		}
-		if len(j.Relations) > 0 {
-			_ = e.journals.ReplaceRelations(ctx, saved.ID, j.Relations)
-		}
-		if len(j.XProperties) > 0 {
-			_ = e.journals.ReplaceXProperties(ctx, saved.ID, j.XProperties)
-		}
+		// Replace child collections unconditionally so server-side removals
+		// (an empty list) are propagated. See the event loop above.
+		_ = e.journals.ReplaceAttendees(ctx, saved.ID, j.Attendees)
+		_ = e.journals.ReplaceAttachments(ctx, saved.ID, j.Attachments)
+		_ = e.journals.ReplaceComments(ctx, saved.ID, j.Comments)
+		_ = e.journals.ReplaceContacts(ctx, saved.ID, j.Contacts)
+		_ = e.journals.ReplaceRelations(ctx, saved.ID, j.Relations)
+		_ = e.journals.ReplaceXProperties(ctx, saved.ID, j.XProperties)
 	}
 
 	return nil

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/calendar"
 	"github.com/douglasdemoura/chroncal/internal/event"
+	icalPkg "github.com/douglasdemoura/chroncal/internal/ical"
 	"github.com/douglasdemoura/chroncal/internal/journal"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
@@ -2029,5 +2030,91 @@ END:VCALENDAR
 	}
 	if _, err := q.GetEventByUID(ctx, "local-only"); err != nil {
 		t.Errorf("never-pushed local-only row must survive: %v", err)
+	}
+}
+
+// TestPersistImportedClearsRemovedAlarms is a regression test for issue #65:
+// a CalDAV pull that re-imports an existing UID whose server component no
+// longer carries an alarm must clear the locally stored alarm. Before the
+// fix, persistImported only replaced child collections when the server sent a
+// non-empty list, so server-side removals were silently dropped and stale
+// alarms lingered.
+func TestPersistImportedClearsRemovedAlarms(t *testing.T) {
+	t.Parallel()
+
+	engine, _, q := newTestEngine(t)
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	const withAlarm = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//chroncal//tests//EN
+BEGIN:VEVENT
+UID:alarm-removal-uid
+DTSTAMP:20260403T120000Z
+DTSTART:20260403T120000Z
+DTEND:20260403T130000Z
+SUMMARY:Has an alarm
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT15M
+DESCRIPTION:Meeting reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+`
+
+	withAlarmResult, err := icalPkg.ImportFile(strings.NewReader(withAlarm))
+	if err != nil {
+		t.Fatalf("ImportFile (with alarm): %v", err)
+	}
+	if err := engine.persistImported(ctx, calendarID, withAlarmResult); err != nil {
+		t.Fatalf("persistImported (with alarm): %v", err)
+	}
+
+	saved, err := q.GetEventByUID(ctx, "alarm-removal-uid")
+	if err != nil {
+		t.Fatalf("GetEventByUID: %v", err)
+	}
+	alarms, err := engine.events.ListAlarms(ctx, saved.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms (after first import): %v", err)
+	}
+	if len(alarms) != 1 {
+		t.Fatalf("alarms after first import = %d, want 1", len(alarms))
+	}
+
+	// Re-import the same UID with no VALARM: the server dropped the alarm.
+	const noAlarm = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//chroncal//tests//EN
+BEGIN:VEVENT
+UID:alarm-removal-uid
+DTSTAMP:20260403T140000Z
+DTSTART:20260403T120000Z
+DTEND:20260403T130000Z
+SUMMARY:Alarm removed on server
+END:VEVENT
+END:VCALENDAR
+`
+
+	noAlarmResult, err := icalPkg.ImportFile(strings.NewReader(noAlarm))
+	if err != nil {
+		t.Fatalf("ImportFile (no alarm): %v", err)
+	}
+	if err := engine.persistImported(ctx, calendarID, noAlarmResult); err != nil {
+		t.Fatalf("persistImported (no alarm): %v", err)
+	}
+
+	alarms, err = engine.events.ListAlarms(ctx, saved.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms (after re-import): %v", err)
+	}
+	if len(alarms) != 0 {
+		t.Fatalf("alarms after server-side removal = %d, want 0 (stale alarm not cleared)", len(alarms))
 	}
 }


### PR DESCRIPTION
## Problem

`persistImported` (the CalDAV pull persistence path) only replaced a child
collection — alarms, attendees, attachments, comments, contacts, resources,
relations, x-props — when the imported server component carried a **non-empty**
list (`if len(ev.Alarms) > 0 { ReplaceAlarms(...) }`). Server-side **removals**,
where the server drops a property entirely (yielding an empty list), were never
propagated, so stale children lingered locally after a pull.

`Categories` was already replaced unconditionally via `UpsertByUID`, making this
an internal asymmetry.

## Fix

A full CalDAV pull sends the complete component, so the absence of a property
means "cleared", not "unknown". Replace child collections **unconditionally**
for events, todos, and journals — mirroring how `Categories` is handled. The
existing `Replace*` methods already delete unmatched stored rows, so passing an
empty slice clears the collection.

Only the conditional-replace logic was touched. The `_ =` error handling is left
unchanged so this stays separable from #69.

## Test

Added `TestPersistImportedClearsRemovedAlarms`: imports an event with an alarm,
asserts the alarm persists, re-imports the same UID with no alarm, and asserts
the local alarm is cleared. Verified it fails before the fix and passes after.

`make fmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/... -count=1`
all pass.

Closes #65
