### PR TITLE
fix(event): make Create/Update atomic in a single transaction

### DIFF
--- a/internal/event/atomic_test.go
+++ b/internal/event/atomic_test.go
@@ -1,0 +1,108 @@
+package event
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/testutil"
+)
+
+// countRows returns the number of rows matching the given query.
+func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(query, args...).Scan(&n); err != nil {
+		t.Fatalf("count query %q: %v", query, err)
+	}
+	return n
+}
+
+// dropCategoriesTable removes the event_categories table so the category
+// child-write fails inside Create/Update, simulating a partial failure.
+func dropCategoriesTable(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`DROP TABLE event_categories`); err != nil {
+		t.Fatalf("drop event_categories: %v", err)
+	}
+}
+
+// TestCreate_AtomicOnCategoryFailure asserts that when the category child-write
+// fails, Create returns an error AND leaves no event row behind. Before the fix
+// the event row was committed in autocommit before categories ran, so a failure
+// left an orphan row (the duplicate-on-retry bug from issue #73).
+func TestCreate_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	dropCategoriesTable(t, db)
+
+	_, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Title:      "Atomic Create",
+		StartTime:  time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Categories: "work,urgent",
+	})
+	if err == nil {
+		t.Fatal("Create succeeded, want error from failing category write")
+	}
+
+	if n := countRows(t, db, `SELECT COUNT(*) FROM events`); n != 0 {
+		t.Fatalf("event rows persisted after failed Create = %d, want 0", n)
+	}
+}
+
+// TestUpdate_AtomicOnCategoryFailure asserts that when the category child-write
+// fails during Update, the original event row and its categories are left
+// unchanged. Before the fix the event row was updated in autocommit before
+// categories ran, so a failure produced a half-updated, category-wiped row.
+func TestUpdate_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	orig, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Title:      "Original Title",
+		StartTime:  time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Categories: "work,urgent",
+	})
+	if err != nil {
+		t.Fatalf("seed create: %v", err)
+	}
+
+	catsBefore := countRows(t, db,
+		`SELECT COUNT(*) FROM event_categories WHERE event_id = ?`, orig.ID)
+	if catsBefore != 2 {
+		t.Fatalf("seed categories = %d, want 2", catsBefore)
+	}
+
+	dropCategoriesTable(t, db)
+
+	_, err = svc.Update(ctx, orig.ID, UpdateParams{
+		CalendarID: 1,
+		Title:      "Changed Title",
+		StartTime:  time.Date(2026, 4, 2, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 2, 15, 0, 0, 0, time.UTC),
+		Categories: "different",
+	})
+	if err == nil {
+		t.Fatal("Update succeeded, want error from failing category write")
+	}
+
+	// The row write must have rolled back: title is unchanged.
+	got, err := svc.Get(ctx, orig.ID)
+	if err != nil {
+		t.Fatalf("get after failed update: %v", err)
+	}
+	if got.Title != "Original Title" {
+		t.Fatalf("title after failed Update = %q, want %q", got.Title, "Original Title")
+	}
+	if !got.StartTime.Equal(orig.StartTime) {
+		t.Fatalf("start time after failed Update = %v, want %v", got.StartTime, orig.StartTime)
+	}
+}

--- a/internal/event/atomic_test.go
+++ b/internal/event/atomic_test.go
@@ -13,7 +13,7 @@ import (
 func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
 	t.Helper()
 	var n int
-	if err := db.QueryRow(query, args...).Scan(&n); err != nil {
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&n); err != nil {
 		t.Fatalf("count query %q: %v", query, err)
 	}
 	return n
@@ -23,7 +23,7 @@ func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
 // child-write fails inside Create/Update, simulating a partial failure.
 func dropCategoriesTable(t *testing.T, db *sql.DB) {
 	t.Helper()
-	if _, err := db.Exec(`DROP TABLE event_categories`); err != nil {
+	if _, err := db.ExecContext(context.Background(), `DROP TABLE event_categories`); err != nil {
 		t.Fatalf("drop event_categories: %v", err)
 	}
 }

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -259,7 +259,15 @@ func (s *Service) markDirtyByID(ctx context.Context, eventID int64) {
 
 func (s *Service) Create(ctx context.Context, p CreateParams) (Event, error) {
 	p.applyDefaults()
-	r, err := s.q.CreateEvent(ctx, storage.CreateEventParams{
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Event{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	r, err := qtx.CreateEvent(ctx, storage.CreateEventParams{
 		Uid:            uuid.New().String(),
 		CalendarID:     p.CalendarID,
 		Title:          p.Title,
@@ -289,9 +297,12 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Event, error) {
 	}
 	e := fromStorage(r)
 	if cats := ParseCategoryList(p.Categories); len(cats) > 0 {
-		if err := s.ReplaceCategories(ctx, e.ID, cats); err != nil {
+		if err := replaceCategoriesTx(ctx, qtx, e.ID, cats); err != nil {
 			return Event{}, fmt.Errorf("replace categories: %w", err)
 		}
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit create event: %w", err)
 	}
 	e.Categories = p.Categories
 	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
@@ -300,7 +311,15 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Event, error) {
 
 func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, error) {
 	p.applyDefaults()
-	r, err := s.q.UpdateEvent(ctx, storage.UpdateEventParams{
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Event{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	r, err := qtx.UpdateEvent(ctx, storage.UpdateEventParams{
 		ID:             id,
 		Title:          p.Title,
 		Description:    storage.StringToNullable(p.Description),
@@ -327,8 +346,11 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, 
 		return Event{}, err
 	}
 	e := fromStorage(r)
-	if err := s.ReplaceCategories(ctx, e.ID, ParseCategoryList(p.Categories)); err != nil {
+	if err := replaceCategoriesTx(ctx, qtx, e.ID, ParseCategoryList(p.Categories)); err != nil {
 		return Event{}, fmt.Errorf("replace categories: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit update event: %w", err)
 	}
 	e.Categories = p.Categories
 	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
@@ -1267,7 +1289,19 @@ func (s *Service) ReplaceCategories(ctx context.Context, eventID int64, categori
 	}
 	defer tx.Rollback()
 
-	qtx := s.q.WithTx(tx)
+	if err := replaceCategoriesTx(ctx, s.q.WithTx(tx), eventID, categories); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit replace categories: %w", err)
+	}
+	return nil
+}
+
+// replaceCategoriesTx replaces an event's categories using a tx-bound Queries.
+// It does not open or commit a transaction, so callers can compose it with
+// other writes inside a single transaction.
+func replaceCategoriesTx(ctx context.Context, qtx *storage.Queries, eventID int64, categories []string) error {
 	if err := qtx.DeleteCategoriesByEventID(ctx, eventID); err != nil {
 		return fmt.Errorf("delete categories: %w", err)
 	}
@@ -1279,9 +1313,6 @@ func (s *Service) ReplaceCategories(ctx context.Context, eventID int64, categori
 		if err != nil {
 			return fmt.Errorf("create category: %w", err)
 		}
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit replace categories: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

`event.Create` committed the event row via `CreateEvent` (autocommit), then ran `ReplaceCategories` in a *separate* transaction; `Update` had the same shape. If the category step failed, the method returned a non-nil error even though the row was already committed.

Callers treat a non-nil error as "no persisted side effect" and retry, which produced:
- **Create**: a duplicate event (orphan row left behind on the failed attempt).
- **Update**: a half-updated, category-wiped row.

## Fix

Wrap the row write **and** the category replacement in a single transaction via `q.WithTx(tx)`, committing only after both succeed. On any failure the deferred `tx.Rollback()` leaves no side effect, honoring the caller's contract.

- Extracted the category replacement into a tx-bound `replaceCategoriesTx(ctx, qtx, ...)` helper so `Create`, `Update`, and the standalone `ReplaceCategories` share one implementation.
- `MarkResourceDirty` remains a best-effort post-commit step (its error is already intentionally discarded), so it is unaffected by the atomicity change.

## Tests

Added `internal/event/atomic_test.go`:
- `TestCreate_AtomicOnCategoryFailure` — drops `event_categories` to force the child write to fail, asserts `Create` errors and **no** event row is persisted.
- `TestUpdate_AtomicOnCategoryFailure` — asserts a failed `Update` leaves the original title/start time unchanged.

Both fail before the fix and pass after. Full `go test ./internal/...` is green; `make fmt`, `go vet ./...`, `go build ./...` all clean.

Closes #73
