### PR TITLE
fix(alarm): only fire after a successful state claim

### DIFF
--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -38,6 +38,12 @@ func parseStateID(s string) (int64, bool, error) {
 	return id, false, nil
 }
 
+// fireAlarmFn is the notification dispatcher used by the mark-and-fire
+// helpers. It is a package var so tests can observe whether a notification
+// was actually dispatched (the duplicate-claim regression hinges on it NOT
+// being called when a competing checker already claimed the alarm).
+var fireAlarmFn = fireAlarm
+
 // fireAlarm dispatches the notification for a due alarm.
 // EMAIL and AUDIO fall back to DISPLAY on failure.
 //
@@ -61,28 +67,47 @@ func fireAlarm(da alarm.DueAlarm, policy alarmExecutionPolicy) error {
 	}
 }
 
-// markAndFireEventAlarm records the firing state for a due event alarm and
-// dispatches its notification. Marking errors are reported to stderr and
-// returned (the daemon's failure breaker counts them — a mark failure means
-// the alarm will re-fire next tick); the returned state ID is 0 when marking
-// failed. The last return value is the notification delivery error, if any.
+// isAlarmAlreadyClaimed reports whether err is the SQLite UNIQUE-constraint
+// violation on the (alarm_id, trigger_at) index. That index lets MarkFired
+// act as an atomic claim: when two checkers overlap, both observe "no state"
+// and both try to insert, but only one INSERT wins — the loser gets this
+// error. It is a benign race, not a database fault, so callers skip firing
+// without counting it against the daemon's failure breaker.
+func isAlarmAlreadyClaimed(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
+}
+
+// markAndFireEventAlarm claims a due event alarm and, only on a successful
+// claim, dispatches its notification. The claim is the INSERT performed by
+// MarkFired (or the refire of an already-owned snoozed state): firing is
+// gated on it so two overlapping checkers cannot both notify for the same
+// alarm. A lost claim race (the (alarm_id, trigger_at) UNIQUE constraint)
+// is treated as "someone else fired it" — no notification, no error.
+//
+// Genuine marking errors are reported to stderr and returned (the daemon's
+// failure breaker counts them — a mark failure means the alarm will re-fire
+// next tick); the returned state ID is 0 when marking failed. The last
+// return value is the notification delivery error, if any.
 func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) (int64, error, error) {
 	stateID := da.StateID
 	var markErr error
 	if stateID != 0 {
-		if markErr = a.Alarms.MarkRefired(ctx, stateID); markErr != nil {
-			fmt.Fprintf(os.Stderr, "chroncal: mark-refired error: event=%q: %v\n", safeText(da.Event.Title), markErr)
-		}
+		markErr = a.Alarms.MarkRefired(ctx, stateID)
 	} else {
 		var newID int64
-		if newID, markErr = a.Alarms.MarkFired(ctx, da); markErr != nil {
-			fmt.Fprintf(os.Stderr, "chroncal: mark-fired error: event=%q: %v\n", safeText(da.Event.Title), markErr)
-		} else {
+		if newID, markErr = a.Alarms.MarkFired(ctx, da); markErr == nil {
 			stateID = newID
 		}
 	}
+	if markErr != nil {
+		if isAlarmAlreadyClaimed(markErr) {
+			return 0, nil, nil // another checker already fired this alarm
+		}
+		fmt.Fprintf(os.Stderr, "chroncal: mark-fired error: event=%q: %v\n", safeText(da.Event.Title), markErr)
+		return stateID, markErr, nil
+	}
 
-	fireErr := fireAlarm(da, policy)
+	fireErr := fireAlarmFn(da, policy)
 	if fireErr != nil {
 		fmt.Fprintf(os.Stderr, "chroncal: alarm error: %s (event=%q action=%s): %v\n",
 			da.TriggerAt.Local().Format("15:04"), safeText(da.Event.Title), da.Alarm.Action, fireErr)
@@ -95,19 +120,22 @@ func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlar
 	stateID := tda.StateID
 	var markErr error
 	if stateID != 0 {
-		if markErr = a.Alarms.MarkTodoRefired(ctx, stateID); markErr != nil {
-			fmt.Fprintf(os.Stderr, "chroncal: mark-refired error: todo=%q: %v\n", safeText(tda.Todo.Summary), markErr)
-		}
+		markErr = a.Alarms.MarkTodoRefired(ctx, stateID)
 	} else {
 		var newID int64
-		if newID, markErr = a.Alarms.MarkTodoFired(ctx, tda); markErr != nil {
-			fmt.Fprintf(os.Stderr, "chroncal: mark-fired error: todo=%q: %v\n", safeText(tda.Todo.Summary), markErr)
-		} else {
+		if newID, markErr = a.Alarms.MarkTodoFired(ctx, tda); markErr == nil {
 			stateID = newID
 		}
 	}
+	if markErr != nil {
+		if isAlarmAlreadyClaimed(markErr) {
+			return 0, nil, nil // another checker already fired this alarm
+		}
+		fmt.Fprintf(os.Stderr, "chroncal: mark-fired error: todo=%q: %v\n", safeText(tda.Todo.Summary), markErr)
+		return stateID, markErr, nil
+	}
 
-	fireErr := fireAlarm(todoDueAlarmToDueAlarm(tda), policy)
+	fireErr := fireAlarmFn(todoDueAlarmToDueAlarm(tda), policy)
 	if fireErr != nil {
 		fmt.Fprintf(os.Stderr, "chroncal: todo alarm error: %s (todo=%q action=%s): %v\n",
 			tda.TriggerAt.Local().Format("15:04"), safeText(tda.Todo.Summary), tda.Alarm.Action, fireErr)

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -77,18 +77,36 @@ func isAlarmAlreadyClaimed(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
 }
 
-// markAndFireEventAlarm claims a due event alarm and, only on a successful
-// claim, dispatches its notification. The claim is the INSERT performed by
-// MarkFired (or the refire of an already-owned snoozed state): firing is
-// gated on it so two overlapping checkers cannot both notify for the same
-// alarm. A lost claim race (the (alarm_id, trigger_at) UNIQUE constraint)
-// is treated as "someone else fired it" — no notification, no error.
+// fireResult reports the outcome of a mark-and-fire attempt. The three
+// outcomes are mutually distinguishable so callers never record a false
+// "fired" entry:
 //
-// Genuine marking errors are reported to stderr and returned (the daemon's
-// failure breaker counts them — a mark failure means the alarm will re-fire
-// next tick); the returned state ID is 0 when marking failed. The last
-// return value is the notification delivery error, if any.
-func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) (int64, error, error) {
+//   - Fired == true: the alarm was claimed and the notification dispatched
+//     (FireErr may still report a delivery failure). StateID is the claimed row.
+//   - Fired == false, MarkErr == nil: the claim was lost to a concurrent
+//     checker (benign UNIQUE-constraint race) — nothing was dispatched, and
+//     callers must emit no record for it.
+//   - MarkErr != nil: a genuine marking failure — the daemon's failure breaker
+//     counts it, and the alarm re-fires next tick.
+type fireResult struct {
+	StateID int64
+	Fired   bool
+	MarkErr error
+	FireErr error
+}
+
+// markAndFireEventAlarm claims a due event alarm and, only on a successful
+// claim, dispatches its notification. For a fresh fire (StateID == 0) the claim
+// is the INSERT performed by MarkFired, guarded by the (alarm_id, trigger_at)
+// UNIQUE index: when two checkers overlap, both observe "no state" and both try
+// to insert, but only one wins. The loser's UNIQUE-constraint error is reported
+// as a non-fired, non-error result so callers suppress output for it.
+//
+// Note: the refire path (StateID != 0, an expired-snoozed alarm) uses MarkRefired,
+// an UPDATE-by-id with no claim semantics, so two overlapping checkers can still
+// both refire one snoozed alarm. That is a separate, pre-existing gap tracked
+// outside this change; the dedup here covers only the fresh-fire INSERT path.
+func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) fireResult {
 	stateID := da.StateID
 	var markErr error
 	op := "mark-fired"
@@ -103,10 +121,10 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 	}
 	if markErr != nil {
 		if isAlarmAlreadyClaimed(markErr) {
-			return 0, nil, nil // another checker already fired this alarm
+			return fireResult{} // another checker already fired this alarm
 		}
 		fmt.Fprintf(os.Stderr, "chroncal: %s error: event=%q: %v\n", op, safeText(da.Event.Title), markErr)
-		return stateID, markErr, nil
+		return fireResult{StateID: stateID, MarkErr: markErr}
 	}
 
 	fireErr := fireAlarmFn(da, policy)
@@ -114,11 +132,11 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 		fmt.Fprintf(os.Stderr, "chroncal: alarm error: %s (event=%q action=%s): %v\n",
 			da.TriggerAt.Local().Format("15:04"), safeText(da.Event.Title), da.Alarm.Action, fireErr)
 	}
-	return stateID, markErr, fireErr
+	return fireResult{StateID: stateID, Fired: true, FireErr: fireErr}
 }
 
 // markAndFireTodoAlarm is the todo counterpart of markAndFireEventAlarm.
-func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlarm, policy alarmExecutionPolicy) (int64, error, error) {
+func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlarm, policy alarmExecutionPolicy) fireResult {
 	stateID := tda.StateID
 	var markErr error
 	op := "mark-fired"
@@ -133,10 +151,10 @@ func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlar
 	}
 	if markErr != nil {
 		if isAlarmAlreadyClaimed(markErr) {
-			return 0, nil, nil // another checker already fired this alarm
+			return fireResult{} // another checker already fired this alarm
 		}
 		fmt.Fprintf(os.Stderr, "chroncal: %s error: todo=%q: %v\n", op, safeText(tda.Todo.Summary), markErr)
-		return stateID, markErr, nil
+		return fireResult{StateID: stateID, MarkErr: markErr}
 	}
 
 	fireErr := fireAlarmFn(todoDueAlarmToDueAlarm(tda), policy)
@@ -144,7 +162,7 @@ func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlar
 		fmt.Fprintf(os.Stderr, "chroncal: todo alarm error: %s (todo=%q action=%s): %v\n",
 			tda.TriggerAt.Local().Format("15:04"), safeText(tda.Todo.Summary), tda.Alarm.Action, fireErr)
 	}
-	return stateID, markErr, fireErr
+	return fireResult{StateID: stateID, Fired: true, FireErr: fireErr}
 }
 
 func alarmCmd() *cobra.Command {
@@ -232,8 +250,17 @@ and exits 0.`,
 	return cmd
 }
 
+// afterCheckForTest, when non-nil, runs once after Check returns the due set
+// but before any alarm is claimed. It is a test seam for deterministically
+// interleaving a second checker into the Check-then-claim window so the
+// lost-claim suppression path can be exercised end-to-end. nil in production.
+var afterCheckForTest func()
+
 func runAlarmCheck(ctx context.Context, a *app.App, w io.Writer, now time.Time, policy alarmExecutionPolicy) error {
 	due, todoDue, err := a.Alarms.Check(ctx, now)
+	if afterCheckForTest != nil {
+		afterCheckForTest()
+	}
 	if err != nil {
 		return fmt.Errorf("check alarms: %w", err)
 	}
@@ -247,65 +274,54 @@ func runAlarmCheck(ctx context.Context, a *app.App, w io.Writer, now time.Time, 
 
 	var results []map[string]any
 	for _, da := range due {
-		stateID, _, fireErr := markAndFireEventAlarm(ctx, a, da, policy)
-		if fireErr != nil {
-			if outputFmt != "text" {
-				results = append(results, map[string]any{
-					"event_id":   da.Event.ID,
-					"event":      da.Event.Title,
-					"alarm_id":   da.Alarm.ID,
-					"state_id":   stateID,
-					"action":     da.Alarm.Action,
-					"trigger_at": da.TriggerAt.UTC().Format(time.RFC3339),
-					"status":     fmt.Sprintf("error: %v", fireErr),
-				})
-			}
+		res := markAndFireEventAlarm(ctx, a, da, policy)
+		if !res.Fired {
+			// Lost claim race or genuine mark failure: no notification was
+			// dispatched, so emit no record (a false "fired" entry would
+			// break scripts consuming -o json).
 			continue
 		}
 
 		if outputFmt != "text" {
+			status := "fired"
+			if res.FireErr != nil {
+				status = fmt.Sprintf("error: %v", res.FireErr)
+			}
 			results = append(results, map[string]any{
 				"event_id":   da.Event.ID,
 				"event":      da.Event.Title,
 				"alarm_id":   da.Alarm.ID,
-				"state_id":   stateID,
+				"state_id":   res.StateID,
 				"action":     da.Alarm.Action,
 				"trigger_at": da.TriggerAt.UTC().Format(time.RFC3339),
-				"status":     "fired",
+				"status":     status,
 			})
-		} else {
+		} else if res.FireErr == nil {
 			writeAlarmCheckLine(w, da.TriggerAt, da.Alarm.Action, da.Event.Title, false)
 		}
 	}
 
 	for _, tda := range todoDue {
-		stateID, _, fireErr := markAndFireTodoAlarm(ctx, a, tda, policy)
-		if fireErr != nil {
-			if outputFmt != "text" {
-				results = append(results, map[string]any{
-					"todo_id":    tda.Todo.ID,
-					"todo":       tda.Todo.Summary,
-					"alarm_id":   tda.Alarm.ID,
-					"state_id":   stateID,
-					"action":     tda.Alarm.Action,
-					"trigger_at": tda.TriggerAt.UTC().Format(time.RFC3339),
-					"status":     fmt.Sprintf("error: %v", fireErr),
-				})
-			}
+		res := markAndFireTodoAlarm(ctx, a, tda, policy)
+		if !res.Fired {
 			continue
 		}
 
 		if outputFmt != "text" {
+			status := "fired"
+			if res.FireErr != nil {
+				status = fmt.Sprintf("error: %v", res.FireErr)
+			}
 			results = append(results, map[string]any{
 				"todo_id":    tda.Todo.ID,
 				"todo":       tda.Todo.Summary,
 				"alarm_id":   tda.Alarm.ID,
-				"state_id":   stateID,
+				"state_id":   res.StateID,
 				"action":     tda.Alarm.Action,
 				"trigger_at": tda.TriggerAt.UTC().Format(time.RFC3339),
-				"status":     "fired",
+				"status":     status,
 			})
-		} else {
+		} else if res.FireErr == nil {
 			writeAlarmCheckLine(w, tda.TriggerAt, tda.Alarm.Action, tda.Todo.Summary, true)
 		}
 	}
@@ -756,21 +772,21 @@ See "chroncal alarm check --help" for notification types and SMTP configuration.
 				}
 				var dbErr error
 				for _, da := range due {
-					_, markErr, fireErr := markAndFireEventAlarm(ctx, a, da, policy)
-					if markErr != nil {
-						dbErr = markErr
+					res := markAndFireEventAlarm(ctx, a, da, policy)
+					if res.MarkErr != nil {
+						dbErr = res.MarkErr
 					}
-					if fireErr != nil {
+					if !res.Fired || res.FireErr != nil {
 						continue
 					}
 					writeAlarmCheckLine(w, da.TriggerAt, da.Alarm.Action, da.Event.Title, false)
 				}
 				for _, tda := range todoDue {
-					_, markErr, fireErr := markAndFireTodoAlarm(ctx, a, tda, policy)
-					if markErr != nil {
-						dbErr = markErr
+					res := markAndFireTodoAlarm(ctx, a, tda, policy)
+					if res.MarkErr != nil {
+						dbErr = res.MarkErr
 					}
-					if fireErr != nil {
+					if !res.Fired || res.FireErr != nil {
 						continue
 					}
 					writeAlarmCheckLine(w, tda.TriggerAt, tda.Alarm.Action, tda.Todo.Summary, true)

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -91,7 +91,9 @@ func isAlarmAlreadyClaimed(err error) bool {
 func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) (int64, error, error) {
 	stateID := da.StateID
 	var markErr error
+	op := "mark-fired"
 	if stateID != 0 {
+		op = "mark-refired"
 		markErr = a.Alarms.MarkRefired(ctx, stateID)
 	} else {
 		var newID int64
@@ -103,7 +105,7 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 		if isAlarmAlreadyClaimed(markErr) {
 			return 0, nil, nil // another checker already fired this alarm
 		}
-		fmt.Fprintf(os.Stderr, "chroncal: mark-fired error: event=%q: %v\n", safeText(da.Event.Title), markErr)
+		fmt.Fprintf(os.Stderr, "chroncal: %s error: event=%q: %v\n", op, safeText(da.Event.Title), markErr)
 		return stateID, markErr, nil
 	}
 
@@ -119,7 +121,9 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlarm, policy alarmExecutionPolicy) (int64, error, error) {
 	stateID := tda.StateID
 	var markErr error
+	op := "mark-fired"
 	if stateID != 0 {
+		op = "mark-refired"
 		markErr = a.Alarms.MarkTodoRefired(ctx, stateID)
 	} else {
 		var newID int64
@@ -131,7 +135,7 @@ func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlar
 		if isAlarmAlreadyClaimed(markErr) {
 			return 0, nil, nil // another checker already fired this alarm
 		}
-		fmt.Fprintf(os.Stderr, "chroncal: mark-fired error: todo=%q: %v\n", safeText(tda.Todo.Summary), markErr)
+		fmt.Fprintf(os.Stderr, "chroncal: %s error: todo=%q: %v\n", op, safeText(tda.Todo.Summary), markErr)
 		return stateID, markErr, nil
 	}
 

--- a/cmd/chroncal/alarm_fire_test.go
+++ b/cmd/chroncal/alarm_fire_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/alarm"
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/todo"
+)
+
+// stubFireAlarm installs a counting stub over fireAlarmFn for the duration of
+// the test and returns a pointer to the invocation count.
+func stubFireAlarm(t *testing.T) *int {
+	t.Helper()
+	orig := fireAlarmFn
+	t.Cleanup(func() { fireAlarmFn = orig })
+	var calls int
+	fireAlarmFn = func(alarm.DueAlarm, alarmExecutionPolicy) error {
+		calls++
+		return nil
+	}
+	return &calls
+}
+
+func newAlarmTestApp(t *testing.T) *app.App {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("CHRONCAL_DB", filepath.Join(dir, "chroncal.db"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg-config"))
+	a, err := app.New(filepath.Join(dir, "chroncal.db"))
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	t.Cleanup(func() { a.Close() })
+	return a
+}
+
+// TestMarkAndFireEventAlarmSkipsFireOnDuplicateClaim is the regression test for
+// issue #70: when two checkers overlap, both observe "no state" and both call
+// MarkFired with the same (alarm_id, trigger_at). The first INSERT wins; the
+// second hits the UNIQUE constraint. fireAlarm must NOT run for the loser, so
+// the alarm fires exactly once.
+func TestMarkAndFireEventAlarmSkipsFireOnDuplicateClaim(t *testing.T) {
+	ctx := context.Background()
+	a := newAlarmTestApp(t)
+	calls := stubFireAlarm(t)
+
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+	start := time.Now().Add(time.Hour)
+	evt, err := a.Events.Create(ctx, event.CreateParams{
+		CalendarID: cal.ID,
+		Title:      "Standup",
+		StartTime:  start,
+		EndTime:    start.Add(30 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	if err := a.Events.ReplaceAlarms(ctx, evt.ID, []model.Alarm{{
+		Action:       "DISPLAY",
+		TriggerValue: "-PT15M",
+		Description:  "Standup reminder",
+		Related:      "START",
+	}}); err != nil {
+		t.Fatalf("replace alarms: %v", err)
+	}
+	alarms, err := a.Events.ListAlarms(ctx, evt.ID)
+	if err != nil || len(alarms) != 1 {
+		t.Fatalf("list alarms: %v (got %d)", err, len(alarms))
+	}
+
+	da := alarm.DueAlarm{
+		Event:     evt,
+		Alarm:     alarms[0],
+		TriggerAt: start.Add(-15 * time.Minute).UTC(),
+	}
+
+	// First checker: claims and fires.
+	if _, markErr, fireErr := markAndFireEventAlarm(ctx, a, da, alarmExecutionPolicy{}); markErr != nil || fireErr != nil {
+		t.Fatalf("first claim: markErr=%v fireErr=%v", markErr, fireErr)
+	}
+	if *calls != 1 {
+		t.Fatalf("after first claim: fireAlarm called %d times, want 1", *calls)
+	}
+
+	// Second (overlapping) checker: same DueAlarm, no state observed. The
+	// MarkFired INSERT collides on (alarm_id, trigger_at).
+	stateID, markErr, fireErr := markAndFireEventAlarm(ctx, a, da, alarmExecutionPolicy{})
+	if markErr != nil {
+		t.Fatalf("duplicate claim returned markErr=%v; a lost race must not count as a DB fault", markErr)
+	}
+	if fireErr != nil {
+		t.Fatalf("duplicate claim returned fireErr=%v, want nil", fireErr)
+	}
+	if stateID != 0 {
+		t.Fatalf("duplicate claim returned stateID=%d, want 0", stateID)
+	}
+	if *calls != 1 {
+		t.Fatalf("duplicate claim fired the alarm: fireAlarm called %d times, want 1", *calls)
+	}
+}
+
+// TestMarkAndFireTodoAlarmSkipsFireOnDuplicateClaim mirrors the event test for
+// the todo variant.
+func TestMarkAndFireTodoAlarmSkipsFireOnDuplicateClaim(t *testing.T) {
+	ctx := context.Background()
+	a := newAlarmTestApp(t)
+	calls := stubFireAlarm(t)
+
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+	due := time.Now().Add(time.Hour)
+	td, err := a.Todos.Create(ctx, todo.CreateParams{
+		CalendarID: cal.ID,
+		Summary:    "File report",
+		DueDate:    due.UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create todo: %v", err)
+	}
+	if err := a.Todos.ReplaceAlarms(ctx, td.ID, []model.Alarm{{
+		Action:       "DISPLAY",
+		TriggerValue: "-PT15M",
+		Description:  "Report reminder",
+		Related:      "START",
+	}}); err != nil {
+		t.Fatalf("replace todo alarms: %v", err)
+	}
+	alarms, err := a.Todos.ListAlarms(ctx, td.ID)
+	if err != nil || len(alarms) != 1 {
+		t.Fatalf("list todo alarms: %v (got %d)", err, len(alarms))
+	}
+
+	tda := alarm.TodoDueAlarm{
+		Todo:      td,
+		Alarm:     alarms[0],
+		TriggerAt: due.Add(-15 * time.Minute).UTC(),
+	}
+
+	if _, markErr, fireErr := markAndFireTodoAlarm(ctx, a, tda, alarmExecutionPolicy{}); markErr != nil || fireErr != nil {
+		t.Fatalf("first claim: markErr=%v fireErr=%v", markErr, fireErr)
+	}
+	if *calls != 1 {
+		t.Fatalf("after first claim: fireAlarm called %d times, want 1", *calls)
+	}
+
+	stateID, markErr, fireErr := markAndFireTodoAlarm(ctx, a, tda, alarmExecutionPolicy{})
+	if markErr != nil {
+		t.Fatalf("duplicate claim returned markErr=%v; a lost race must not count as a DB fault", markErr)
+	}
+	if fireErr != nil {
+		t.Fatalf("duplicate claim returned fireErr=%v, want nil", fireErr)
+	}
+	if stateID != 0 {
+		t.Fatalf("duplicate claim returned stateID=%d, want 0", stateID)
+	}
+	if *calls != 1 {
+		t.Fatalf("duplicate claim fired the alarm: fireAlarm called %d times, want 1", *calls)
+	}
+}

--- a/cmd/chroncal/alarm_fire_test.go
+++ b/cmd/chroncal/alarm_fire_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -29,15 +31,25 @@ func stubFireAlarm(t *testing.T) *int {
 
 func newAlarmTestApp(t *testing.T) *app.App {
 	t.Helper()
+	a, _ := newAlarmTestAppWithPath(t)
+	return a
+}
+
+// newAlarmTestAppWithPath builds a fresh app on a temp DB and returns both the
+// app and the DB path, so a test can open a second connection on the same DB
+// to model two concurrent checkers.
+func newAlarmTestAppWithPath(t *testing.T) (*app.App, string) {
+	t.Helper()
 	dir := t.TempDir()
-	t.Setenv("CHRONCAL_DB", filepath.Join(dir, "chroncal.db"))
+	dbPath := filepath.Join(dir, "chroncal.db")
+	t.Setenv("CHRONCAL_DB", dbPath)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg-config"))
-	a, err := app.New(filepath.Join(dir, "chroncal.db"))
+	a, err := app.New(dbPath)
 	if err != nil {
 		t.Fatalf("app.New: %v", err)
 	}
 	t.Cleanup(func() { a.Close() })
-	return a
+	return a, dbPath
 }
 
 // TestMarkAndFireEventAlarmSkipsFireOnDuplicateClaim is the regression test for
@@ -84,8 +96,8 @@ func TestMarkAndFireEventAlarmSkipsFireOnDuplicateClaim(t *testing.T) {
 	}
 
 	// First checker: claims and fires.
-	if _, markErr, fireErr := markAndFireEventAlarm(ctx, a, da, alarmExecutionPolicy{}); markErr != nil || fireErr != nil {
-		t.Fatalf("first claim: markErr=%v fireErr=%v", markErr, fireErr)
+	if res := markAndFireEventAlarm(ctx, a, da, alarmExecutionPolicy{}); res.MarkErr != nil || res.FireErr != nil || !res.Fired {
+		t.Fatalf("first claim: %+v, want Fired=true with no errors", res)
 	}
 	if *calls != 1 {
 		t.Fatalf("after first claim: fireAlarm called %d times, want 1", *calls)
@@ -93,18 +105,111 @@ func TestMarkAndFireEventAlarmSkipsFireOnDuplicateClaim(t *testing.T) {
 
 	// Second (overlapping) checker: same DueAlarm, no state observed. The
 	// MarkFired INSERT collides on (alarm_id, trigger_at).
-	stateID, markErr, fireErr := markAndFireEventAlarm(ctx, a, da, alarmExecutionPolicy{})
-	if markErr != nil {
-		t.Fatalf("duplicate claim returned markErr=%v; a lost race must not count as a DB fault", markErr)
+	res := markAndFireEventAlarm(ctx, a, da, alarmExecutionPolicy{})
+	if res.MarkErr != nil {
+		t.Fatalf("duplicate claim returned MarkErr=%v; a lost race must not count as a DB fault", res.MarkErr)
 	}
-	if fireErr != nil {
-		t.Fatalf("duplicate claim returned fireErr=%v, want nil", fireErr)
+	if res.FireErr != nil {
+		t.Fatalf("duplicate claim returned FireErr=%v, want nil", res.FireErr)
 	}
-	if stateID != 0 {
-		t.Fatalf("duplicate claim returned stateID=%d, want 0", stateID)
+	if res.Fired {
+		t.Fatalf("duplicate claim reported Fired=true; the lost claim must signal not-fired")
+	}
+	if res.StateID != 0 {
+		t.Fatalf("duplicate claim returned StateID=%d, want 0", res.StateID)
 	}
 	if *calls != 1 {
 		t.Fatalf("duplicate claim fired the alarm: fireAlarm called %d times, want 1", *calls)
+	}
+}
+
+// TestRunAlarmCheckEmitsNoFiredRecordOnLostClaim is the end-to-end regression
+// for issue #70's review follow-up: a checker that loses the claim race must
+// not emit a "fired" JSON record (which would carry state_id:0 and break
+// scripts consuming -o json).
+//
+// It reproduces the Check-then-claim TOCTOU window deterministically: checker B
+// runs runAlarmCheck and captures the due alarm in Check; the afterCheckForTest
+// seam then lets a competing checker A claim and fire the same alarm before B
+// reaches MarkFired. B therefore loses the UNIQUE (alarm_id, trigger_at) race
+// at claim time and must emit no record.
+func TestRunAlarmCheckEmitsNoFiredRecordOnLostClaim(t *testing.T) {
+	ctx := context.Background()
+	a, dbPath := newAlarmTestAppWithPath(t)
+
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+	// Trigger fires 15m before start; place start a minute ago so the alarm
+	// is already due (trigger ~16m in the past, well inside StaleThreshold).
+	start := time.Now().Add(-time.Minute)
+	evt, err := a.Events.Create(ctx, event.CreateParams{
+		CalendarID: cal.ID,
+		Title:      "Standup",
+		StartTime:  start,
+		EndTime:    start.Add(30 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	if err := a.Events.ReplaceAlarms(ctx, evt.ID, []model.Alarm{{
+		Action:       "DISPLAY",
+		TriggerValue: "-PT15M",
+		Description:  "Standup reminder",
+		Related:      "START",
+	}}); err != nil {
+		t.Fatalf("replace alarms: %v", err)
+	}
+
+	// Competing checker A on the same DB. Its mark-and-fire is driven from B's
+	// after-Check seam so the claim lands in B's TOCTOU window.
+	b, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (checker B): %v", err)
+	}
+	defer b.Close()
+
+	due, _, err := b.Alarms.Check(ctx, time.Now())
+	if err != nil || len(due) != 1 {
+		t.Fatalf("precondition Check: err=%v due=%d, want one due alarm", err, len(due))
+	}
+	aDueAlarm := due[0]
+
+	calls := stubFireAlarm(t)
+
+	var aClaimed bool
+	prevHook := afterCheckForTest
+	afterCheckForTest = func() {
+		if aClaimed {
+			return // claim exactly once, even if the seam runs again
+		}
+		aClaimed = true
+		if res := markAndFireEventAlarm(ctx, a, aDueAlarm, alarmExecutionPolicy{}); !res.Fired {
+			t.Errorf("competing checker A failed to claim: %+v", res)
+		}
+	}
+	t.Cleanup(func() { afterCheckForTest = prevHook })
+
+	prevFmt := outputFmt
+	outputFmt = "json"
+	t.Cleanup(func() { outputFmt = prevFmt })
+
+	var bOut bytes.Buffer
+	if err := runAlarmCheck(ctx, b, &bOut, time.Now(), alarmExecutionPolicy{}); err != nil {
+		t.Fatalf("checker B runAlarmCheck: %v", err)
+	}
+
+	if *calls != 1 {
+		t.Fatalf("alarm fired %d times across both checkers, want exactly 1", *calls)
+	}
+
+	var records []map[string]any
+	if err := json.Unmarshal(bOut.Bytes(), &records); err != nil {
+		t.Fatalf("parse checker B JSON %q: %v", bOut.String(), err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("checker B emitted %d record(s) on a lost claim, want 0: %s", len(records), bOut.String())
 	}
 }
 
@@ -147,22 +252,25 @@ func TestMarkAndFireTodoAlarmSkipsFireOnDuplicateClaim(t *testing.T) {
 		TriggerAt: due.Add(-15 * time.Minute).UTC(),
 	}
 
-	if _, markErr, fireErr := markAndFireTodoAlarm(ctx, a, tda, alarmExecutionPolicy{}); markErr != nil || fireErr != nil {
-		t.Fatalf("first claim: markErr=%v fireErr=%v", markErr, fireErr)
+	if res := markAndFireTodoAlarm(ctx, a, tda, alarmExecutionPolicy{}); res.MarkErr != nil || res.FireErr != nil || !res.Fired {
+		t.Fatalf("first claim: %+v, want Fired=true with no errors", res)
 	}
 	if *calls != 1 {
 		t.Fatalf("after first claim: fireAlarm called %d times, want 1", *calls)
 	}
 
-	stateID, markErr, fireErr := markAndFireTodoAlarm(ctx, a, tda, alarmExecutionPolicy{})
-	if markErr != nil {
-		t.Fatalf("duplicate claim returned markErr=%v; a lost race must not count as a DB fault", markErr)
+	res := markAndFireTodoAlarm(ctx, a, tda, alarmExecutionPolicy{})
+	if res.MarkErr != nil {
+		t.Fatalf("duplicate claim returned MarkErr=%v; a lost race must not count as a DB fault", res.MarkErr)
 	}
-	if fireErr != nil {
-		t.Fatalf("duplicate claim returned fireErr=%v, want nil", fireErr)
+	if res.FireErr != nil {
+		t.Fatalf("duplicate claim returned FireErr=%v, want nil", res.FireErr)
 	}
-	if stateID != 0 {
-		t.Fatalf("duplicate claim returned stateID=%d, want 0", stateID)
+	if res.Fired {
+		t.Fatalf("duplicate claim reported Fired=true; the lost claim must signal not-fired")
+	}
+	if res.StateID != 0 {
+		t.Fatalf("duplicate claim returned StateID=%d, want 0", res.StateID)
 	}
 	if *calls != 1 {
 		t.Fatalf("duplicate claim fired the alarm: fireAlarm called %d times, want 1", *calls)


### PR DESCRIPTION
## Problem

`markAndFireEventAlarm` / `markAndFireTodoAlarm` in `cmd/chroncal/alarm.go`
called `fireAlarm` **unconditionally** after `MarkFired`/`MarkRefired`, even
when marking failed. There is no atomic check-and-claim, so when two checkers
overlap (the daemon plus a cron/systemd `alarm check`, or two ticks) both
observe "no state" and both call `MarkFired` with the same
`(alarm_id, trigger_at)`. The first INSERT wins; the second hits the
`idx_alarm_state_unique` UNIQUE constraint — yet `fireAlarm` still ran,
producing duplicate desktop notifications and duplicate EMAIL alarms.

## Fix

Gate firing on a successful claim. `fireAlarm` now runs only when `MarkFired`
actually inserted the state row (or a snoozed state was refired). A lost claim
race is detected via the SQLite UNIQUE-constraint violation
(`isAlarmAlreadyClaimed`) and treated as "someone else already fired it": no
notification, no error — so the daemon's consecutive-failure breaker does not
count a benign overlap. Genuine marking errors are still logged and returned.

Applied to both the event and todo variants. The check loop in
`internal/alarm/service.go` is untouched (that is issue #71's scope).

## Test

`cmd/chroncal/alarm_fire_test.go` adds a regression test for both variants that
drives a real duplicate claim through the `alarm_state` / `todo_alarm_state`
UNIQUE index (against an in-memory app DB) and asserts `fireAlarm` is invoked
exactly once. Verified it fails on the pre-fix unconditional logic and passes
after.

Closes #70
