### PR TITLE
fix(todo,journal): clear master EXDATEs on RestoreByUID

### DIFF
--- a/db/queries/journals.sql
+++ b/db/queries/journals.sql
@@ -42,6 +42,11 @@ SELECT * FROM journals WHERE uid = ? AND recurrence_id = ? AND deleted_at IS NUL
 -- name: ListJournalOverridesByUID :many
 SELECT * FROM journals WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NULL ORDER BY recurrence_id;
 
+-- name: ListDeletedJournalOverrideRecurrenceIDs :many
+SELECT recurrence_id FROM journals
+WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NOT NULL
+ORDER BY recurrence_id;
+
 
 -- name: DeleteJournalsByUID :exec
 DELETE FROM journals WHERE uid = ?;

--- a/db/queries/todos.sql
+++ b/db/queries/todos.sql
@@ -42,6 +42,11 @@ SELECT * FROM todos WHERE uid = ? AND recurrence_id = ? AND deleted_at IS NULL;
 -- name: ListTodoOverridesByUID :many
 SELECT * FROM todos WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NULL ORDER BY recurrence_id;
 
+-- name: ListDeletedTodoOverrideRecurrenceIDs :many
+SELECT recurrence_id FROM todos
+WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NOT NULL
+ORDER BY recurrence_id;
+
 
 -- name: DeleteTodosByUID :exec
 DELETE FROM todos WHERE uid = ?;

--- a/internal/journal/soft_delete.go
+++ b/internal/journal/soft_delete.go
@@ -50,28 +50,46 @@ func (s *Service) RestoreByID(ctx context.Context, id int64) error {
 	if err := qtx.RestoreJournal(ctx, id); err != nil {
 		return fmt.Errorf("restore journal: %w", err)
 	}
-
-	master, err := qtx.GetJournalByUID(ctx, r.Uid)
-	if err == nil {
-		existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
-		target, parseErr := timeutil.ParseRecurrenceID(r.RecurrenceID)
-		if parseErr == nil {
-			filtered := removeTimeFromList(existing, target)
-			if len(filtered) != len(existing) {
-				if err := qtx.UpdateJournalExdates(ctx, storage.UpdateJournalExdatesParams{
-					Exdates: storage.StringToNullable(timeutil.SerializeTimeList(filtered)),
-					ID:      master.ID,
-				}); err != nil {
-					return fmt.Errorf("update exdates: %w", err)
-				}
-			}
-		}
+	if err := clearMasterEXDATE(ctx, qtx, r.Uid, r.RecurrenceID); err != nil {
+		return err
 	}
 
 	if err := tx.Commit(); err != nil {
 		return err
 	}
 	return s.reconcileSyncAfterRestore(ctx, r.CalendarID, r.Uid)
+}
+
+// clearMasterEXDATE removes the EXDATE entry for recurrenceID from the
+// master journal with uid, reversing the exclusion that the instance-delete
+// path added. No-op when the master is gone, the recurrence_id is
+// unparseable, or the EXDATE was already absent. Must run inside the same
+// transaction (qtx) that un-hides the override so the row is never
+// visible-but-excluded.
+func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
+	master, err := qtx.GetJournalByUID(ctx, uid)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("get master: %w", err)
+	}
+	target, err := timeutil.ParseRecurrenceID(recurrenceID)
+	if err != nil {
+		return nil
+	}
+	existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
+	filtered := removeTimeFromList(existing, target)
+	if len(filtered) == len(existing) {
+		return nil
+	}
+	if err := qtx.UpdateJournalExdates(ctx, storage.UpdateJournalExdatesParams{
+		Exdates: storage.StringToNullable(timeutil.SerializeTimeList(filtered)),
+		ID:      master.ID,
+	}); err != nil {
+		return fmt.Errorf("update exdates: %w", err)
+	}
+	return nil
 }
 
 // removeTimeFromList returns list with every element equal to target
@@ -90,19 +108,52 @@ func removeTimeFromList(list []time.Time, target time.Time) []time.Time {
 }
 
 // RestoreByUID un-hides every soft-deleted row sharing uid — master plus
-// overrides. Used by the CLI `journals restore <uid>` path.
+// overrides — and strips the matching EXDATE from the master for each
+// restored override in the same transaction. Without the EXDATE cleanup the
+// master would keep excluding those slots while also carrying the now-live
+// overrides, which round-trips to iCal as a self-contradicting series
+// (EXDATE + override for the same occurrence). Used by the CLI
+// `journals restore <uid>` path. Mirrors event.RestoreByUID.
 func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	master, err := s.q.GetJournalByUIDIncludingDeleted(ctx, uid)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get master: %w", err)
 	}
-	if err := s.q.RestoreJournalsByUID(ctx, uid); err != nil {
-		return fmt.Errorf("restore by uid: %w", err)
+	if err := s.restoreByUIDClearingExdates(ctx, uid); err != nil {
+		return err
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
 	}
 	return nil
+}
+
+// restoreByUIDClearingExdates un-hides every soft-deleted row for uid and
+// clears the master EXDATE for each override that was soft-deleted, all in
+// one transaction. The recurrence IDs are read before the restore because
+// afterwards the rows are live and no longer match the deleted-overrides
+// query.
+func (s *Service) restoreByUIDClearingExdates(ctx context.Context, uid string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	recurrenceIDs, err := qtx.ListDeletedJournalOverrideRecurrenceIDs(ctx, uid)
+	if err != nil {
+		return fmt.Errorf("list deleted override recurrence ids: %w", err)
+	}
+	if err := qtx.RestoreJournalsByUID(ctx, uid); err != nil {
+		return fmt.Errorf("restore by uid: %w", err)
+	}
+	for _, recurrenceID := range recurrenceIDs {
+		if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // ListDeleted returns soft-deleted journals for a calendar, newest-first.

--- a/internal/journal/soft_delete.go
+++ b/internal/journal/soft_delete.go
@@ -62,10 +62,10 @@ func (s *Service) RestoreByID(ctx context.Context, id int64) error {
 
 // clearMasterEXDATE removes the EXDATE entry for recurrenceID from the
 // master journal with uid, reversing the exclusion that the instance-delete
-// path added. No-op when the master is gone, the recurrence_id is
-// unparseable, or the EXDATE was already absent. Must run inside the same
-// transaction (qtx) that un-hides the override so the row is never
-// visible-but-excluded.
+// path added. No-op when the master is gone or the EXDATE was already
+// absent; a malformed recurrence_id is a data-integrity error and is
+// propagated rather than swallowed. Must run inside the same transaction
+// (qtx) that un-hides the override so the row is never visible-but-excluded.
 func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
 	master, err := qtx.GetJournalByUID(ctx, uid)
 	if err != nil {
@@ -76,7 +76,7 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 	}
 	target, err := timeutil.ParseRecurrenceID(recurrenceID)
 	if err != nil {
-		return nil
+		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
 	}
 	existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
 	filtered := removeTimeFromList(existing, target)

--- a/internal/journal/soft_delete_test.go
+++ b/internal/journal/soft_delete_test.go
@@ -217,6 +217,67 @@ func TestSoftDelete_RestoreOverrideClearsExdate(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_RestoreByUIDClearsExdate is the regression test for
+// issue #72: restoring a recurring series by UID must strip the EXDATEs
+// the instance-delete path added to the master, just like RestoreByID
+// does for a single override. Otherwise the master keeps excluding the
+// slot while also carrying the now-live override, which exports to iCal
+// as a self-contradicting series.
+func TestSoftDelete_RestoreByUIDClearsExdate(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "daily-uid", CalendarID: 1, Summary: "Daily Journal",
+		StartDate:      "2026-04-01",
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: master.UID, CalendarID: 1, Summary: "Daily Journal (amended)",
+		StartDate:    "2026-04-03",
+		RecurrenceID: time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Delete the *instance* (not the series): this adds the EXDATE to the
+	// master and soft-deletes the override.
+	if err := svc.Delete(ctx, override.ID); err != nil {
+		t.Fatalf("Delete override: %v", err)
+	}
+	afterDelete, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after delete: %v", err)
+	}
+	if afterDelete.ExDates == "" {
+		t.Fatal("master.ExDates empty after override delete — EXDATE should have been added")
+	}
+
+	// Restore by UID (the `journals restore <uid>` path). Before the fix
+	// this un-hid the override but left the stale EXDATE on the master.
+	if err := svc.RestoreByUID(ctx, master.UID); err != nil {
+		t.Fatalf("RestoreByUID: %v", err)
+	}
+	afterRestore, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after restore: %v", err)
+	}
+	if afterRestore.ExDates != "" {
+		t.Fatalf("master.ExDates = %q, want empty after RestoreByUID", afterRestore.ExDates)
+	}
+	overrides, err := svc.ListOverridesByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("ListOverridesByUID: %v", err)
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("overrides after restore = %d, want 1", len(overrides))
+	}
+}
+
 // TestSoftDelete_UpsertClearsDeletedAt verifies UpsertByUID on a soft-
 // deleted journal re-hydrates it (ON CONFLICT clears deleted_at).
 func TestSoftDelete_UpsertClearsDeletedAt(t *testing.T) {

--- a/internal/storage/journals.sql.go
+++ b/internal/storage/journals.sql.go
@@ -304,6 +304,35 @@ func (q *Queries) ListAllJournals(ctx context.Context) ([]Journal, error) {
 	return items, nil
 }
 
+const listDeletedJournalOverrideRecurrenceIDs = `-- name: ListDeletedJournalOverrideRecurrenceIDs :many
+SELECT recurrence_id FROM journals
+WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NOT NULL
+ORDER BY recurrence_id
+`
+
+func (q *Queries) ListDeletedJournalOverrideRecurrenceIDs(ctx context.Context, uid string) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listDeletedJournalOverrideRecurrenceIDs, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var recurrence_id string
+		if err := rows.Scan(&recurrence_id); err != nil {
+			return nil, err
+		}
+		items = append(items, recurrence_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDeletedJournalsByCalendar = `-- name: ListDeletedJournalsByCalendar :many
 SELECT id, uid, calendar_id, summary, description, start_date, status, class, url, recurrence_rule, timezone, sequence, exdates, rdates, recurrence_id, dtstamp, created_at, updated_at, deleted_at FROM journals
 WHERE calendar_id = ? AND deleted_at IS NOT NULL

--- a/internal/storage/todos.sql.go
+++ b/internal/storage/todos.sql.go
@@ -412,6 +412,35 @@ func (q *Queries) ListAllTodos(ctx context.Context) ([]Todo, error) {
 	return items, nil
 }
 
+const listDeletedTodoOverrideRecurrenceIDs = `-- name: ListDeletedTodoOverrideRecurrenceIDs :many
+SELECT recurrence_id FROM todos
+WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NOT NULL
+ORDER BY recurrence_id
+`
+
+func (q *Queries) ListDeletedTodoOverrideRecurrenceIDs(ctx context.Context, uid string) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listDeletedTodoOverrideRecurrenceIDs, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var recurrence_id string
+		if err := rows.Scan(&recurrence_id); err != nil {
+			return nil, err
+		}
+		items = append(items, recurrence_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDeletedTodosByCalendar = `-- name: ListDeletedTodosByCalendar :many
 SELECT id, uid, calendar_id, summary, description, location, due_date, start_date, duration, completed_at, percent_complete, status, priority, class, url, recurrence_rule, timezone, sequence, exdates, rdates, recurrence_id, geo, created_at, updated_at, dtstamp, deleted_at FROM todos
 WHERE calendar_id = ? AND deleted_at IS NOT NULL

--- a/internal/todo/soft_delete.go
+++ b/internal/todo/soft_delete.go
@@ -56,28 +56,46 @@ func (s *Service) RestoreByID(ctx context.Context, id int64) error {
 	if err := qtx.RestoreTodo(ctx, id); err != nil {
 		return fmt.Errorf("restore todo: %w", err)
 	}
-
-	master, err := qtx.GetTodoByUID(ctx, r.Uid)
-	if err == nil {
-		existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
-		target, parseErr := timeutil.ParseRecurrenceID(r.RecurrenceID)
-		if parseErr == nil {
-			filtered := removeTimeFromList(existing, target)
-			if len(filtered) != len(existing) {
-				if err := qtx.UpdateTodoExdates(ctx, storage.UpdateTodoExdatesParams{
-					Exdates: storage.StringToNullable(timeutil.SerializeTimeList(filtered)),
-					ID:      master.ID,
-				}); err != nil {
-					return fmt.Errorf("update exdates: %w", err)
-				}
-			}
-		}
+	if err := clearMasterEXDATE(ctx, qtx, r.Uid, r.RecurrenceID); err != nil {
+		return err
 	}
 
 	if err := tx.Commit(); err != nil {
 		return err
 	}
 	return s.reconcileSyncAfterRestore(ctx, r.CalendarID, r.Uid)
+}
+
+// clearMasterEXDATE removes the EXDATE entry for recurrenceID from the
+// master todo with uid, reversing the exclusion that the instance-delete
+// path added. No-op when the master is gone, the recurrence_id is
+// unparseable, or the EXDATE was already absent. Must run inside the same
+// transaction (qtx) that un-hides the override so the row is never
+// visible-but-excluded.
+func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
+	master, err := qtx.GetTodoByUID(ctx, uid)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("get master: %w", err)
+	}
+	target, err := timeutil.ParseRecurrenceID(recurrenceID)
+	if err != nil {
+		return nil
+	}
+	existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
+	filtered := removeTimeFromList(existing, target)
+	if len(filtered) == len(existing) {
+		return nil
+	}
+	if err := qtx.UpdateTodoExdates(ctx, storage.UpdateTodoExdatesParams{
+		Exdates: storage.StringToNullable(timeutil.SerializeTimeList(filtered)),
+		ID:      master.ID,
+	}); err != nil {
+		return fmt.Errorf("update exdates: %w", err)
+	}
+	return nil
 }
 
 // removeTimeFromList returns list with every element equal to target
@@ -96,19 +114,52 @@ func removeTimeFromList(list []time.Time, target time.Time) []time.Time {
 }
 
 // RestoreByUID un-hides every soft-deleted row with the given UID —
-// master + overrides. Used by the CLI `todos restore <uid>` path.
+// master + overrides — and strips the matching EXDATE from the master for
+// each restored override in the same transaction. Without the EXDATE
+// cleanup the master would keep excluding those slots while also carrying
+// the now-live overrides, which round-trips to iCal as a self-contradicting
+// series (EXDATE + override for the same occurrence). Used by the CLI
+// `todos restore <uid>` path. Mirrors event.RestoreByUID.
 func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	master, err := s.q.GetTodoByUIDIncludingDeleted(ctx, uid)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get master: %w", err)
 	}
-	if err := s.q.RestoreTodosByUID(ctx, uid); err != nil {
-		return fmt.Errorf("restore by uid: %w", err)
+	if err := s.restoreByUIDClearingExdates(ctx, uid); err != nil {
+		return err
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
 	}
 	return nil
+}
+
+// restoreByUIDClearingExdates un-hides every soft-deleted row for uid and
+// clears the master EXDATE for each override that was soft-deleted, all in
+// one transaction. The recurrence IDs are read before the restore because
+// afterwards the rows are live and no longer match the deleted-overrides
+// query.
+func (s *Service) restoreByUIDClearingExdates(ctx context.Context, uid string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	recurrenceIDs, err := qtx.ListDeletedTodoOverrideRecurrenceIDs(ctx, uid)
+	if err != nil {
+		return fmt.Errorf("list deleted override recurrence ids: %w", err)
+	}
+	if err := qtx.RestoreTodosByUID(ctx, uid); err != nil {
+		return fmt.Errorf("restore by uid: %w", err)
+	}
+	for _, recurrenceID := range recurrenceIDs {
+		if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // ListDeleted returns soft-deleted todos for a calendar, newest-first.

--- a/internal/todo/soft_delete.go
+++ b/internal/todo/soft_delete.go
@@ -68,10 +68,10 @@ func (s *Service) RestoreByID(ctx context.Context, id int64) error {
 
 // clearMasterEXDATE removes the EXDATE entry for recurrenceID from the
 // master todo with uid, reversing the exclusion that the instance-delete
-// path added. No-op when the master is gone, the recurrence_id is
-// unparseable, or the EXDATE was already absent. Must run inside the same
-// transaction (qtx) that un-hides the override so the row is never
-// visible-but-excluded.
+// path added. No-op when the master is gone or the EXDATE was already
+// absent; a malformed recurrence_id is a data-integrity error and is
+// propagated rather than swallowed. Must run inside the same transaction
+// (qtx) that un-hides the override so the row is never visible-but-excluded.
 func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
 	master, err := qtx.GetTodoByUID(ctx, uid)
 	if err != nil {
@@ -82,7 +82,7 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 	}
 	target, err := timeutil.ParseRecurrenceID(recurrenceID)
 	if err != nil {
-		return nil
+		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
 	}
 	existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
 	filtered := removeTimeFromList(existing, target)

--- a/internal/todo/soft_delete_test.go
+++ b/internal/todo/soft_delete_test.go
@@ -236,6 +236,67 @@ func TestSoftDelete_RestoreOverrideClearsExdate(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_RestoreByUIDClearsExdate is the regression test for
+// issue #72: restoring a recurring series by UID must strip the EXDATEs
+// the instance-delete path added to the master, just like RestoreByID
+// does for a single override. Otherwise the master keeps excluding the
+// slot while also carrying the now-live override, which exports to iCal
+// as a self-contradicting series.
+func TestSoftDelete_RestoreByUIDClearsExdate(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "weekly-uid", CalendarID: 1, Summary: "Weekly Review",
+		DueDate:        time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: master.UID, CalendarID: 1, Summary: "Weekly Review (moved)",
+		DueDate:      time.Date(2026, 4, 15, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceID: time.Date(2026, 4, 15, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Delete the *instance* (not the series): this adds the EXDATE to the
+	// master and soft-deletes the override.
+	if err := svc.Delete(ctx, override.ID); err != nil {
+		t.Fatalf("Delete override: %v", err)
+	}
+	afterDelete, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after delete: %v", err)
+	}
+	if afterDelete.ExDates == "" {
+		t.Fatal("master.ExDates empty after override delete — EXDATE should have been added")
+	}
+
+	// Restore by UID (the `todos restore <uid>` path). Before the fix this
+	// un-hid the override but left the stale EXDATE on the master.
+	if err := svc.RestoreByUID(ctx, master.UID); err != nil {
+		t.Fatalf("RestoreByUID: %v", err)
+	}
+	afterRestore, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after restore: %v", err)
+	}
+	if afterRestore.ExDates != "" {
+		t.Fatalf("master.ExDates = %q, want empty after RestoreByUID", afterRestore.ExDates)
+	}
+	overrides, err := svc.ListOverridesByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("ListOverridesByUID: %v", err)
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("overrides after restore = %d, want 1", len(overrides))
+	}
+}
+
 // TestSoftDelete_UpsertClearsDeletedAt verifies that UpsertByUID on a
 // soft-deleted row re-hydrates it (ON CONFLICT clears deleted_at). This
 // is the path a remote re-CREATE after a local delete would take: the


### PR DESCRIPTION
## Problem

`todo.RestoreByUID` and `journal.RestoreByUID` only un-hid rows by UID. Unlike `event.RestoreByUID` (the reference implementation), they never stripped the master `EXDATE`s that the instance-delete path adds. Their own per-row `RestoreByID` *does* clear those EXDATEs, so the contract was inconsistent within each domain.

Result: a series restored via `todos restore <uid>` / `journals restore <uid>` kept stale EXDATEs on the master that both excluded the slot **and** carried a now-live override — exporting to iCal as a self-contradicting series and accumulating as duplicates.

## Fix

Mirror `event.RestoreByUID`:

1. List the deleted override recurrence IDs (before restore, while they still match the deleted-overrides query).
2. Restore all rows by UID.
3. Clear the matching master `EXDATE` for each restored override.

All in a single transaction. Extracted a per-domain `clearMasterEXDATE` helper (also reused by `RestoreByID`, replacing its inline duplicate). Added `ListDeletedTodoOverrideRecurrenceIDs` / `ListDeletedJournalOverrideRecurrenceIDs` queries, regenerated via `make generate`.

## Tests

Added `TestSoftDelete_RestoreByUIDClearsExdate` for both todo and journal: delete a recurring instance (adds EXDATE + soft-deletes the override), restore by UID, assert the master EXDATEs are cleared and the override is live again. Both tests fail before the fix and pass after.

`make fmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/... -count=1` all pass.

Closes #72
