### PR TITLE
fix(sync): propagate child-replace errors and keep resource dirty on failure

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1251,15 +1251,32 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		// Replace child collections unconditionally so server-side removals
 		// (an empty list) are propagated, mirroring how Categories are handled
 		// via UpsertByUID. A full CalDAV pull sends the complete component, so
-		// the absence of a property means "cleared", not "unknown".
-		_ = e.events.ReplaceAlarms(ctx, saved.ID, ev.Alarms)
-		_ = e.events.ReplaceAttendees(ctx, saved.ID, ev.Attendees)
-		_ = e.events.ReplaceAttachments(ctx, saved.ID, ev.Attachments)
-		_ = e.events.ReplaceComments(ctx, saved.ID, ev.Comments)
-		_ = e.events.ReplaceContacts(ctx, saved.ID, ev.Contacts)
-		_ = e.events.ReplaceResources(ctx, saved.ID, ev.Resources)
-		_ = e.events.ReplaceRelations(ctx, saved.ID, ev.Relations)
-		_ = e.events.ReplaceXProperties(ctx, saved.ID, ev.XProperties)
+		// the absence of a property means "cleared", not "unknown". Propagate
+		// any replace error so the caller keeps the resource dirty and retries.
+		if err := e.events.ReplaceAlarms(ctx, saved.ID, ev.Alarms); err != nil {
+			return fmt.Errorf("replace alarms for event %q: %w", ev.UID, err)
+		}
+		if err := e.events.ReplaceAttendees(ctx, saved.ID, ev.Attendees); err != nil {
+			return fmt.Errorf("replace attendees for event %q: %w", ev.UID, err)
+		}
+		if err := e.events.ReplaceAttachments(ctx, saved.ID, ev.Attachments); err != nil {
+			return fmt.Errorf("replace attachments for event %q: %w", ev.UID, err)
+		}
+		if err := e.events.ReplaceComments(ctx, saved.ID, ev.Comments); err != nil {
+			return fmt.Errorf("replace comments for event %q: %w", ev.UID, err)
+		}
+		if err := e.events.ReplaceContacts(ctx, saved.ID, ev.Contacts); err != nil {
+			return fmt.Errorf("replace contacts for event %q: %w", ev.UID, err)
+		}
+		if err := e.events.ReplaceResources(ctx, saved.ID, ev.Resources); err != nil {
+			return fmt.Errorf("replace resources for event %q: %w", ev.UID, err)
+		}
+		if err := e.events.ReplaceRelations(ctx, saved.ID, ev.Relations); err != nil {
+			return fmt.Errorf("replace relations for event %q: %w", ev.UID, err)
+		}
+		if err := e.events.ReplaceXProperties(ctx, saved.ID, ev.XProperties); err != nil {
+			return fmt.Errorf("replace xproperties for event %q: %w", ev.UID, err)
+		}
 	}
 
 	// Import todos
@@ -1281,14 +1298,30 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		}
 		// Replace child collections unconditionally so server-side removals
 		// (an empty list) are propagated. See the event loop above.
-		_ = e.todos.ReplaceAlarms(ctx, saved.ID, t.Alarms)
-		_ = e.todos.ReplaceAttendees(ctx, saved.ID, t.Attendees)
-		_ = e.todos.ReplaceAttachments(ctx, saved.ID, t.Attachments)
-		_ = e.todos.ReplaceComments(ctx, saved.ID, t.Comments)
-		_ = e.todos.ReplaceContacts(ctx, saved.ID, t.Contacts)
-		_ = e.todos.ReplaceResources(ctx, saved.ID, t.Resources)
-		_ = e.todos.ReplaceRelations(ctx, saved.ID, t.Relations)
-		_ = e.todos.ReplaceXProperties(ctx, saved.ID, t.XProperties)
+		if err := e.todos.ReplaceAlarms(ctx, saved.ID, t.Alarms); err != nil {
+			return fmt.Errorf("replace alarms for todo %q: %w", t.UID, err)
+		}
+		if err := e.todos.ReplaceAttendees(ctx, saved.ID, t.Attendees); err != nil {
+			return fmt.Errorf("replace attendees for todo %q: %w", t.UID, err)
+		}
+		if err := e.todos.ReplaceAttachments(ctx, saved.ID, t.Attachments); err != nil {
+			return fmt.Errorf("replace attachments for todo %q: %w", t.UID, err)
+		}
+		if err := e.todos.ReplaceComments(ctx, saved.ID, t.Comments); err != nil {
+			return fmt.Errorf("replace comments for todo %q: %w", t.UID, err)
+		}
+		if err := e.todos.ReplaceContacts(ctx, saved.ID, t.Contacts); err != nil {
+			return fmt.Errorf("replace contacts for todo %q: %w", t.UID, err)
+		}
+		if err := e.todos.ReplaceResources(ctx, saved.ID, t.Resources); err != nil {
+			return fmt.Errorf("replace resources for todo %q: %w", t.UID, err)
+		}
+		if err := e.todos.ReplaceRelations(ctx, saved.ID, t.Relations); err != nil {
+			return fmt.Errorf("replace relations for todo %q: %w", t.UID, err)
+		}
+		if err := e.todos.ReplaceXProperties(ctx, saved.ID, t.XProperties); err != nil {
+			return fmt.Errorf("replace xproperties for todo %q: %w", t.UID, err)
+		}
 	}
 
 	// Import journals
@@ -1308,12 +1341,24 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		}
 		// Replace child collections unconditionally so server-side removals
 		// (an empty list) are propagated. See the event loop above.
-		_ = e.journals.ReplaceAttendees(ctx, saved.ID, j.Attendees)
-		_ = e.journals.ReplaceAttachments(ctx, saved.ID, j.Attachments)
-		_ = e.journals.ReplaceComments(ctx, saved.ID, j.Comments)
-		_ = e.journals.ReplaceContacts(ctx, saved.ID, j.Contacts)
-		_ = e.journals.ReplaceRelations(ctx, saved.ID, j.Relations)
-		_ = e.journals.ReplaceXProperties(ctx, saved.ID, j.XProperties)
+		if err := e.journals.ReplaceAttendees(ctx, saved.ID, j.Attendees); err != nil {
+			return fmt.Errorf("replace attendees for journal %q: %w", j.UID, err)
+		}
+		if err := e.journals.ReplaceAttachments(ctx, saved.ID, j.Attachments); err != nil {
+			return fmt.Errorf("replace attachments for journal %q: %w", j.UID, err)
+		}
+		if err := e.journals.ReplaceComments(ctx, saved.ID, j.Comments); err != nil {
+			return fmt.Errorf("replace comments for journal %q: %w", j.UID, err)
+		}
+		if err := e.journals.ReplaceContacts(ctx, saved.ID, j.Contacts); err != nil {
+			return fmt.Errorf("replace contacts for journal %q: %w", j.UID, err)
+		}
+		if err := e.journals.ReplaceRelations(ctx, saved.ID, j.Relations); err != nil {
+			return fmt.Errorf("replace relations for journal %q: %w", j.UID, err)
+		}
+		if err := e.journals.ReplaceXProperties(ctx, saved.ID, j.XProperties); err != nil {
+			return fmt.Errorf("replace xproperties for journal %q: %w", j.UID, err)
+		}
 	}
 
 	return nil

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/caldav"
@@ -16,6 +17,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/event"
 	icalPkg "github.com/douglasdemoura/chroncal/internal/ical"
 	"github.com/douglasdemoura/chroncal/internal/journal"
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
 	"github.com/douglasdemoura/chroncal/internal/todo"
@@ -426,6 +428,86 @@ END:VCALENDAR
 	}
 	if len(dirty) != 0 {
 		t.Fatalf("dirty after pull = %d, want 0 (sync-imports must land clean)", len(dirty))
+	}
+}
+
+// TestEnginePersistImportedKeepsDirtyOnChildReplaceError pins issue #69: a
+// transient failure while replacing an imported resource's child collections
+// (alarms/attendees/...) must propagate out of persistImported. Previously the
+// Replace* errors were discarded with `_ =`, so the caller cleared the dirty
+// flag and the stale children were never retried. Here we let the parent
+// UpsertByUID succeed but force ReplaceAlarms to fail (by dropping the
+// event_alarms table), then assert persistImported returns an error and the
+// sync_resource stays dirty so the next sync retries it.
+func TestEnginePersistImportedKeepsDirtyOnChildReplaceError(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	const uid = "child-replace-fail"
+
+	// Seed a dirty sync_resource for the UID, mirroring a resource the pull
+	// loop is about to absorb. If persistImported swallowed the child error,
+	// the caller would clear this flag.
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          uid,
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/child-replace-fail.ics",
+		Etag:         "etag-old",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	// Drop the event_alarms table so the parent event upsert still succeeds but
+	// the subsequent ReplaceAlarms fails, simulating a transient child-replace
+	// error.
+	if _, err := db.ExecContext(ctx, "DROP TABLE event_alarms"); err != nil {
+		t.Fatalf("drop event_alarms table: %v", err)
+	}
+
+	result := icalPkg.ImportResult{
+		Events: []event.Event{{
+			UID:        uid,
+			CalendarID: calendarID,
+			Title:      "Has alarm",
+			StartTime:  time.Date(2026, 4, 3, 10, 0, 0, 0, time.UTC),
+			EndTime:    time.Date(2026, 4, 3, 11, 0, 0, 0, time.UTC),
+			Alarms: []model.Alarm{{
+				Action:       "DISPLAY",
+				TriggerValue: "-PT15M",
+				Description:  "Reminder",
+				Related:      "START",
+			}},
+		}},
+	}
+
+	if err := engine.persistImported(ctx, calendarID, result); err == nil {
+		t.Fatal("persistImported returned nil, want child-replace error to propagate")
+	}
+
+	dirty, err := q.ListDirtySyncResources(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("ListDirtySyncResources: %v", err)
+	}
+	var found bool
+	for _, r := range dirty {
+		if r.Uid == uid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("resource %q no longer dirty after child-replace failure; sync would never retry", uid)
 	}
 }
 


### PR DESCRIPTION
## Problem

In `internal/sync/engine.go`, `persistImported` discarded errors from the
child-collection `Replace*` calls (`ReplaceAlarms`, `ReplaceAttendees`,
`ReplaceAttachments`, `ReplaceComments`, `ReplaceContacts`,
`ReplaceResources`, `ReplaceRelations`, `ReplaceXProperties`) with `_ =`.

During a pull, the parent `UpsertByUID` would succeed while a transient
child-replace failure was silently swallowed. The caller then cleared the
`sync_resource` dirty flag, so the stale children were never retried — the
resource was no longer dirty and no error surfaced. Silent staleness with
no retry.

## Fix

Propagate the `Replace*` errors out of `persistImported`. Every call site
(lines ~388, ~642, ~923) already `continue`s past `ClearSyncResourceDirty`
when `persistImported` returns non-nil, so the resource now stays dirty and
the next sync retries it. No call-site changes were needed — the dirty-clear
was already gated behind the success path.

The `len(...) > 0` conditionals are intentionally left unchanged so this PR
stays separable from the sibling change (#65) that replaces child
collections unconditionally.

## Test

Added `TestEnginePersistImportedKeepsDirtyOnChildReplaceError`: seeds a dirty
`sync_resource`, lets the parent event upsert succeed, then forces
`ReplaceAlarms` to fail by dropping the `event_alarms` table. Asserts that
`persistImported` returns an error and the resource stays dirty. Fails before
the fix, passes after.

## Verification

- `make fmt`, `go vet ./...`, `go build ./...` clean
- `go test ./internal/... -count=1` all pass

Closes #69
