### PR TITLE
fix(alarm): only treat ErrNoRows as not-fired in check loop

### DIFF
--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -253,7 +253,13 @@ func (s *Service) checkEventAlarms(ctx context.Context, now time.Time) ([]DueAla
 					TriggerAt: triggerKey,
 				})
 				if err == nil {
-					continue
+					continue // already fired/acknowledged
+				}
+				if !errors.Is(err, sql.ErrNoRows) {
+					// Transient DB error (e.g. SQLITE_BUSY): we can't tell
+					// whether this alarm already fired, so abort rather than
+					// risk re-firing it. Propagate to the caller.
+					return nil, fmt.Errorf("get alarm state: %w", err)
 				}
 
 				due = append(due, DueAlarm{

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -2,12 +2,15 @@ package alarm
 
 import (
 	"context"
+	"database/sql"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
@@ -27,6 +30,39 @@ func newTestServicesWithTodos(t *testing.T) (*Service, *event.Service, *todo.Ser
 	todoSvc := todo.NewService(db, q)
 	alarmSvc := NewService(db, q, evtSvc, todoSvc)
 	return alarmSvc, evtSvc, todoSvc
+}
+
+// newFileTestDB opens a file-backed test DB (not :memory:) so that a pinned
+// connection sees the same schema as the pool. The transient-error regression
+// tests need to insert a deliberately malformed row on a connection with
+// foreign keys disabled, which an in-memory-per-connection DB cannot share.
+func newFileTestDB(t *testing.T) (*sql.DB, *storage.Queries) {
+	t.Helper()
+	db, q, err := storage.Open(filepath.Join(t.TempDir(), "alarm_test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db, q
+}
+
+// insertPoisonAlarmState inserts a malformed *_alarm_state row used to force a
+// non-ErrNoRows error out of GetAlarmState / GetTodoAlarmState. It pins a
+// single connection and disables foreign keys on it so the malformed row (a
+// TEXT value in an integer FK column) can be written.
+func insertPoisonAlarmState(ctx context.Context, t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin connection: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys=OFF"); err != nil {
+		t.Fatalf("disable foreign keys: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, query, args...); err != nil {
+		t.Fatalf("insert poison row: %v", err)
+	}
 }
 
 func TestCheck_FiresDueAlarm(t *testing.T) {
@@ -113,6 +149,63 @@ func TestCheck_SkipsAlreadyFired(t *testing.T) {
 	}
 	if len(due) != 0 {
 		t.Fatalf("second check: got %d, want 0", len(due))
+	}
+}
+
+// TestCheck_TransientStateErrorDoesNotFire guards against re-firing an alarm
+// when GetAlarmState returns a transient (non-ErrNoRows) error. A SQLITE_BUSY
+// or similar error must abort the per-alarm evaluation and propagate, never be
+// treated as "not fired".
+//
+// We simulate the transient error precisely: a poison alarm_state row whose
+// event_id holds a TEXT value fails the int64 Scan in GetAlarmState (a
+// non-ErrNoRows error) while leaving snoozed_to NULL so the later
+// ListExpiredSnoozedAlarmStates query — which filters on snoozed_to IS NOT
+// NULL — still succeeds. That isolates the failure to the in-loop
+// GetAlarmState lookup, which is the code path under test.
+func TestCheck_TransientStateErrorDoesNotFire(t *testing.T) {
+	db, q := newFileTestDB(t)
+	evtSvc := event.NewService(db, q)
+	svc := NewService(db, q, evtSvc, nil)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	start := now.Add(10 * time.Minute) // alarm fires at start-15m = 5m ago
+	e, err := evtSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Meeting",
+		StartTime:  start,
+		EndTime:    start.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	alarms, err := evtSvc.ListAlarms(ctx, e.ID)
+	if err != nil || len(alarms) != 1 {
+		t.Fatalf("list alarms: got %d (err %v), want 1", len(alarms), err)
+	}
+	triggerKey := start.Add(-15 * time.Minute).UTC().Format(time.RFC3339)
+
+	// Poison row: event_id holds TEXT, so GetAlarmState's int64 Scan of that
+	// row fails. snoozed_to stays NULL so ListExpiredSnoozedAlarmStates (which
+	// filters snoozed_to IS NOT NULL) skips it — isolating the failure to the
+	// in-loop GetAlarmState lookup.
+	insertPoisonAlarmState(ctx, t, db,
+		"INSERT INTO alarm_state (alarm_id, event_id, trigger_at) VALUES (?, 'not-an-int', ?)",
+		alarms[0].ID, triggerKey)
+
+	due, _, err := svc.Check(ctx, now)
+	if err == nil {
+		t.Fatal("expected error from transient GetAlarmState failure, got nil")
+	}
+	if len(due) != 0 {
+		t.Fatalf("got %d due alarms on transient error, want 0 (must not re-fire)", len(due))
 	}
 }
 

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -3,6 +3,7 @@ package alarm
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -108,7 +109,13 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 						TriggerAt: triggerKey,
 					})
 					if err == nil {
-						continue
+						continue // already fired/acknowledged
+					}
+					if !errors.Is(err, sql.ErrNoRows) {
+						// Transient DB error (e.g. SQLITE_BUSY): we can't
+						// tell whether this alarm already fired, so abort
+						// rather than risk re-firing it. Propagate.
+						return nil, fmt.Errorf("get todo alarm state: %w", err)
 					}
 
 					due = append(due, TodoDueAlarm{

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -69,6 +69,56 @@ func TestCheckTodoAlarms_DueAlarm(t *testing.T) {
 	}
 }
 
+// TestCheckTodoAlarms_TransientStateErrorDoesNotFire is the todo-side mirror of
+// TestCheck_TransientStateErrorDoesNotFire: a transient (non-ErrNoRows) error
+// from GetTodoAlarmState must abort and propagate, never be treated as "not
+// fired". We drop todo_alarm_state to force a "no such table" error.
+func TestCheckTodoAlarms_TransientStateErrorDoesNotFire(t *testing.T) {
+	ctx := context.Background()
+	db, q := newFileTestDB(t)
+
+	todoSvc := todo.NewService(db, q)
+	base := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	if _, err := todoSvc.Create(ctx, todo.CreateParams{
+		CalendarID: 1,
+		Summary:    "Submit Report",
+		DueDate:    base.Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("create todo: %v", err)
+	}
+
+	checkTime := time.Date(2026, 4, 1, 16, 30, 0, 0, time.UTC)
+	triggerKey := time.Date(2026, 4, 1, 16, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	const alarmID = 1
+	mockLister := &mockTodoAlarmLister{
+		alarms: []model.Alarm{{
+			ID:           alarmID,
+			UID:          "todo-alarm-1",
+			Action:       "DISPLAY",
+			TriggerValue: "-PT1H",
+			Description:  "Report due in 1 hour",
+		}},
+	}
+
+	// Poison row: todo_id holds TEXT, so GetTodoAlarmState's int64 Scan of that
+	// row fails (stand-in for a transient DB error like SQLITE_BUSY).
+	// snoozed_to stays NULL so ListExpiredTodoSnoozed (which filters snoozed_to
+	// IS NOT NULL) skips it — isolating the failure to the in-loop
+	// GetTodoAlarmState lookup.
+	insertPoisonAlarmState(ctx, t, db,
+		"INSERT INTO todo_alarm_state (alarm_id, todo_id, trigger_at) VALUES (?, 'not-an-int', ?)",
+		alarmID, triggerKey)
+
+	todoAlarmSvc := NewTodoService(db, q, mockLister)
+	due, err := todoAlarmSvc.CheckTodos(ctx, checkTime)
+	if err == nil {
+		t.Fatal("expected error from transient GetTodoAlarmState failure, got nil")
+	}
+	if len(due) != 0 {
+		t.Fatalf("got %d due todo alarms on transient error, want 0 (must not re-fire)", len(due))
+	}
+}
+
 func TestCheckTodoAlarms_SkipsCompleted(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 


### PR DESCRIPTION
## Problem

`checkEventAlarms` (`internal/alarm/service.go`) and `CheckTodos`
(`internal/alarm/todo_service.go`) treated **any** error from
`GetAlarmState` / `GetTodoAlarmState` as "this alarm has not fired yet",
because they only `continue`d when `err == nil`. A transient DB error
(e.g. `SQLITE_BUSY`, a locked database) therefore fell through and
**re-fired an already-fired alarm**.

The sibling `CheckMissed` already guards correctly with
`errors.Is(err, sql.ErrNoRows)`; this brings the two check loops in line.

## Fix

In both check loops, `continue` only on a genuine `sql.ErrNoRows`
("no state row" → not fired). On any other error, abort the per-alarm
evaluation and propagate it, so the caller retries on the next tick
rather than spuriously re-firing.

## Tests

Added a regression test for each loop. Each injects a malformed
`*_alarm_state` row (TEXT in an integer column) so the in-loop
`GetAlarmState` / `GetTodoAlarmState` `Scan` fails with a non-`ErrNoRows`
error, while leaving `snoozed_to` NULL so the later expired-snoozed query
still succeeds — isolating the failure to the code path under test. Both
tests fail before the fix and pass after.

`make fmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/...`
all pass.

Closes #71