### PR TITLE
refactor: consolidate duplicated helpers (issue #74)

### DIFF
--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -280,38 +280,41 @@ func main() {
 	}
 }
 
-// resolveEvent looks up an event by numeric ID, string UID, or UID + recurrence-id.
-func resolveEvent(ctx context.Context, a *app.App, ref, recurrenceID string) (event.Event, error) {
-	var e event.Event
+// resolveRef looks up a resource by numeric ID, string UID, or UID +
+// recurrence-id, using the three lookup functions for the resource kind. It
+// is the shared body behind resolveEvent / resolveTodo / resolveJournal.
+func resolveRef[T any](
+	ctx context.Context,
+	ref, recurrenceID, kind string,
+	getByID func(context.Context, int64) (T, error),
+	getByUID func(context.Context, string) (T, error),
+	getByUIDAndRecurrenceID func(context.Context, string, string) (T, error),
+) (T, error) {
+	var v T
 	var err error
 	if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
-		e, err = a.Events.Get(ctx, id)
+		v, err = getByID(ctx, id)
 	} else if recurrenceID != "" {
-		e, err = a.Events.GetByUIDAndRecurrenceID(ctx, ref, recurrenceID)
+		v, err = getByUIDAndRecurrenceID(ctx, ref, recurrenceID)
 	} else {
-		e, err = a.Events.GetByUID(ctx, ref)
+		v, err = getByUID(ctx, ref)
 	}
 	if err != nil {
-		return e, notFoundErr(err, "event", ref)
+		return v, notFoundErr(err, kind, ref)
 	}
-	return e, nil
+	return v, nil
+}
+
+// resolveEvent looks up an event by numeric ID, string UID, or UID + recurrence-id.
+func resolveEvent(ctx context.Context, a *app.App, ref, recurrenceID string) (event.Event, error) {
+	return resolveRef(ctx, ref, recurrenceID, "event",
+		a.Events.Get, a.Events.GetByUID, a.Events.GetByUIDAndRecurrenceID)
 }
 
 // resolveTodo looks up a todo by numeric ID, string UID, or UID + recurrence-id.
 func resolveTodo(ctx context.Context, a *app.App, ref, recurrenceID string) (todo.Todo, error) {
-	var t todo.Todo
-	var err error
-	if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
-		t, err = a.Todos.Get(ctx, id)
-	} else if recurrenceID != "" {
-		t, err = a.Todos.GetByUIDAndRecurrenceID(ctx, ref, recurrenceID)
-	} else {
-		t, err = a.Todos.GetByUID(ctx, ref)
-	}
-	if err != nil {
-		return t, notFoundErr(err, "todo", ref)
-	}
-	return t, nil
+	return resolveRef(ctx, ref, recurrenceID, "todo",
+		a.Todos.Get, a.Todos.GetByUID, a.Todos.GetByUIDAndRecurrenceID)
 }
 
 func resolveCalendarID(ctx context.Context, a *app.App, name string) (int64, error) {
@@ -347,19 +350,8 @@ func resolveCalendarID(ctx context.Context, a *app.App, name string) (int64, err
 
 // resolveJournal looks up a journal by numeric ID, string UID, or UID + recurrence-id.
 func resolveJournal(ctx context.Context, a *app.App, ref, recurrenceID string) (journal.Journal, error) {
-	var j journal.Journal
-	var err error
-	if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
-		j, err = a.Journals.Get(ctx, id)
-	} else if recurrenceID != "" {
-		j, err = a.Journals.GetByUIDAndRecurrenceID(ctx, ref, recurrenceID)
-	} else {
-		j, err = a.Journals.GetByUID(ctx, ref)
-	}
-	if err != nil {
-		return j, notFoundErr(err, "journal", ref)
-	}
-	return j, nil
+	return resolveRef(ctx, ref, recurrenceID, "journal",
+		a.Journals.Get, a.Journals.GetByUID, a.Journals.GetByUIDAndRecurrenceID)
 }
 
 func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {

--- a/cmd/chroncal/output.go
+++ b/cmd/chroncal/output.go
@@ -12,6 +12,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/journal"
 	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/textsafe"
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
@@ -264,7 +265,7 @@ func parseListDate(stored string) string {
 	if stored == "" {
 		return ""
 	}
-	if _, err := time.Parse("2006-01-02", stored); err == nil {
+	if timeutil.IsDateOnly(stored) {
 		return stored
 	}
 	if t, err := time.Parse(time.RFC3339, stored); err == nil {
@@ -286,7 +287,8 @@ func formatTodoDate(date string) string {
 	if date == "" {
 		return ""
 	}
-	if d, err := time.Parse("2006-01-02", date); err == nil {
+	if timeutil.IsDateOnly(date) {
+		d, _ := time.Parse("2006-01-02", date)
 		return d.Format("Mon, Jan 2 2006")
 	}
 	if d, err := time.Parse(time.RFC3339, date); err == nil {

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -103,31 +103,14 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			if err != nil {
 				continue
 			}
-
-			triggers := buildRepeatTriggers(triggerAt, a.Repeat, a.Duration)
-
-			for _, t := range triggers {
-				if t.After(now) || now.Sub(t) <= StaleThreshold {
-					continue // not stale yet
-				}
-				triggerKey := t.UTC().Format(time.RFC3339)
-				_, err := s.q.GetAlarmState(ctx, storage.GetAlarmStateParams{
-					AlarmID:   a.ID,
-					TriggerAt: triggerKey,
-				})
-				if err == nil {
-					continue // already fired/acknowledged
-				}
-				if !errors.Is(err, sql.ErrNoRows) {
-					continue // real DB error, skip rather than false-positive
-				}
+			s.collectMissedTriggers(ctx, triggerAt, a, now, s.eventAlarmStateExists, func(t time.Time) {
 				missed = append(missed, MissedAlarm{
 					EventTitle: expEvt.Title,
 					AlarmID:    a.ID,
 					TriggerAt:  t,
 					Age:        now.Sub(t),
 				})
-			}
+			})
 		}
 	}
 
@@ -157,37 +140,78 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 					if err != nil {
 						continue
 					}
-
-					triggers := buildRepeatTriggers(triggerAt, a.Repeat, a.Duration)
-
-					for _, t := range triggers {
-						if t.After(now) || now.Sub(t) <= StaleThreshold {
-							continue
-						}
-						triggerKey := t.UTC().Format(time.RFC3339)
-						_, err := s.q.GetTodoAlarmState(ctx, storage.GetTodoAlarmStateParams{
-							AlarmID:   a.ID,
-							TriggerAt: triggerKey,
-						})
-						if err == nil {
-							continue
-						}
-						if !errors.Is(err, sql.ErrNoRows) {
-							continue
-						}
+					s.collectMissedTriggers(ctx, triggerAt, a, now, s.todoAlarmStateExists, func(t time.Time) {
 						missedTodos = append(missedTodos, MissedTodoAlarm{
 							TodoSummary: td.Summary,
 							AlarmID:     a.ID,
 							TriggerAt:   t,
 							Age:         now.Sub(t),
 						})
-					}
+					})
 				}
 			}
 		}
 	}
 
 	return missed, missedTodos, nil
+}
+
+// collectMissedTriggers walks every repeat trigger of an alarm whose initial
+// firing is triggerAt, and calls record(t) for each one that is stale (past
+// StaleThreshold) and has no state row according to stateExists. stateExists
+// reports whether a state row exists for the (alarm, triggerKey) pair; a real
+// DB error there is treated as "skip" rather than a false-positive miss.
+func (s *Service) collectMissedTriggers(
+	ctx context.Context,
+	triggerAt time.Time,
+	a model.Alarm,
+	now time.Time,
+	stateExists func(ctx context.Context, alarmID int64, triggerKey string) (bool, error),
+	record func(t time.Time),
+) {
+	for _, t := range buildRepeatTriggers(triggerAt, a.Repeat, a.Duration) {
+		if t.After(now) || now.Sub(t) <= StaleThreshold {
+			continue // not stale yet
+		}
+		triggerKey := t.UTC().Format(time.RFC3339)
+		exists, err := stateExists(ctx, a.ID, triggerKey)
+		if err != nil || exists {
+			continue // already fired/acknowledged, or DB error: skip
+		}
+		record(t)
+	}
+}
+
+// eventAlarmStateExists reports whether an alarm_state row exists for the
+// given event alarm and trigger key.
+func (s *Service) eventAlarmStateExists(ctx context.Context, alarmID int64, triggerKey string) (bool, error) {
+	_, err := s.q.GetAlarmState(ctx, storage.GetAlarmStateParams{
+		AlarmID:   alarmID,
+		TriggerAt: triggerKey,
+	})
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, err
+}
+
+// todoAlarmStateExists reports whether a todo_alarm_state row exists for the
+// given todo alarm and trigger key.
+func (s *Service) todoAlarmStateExists(ctx context.Context, alarmID int64, triggerKey string) (bool, error) {
+	_, err := s.q.GetTodoAlarmState(ctx, storage.GetTodoAlarmStateParams{
+		AlarmID:   alarmID,
+		TriggerAt: triggerKey,
+	})
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, err
 }
 
 // checkEventAlarms finds due event alarms
@@ -314,27 +338,7 @@ func computeTriggerTimeForInstance(expEvt recurrence.ExpandedEvent, alarm model.
 		return duration.Add(anchor, trigger), nil
 	}
 
-	return parseAbsoluteTrigger(trigger, expEvt.Timezone)
-}
-
-// parseAbsoluteTrigger parses an absolute trigger value (iCal UTC, floating, or RFC 3339).
-// Floating times are interpreted in the given timezone if non-empty.
-func parseAbsoluteTrigger(trigger, timezone string) (time.Time, error) {
-	if t, err := time.Parse("20060102T150405Z", trigger); err == nil {
-		return t, nil
-	}
-	if t, err := time.Parse("20060102T150405", trigger); err == nil {
-		if timezone != "" {
-			if loc, lerr := time.LoadLocation(timezone); lerr == nil {
-				return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, loc), nil
-			}
-		}
-		return t, nil
-	}
-	if t, err := time.Parse(time.RFC3339, trigger); err == nil {
-		return t, nil
-	}
-	return time.Time{}, fmt.Errorf("invalid trigger format: %q", trigger)
+	return model.ParseAbsoluteTime(trigger, expEvt.Timezone)
 }
 
 // ListExpiredSnoozed returns snoozed alarms whose snooze-until time is at or

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -195,7 +195,7 @@ func computeTodoTriggerTimeForInstance(inst recurrence.ExpandedTodo, alarm model
 	}
 
 	// Absolute triggers
-	return parseAbsoluteTrigger(alarm.TriggerValue, inst.Timezone)
+	return model.ParseAbsoluteTime(alarm.TriggerValue, inst.Timezone)
 }
 
 // MarkTodoAlarmFired records that a todo alarm has fired

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -227,7 +227,7 @@ func (s *Service) GetIncludingDeleted(ctx context.Context, id int64) (Event, err
 // PurgeDeleted hard-deletes rows soft-deleted before olderThan. Returns the
 // number of rows purged. Children cascade via existing FK ON DELETE CASCADE.
 func (s *Service) PurgeDeleted(ctx context.Context, olderThan time.Time) (int, error) {
-	cutoff := olderThan.UTC().Format(storageTimeFormat)
+	cutoff := olderThan.UTC().Format(timeutil.StorageTimeFormat)
 	n, err := s.q.PurgeSoftDeletedEvents(ctx, &cutoff)
 	if err != nil {
 		return 0, err
@@ -457,13 +457,11 @@ func (s *Service) reconcileSyncAfterRestore(ctx context.Context, calendarID int6
 	return nil
 }
 
-const storageTimeFormat = "2006-01-02T15:04:05Z"
-
 func parseStorageTime(s string) time.Time {
 	if s == "" {
 		return time.Time{}
 	}
-	t, err := time.Parse(storageTimeFormat, s)
+	t, err := time.Parse(timeutil.StorageTimeFormat, s)
 	if err != nil {
 		t, _ = time.Parse(time.RFC3339, s)
 	}

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
 
 // TestSoftDelete_Standalone verifies:
@@ -345,7 +347,7 @@ func TestSoftDelete_FromInstance_UndoAfterGap(t *testing.T) {
 	// Backdate the master's updated_at well into the past so its last real edit
 	// is more than one second before the truncation — the production scenario
 	// the old guard failed on.
-	pastEdit := time.Now().UTC().Add(-1 * time.Hour).Format(storageTimeFormat)
+	pastEdit := time.Now().UTC().Add(-1 * time.Hour).Format(timeutil.StorageTimeFormat)
 	if _, err := svc.db.ExecContext(ctx,
 		"UPDATE events SET updated_at = ? WHERE id = ?", pastEdit, master.ID); err != nil {
 		t.Fatalf("backdate updated_at: %v", err)
@@ -391,7 +393,7 @@ func TestSoftDelete_FromInstance_UndoAfterGap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteFromInstanceWithUndo (2): %v", err)
 	}
-	future := time.Now().UTC().Add(1 * time.Hour).Format(storageTimeFormat)
+	future := time.Now().UTC().Add(1 * time.Hour).Format(timeutil.StorageTimeFormat)
 	if _, err := svc.db.ExecContext(ctx,
 		"UPDATE events SET updated_at = ? WHERE id = ?", future, master.ID); err != nil {
 		t.Fatalf("simulate concurrent edit: %v", err)

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
 
 // TrashKind discriminates the three shapes a trash row can have: a full
@@ -199,7 +200,7 @@ func (s *Service) RestoreTrash(ctx context.Context, entry TrashEntry) error {
 // Returns the number of rows purged. The corresponding EXDATEs on the master
 // stay in place — the user intended those instances to be gone.
 func (s *Service) PurgeOldInstanceDeletes(ctx context.Context, olderThan time.Time) (int, error) {
-	cutoff := olderThan.UTC().Format(storageTimeFormat)
+	cutoff := olderThan.UTC().Format(timeutil.StorageTimeFormat)
 	n, err := s.q.PurgeOldEventExdateDeletes(ctx, cutoff)
 	if err != nil {
 		return 0, err
@@ -211,7 +212,7 @@ func (s *Service) PurgeOldInstanceDeletes(ctx context.Context, olderThan time.Ti
 // olderThan. Returns the number of rows purged. The truncated RRULE and
 // soft-deleted overrides on the master stay in place.
 func (s *Service) PurgeOldTruncationDeletes(ctx context.Context, olderThan time.Time) (int, error) {
-	cutoff := olderThan.UTC().Format(storageTimeFormat)
+	cutoff := olderThan.UTC().Format(timeutil.StorageTimeFormat)
 	n, err := s.q.PurgeOldEventTruncateDeletes(ctx, cutoff)
 	if err != nil {
 		return 0, err

--- a/internal/journal/soft_delete.go
+++ b/internal/journal/soft_delete.go
@@ -178,7 +178,7 @@ func (s *Service) GetIncludingDeleted(ctx context.Context, id int64) (Journal, e
 // PurgeDeleted hard-deletes soft-deleted journals whose deleted_at
 // predates olderThan. Children cascade via FK ON DELETE CASCADE.
 func (s *Service) PurgeDeleted(ctx context.Context, olderThan time.Time) (int, error) {
-	cutoff := olderThan.UTC().Format(storageTimeFormat)
+	cutoff := olderThan.UTC().Format(timeutil.StorageTimeFormat)
 	n, err := s.q.PurgeSoftDeletedJournals(ctx, &cutoff)
 	if err != nil {
 		return 0, err
@@ -211,5 +211,3 @@ func (s *Service) reconcileSyncAfterRestore(ctx context.Context, calendarID int6
 	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "journal")
 	return nil
 }
-
-const storageTimeFormat = "2006-01-02T15:04:05Z"

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -71,16 +72,30 @@ func triggerValuesEqual(a, b string) bool {
 }
 
 func parseTriggerTime(s string) (time.Time, bool) {
-	for _, layout := range []string{
-		"20060102T150405Z", // iCal UTC
-		time.RFC3339,       // RFC 3339
-		"20060102T150405",  // iCal floating (no timezone)
-	} {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t, true
-		}
+	t, err := ParseAbsoluteTime(s, "")
+	return t, err == nil
+}
+
+// ParseAbsoluteTime parses an absolute iCal datetime value in any of the three
+// recognized forms: iCal UTC (20060102T150405Z), iCal floating (20060102T150405),
+// or RFC 3339. A floating value is interpreted in timezone (a tz database name)
+// when non-empty and loadable; otherwise it is returned with its zero offset.
+func ParseAbsoluteTime(value, timezone string) (time.Time, error) {
+	if t, err := time.Parse("20060102T150405Z", value); err == nil {
+		return t, nil
 	}
-	return time.Time{}, false
+	if t, err := time.Parse("20060102T150405", value); err == nil {
+		if timezone != "" {
+			if loc, lerr := time.LoadLocation(timezone); lerr == nil {
+				return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, loc), nil
+			}
+		}
+		return t, nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("invalid trigger format: %q", value)
 }
 
 func attendeesEqual(a, b []AlarmAttendee) bool {

--- a/internal/model/alarm_parse_test.go
+++ b/internal/model/alarm_parse_test.go
@@ -1,0 +1,64 @@
+package model
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseAbsoluteTime(t *testing.T) {
+	t.Run("iCal UTC", func(t *testing.T) {
+		got, err := ParseAbsoluteTime("20260401T120000Z", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("RFC 3339", func(t *testing.T) {
+		got, err := ParseAbsoluteTime("2026-04-01T12:00:00Z", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("floating with timezone", func(t *testing.T) {
+		loc, err := time.LoadLocation("America/New_York")
+		if err != nil {
+			t.Skipf("tz database unavailable: %v", err)
+		}
+		got, err := ParseAbsoluteTime("20260401T120000", "America/New_York")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 4, 1, 12, 0, 0, 0, loc)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if got.Location().String() != loc.String() {
+			t.Errorf("location = %q, want %q", got.Location(), loc)
+		}
+	})
+
+	t.Run("floating without timezone keeps zero offset", func(t *testing.T) {
+		got, err := ParseAbsoluteTime("20260401T120000", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Year() != 2026 || got.Hour() != 12 {
+			t.Errorf("unexpected parsed time: %v", got)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		if _, err := ParseAbsoluteTime("not-a-time", ""); err == nil {
+			t.Error("expected error for invalid input, got nil")
+		}
+	})
+}

--- a/internal/storage/attendees_dynamic.go
+++ b/internal/storage/attendees_dynamic.go
@@ -1,9 +1,6 @@
 package storage
 
-import (
-	"context"
-	"strings"
-)
+import "context"
 
 // ListAttendeesByEventIDs returns attendees for the given event IDs.
 // Hand-written because database/sql does not support slice parameters.
@@ -11,14 +8,8 @@ func (q *Queries) ListAttendeesByEventIDs(ctx context.Context, ids []int64) ([]E
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	placeholders := strings.Repeat("?,", len(ids))
-	placeholders = placeholders[:len(placeholders)-1]
+	placeholders, args := expandInPlaceholders(ids)
 	query := "SELECT id, event_id, email, name, rsvp_status, role, organizer, cutype, rsvp, sent_by, delegated_to, delegated_from, member, dir, language FROM event_attendees WHERE event_id IN (" + placeholders + ") ORDER BY event_id, organizer DESC, name"
-
-	args := make([]interface{}, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
 
 	rows, err := q.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/storage/categories_dynamic.go
+++ b/internal/storage/categories_dynamic.go
@@ -1,9 +1,6 @@
 package storage
 
-import (
-	"context"
-	"strings"
-)
+import "context"
 
 // ListCategoriesByEventIDs returns categories for the given event IDs.
 // Hand-written because database/sql does not support slice parameters.
@@ -11,14 +8,8 @@ func (q *Queries) ListCategoriesByEventIDs(ctx context.Context, ids []int64) ([]
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	placeholders := strings.Repeat("?,", len(ids))
-	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+	placeholders, args := expandInPlaceholders(ids)
 	query := "SELECT event_id, category FROM event_categories WHERE event_id IN (" + placeholders + ") ORDER BY event_id, category"
-
-	args := make([]interface{}, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
 
 	rows, err := q.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -42,14 +33,8 @@ func (q *Queries) ListCategoriesByTodoIDs(ctx context.Context, ids []int64) ([]T
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	placeholders := strings.Repeat("?,", len(ids))
-	placeholders = placeholders[:len(placeholders)-1]
+	placeholders, args := expandInPlaceholders(ids)
 	query := "SELECT todo_id, category FROM todo_categories WHERE todo_id IN (" + placeholders + ") ORDER BY todo_id, category"
-
-	args := make([]interface{}, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
 
 	rows, err := q.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -73,14 +58,8 @@ func (q *Queries) ListCategoriesByJournalIDs(ctx context.Context, ids []int64) (
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	placeholders := strings.Repeat("?,", len(ids))
-	placeholders = placeholders[:len(placeholders)-1]
+	placeholders, args := expandInPlaceholders(ids)
 	query := "SELECT journal_id, category FROM journal_categories WHERE journal_id IN (" + placeholders + ") ORDER BY journal_id, category"
-
-	args := make([]interface{}, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
 
 	rows, err := q.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/storage/events_dynamic.go
+++ b/internal/storage/events_dynamic.go
@@ -22,11 +22,7 @@ type EventFilterParams struct {
 const eventCategoryExists = "EXISTS (SELECT 1 FROM event_categories ec WHERE ec.event_id = events.id AND ec.category = ?)"
 
 func (w *whereBuilder) addEventFilters(arg EventFilterParams) {
-	if arg.DeletedOnly {
-		w.add("deleted_at IS NOT NULL")
-	} else if !arg.IncludeDeleted {
-		w.add("deleted_at IS NULL")
-	}
+	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}

--- a/internal/storage/fts.go
+++ b/internal/storage/fts.go
@@ -23,7 +23,7 @@ func FTSQuery(input string) string {
 
 func (q *Queries) SearchEventsFTS(ctx context.Context, query string, calendarID int64, fromTime, toTime, filterStatus string) ([]Event, error) {
 	var w whereBuilder
-	w.add("deleted_at IS NULL")
+	w.addSoftDeleteFilter(false, false)
 	w.add("id IN (SELECT rowid FROM events_fts WHERE events_fts MATCH ?)", query)
 	if calendarID != 0 {
 		w.add("calendar_id = ?", calendarID)
@@ -43,7 +43,7 @@ func (q *Queries) SearchEventsFTS(ctx context.Context, query string, calendarID 
 
 func (q *Queries) SearchTodosFTS(ctx context.Context, query string, calendarID int64, filterStatus string, completedFilter int64) ([]Todo, error) {
 	var w whereBuilder
-	w.add("deleted_at IS NULL")
+	w.addSoftDeleteFilter(false, false)
 	w.add("id IN (SELECT rowid FROM todos_fts WHERE todos_fts MATCH ?)", query)
 	if calendarID != 0 {
 		w.add("calendar_id = ?", calendarID)
@@ -62,7 +62,7 @@ func (q *Queries) SearchTodosFTS(ctx context.Context, query string, calendarID i
 
 func (q *Queries) SearchJournalsFTS(ctx context.Context, query string, calendarID int64, filterStatus string) ([]Journal, error) {
 	var w whereBuilder
-	w.add("deleted_at IS NULL")
+	w.addSoftDeleteFilter(false, false)
 	w.add("id IN (SELECT rowid FROM journals_fts WHERE journals_fts MATCH ?)", query)
 	if calendarID != 0 {
 		w.add("calendar_id = ?", calendarID)

--- a/internal/storage/journals_dynamic.go
+++ b/internal/storage/journals_dynamic.go
@@ -4,18 +4,6 @@ import "context"
 
 const journalCategoryExists = "EXISTS (SELECT 1 FROM journal_categories jc WHERE jc.journal_id = journals.id AND jc.category = ?)"
 
-// journalDeletedFilter mirrors todoDeletedFilter / event equivalents so the
-// journals read path hides soft-deleted rows by default and exposes an
-// explicit opt-in for trash views.
-func journalDeletedFilter(w *whereBuilder, includeDeleted, deletedOnly bool) {
-	switch {
-	case deletedOnly:
-		w.add("deleted_at IS NOT NULL")
-	case !includeDeleted:
-		w.add("deleted_at IS NULL")
-	}
-}
-
 type ListJournalsFilteredParams struct {
 	CalendarID     int64
 	FilterStatus   string
@@ -29,7 +17,7 @@ type ListJournalsFilteredParams struct {
 func (q *Queries) ListJournalsFiltered(ctx context.Context, arg ListJournalsFilteredParams) ([]Journal, error) {
 	var w whereBuilder
 	w.add("recurrence_rule IS NULL AND recurrence_id = ''")
-	journalDeletedFilter(&w, arg.IncludeDeleted, arg.DeletedOnly)
+	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}
@@ -59,7 +47,7 @@ type ListRecurringJournalsFilteredParams struct {
 func (q *Queries) ListRecurringJournalsFiltered(ctx context.Context, arg ListRecurringJournalsFilteredParams) ([]Journal, error) {
 	var w whereBuilder
 	w.add("recurrence_rule IS NOT NULL AND recurrence_id = ''")
-	journalDeletedFilter(&w, arg.IncludeDeleted, arg.DeletedOnly)
+	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}
@@ -80,7 +68,7 @@ type ListJournalsForExportParams struct {
 
 func (q *Queries) ListJournalsForExport(ctx context.Context, arg ListJournalsForExportParams) ([]Journal, error) {
 	var w whereBuilder
-	journalDeletedFilter(&w, arg.IncludeDeleted, arg.DeletedOnly)
+	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}

--- a/internal/storage/query_builder.go
+++ b/internal/storage/query_builder.go
@@ -24,6 +24,33 @@ func (w *whereBuilder) build() (string, []interface{}) {
 	return "WHERE " + strings.Join(w.clauses, " AND "), w.args
 }
 
+// addSoftDeleteFilter appends the canonical deleted_at clause shared by every
+// dynamic read path (events, todos, journals). Default: hide soft-deleted
+// rows. Callers that need to see them (trash views, --include-deleted) set
+// includeDeleted; deletedOnly inverts the filter to surface only trashed rows.
+func (w *whereBuilder) addSoftDeleteFilter(includeDeleted, deletedOnly bool) {
+	switch {
+	case deletedOnly:
+		w.add("deleted_at IS NOT NULL")
+	case !includeDeleted:
+		w.add("deleted_at IS NULL")
+	}
+}
+
+// expandInPlaceholders builds the "?,?,?" placeholder list and the matching
+// positional args slice for a SQL `IN (...)` clause over the given int64 ids.
+// database/sql has no native slice-parameter support, so every hand-written
+// IN query needs this. Callers must ensure len(ids) > 0.
+func expandInPlaceholders(ids []int64) (string, []interface{}) {
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+	args := make([]interface{}, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	return placeholders, args
+}
+
 func (q *Queries) queryEvents(ctx context.Context, where string, args []interface{}, orderBy string) ([]Event, error) {
 	query := "SELECT * FROM events " + where + " ORDER BY " + orderBy
 	rows, err := q.db.QueryContext(ctx, query, args...)

--- a/internal/storage/query_builder_test.go
+++ b/internal/storage/query_builder_test.go
@@ -1,0 +1,69 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandInPlaceholders(t *testing.T) {
+	tests := []struct {
+		name         string
+		ids          []int64
+		wantPlace    string
+		wantArgsLen  int
+		wantArgsVals []int64
+	}{
+		{name: "single", ids: []int64{7}, wantPlace: "?", wantArgsLen: 1, wantArgsVals: []int64{7}},
+		{name: "multiple", ids: []int64{1, 2, 3}, wantPlace: "?,?,?", wantArgsLen: 3, wantArgsVals: []int64{1, 2, 3}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			place, args := expandInPlaceholders(tt.ids)
+			if place != tt.wantPlace {
+				t.Errorf("placeholders = %q, want %q", place, tt.wantPlace)
+			}
+			if strings.HasSuffix(place, ",") {
+				t.Errorf("placeholders %q has trailing comma", place)
+			}
+			if len(args) != tt.wantArgsLen {
+				t.Fatalf("len(args) = %d, want %d", len(args), tt.wantArgsLen)
+			}
+			for i, want := range tt.wantArgsVals {
+				got, ok := args[i].(int64)
+				if !ok || got != want {
+					t.Errorf("args[%d] = %v, want %d", i, args[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestAddSoftDeleteFilter(t *testing.T) {
+	tests := []struct {
+		name           string
+		includeDeleted bool
+		deletedOnly    bool
+		want           string
+	}{
+		{name: "default hides deleted", want: "deleted_at IS NULL"},
+		{name: "include deleted adds no clause", includeDeleted: true, want: ""},
+		{name: "deleted only inverts", deletedOnly: true, want: "deleted_at IS NOT NULL"},
+		{name: "deleted only overrides include", includeDeleted: true, deletedOnly: true, want: "deleted_at IS NOT NULL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var w whereBuilder
+			w.addSoftDeleteFilter(tt.includeDeleted, tt.deletedOnly)
+			where, _ := w.build()
+			if tt.want == "" {
+				if where != "" {
+					t.Errorf("where = %q, want empty", where)
+				}
+				return
+			}
+			if !strings.Contains(where, tt.want) {
+				t.Errorf("where = %q, want it to contain %q", where, tt.want)
+			}
+		})
+	}
+}

--- a/internal/storage/todos_dynamic.go
+++ b/internal/storage/todos_dynamic.go
@@ -4,16 +4,18 @@ import "context"
 
 const todoCategoryExists = "EXISTS (SELECT 1 FROM todo_categories tc WHERE tc.todo_id = todos.id AND tc.category = ?)"
 
-// todoDeletedFilter appends the canonical deleted_at clause used by every
-// todos read path. Default: hide soft-deleted rows. Callers that need to
-// see them (trash views, --include-deleted) set IncludeDeleted or
-// DeletedOnly on their *FilteredParams.
-func todoDeletedFilter(w *whereBuilder, includeDeleted, deletedOnly bool) {
-	switch {
-	case deletedOnly:
-		w.add("deleted_at IS NOT NULL")
-	case !includeDeleted:
-		w.add("deleted_at IS NULL")
+// addTodoListFilters appends the calendar / status / hide-completed clauses
+// shared verbatim by ListTodosFiltered and ListRecurringTodosFiltered, in the
+// same order so positional args line up.
+func (w *whereBuilder) addTodoListFilters(calendarID int64, filterStatus string, hideCompleted int64) {
+	if calendarID != 0 {
+		w.add("calendar_id = ?", calendarID)
+	}
+	if filterStatus != "" {
+		w.add("status = ?", filterStatus)
+	}
+	if hideCompleted != 0 {
+		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
 	}
 }
 
@@ -30,16 +32,8 @@ type ListTodosFilteredParams struct {
 func (q *Queries) ListTodosFiltered(ctx context.Context, arg ListTodosFilteredParams) ([]Todo, error) {
 	var w whereBuilder
 	w.add("recurrence_rule IS NULL AND recurrence_id = ''")
-	todoDeletedFilter(&w, arg.IncludeDeleted, arg.DeletedOnly)
-	if arg.CalendarID != 0 {
-		w.add("calendar_id = ?", arg.CalendarID)
-	}
-	if arg.FilterStatus != "" {
-		w.add("status = ?", arg.FilterStatus)
-	}
-	if arg.HideCompleted != 0 {
-		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
-	}
+	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
+	w.addTodoListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCompleted)
 	if arg.FromDate != "" {
 		w.add("(due_date IS NULL OR due_date >= ?)", arg.FromDate)
 	}
@@ -61,16 +55,8 @@ type ListRecurringTodosFilteredParams struct {
 func (q *Queries) ListRecurringTodosFiltered(ctx context.Context, arg ListRecurringTodosFilteredParams) ([]Todo, error) {
 	var w whereBuilder
 	w.add("recurrence_rule IS NOT NULL AND recurrence_id = ''")
-	todoDeletedFilter(&w, arg.IncludeDeleted, arg.DeletedOnly)
-	if arg.CalendarID != 0 {
-		w.add("calendar_id = ?", arg.CalendarID)
-	}
-	if arg.FilterStatus != "" {
-		w.add("status = ?", arg.FilterStatus)
-	}
-	if arg.HideCompleted != 0 {
-		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
-	}
+	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
+	w.addTodoListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCompleted)
 	where, args := w.build()
 	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
 }
@@ -86,7 +72,7 @@ type ListTodosForExportParams struct {
 
 func (q *Queries) ListTodosForExport(ctx context.Context, arg ListTodosForExportParams) ([]Todo, error) {
 	var w whereBuilder
-	todoDeletedFilter(&w, arg.IncludeDeleted, arg.DeletedOnly)
+	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -15,6 +15,11 @@ import (
 // UTC, which must round-trip as a full RFC 3339 DATE-TIME.
 var dateOnlyLoc = time.FixedZone("DATE", 0)
 
+// StorageTimeFormat is the canonical layout for UTC timestamps written to the
+// database (e.g. deleted_at cutoffs). It is RFC 3339 without the explicit
+// numeric offset, since all stored times are UTC.
+const StorageTimeFormat = "2006-01-02T15:04:05Z"
+
 // IsDateOnly returns true if s is a date-only string in YYYY-MM-DD format.
 func IsDateOnly(s string) bool {
 	if len(s) != 10 {

--- a/internal/todo/soft_delete.go
+++ b/internal/todo/soft_delete.go
@@ -184,7 +184,7 @@ func (s *Service) GetIncludingDeleted(ctx context.Context, id int64) (Todo, erro
 // PurgeDeleted hard-deletes soft-deleted todos whose deleted_at predates
 // olderThan. Children cascade via FK ON DELETE CASCADE.
 func (s *Service) PurgeDeleted(ctx context.Context, olderThan time.Time) (int, error) {
-	cutoff := olderThan.UTC().Format(storageTimeFormat)
+	cutoff := olderThan.UTC().Format(timeutil.StorageTimeFormat)
 	n, err := s.q.PurgeSoftDeletedTodos(ctx, &cutoff)
 	if err != nil {
 		return 0, err
@@ -217,5 +217,3 @@ func (s *Service) reconcileSyncAfterRestore(ctx context.Context, calendarID int6
 	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "todo")
 	return nil
 }
-
-const storageTimeFormat = "2006-01-02T15:04:05Z"

--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -492,10 +492,7 @@ func parseRecurrenceRule(rule string, fallbackDate time.Time) (int, string, ends
 			ends = endsAfter
 		case strings.HasPrefix(upper, "UNTIL="):
 			ends = endsOnDate
-			val := strings.TrimPrefix(upper, "UNTIL=")
-			if t, err := time.Parse("20060102T150405Z", val); err == nil {
-				endsDate = t
-			} else if t, err := time.Parse("20060102", val); err == nil {
+			if t, ok := parseRRuleUntil(strings.TrimPrefix(upper, "UNTIL=")); ok {
 				endsDate = t
 			}
 		default:
@@ -514,6 +511,24 @@ func parseRecurrenceRule(rule string, fallbackDate time.Time) (int, string, ends
 	}
 
 	return repeatCustomIdx, rule, ends, endsDate
+}
+
+// parseRRuleUntil parses an RRULE UNTIL value as either a UTC datetime
+// (20060102T150405Z) or a date-only value (20060102), returning ok=false when
+// neither layout matches.
+func parseRRuleUntil(val string) (time.Time, bool) {
+	if t, err := time.Parse("20060102T150405Z", val); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("20060102", val); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// formatRRuleUntil renders a time as an RRULE UNTIL value in iCal UTC form.
+func formatRRuleUntil(t time.Time) string {
+	return t.UTC().Format("20060102T150405Z")
 }
 
 func rruleParam(rule, name string) string {
@@ -1563,7 +1578,7 @@ func (m EventFormModel) buildRecurrenceRule() string {
 			rule += ";COUNT=" + count
 		}
 	case endsOnDate:
-		rule += ";UNTIL=" + m.endsDate.UTC().Format("20060102T150405Z")
+		rule += ";UNTIL=" + formatRRuleUntil(m.endsDate)
 	default:
 		// endsNever
 	}

--- a/internal/tui/recurrence_editor.go
+++ b/internal/tui/recurrence_editor.go
@@ -177,9 +177,7 @@ func (m *RecurrenceEditorModel) LoadRule(rule string) {
 			m.endsCountField.SetValue(val)
 		case "UNTIL":
 			m.endsField.SetSelected(int(endsOnDate))
-			if t, err := time.Parse("20060102T150405Z", val); err == nil {
-				m.endsDate = t
-			} else if t, err := time.Parse("20060102", val); err == nil {
+			if t, ok := parseRRuleUntil(val); ok {
 				m.endsDate = t
 			}
 		}
@@ -520,7 +518,7 @@ func (m RecurrenceEditorModel) BuildRule() string {
 			rule += ";COUNT=" + c
 		}
 	case endsOnDate:
-		rule += ";UNTIL=" + m.endsDate.UTC().Format("20060102T150405Z")
+		rule += ";UNTIL=" + formatRRuleUntil(m.endsDate)
 	}
 
 	return rule


### PR DESCRIPTION
Consolidation / duplication cleanup from issue #74. Pure refactors — no behavior change. Existing tests cover the touched paths; focused unit tests added for the new shared helpers.

## Items completed (all 9)

1. **alarm absolute-trigger parse** — `parseAbsoluteTrigger` (alarm/service.go + todo_service.go) replaced by `model.ParseAbsoluteTime(value, timezone)`, the single iCal absolute-datetime parser (UTC / floating-with-TZID / RFC 3339). The model's internal `parseTriggerTime` now delegates to it too.
2. **RRULE UNTIL parse/serialize** — extracted `parseRRuleUntil` / `formatRRuleUntil` in the tui package; routed both `event_form.go` and `recurrence_editor.go` (which had the same verbatim duplication) through them.
3. **CLI list date formatting** — `parseListDate` / `formatTodoDate` now use `timeutil.IsDateOnly` for date-only-vs-RFC3339 detection. `formatDateTime` left untouched: it is RFC3339-only with a `textsafe` fallback, not the same detection (changing it would lose the fallback).
4. **IN(?) placeholder construction** — `expandInPlaceholders` in storage; applied to `categories_dynamic.go` (3 funcs) and `attendees_dynamic.go`.
5. **storageTimeFormat constant** — promoted to `timeutil.StorageTimeFormat`; removed the three copy-pasted local consts (event/todo/journal soft_delete.go).
6. **deleted_at clause** — `whereBuilder.addSoftDeleteFilter` replaces `todoDeletedFilter`, `journalDeletedFilter`, and the inline block in `addEventFilters`.
7. **todo list clause** — `whereBuilder.addTodoListFilters` extracts the CalendarID + FilterStatus + HideCompleted trio shared verbatim by `ListTodosFiltered` and `ListRecurringTodosFiltered`.
8. **resolveEvent/Todo/Journal** — parameterized into a generic `resolveRef[T]`; the three named wrappers keep their signatures so call sites are unchanged.
9. **CheckMissed stale loops** — the two ~40-line near-identical loops now share `collectMissedTriggers`, parameterized by a state-existence callback (`eventAlarmStateExists` / `todoAlarmStateExists`).

## Notes
- Clause ordering and positional args in storage builders are preserved, so generated SQL is byte-identical.
- `ListTodosForExport` / `ListJournalsForExport` were left out of the `addTodoListFilters` extraction (item 7) because they interleave Category / CompletedFilter clauses differently; forcing them in would reorder args. They do share `addSoftDeleteFilter` (item 6).
- `fts.go` keeps its single-line `deleted_at IS NULL` adds — no switch duplication there to consolidate.

## Verification
`make fmt`, `go vet ./...`, `go build ./...`, `go test ./... -count=1` all pass.

Closes #74
