### PR TITLE
fix(alarm): claim snoozed refire so overlapping checkers don't double-fire

### DIFF
--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -102,17 +102,21 @@ type fireResult struct {
 // to insert, but only one wins. The loser's UNIQUE-constraint error is reported
 // as a non-fired, non-error result so callers suppress output for it.
 //
-// Note: the refire path (StateID != 0, an expired-snoozed alarm) uses MarkRefired,
-// an UPDATE-by-id with no claim semantics, so two overlapping checkers can still
-// both refire one snoozed alarm. That is a separate, pre-existing gap tracked
-// outside this change; the dedup here covers only the fresh-fire INSERT path.
+// The refire path (StateID != 0, an expired-snoozed alarm) uses MarkRefired,
+// whose UPDATE is gated on snoozed_to IS NOT NULL: when two checkers overlap,
+// both observe the expired-snoozed row, but only the one whose UPDATE clears
+// snoozed_to first affects a row and wins the claim. The loser sees claimed ==
+// false and is likewise reported as a non-fired, non-error result.
 func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) fireResult {
 	stateID := da.StateID
 	var markErr error
 	op := "mark-fired"
 	if stateID != 0 {
 		op = "mark-refired"
-		markErr = a.Alarms.MarkRefired(ctx, stateID)
+		var claimed bool
+		if claimed, markErr = a.Alarms.MarkRefired(ctx, stateID); markErr == nil && !claimed {
+			return fireResult{} // another checker already re-fired this alarm
+		}
 	} else {
 		var newID int64
 		if newID, markErr = a.Alarms.MarkFired(ctx, da); markErr == nil {
@@ -142,7 +146,10 @@ func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlar
 	op := "mark-fired"
 	if stateID != 0 {
 		op = "mark-refired"
-		markErr = a.Alarms.MarkTodoRefired(ctx, stateID)
+		var claimed bool
+		if claimed, markErr = a.Alarms.MarkTodoRefired(ctx, stateID); markErr == nil && !claimed {
+			return fireResult{} // another checker already re-fired this alarm
+		}
 	} else {
 		var newID int64
 		if newID, markErr = a.Alarms.MarkTodoFired(ctx, tda); markErr == nil {

--- a/db/queries/alarm_state.sql
+++ b/db/queries/alarm_state.sql
@@ -25,8 +25,9 @@ WHERE fired_at IS NOT NULL
   AND snoozed_to <= ?
 ORDER BY snoozed_to;
 
--- name: RefireAlarmState :exec
-UPDATE alarm_state SET fired_at = ?, snoozed_to = NULL WHERE id = ?;
+-- name: RefireAlarmState :execrows
+UPDATE alarm_state SET fired_at = ?, snoozed_to = NULL
+WHERE id = ? AND snoozed_to IS NOT NULL;
 
 -- name: ListAlarmStatesByEventID :many
 SELECT * FROM alarm_state WHERE event_id = ? ORDER BY trigger_at;

--- a/db/queries/todo_alarm_state.sql
+++ b/db/queries/todo_alarm_state.sql
@@ -27,8 +27,9 @@ SELECT * FROM todo_alarm_state
 WHERE snoozed_to IS NOT NULL AND snoozed_to <= ?
 ORDER BY snoozed_to;
 
--- name: RefireTodoAlarmState :exec
-UPDATE todo_alarm_state SET fired_at = ?, snoozed_to = NULL WHERE id = ?;
+-- name: RefireTodoAlarmState :execrows
+UPDATE todo_alarm_state SET fired_at = ?, snoozed_to = NULL
+WHERE id = ? AND snoozed_to IS NOT NULL;
 
 -- name: DeleteTodoAlarmState :exec
 DELETE FROM todo_alarm_state WHERE id = ?;

--- a/internal/alarm/integration_test.go
+++ b/internal/alarm/integration_test.go
@@ -176,9 +176,12 @@ func TestAlarmLifecycle_Snooze(t *testing.T) {
 	}
 
 	// 9. MarkRefired and dismiss
-	err = svc.MarkRefired(ctx, due[0].StateID)
+	claimed, err := svc.MarkRefired(ctx, due[0].StateID)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !claimed {
+		t.Fatal("step 9: MarkRefired should claim the expired-snoozed alarm")
 	}
 	err = svc.Dismiss(ctx, due[0].StateID)
 	if err != nil {
@@ -192,6 +195,74 @@ func TestAlarmLifecycle_Snooze(t *testing.T) {
 	}
 	if len(pending) != 0 {
 		t.Fatalf("step 10: got %d pending alarms, want 0", len(pending))
+	}
+}
+
+// TestMarkRefired_ConcurrentClaim reproduces issue #88: two overlapping
+// checkers both observe the same expired-snoozed alarm and both call
+// MarkRefired. Only one may win the claim; the other must be told it lost
+// (claimed == false) so the CLI does not dispatch a duplicate notification.
+func TestMarkRefired_ConcurrentClaim(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	evtSvc := event.NewService(db, q)
+	svc := NewService(db, q, evtSvc, nil)
+	ctx := context.Background()
+
+	start := time.Now().Add(10 * time.Minute)
+	e, err := evtSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Refire Race",
+		StartTime:  start,
+		EndTime:    start.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M", Description: "15 min reminder"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fire and snooze into the past so the alarm is an expired-snoozed row.
+	due, _, err := svc.Check(ctx, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("got %d due alarms, want 1", len(due))
+	}
+	stateID, err := svc.MarkFired(ctx, due[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Snooze(ctx, stateID, time.Now().Add(-1*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two checkers each observe the expired-snoozed row (Check returns it with
+	// the same StateID) and both attempt to claim it.
+	due, _, err = svc.Check(ctx, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(due) != 1 || due[0].StateID != stateID {
+		t.Fatalf("expected one expired-snoozed refire for state %d, got %+v", stateID, due)
+	}
+
+	first, err := svc.MarkRefired(ctx, stateID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := svc.MarkRefired(ctx, stateID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first {
+		t.Error("first MarkRefired should win the claim")
+	}
+	if second {
+		t.Error("second MarkRefired must lose the claim, but it double-fired (issue #88)")
 	}
 }
 

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -404,13 +404,22 @@ func (s *Service) MarkTodoFired(ctx context.Context, tda TodoDueAlarm) (int64, e
 	return todoSvc.MarkTodoAlarmFired(ctx, tda.Alarm.ID, tda.Todo.ID, tda.TriggerAt)
 }
 
-// MarkTodoRefired re-fires a snoozed todo alarm, clearing the snooze.
-func (s *Service) MarkTodoRefired(ctx context.Context, stateID int64) error {
+// MarkTodoRefired re-fires a snoozed todo alarm, clearing the snooze. The
+// UPDATE is gated on snoozed_to IS NOT NULL so it acts as an atomic claim:
+// when two checkers overlap, both observe the expired-snoozed row, but only
+// the one whose UPDATE clears snoozed_to first affects a row. claimed reports
+// whether this caller won the claim; a false claimed means another checker
+// already re-fired the alarm and this caller must not dispatch a duplicate.
+func (s *Service) MarkTodoRefired(ctx context.Context, stateID int64) (claimed bool, err error) {
 	now := time.Now().UTC().Format(time.RFC3339)
-	return s.q.RefireTodoAlarmState(ctx, storage.RefireTodoAlarmStateParams{
+	rows, err := s.q.RefireTodoAlarmState(ctx, storage.RefireTodoAlarmStateParams{
 		FiredAt: &now,
 		ID:      stateID,
 	})
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // Dismiss acknowledges a fired alarm so it won't show as pending.
@@ -433,13 +442,22 @@ func (s *Service) Dismiss(ctx context.Context, stateID int64) error {
 	})
 }
 
-// MarkRefired updates a snoozed alarm's fired_at and clears snoozed_to.
-func (s *Service) MarkRefired(ctx context.Context, stateID int64) error {
+// MarkRefired updates a snoozed alarm's fired_at and clears snoozed_to. The
+// UPDATE is gated on snoozed_to IS NOT NULL so it acts as an atomic claim:
+// when two checkers overlap, both observe the expired-snoozed row, but only
+// the one whose UPDATE clears snoozed_to first affects a row. claimed reports
+// whether this caller won the claim; a false claimed means another checker
+// already re-fired the alarm and this caller must not dispatch a duplicate.
+func (s *Service) MarkRefired(ctx context.Context, stateID int64) (claimed bool, err error) {
 	now := time.Now().UTC().Format(time.RFC3339)
-	return s.q.RefireAlarmState(ctx, storage.RefireAlarmStateParams{
+	rows, err := s.q.RefireAlarmState(ctx, storage.RefireAlarmStateParams{
 		FiredAt: &now,
 		ID:      stateID,
 	})
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // SnoozeResult describes what happened when computing a snooze time.

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -325,8 +325,10 @@ func TestCheck_RefiresSnoozedAlarm(t *testing.T) {
 	}
 
 	// MarkRefired clears snoozed_to
-	if err := svc.MarkRefired(ctx, due[0].StateID); err != nil {
+	if claimed, err := svc.MarkRefired(ctx, due[0].StateID); err != nil {
 		t.Fatal(err)
+	} else if !claimed {
+		t.Fatal("MarkRefired should claim the expired-snoozed alarm")
 	}
 
 	// Check again: no expired snoozes, no fresh alarms (already has state row)

--- a/internal/storage/alarm_state.sql.go
+++ b/internal/storage/alarm_state.sql.go
@@ -244,8 +244,9 @@ func (q *Queries) PurgeStaleUnacknowledgedAlarmStates(ctx context.Context, trigg
 	return result.RowsAffected()
 }
 
-const refireAlarmState = `-- name: RefireAlarmState :exec
-UPDATE alarm_state SET fired_at = ?, snoozed_to = NULL WHERE id = ?
+const refireAlarmState = `-- name: RefireAlarmState :execrows
+UPDATE alarm_state SET fired_at = ?, snoozed_to = NULL
+WHERE id = ? AND snoozed_to IS NOT NULL
 `
 
 type RefireAlarmStateParams struct {
@@ -253,9 +254,12 @@ type RefireAlarmStateParams struct {
 	ID      int64
 }
 
-func (q *Queries) RefireAlarmState(ctx context.Context, arg RefireAlarmStateParams) error {
-	_, err := q.db.ExecContext(ctx, refireAlarmState, arg.FiredAt, arg.ID)
-	return err
+func (q *Queries) RefireAlarmState(ctx context.Context, arg RefireAlarmStateParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, refireAlarmState, arg.FiredAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const snoozeAlarmState = `-- name: SnoozeAlarmState :exec

--- a/internal/storage/todo_alarm_state.sql.go
+++ b/internal/storage/todo_alarm_state.sql.go
@@ -285,8 +285,9 @@ func (q *Queries) PurgeStaleUnacknowledgedTodoAlarmStates(ctx context.Context, t
 	return result.RowsAffected()
 }
 
-const refireTodoAlarmState = `-- name: RefireTodoAlarmState :exec
-UPDATE todo_alarm_state SET fired_at = ?, snoozed_to = NULL WHERE id = ?
+const refireTodoAlarmState = `-- name: RefireTodoAlarmState :execrows
+UPDATE todo_alarm_state SET fired_at = ?, snoozed_to = NULL
+WHERE id = ? AND snoozed_to IS NOT NULL
 `
 
 type RefireTodoAlarmStateParams struct {
@@ -294,9 +295,12 @@ type RefireTodoAlarmStateParams struct {
 	ID      int64
 }
 
-func (q *Queries) RefireTodoAlarmState(ctx context.Context, arg RefireTodoAlarmStateParams) error {
-	_, err := q.db.ExecContext(ctx, refireTodoAlarmState, arg.FiredAt, arg.ID)
-	return err
+func (q *Queries) RefireTodoAlarmState(ctx context.Context, arg RefireTodoAlarmStateParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, refireTodoAlarmState, arg.FiredAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const updateTodoAlarmState = `-- name: UpdateTodoAlarmState :exec


### PR DESCRIPTION
Fixes #88

## Root cause

PR #81 (issue #70) made the **fresh-fire** path claim-safe via a unique INSERT
on `(alarm_id, trigger_at)`, but the **snoozed-refire** path stayed unguarded.
`MarkRefired` / `MarkTodoRefired` ran an unconditional
`UPDATE alarm_state SET fired_at=?, snoozed_to=NULL WHERE id=?`. Two overlapping
checkers both observe the same expired-snoozed row
(`snoozed_to IS NOT NULL AND snoozed_to <= now`), both UPDATE successfully, and
**both fire** — a double-fire for snoozed alarms.

## Fix

- Gate the refire UPDATE on `snoozed_to IS NOT NULL` and switch
  `RefireAlarmState` / `RefireTodoAlarmState` to `:execrows`
  (`db/queries/alarm_state.sql`, `db/queries/todo_alarm_state.sql`, regenerated
  via `make generate`). The clause makes the UPDATE an atomic claim: only the
  checker whose UPDATE clears `snoozed_to` first affects a row.
- `MarkRefired` / `MarkTodoRefired` now return `(claimed bool, err error)` from
  the rows-affected count.
- `cmd/chroncal/alarm.go` fires only on a successful claim; the loser is
  reported as a non-fired, non-error result (no duplicate notification),
  mirroring the fresh-fire dedup.

## Test coverage

`TestMarkRefired_ConcurrentClaim` reproduces the race: it fires and snoozes an
alarm into the past, then has two checkers each call `MarkRefired` on the same
state. The first must win (`claimed == true`) and the second must lose
(`claimed == false`). Against the pre-fix unconditional UPDATE the second call
also "succeeds" and the test fails on the double-fire assertion; with the fix it
passes. Existing lifecycle/snooze tests were updated to the new two-value return
and assert `claimed == true` on the legitimate refire.

`go vet ./...`, `make fmt`, and `go test ./internal/... ./cmd/...` are all green.
