### PR TITLE
fix(sync): tombstone-aware, atomic conflict resolution

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1372,11 +1372,68 @@ func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) 
 	if err != nil {
 		return false, fmt.Errorf("import ical: %w", err)
 	}
+	// imported reflects whether the SERVER payload carried any component. It is
+	// computed before tombstone filtering so the empty-iCal guard in callers
+	// still fires for a genuinely empty server version, and never falsely fires
+	// just because the only component was tombstoned away.
+	imported = len(importResult.Events) > 0 || len(importResult.Todos) > 0 || len(importResult.Journals) > 0
+
+	// Tombstone-aware import: drop any UID the user has locally deleted
+	// (tombstoned, pending propagation to the server). UpsertByUID clears
+	// deleted_at, so persisting a tombstoned UID would resurrect a row the user
+	// just deleted. The pull path filters tombstoned UIDs inline (see the NOTE
+	// in db/queries/events.sql); doing the same here keeps the accept-server
+	// conflict paths — manual `sync resolve <id> server` and auto
+	// ConflictServerWins — consistent with it. Issue #89 gap #2.
+	importResult, err = e.dropTombstonedFromImport(ctx, calendarID, importResult)
+	if err != nil {
+		return false, err
+	}
 	if err := e.persistImported(ctx, calendarID, importResult); err != nil {
 		return false, err
 	}
-	imported = len(importResult.Events) > 0 || len(importResult.Todos) > 0 || len(importResult.Journals) > 0
 	return imported, nil
+}
+
+// dropTombstonedFromImport removes events/todos/journals whose UID is
+// tombstoned for the calendar, so an accept-server import never resurrects a
+// row the user has locally deleted. Returns the result unchanged when nothing
+// is tombstoned.
+func (e *Engine) dropTombstonedFromImport(ctx context.Context, calendarID int64, result icalPkg.ImportResult) (icalPkg.ImportResult, error) {
+	tombstones, err := e.q.ListTombstonesByCalendar(ctx, calendarID)
+	if err != nil {
+		return result, fmt.Errorf("list tombstones: %w", err)
+	}
+	if len(tombstones) == 0 {
+		return result, nil
+	}
+	tombstoned := make(map[string]bool, len(tombstones))
+	for _, ts := range tombstones {
+		if ts.Uid != "" {
+			tombstoned[ts.Uid] = true
+		}
+	}
+
+	result.Events = filterTombstoned(e.logger, result.Events, tombstoned, "event", func(ev event.Event) string { return ev.UID })
+	result.Todos = filterTombstoned(e.logger, result.Todos, tombstoned, "todo", func(t todo.Todo) string { return t.UID })
+	result.Journals = filterTombstoned(e.logger, result.Journals, tombstoned, "journal", func(j journal.Journal) string { return j.UID })
+
+	return result, nil
+}
+
+// filterTombstoned returns items whose UID (via uidOf) is not tombstoned,
+// logging each one it drops. The result reuses a zero-capacity head of the
+// input so append always allocates fresh and never clobbers the caller's slice.
+func filterTombstoned[T any](logger *slog.Logger, items []T, tombstoned map[string]bool, ownerType string, uidOf func(T) string) []T {
+	kept := items[:0:0]
+	for _, it := range items {
+		if uid := uidOf(it); tombstoned[uid] {
+			logger.Info("skip accept-server import: UID tombstoned locally", "uid", uid, "owner_type", ownerType)
+			continue
+		}
+		kept = append(kept, it)
+	}
+	return kept
 }
 
 func parseICalData(data []byte) (*ical.Calendar, error) {

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -131,18 +131,27 @@ func (s *Service) ListConflicts(ctx context.Context) ([]Conflict, error) {
 
 // ResolveConflict resolves a conflict by picking local or server version.
 func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick string) error {
+	if pick != "server" && pick != "local" {
+		return fmt.Errorf("invalid pick: %q (use 'local' or 'server')", pick)
+	}
+
 	conflict, err := s.q.GetSyncConflict(ctx, conflictID)
 	if err != nil {
 		return fmt.Errorf("get conflict: %w", err)
 	}
 
-	switch pick {
-	case "server":
+	if pick == "server" {
 		// Accept the server version: import the recorded server iCal into the
-		// local row so it reflects the server state, then clear the pending
-		// local push and store the server ETag. Without the import the local
-		// row keeps its divergent local copy while the ETag claims it matches
-		// the server, so a later local edit silently overwrites the server.
+		// local row so it reflects the server state. Without the import the
+		// local row keeps its divergent local copy while the ETag (cleared
+		// below) claims it matches the server, so a later local edit silently
+		// overwrites the server. importICal is tombstone-aware, so a UID the
+		// user has locally deleted is not resurrected here (issue #89 gap #2).
+		//
+		// The import runs before the transaction below because it flows through
+		// the event/todo/journal services, which use their own connection.
+		// UpsertByUID is idempotent, so if the transaction fails to commit the
+		// conflict survives and the whole resolution replays cleanly.
 		imported, err := s.engine.importICal(ctx, conflict.CalendarID, conflict.ServerIcal)
 		if err != nil {
 			return fmt.Errorf("import server version: %w", err)
@@ -154,7 +163,24 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 			// branch exists to prevent. Refuse instead of resolving falsely.
 			return fmt.Errorf("server version has no importable data for %q", conflict.Uid)
 		}
-		if err := s.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
+	}
+
+	// Wrap the dirty/etag mutation and the conflict deletion in one transaction
+	// so a failure can't half-resolve the conflict — e.g. dirty cleared with a
+	// stale ETag but the conflict still recorded, which would re-trigger an HTTP
+	// 412 loop on the next push. Issue #89 gap #3.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	switch pick {
+	case "server":
+		// Clear the pending local push and adopt the server ETag now that the
+		// local row reflects the server version.
+		if err := qtx.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
 			CalendarID: conflict.CalendarID,
 			Uid:        conflict.Uid,
 			Etag:       conflict.ServerEtag,
@@ -171,18 +197,19 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 		// If-Match: <ServerEtag>, which succeeds if the server is unchanged
 		// (fixing the loop) but 412s and surfaces a fresh conflict if the
 		// server was edited again after this conflict was recorded.
-		if err := s.q.MarkSyncResourceDirtyWithEtag(ctx, storage.MarkSyncResourceDirtyWithEtagParams{
+		if err := qtx.MarkSyncResourceDirtyWithEtag(ctx, storage.MarkSyncResourceDirtyWithEtagParams{
 			CalendarID: conflict.CalendarID,
 			Uid:        conflict.Uid,
 			Etag:       conflict.ServerEtag,
 		}); err != nil {
 			return fmt.Errorf("mark dirty: %w", err)
 		}
-	default:
-		return fmt.Errorf("invalid pick: %q (use 'local' or 'server')", pick)
 	}
 
-	return s.q.DeleteSyncConflict(ctx, conflictID)
+	if err := qtx.DeleteSyncConflict(ctx, conflictID); err != nil {
+		return fmt.Errorf("delete conflict: %w", err)
+	}
+	return tx.Commit()
 }
 
 // ResetCalendar clears all sync state for a calendar without deleting local data.

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -288,6 +289,92 @@ func TestService_ResolveConflict_Server(t *testing.T) {
 	}
 	if res.Etag != "etag-456" {
 		t.Fatalf("Etag = %q, want %q", res.Etag, "etag-456")
+	}
+}
+
+// TestService_ResolveConflict_ServerDoesNotResurrectDeleted is the regression
+// test for issue #89 (gap #2): accepting the server version of a conflict must
+// NOT un-delete a row the user has locally soft-deleted and tombstoned for
+// propagation. UpsertByUID clears deleted_at, so without tombstone-aware import
+// the resolve resurrects the local row and contradicts the pending delete. The
+// tombstone-safe pull path skips tombstoned UIDs; the resolve path must match.
+func TestService_ResolveConflict_ServerDoesNotResurrectDeleted(t *testing.T) {
+	svc, db, q := newTestServiceWithDB(t)
+	ctx := context.Background()
+
+	cals, _ := q.ListCalendars(ctx)
+	calID := cals[0].ID
+
+	const uid = "resolve-server-deleted-uid"
+	events := event.NewService(db, q)
+
+	created, err := events.UpsertByUID(ctx, event.UpsertParams{
+		UID:        uid,
+		CalendarID: calID,
+		Title:      "Local Title",
+		StartTime:  time.Date(2026, 4, 3, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 3, 11, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("seed local event: %v", err)
+	}
+
+	// Mark the resource synced (non-empty remote_url) so deleting it queues a
+	// tombstone via CreateTombstoneIfSynced.
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calID,
+		Uid:          uid,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/" + uid + ".ics",
+		Etag:         "etag-before",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	// User deletes the event locally: soft-deletes the row and queues a tombstone.
+	if err := events.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := events.GetByUID(ctx, uid); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("precondition: event should be soft-deleted, GetByUID err = %v", err)
+	}
+
+	// A pre-existing conflict for the same UID carries the server's version.
+	serverIcal := "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\nPRODID:-//chroncal//test//EN\r\n" +
+		"BEGIN:VEVENT\r\nUID:" + uid + "\r\n" +
+		"DTSTART:20260403T120000Z\r\nDTEND:20260403T130000Z\r\n" +
+		"SUMMARY:Server Title\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+	if err := q.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
+		CalendarID: calID, OwnerType: "event", OwnerID: created.ID, Uid: uid,
+		LocalIcal: "local", ServerIcal: serverIcal, ServerEtag: "etag-456",
+	}); err != nil {
+		t.Fatalf("CreateSyncConflict: %v", err)
+	}
+
+	conflicts, _ := q.ListSyncConflicts(ctx)
+	if err := svc.ResolveConflict(ctx, conflicts[0].ID, "server"); err != nil {
+		t.Fatalf("ResolveConflict server: %v", err)
+	}
+
+	// The row must STAY deleted — the pending local delete wins, matching the
+	// tombstone-safe pull path. Resurrection here is the bug.
+	if _, err := events.GetByUID(ctx, uid); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("event was resurrected by resolve 'server'; GetByUID err = %v, want sql.ErrNoRows", err)
+	}
+
+	// The tombstone must survive so the delete still propagates to the server.
+	tombstones, _ := q.ListTombstonesByCalendar(ctx, calID)
+	if len(tombstones) != 1 {
+		t.Fatalf("tombstones = %d, want 1 (delete intent must survive)", len(tombstones))
+	}
+
+	// The conflict must be cleared so we stop looping.
+	remaining, _ := q.ListSyncConflicts(ctx)
+	if len(remaining) != 0 {
+		t.Fatalf("conflicts after resolve = %d, want 0", len(remaining))
 	}
 }
 


### PR DESCRIPTION
Fixes #89

## Root cause

The shared "accept the server version" path — manual `sync resolve <id> server`
and auto `ConflictServerWins` — runs through `importICal` → `persistImported` →
`UpsertByUID`, and `UpsertByUID` clears `deleted_at`. So accepting the server
version of a conflict **resurrected a row the user had locally deleted** (a
soft-deleted row with a pending tombstone), even though the tombstone-safe pull
path explicitly skips such UIDs (gap #2). Separately, the manual resolve cleared
the dirty flag, stamped the server ETag, and deleted the conflict as three
unwrapped statements; a failure after clearing dirty could leave `dirty=1` with
a stale ETag and re-trigger a 412 conflict loop on the next push (gap #3).

## Fix

- **Tombstone-aware import (gap #2):** `importICal` now drops any imported
  event/todo/journal whose UID is tombstoned for the calendar before persisting,
  mirroring the pull path's inline filter. The `imported` bool that callers use
  to refuse an empty server payload is computed *before* filtering, so the
  empty-iCal guard still fires for a genuinely empty version and never falsely
  fires just because the only component was tombstoned away. The filter lives at
  the low-frequency conflict-resolution chokepoint (not in `persistImported`) so
  the hot pull loop keeps loading tombstones once per sync instead of once per
  resource.
- **Atomic resolution (gap #3):** the dirty/etag mutation and the conflict
  deletion are wrapped in a single transaction. The server import runs before
  the transaction (it flows through the per-domain services on their own
  connection); `UpsertByUID` is idempotent, so a commit failure leaves the
  conflict intact for a clean replay rather than a half-resolved 412 loop.

Gap #1 (propagate a server hard-delete) has narrow reachability — a true server
delete 404s `GetResource` and records no conflict, and a conflict whose
`ServerIcal` is empty is already refused rather than falsely resolved (the
existing `!imported` guard), so no phantom row is created.

## Test coverage

New regression test `TestService_ResolveConflict_ServerDoesNotResurrectDeleted`:
seeds a synced event, deletes it locally (soft-delete + tombstone), records a
conflict carrying the server's version, then resolves "server". It asserts the
row stays deleted, the tombstone survives so the delete still propagates, and
the conflict is cleared. The test fails on `master` (row resurrected) and passes
with the fix. Existing resolve tests (`_Server`, `_Local`, `_ServerEmptyIcal`,
`_InvalidPick`) remain green, confirming the empty-iCal refusal and validation
behavior are unchanged.
