### PR TITLE
fix(ical): export floating times as UTC wall clock, not host-local

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -242,13 +242,14 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 			vevent.Props.SetDate(ical.PropDateTimeEnd, allDayExportDate(e.EndTime, e.Timezone))
 		}
 	} else if e.Timezone == "FLOATING" {
-		local := e.StartTime.Local()
-		setPropFloating(vevent, ical.PropDateTimeStart, local)
+		// Floating times are host-independent wall clocks. Import interprets
+		// them as UTC, so export must emit the stored UTC wall clock (not
+		// .Local(), which would shift the clock on non-UTC hosts).
+		setPropFloating(vevent, ical.PropDateTimeStart, e.StartTime.UTC())
 		if useDuration {
 			setPropDuration(vevent, e.DurationValue)
 		} else {
-			local = e.EndTime.Local()
-			setPropFloating(vevent, ical.PropDateTimeEnd, local)
+			setPropFloating(vevent, ical.PropDateTimeEnd, e.EndTime.UTC())
 		}
 	} else if e.Timezone != "" {
 		loc, err := time.LoadLocation(e.Timezone)
@@ -345,7 +346,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			} else if due, err := time.Parse(time.RFC3339, t.DueDate); err == nil {
 				if t.Timezone == "FLOATING" {
 					p := &ical.Prop{Name: ical.PropDue}
-					p.Value = due.Local().Format("20060102T150405")
+					p.Value = due.UTC().Format("20060102T150405")
 					vtodo.Props.Set(p)
 				} else if t.Timezone != "" {
 					if loc, lerr := time.LoadLocation(t.Timezone); lerr == nil {
@@ -367,7 +368,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			} else if start, err := time.Parse(time.RFC3339, t.StartDate); err == nil {
 				if t.Timezone == "FLOATING" {
 					p := &ical.Prop{Name: ical.PropDateTimeStart}
-					p.Value = start.Local().Format("20060102T150405")
+					p.Value = start.UTC().Format("20060102T150405")
 					vtodo.Props.Set(p)
 				} else if t.Timezone != "" {
 					if loc, lerr := time.LoadLocation(t.Timezone); lerr == nil {
@@ -955,7 +956,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 			} else if start, err := time.Parse(time.RFC3339, j.StartDate); err == nil {
 				if j.Timezone == "FLOATING" {
 					p := &ical.Prop{Name: ical.PropDateTimeStart}
-					p.Value = start.Local().Format("20060102T150405")
+					p.Value = start.UTC().Format("20060102T150405")
 					vjournal.Props.Set(p)
 				} else if j.Timezone != "" {
 					if loc, lerr := time.LoadLocation(j.Timezone); lerr == nil {

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -1826,6 +1826,82 @@ func TestRoundtrip_EventDurationFloating(t *testing.T) {
 	}
 }
 
+// TestRoundtrip_FloatingClockHostIndependent verifies that floating-time
+// values export the stored wall clock unchanged, regardless of the host's
+// local timezone. Import interprets a floating DTSTART as UTC (storing the
+// wall clock as e.g. 09:00:00Z), so export must format the UTC wall clock —
+// not e.Local() — otherwise the displayed clock shifts on non-UTC hosts.
+func TestRoundtrip_FloatingClockHostIndependent(t *testing.T) {
+	// Force a non-UTC host timezone so .Local() would visibly shift the clock.
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	orig := time.Local
+	time.Local = loc
+	t.Cleanup(func() { time.Local = orig })
+
+	t.Run("event", func(t *testing.T) {
+		data, err := ExportEvents([]event.Event{{
+			UID:       "floating-event",
+			Title:     "Floating",
+			StartTime: time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC),
+			Timezone:  "FLOATING",
+			Status:    "CONFIRMED",
+			Transp:    "OPAQUE",
+		}}, "")
+		if err != nil {
+			t.Fatalf("export: %v", err)
+		}
+		exported := string(data)
+		if !strings.Contains(exported, "DTSTART:20260401T090000") {
+			t.Errorf("floating DTSTART clock shifted by host TZ; want DTSTART:20260401T090000\n%s", exported)
+		}
+		if !strings.Contains(exported, "DTEND:20260401T093000") {
+			t.Errorf("floating DTEND clock shifted by host TZ; want DTEND:20260401T093000\n%s", exported)
+		}
+	})
+
+	t.Run("todo", func(t *testing.T) {
+		data, err := ExportTodos([]todo.Todo{{
+			UID:       "floating-todo",
+			Summary:   "Floating",
+			StartDate: "2026-04-01T09:00:00Z",
+			DueDate:   "2026-04-01T17:00:00Z",
+			Timezone:  "FLOATING",
+			Status:    "NEEDS-ACTION",
+		}}, "")
+		if err != nil {
+			t.Fatalf("export: %v", err)
+		}
+		exported := string(data)
+		if !strings.Contains(exported, "DTSTART:20260401T090000") {
+			t.Errorf("floating todo DTSTART clock shifted by host TZ; want DTSTART:20260401T090000\n%s", exported)
+		}
+		if !strings.Contains(exported, "DUE:20260401T170000") {
+			t.Errorf("floating todo DUE clock shifted by host TZ; want DUE:20260401T170000\n%s", exported)
+		}
+	})
+
+	t.Run("journal", func(t *testing.T) {
+		data, err := ExportJournals([]journal.Journal{{
+			UID:       "floating-journal",
+			Summary:   "Floating",
+			StartDate: "2026-04-01T09:00:00Z",
+			Timezone:  "FLOATING",
+			Status:    "FINAL",
+		}}, "")
+		if err != nil {
+			t.Fatalf("export: %v", err)
+		}
+		exported := string(data)
+		if !strings.Contains(exported, "DTSTART:20260401T090000") {
+			t.Errorf("floating journal DTSTART clock shifted by host TZ; want DTSTART:20260401T090000\n%s", exported)
+		}
+	})
+}
+
 func TestRoundtrip_EventDurationWithTimezone(t *testing.T) {
 	t.Parallel()
 	original := event.Event{


### PR DESCRIPTION
Fixes #90

## Root cause

Floating DTSTART/DTEND/DUE values are host-independent wall clocks. Import
parses them with go-ical's `DateTime(nil)`, which interprets the wall clock as
UTC and stores it (e.g. `09:00` → `2026-04-01T09:00:00Z`). Export, however,
formatted floating times via `e.StartTime.Local().Format(...)`, converting the
stored instant to the host's local wall clock. Import and export were therefore
asymmetric: on any host where `TZ != UTC`, a floating `09:00` round-tripped to a
different time (e.g. `05:00` under `America/New_York`), silently shifting the
displayed clock.

## Fix

Format the stored UTC wall clock instead of `.Local()` at all five floating-time
sites in `internal/ical/export.go`:

- event `DTSTART` / `DTEND`
- todo `DUE` / `DTSTART`
- journal `DTSTART`

This makes import (UTC interpretation) and export symmetric, so floating times
round-trip unchanged regardless of host timezone.

## Test

Adds `TestRoundtrip_FloatingClockHostIndependent`, which forces a non-UTC
`time.Local` (`America/New_York`) and asserts the *emitted clock value* (not just
`DURATION:` presence) for floating events, todos, and journals. The test fails
on the old `.Local()` code (emitting `05:00`) and passes with the fix
(`09:00`). The existing `TestRoundtrip_EventDurationFloating` only asserted
`DURATION:` presence, so it never caught the shift.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` are all green.
