### PR TITLE
fix(tui): anchor edit-form date to display tz to stop day shift

### DIFF
--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -410,7 +410,16 @@ func NewEventFormModelForEditInstance(ev event.Event, instanceTime time.Time, ca
 		m.allDay = true
 	}
 	if !ev.AllDay {
-		m.timeField.SetStartValue(ev.StartTime.In(displayLoc).Format("15:04"))
+		// Anchor the Date field to the same wall-clock day as the Time
+		// field. NewEventFormModel seeded m.day from the raw (UTC)
+		// StartTime, but the Time field renders in displayLoc; if the
+		// event's UTC date differs from its display-tz date, save() would
+		// recombine a mismatched date and time and shift the event by a
+		// day. Re-anchoring m.day to displayLoc keeps both columns on the
+		// same day (see issue #91).
+		start := ev.StartTime.In(displayLoc)
+		m.day = start
+		m.timeField.SetStartValue(start.Format("15:04"))
 		m.timeField.SetEndValue(ev.EndTime.In(displayLoc).Format("15:04"))
 	}
 

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -292,6 +292,34 @@ func TestEventForm_SaveIncludesShowAsAndVisibility(t *testing.T) {
 	assert.Equal(t, "CONFIDENTIAL", msg.Class)
 }
 
+func TestEventForm_EditNoOpPreservesTimedStartAcrossUTCDateBoundary(t *testing.T) {
+	// Event stored 2026-04-16T02:00:00Z in America/New_York. Its UTC date
+	// (Apr 16) differs from its display-tz wall-clock date (Apr 15, 22:00 NY).
+	// A no-op edit (just save) must not shift the event by a day.
+	start := time.Date(2026, 4, 16, 2, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 16, 3, 0, 0, 0, time.UTC)
+	m, _ := NewEventFormModelForEdit(event.Event{
+		ID:         7,
+		UID:        "boundary-uid",
+		Title:      "Late meeting",
+		StartTime:  start,
+		EndTime:    end,
+		Timezone:   "America/New_York",
+		CalendarID: 1,
+	}, testEventFormCalendars(), Theme{})
+
+	cmd := m.save(&m.form)
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(EventFormSaveMsg)
+	require.True(t, ok)
+	assert.True(t, msg.StartTime.Equal(start),
+		"no-op edit must preserve StartTime; got %s want %s",
+		msg.StartTime.Format(time.RFC3339), start.Format(time.RFC3339))
+	assert.True(t, msg.EndTime.Equal(end),
+		"no-op edit must preserve EndTime; got %s want %s",
+		msg.EndTime.Format(time.RFC3339), end.Format(time.RFC3339))
+}
+
 func TestEventForm_EnterOnTimeDoesNotOpenDatePicker(t *testing.T) {
 	m, _ := NewEventFormModel(time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), testEventFormCalendars(), Theme{})
 


### PR DESCRIPTION
Fixes #91

## Root cause

When opening the event edit form, `m.day` was seeded from the raw
`ev.StartTime` (UTC), but the Time field was initialized in the display
timezone (`ev.StartTime.In(displayLoc)`). `save()` recombines the Date
column's Y/M/D with the Time column's HH:MM in the selected timezone.
When an event's UTC calendar date differs from its display-tz date
(e.g. an evening event in a western-hemisphere zone, like
`2026-04-16T02:00:00Z` in America/New_York which is Apr 15 22:00 local),
the two columns refer to different days, so a no-op edit shifted the
event forward by a day on save.

## Fix

Re-anchor `m.day` to `ev.StartTime.In(displayLoc)` — the same location
used for the Time field — so the Date and Time columns are anchored to
the same wall-clock day and stay consistent through `save()`. All-day
events are unaffected (they keep their UTC-midnight anchor).

## Test coverage

`TestEventForm_EditNoOpPreservesTimedStartAcrossUTCDateBoundary` builds
an edit form for an event stored `2026-04-16T02:00:00Z` in
America/New_York, calls `save()` with no changes, and asserts the
emitted `StartTime`/`EndTime` are unchanged. It fails before the fix
(event jumps to `2026-04-17`) and passes after.
