### PR TITLE
fix(storage): backfill todo alarm UIDs when no event alarm needs one

### DIFF
--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -82,7 +82,11 @@ func backfillAlarmUIDs(conn *sql.DB, q *Queries) error {
 	if err != nil {
 		return fmt.Errorf("list alarms with empty uid: %w", err)
 	}
-	if len(alarms) == 0 {
+	todoAlarms, err := q.ListTodoAlarmsWithEmptyUID(ctx)
+	if err != nil {
+		return fmt.Errorf("list todo alarms with empty uid: %w", err)
+	}
+	if len(alarms) == 0 && len(todoAlarms) == 0 {
 		return nil
 	}
 
@@ -100,17 +104,6 @@ func backfillAlarmUIDs(conn *sql.DB, q *Queries) error {
 		}); err != nil {
 			return err
 		}
-	}
-
-	todoAlarms, err := q.ListTodoAlarmsWithEmptyUID(ctx)
-	if err != nil {
-		return fmt.Errorf("list todo alarms with empty uid: %w", err)
-	}
-	if len(todoAlarms) == 0 {
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit alarm UID backfill: %w", err)
-		}
-		return nil
 	}
 	for _, a := range todoAlarms {
 		if err := qtx.UpdateTodoAlarmUID(ctx, UpdateTodoAlarmUIDParams{

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -53,6 +53,51 @@ func TestOpen_SeedData(t *testing.T) {
 	}
 }
 
+// TestBackfillAlarmUIDs_TodoOnly guards issue #95: when there are no event
+// alarms needing a UID but todo alarms do, the backfill must still assign
+// UUIDs to those todo alarms instead of early-returning on the empty event
+// alarm list.
+func TestBackfillAlarmUIDs_TodoOnly(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open error: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Seed a todo (calendar 1 is seeded by Open) and a todo alarm with a
+	// NULL uid, simulating a row carried over from the pre-UID schema. No
+	// event alarms exist, so the event alarm list is empty.
+	res, err := db.ExecContext(ctx,
+		`INSERT INTO todos (uid, calendar_id, summary) VALUES (?, 1, ?)`,
+		"todo-uid-95", "backfill me")
+	if err != nil {
+		t.Fatalf("insert todo: %v", err)
+	}
+	todoID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO todo_alarms (todo_id, action, trigger_value, uid) VALUES (?, 'DISPLAY', '-PT15M', NULL)`,
+		todoID); err != nil {
+		t.Fatalf("insert todo alarm: %v", err)
+	}
+
+	if err := backfillAlarmUIDs(db, q); err != nil {
+		t.Fatalf("backfillAlarmUIDs error: %v", err)
+	}
+
+	remaining, err := q.ListTodoAlarmsWithEmptyUID(ctx)
+	if err != nil {
+		t.Fatalf("ListTodoAlarmsWithEmptyUID error: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected 0 todo alarms with empty uid after backfill, got %d", len(remaining))
+	}
+}
+
 func TestOpen_ForeignKeys(t *testing.T) {
 	db, _, err := Open(":memory:")
 	if err != nil {


### PR DESCRIPTION
Fixes #95

## Root cause
`backfillAlarmUIDs` in `internal/storage/connect.go` listed event alarms with NULL `uid` and then did `if len(alarms) == 0 { return nil }` before it ever queried `todo_alarms`. On upgrade from the pre-UID schema, if all event alarms already had UIDs (or there were no event alarms) while todo alarms still had NULL `uid`, those todo alarms were never assigned UUIDs. Since the backfill no-ops once all alarms have UIDs, it never self-healed — breaking iCal round-trip and alarm-state keying for VTODO alarms.

## Fix
Compute both empty-UID lists (event and todo) up front, `return nil` only when both are empty, then backfill whichever list is non-empty inside a single transaction. This also collapses the two separate commit paths into one.

## Test
`TestBackfillAlarmUIDs_TodoOnly` seeds a todo alarm with NULL `uid` and no event alarms, runs `backfillAlarmUIDs`, and asserts no todo alarms remain with an empty UID. It fails on the old code (`got 1`) and passes with the fix.

## Verification
- `make fmt`, `go vet ./...` clean
- `go test ./internal/... -count=1` all green