### PR TITLE
fix(todo): mark resource dirty on Complete so completions sync

### DIFF
--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -386,7 +386,9 @@ func (s *Service) Complete(ctx context.Context, id int64) (Todo, error) {
 	if err != nil {
 		return Todo{}, err
 	}
-	return fromStorage(r), nil
+	t := fromStorage(r)
+	_ = storage.MarkResourceDirty(ctx, s.db, t.CalendarID, t.UID, "todo")
+	return t, nil
 }
 
 func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Todo, error) {

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
 
@@ -81,6 +82,49 @@ func TestTodoService_List(t *testing.T) {
 	todos, _ := svc.List(ctx)
 	if len(todos) != 1 {
 		t.Errorf("List (incomplete) = %d, want 1", len(todos))
+	}
+}
+
+func TestTodoService_Complete_MarksResourceDirty(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	// Link calendar 1 to an account so sync tracking is active.
+	account, err := svc.q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name: "test", ServerUrl: "https://example.com", AuthType: "basic", Username: "u",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	remote := "https://example.com/cal/"
+	if err := svc.q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		AccountID: &account.ID, RemoteUrl: &remote, ID: 1,
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+
+	td := createTodo(t, svc)
+
+	// Creation dirties the row; clear it so the test isolates Complete.
+	if err := svc.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
+		Etag: "", CalendarID: td.CalendarID, Uid: td.UID,
+	}); err != nil {
+		t.Fatalf("ClearSyncResourceDirty: %v", err)
+	}
+	if dirty, _ := svc.q.ListDirtySyncResources(ctx, td.CalendarID); len(dirty) != 0 {
+		t.Fatalf("precondition: expected 0 dirty resources, got %d", len(dirty))
+	}
+
+	if _, err := svc.Complete(ctx, td.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	dirty, err := svc.q.ListDirtySyncResources(ctx, td.CalendarID)
+	if err != nil {
+		t.Fatalf("ListDirtySyncResources: %v", err)
+	}
+	if len(dirty) != 1 || dirty[0].Uid != td.UID {
+		t.Fatalf("Complete did not mark resource dirty: got %d dirty resources", len(dirty))
 	}
 }
 


### PR DESCRIPTION
Fixes #94

## Root cause
`todo.Service.Complete` ran `CompleteTodo` (status=COMPLETED, completed_at,
percent_complete=100) but never called `storage.MarkResourceDirty`. Every other
mutating path (Create, Update, UpsertByUID, Delete) marks the resource dirty,
and the sync engine only pushes rows whose `sync_resources.dirty=1`. On a
CalDAV-backed calendar, completing a todo updated the DB locally but the
completion was never pushed to the server until an unrelated edit happened to
dirty the row.

## Fix
After a successful `CompleteTodo`, mark the resource dirty by calendar ID + UID
(`owner_type="todo"`), mirroring `Update`. For local-only calendars
`MarkResourceDirty` is a no-op, so behavior there is unchanged.

## Test
`TestTodoService_Complete_MarksResourceDirty` links calendar 1 to an account,
creates a todo, clears the dirty flag set by creation, calls `Complete`, then
asserts the todo's UID appears in `ListDirtySyncResources`. Fails before the fix
(0 dirty resources), passes after.
