### PR TITLE
fix(ical): drop conflicting VTODO DURATION so export batch survives

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -384,7 +384,14 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 				}
 			}
 		}
-		if t.Duration != "" {
+		// RFC 5545 (and go-ical's encoder) only accept DURATION on a VTODO when
+		// DTSTART is present and DUE is absent. A stored todo can violate this
+		// (import enforces no mutual exclusion), and a single bad component makes
+		// enc.Encode reject the whole calendar, dropping every todo. Drop the
+		// conflicting DURATION instead so the rest of the batch still exports.
+		if t.Duration != "" &&
+			vtodo.Props.Get(ical.PropDue) == nil &&
+			vtodo.Props.Get(ical.PropDateTimeStart) != nil {
 			p := &ical.Prop{Name: ical.PropDuration}
 			p.Value = t.Duration
 			vtodo.Props.Set(p)

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -488,6 +488,76 @@ func TestExport_TodoAllFields(t *testing.T) {
 	}
 }
 
+// TestExport_TodoDurationWithoutStart guards issue #102: a stored VTODO with
+// DURATION but no DTSTART (which go-ical's encoder rejects) must not abort the
+// whole export batch and drop every todo.
+func TestExport_TodoDurationWithoutStart(t *testing.T) {
+	t.Parallel()
+	todos := []todo.Todo{
+		{
+			UID:       "todo-bad-duration",
+			Summary:   "Bad Duration",
+			Status:    "NEEDS-ACTION",
+			Duration:  "PT1H", // DURATION without DTSTART -> encoder rejects
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		{
+			UID:       "todo-good",
+			Summary:   "Good Todo",
+			Status:    "NEEDS-ACTION",
+			DueDate:   "2026-04-05T17:00:00Z",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	data, err := ExportTodos(todos, "")
+	if err != nil {
+		t.Fatalf("ExportTodos error: %v", err)
+	}
+	ics := string(data)
+
+	// The good todo must survive (no all-or-nothing failure).
+	if !strings.Contains(ics, "UID:todo-good") {
+		t.Errorf("good todo dropped; export aborted by malformed sibling")
+	}
+	// The malformed todo must still export, sanitized (DURATION dropped).
+	if !strings.Contains(ics, "UID:todo-bad-duration") {
+		t.Errorf("malformed todo missing from export")
+	}
+	if strings.Contains(ics, "DURATION:") {
+		t.Errorf("DURATION without DTSTART should have been dropped, got:\n%s", ics)
+	}
+}
+
+// TestExport_TodoDueAndDuration guards issue #102: DUE + DURATION together is
+// rejected by the encoder; DURATION must be dropped so the batch still encodes.
+func TestExport_TodoDueAndDuration(t *testing.T) {
+	t.Parallel()
+	todos := []todo.Todo{{
+		UID:       "todo-due-and-duration",
+		Summary:   "Due And Duration",
+		Status:    "NEEDS-ACTION",
+		DueDate:   "2026-04-05T17:00:00Z",
+		Duration:  "PT1H",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}}
+
+	data, err := ExportTodos(todos, "")
+	if err != nil {
+		t.Fatalf("ExportTodos error: %v", err)
+	}
+	ics := string(data)
+	if !strings.Contains(ics, "DUE:") {
+		t.Errorf("DUE should be preserved")
+	}
+	if strings.Contains(ics, "DURATION:") {
+		t.Errorf("DURATION should be dropped when DUE present, got:\n%s", ics)
+	}
+}
+
 func TestExport_MergeCalendars(t *testing.T) {
 	t.Parallel()
 	a := []byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:e1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n")


### PR DESCRIPTION
Fixes #102

## Root cause
`go-ical`'s `checkComponent` rejects a VTODO that has `DURATION` without
`DTSTART`, or both `DUE` and `DURATION`. `ExportTodos` set `DUE`, `DTSTART`,
and `DURATION` independently from stored fields, so a single malformed todo
caused `enc.Encode(cal)` to fail for the entire calendar. `ExportTodos` then
returned `nil, err` and dropped **every** todo in the batch (all-or-nothing).
Import does not enforce mutual exclusion, so such a todo can already exist in
the store.

## Fix
Gate the `DURATION` property on the same conditions the encoder enforces:
emit it only when `DTSTART` is present and `DUE` is absent (checked against
the actual props already set on the component, so unparseable dates are
handled too). The malformed todo still exports — minus the invalid
`DURATION` — and its siblings are no longer lost to a batch-wide encode
failure. This mirrors the existing VEVENT DTEND/DURATION XOR handling in
`setEventTimes`.

## Test coverage
- `TestExport_TodoDurationWithoutStart`: a todo with `DURATION` and no
  `DTSTART` alongside a valid todo — both survive export, invalid `DURATION`
  dropped (previously the whole batch errored).
- `TestExport_TodoDueAndDuration`: a todo with both `DUE` and `DURATION` —
  `DUE` preserved, `DURATION` dropped.

Both tests fail on master with the exact encoder errors and pass with the fix.
`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` are all green.
