### PR TITLE
fix(recurrence): keep multi-day RRULE instances straddling window start

### DIFF
--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -54,12 +54,21 @@ func inWindow(t, from, to time.Time) bool {
 
 // overlapsWindow reports whether the half-open interval [start, end) intersects
 // [from, to). This matches the SQL range predicate (start_time < to AND
-// end_time > from) used for non-recurring events, so a multi-day override that
-// spans into the window is not dropped just because its start precedes it.
-// (Regular RRULE instances are still matched by their start via rrule.Between;
-// aligning those with overlap is a broader, separate change.)
+// end_time > from) used for non-recurring events, so a multi-day instance or
+// override that spans into the window is not dropped just because its start
+// precedes it. Regular RRULE instances are filtered by this same overlap in
+// ExpandEvent/ExpandTodo, generating from from-duration so a straddling
+// occurrence is produced before being kept.
 func overlapsWindow(start, end, from, to time.Time) bool {
 	return start.Before(to) && end.After(from)
+}
+
+// keepOccurrence reports whether an expanded occurrence at occ with instance
+// duration dur belongs in the half-open window [from, to): its [occ, occ+dur)
+// interval overlaps the window, or (for a zero-duration occurrence whose open
+// end boundary overlapsWindow would reject) occ itself falls inside it.
+func keepOccurrence(occ time.Time, dur time.Duration, from, to time.Time) bool {
+	return overlapsWindow(occ, occ.Add(dur), from, to) || inWindow(occ, from, to)
 }
 
 // canonicalRecurrenceID normalizes a stored recurrence_id to the same UTC
@@ -216,12 +225,20 @@ func ExpandEvent(evt event.Event, from, to time.Time) []ExpandedEvent {
 		rdateSet[rd] = struct{}{}
 	}
 
-	// Get all occurrences in range [from, to)
-	occurrences := set.Between(localFrom, localTo, true)
-	// Enforce half-open upper bound: exclude occurrences exactly at 'to'.
+	// A multi-day instance whose start precedes 'from' can still overlap the
+	// window via its duration, so begin generation one instance-duration early
+	// and keep occurrences by [start, end) overlap rather than start alone.
+	dur := evt.EndTime.Sub(evt.StartTime)
+	if dur < 0 {
+		dur = 0
+	}
+
+	// Get all occurrences that could overlap [from, to).
+	occurrences := set.Between(localFrom.Add(-dur), localTo, true)
+	// Keep occurrences whose [start, start+dur) interval overlaps the window.
 	filtered := occurrences[:0]
 	for _, occ := range occurrences {
-		if occ.Before(localTo) {
+		if keepOccurrence(occ, dur, localFrom, localTo) {
 			filtered = append(filtered, occ)
 		}
 	}
@@ -1005,10 +1022,20 @@ func ExpandTodo(td todo.Todo, from, to time.Time) []ExpandedTodo {
 		rdateSet[rd] = struct{}{}
 	}
 
-	occurrences := set.Between(localFrom, localTo, true)
+	// A todo spanning START->DUE can straddle the window start, so generate
+	// from from-duration and keep occurrences by [start, end) overlap. The
+	// span is the START->DUE distance; a due-only (point) todo has none.
+	dur := time.Duration(0)
+	if start := td.ParseStartDate(); !start.IsZero() {
+		if due := td.ParseDueDate(); !due.IsZero() && due.After(start) {
+			dur = due.Sub(start)
+		}
+	}
+
+	occurrences := set.Between(localFrom.Add(-dur), localTo, true)
 	filteredOcc := occurrences[:0]
 	for _, occ := range occurrences {
-		if occ.Before(localTo) {
+		if keepOccurrence(occ, dur, localFrom, localTo) {
 			filteredOcc = append(filteredOcc, occ)
 		}
 	}

--- a/internal/recurrence/service_test.go
+++ b/internal/recurrence/service_test.go
@@ -9,6 +9,32 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
+func TestExpandEvent_MultiDayInstanceStraddlingWindowStart(t *testing.T) {
+	// A weekly 3-day on-call block: Friday 09:00 -> Sunday 09:00.
+	friday := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC) // first Friday
+	evt := event.Event{
+		ID:             1,
+		UID:            "oncall-weekly",
+		Title:          "On-call",
+		StartTime:      friday,
+		EndTime:        friday.AddDate(0, 0, 2), // Sunday 09:00 (48h span)
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=FR;COUNT=4",
+	}
+
+	// Query a window that opens Saturday: the block began Friday (before the
+	// window) but runs through Sunday, so it overlaps and must appear.
+	from := time.Date(2026, 4, 4, 0, 0, 0, 0, time.UTC) // Saturday
+	to := time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)   // Sunday 00:00
+
+	instances := ExpandEvent(evt, from, to)
+	if len(instances) != 1 {
+		t.Fatalf("ExpandEvent() = %d instances, want 1 (straddling instance dropped)", len(instances))
+	}
+	if !instances[0].InstanceTime.Equal(friday) {
+		t.Errorf("instance start = %v, want %v", instances[0].InstanceTime, friday)
+	}
+}
+
 func TestExpandDailyEvent(t *testing.T) {
 	base := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
 	evt := event.Event{


### PR DESCRIPTION
Fixes #96

## Root cause
`recurrence.ExpandEvent` / `ExpandTodo` matched RRULE occurrences purely by
their start time via `set.Between(from, to)`. A recurring instance whose start
precedes `from` but whose `[start, end)` interval extends into the window was
excluded. The `overlapsWindow` helper was applied only to overrides, not to
regular RRULE instances (the prior code comment acknowledged the gap).

Effect: a weekly multi-day block (e.g. an on-call/conference Fri->Sun) queried
from a window opening Saturday disappeared from the calendar view, alarm
checks, and free/busy — so a genuinely busy slot read as free.

## Fix
Generate occurrences starting from `from - duration` and keep them by
`[start, end)` overlap with the window (new `keepOccurrence` helper) instead of
start-only membership, mirroring the overlap predicate already used for
overrides. The instance duration is the event `DTSTART`->`DTEND` span (todo
`START`->`DUE` span). The half-open upper bound and the zero-duration boundary
behavior are preserved (a zero-length instance exactly at `from` is still kept
via `inWindow`). A defensive clamp handles a negative/unset duration.

## Test coverage
`TestExpandEvent_MultiDayInstanceStraddlingWindowStart`: a weekly Fri 09:00 ->
Sun 09:00 block, queried for a Saturday-only window, must yield exactly one
instance anchored to Friday. Fails before the fix (0 instances), passes after.

## Verification
`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.
