### PR TITLE
fix(ical): match RECURRENCE-ID value type to all-day master

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -14,6 +14,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/journal"
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
@@ -110,9 +111,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 
 		// RECURRENCE-ID
 		if e.RecurrenceID != "" {
-			if t, err := time.Parse(time.RFC3339, e.RecurrenceID); err == nil {
-				vevent.Props.SetDateTime(ical.PropRecurrenceID, t.UTC())
-			}
+			emitRecurrenceID(vevent.Props, e.RecurrenceID, e.AllDay)
 		}
 
 		if e.Geo != "" {
@@ -448,9 +447,13 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 		emitDateListOnComponent(vtodo, ical.PropRecurrenceDates, t.RDates)
 
 		if t.RecurrenceID != "" {
-			if rid, err := time.Parse(time.RFC3339, t.RecurrenceID); err == nil {
-				vtodo.Props.SetDateTime(ical.PropRecurrenceID, rid.UTC())
+			// A VTODO is all-day when its recurrence anchor (DTSTART, else DUE)
+			// is a date-only value; the RECURRENCE-ID type must match.
+			anchor := t.StartDate
+			if anchor == "" {
+				anchor = t.DueDate
 			}
+			emitRecurrenceID(vtodo.Props, t.RecurrenceID, timeutil.IsDateOnly(anchor))
 		}
 
 		if t.Geo != "" {
@@ -637,6 +640,23 @@ func emitDateListOnComponent(comp *ical.Component, propName, dates string) {
 			prop.SetDateTime(t.UTC())
 			comp.Props.Add(prop)
 		}
+	}
+}
+
+// emitRecurrenceID writes RECURRENCE-ID onto props. recurrenceID is the stored
+// RFC 3339 string. Per RFC 5545 the RECURRENCE-ID value type must match the
+// master's DTSTART: when the component is all-day it is emitted as VALUE=DATE
+// (YYYYMMDD), otherwise as a UTC DATE-TIME. A type mismatch prevents CalDAV
+// servers from binding the override to its master.
+func emitRecurrenceID(props ical.Props, recurrenceID string, allDay bool) {
+	t, err := time.Parse(time.RFC3339, recurrenceID)
+	if err != nil {
+		return
+	}
+	if allDay {
+		props.SetDate(ical.PropRecurrenceID, t.UTC())
+	} else {
+		props.SetDateTime(ical.PropRecurrenceID, t.UTC())
 	}
 }
 
@@ -1013,9 +1033,9 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 		emitDateListOnComponent(vjournal, ical.PropRecurrenceDates, j.RDates)
 
 		if j.RecurrenceID != "" {
-			if rid, err := time.Parse(time.RFC3339, j.RecurrenceID); err == nil {
-				vjournal.Props.SetDateTime(ical.PropRecurrenceID, rid.UTC())
-			}
+			// A VJOURNAL is all-day when its DTSTART is a date-only value;
+			// the RECURRENCE-ID type must match.
+			emitRecurrenceID(vjournal.Props, j.RecurrenceID, timeutil.IsDateOnly(j.StartDate))
 		}
 
 		if j.DtStamp != "" {

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -730,3 +730,144 @@ func TestExportJournals_DateOnly(t *testing.T) {
 		}
 	}
 }
+
+// recurrenceIDLine returns the unfolded RECURRENCE-ID property line from an
+// exported iCalendar payload, or "" if none is present.
+func recurrenceIDLine(ics string) string {
+	for _, line := range strings.Split(ics, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, "RECURRENCE-ID") {
+			return line
+		}
+	}
+	return ""
+}
+
+// recurrenceIDValue returns the value portion (after the colon) of a
+// RECURRENCE-ID property line.
+func recurrenceIDValue(line string) string {
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+func TestExport_AllDayOverrideRecurrenceIDIsDate(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{
+		{
+			UID:            "allday-recurring",
+			Title:          "Daily Standup",
+			StartTime:      time.Date(2026, 4, 13, 0, 0, 0, 0, time.UTC),
+			EndTime:        time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC),
+			AllDay:         true,
+			Status:         "CONFIRMED",
+			RecurrenceRule: "FREQ=DAILY;COUNT=4",
+		},
+		{
+			UID:          "allday-recurring",
+			Title:        "Daily Standup (moved)",
+			StartTime:    time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),
+			EndTime:      time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+			AllDay:       true,
+			Status:       "CONFIRMED",
+			RecurrenceID: "2026-04-15T00:00:00Z",
+		},
+	}
+
+	data, err := ExportEvents(events, "Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := recurrenceIDLine(string(data))
+	if line == "" {
+		t.Fatal("missing RECURRENCE-ID")
+	}
+	if !strings.Contains(line, "VALUE=DATE") {
+		t.Errorf("all-day override RECURRENCE-ID must carry VALUE=DATE, got %q", line)
+	}
+	if strings.Contains(recurrenceIDValue(line), "T") {
+		t.Errorf("all-day override RECURRENCE-ID must be date-only (no time component), got %q", line)
+	}
+}
+
+func TestExport_TimedOverrideRecurrenceIDIsDateTime(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{
+		{
+			UID:          "timed-recurring",
+			Title:        "Weekly Sync (moved)",
+			StartTime:    time.Date(2026, 4, 13, 14, 0, 0, 0, time.UTC),
+			EndTime:      time.Date(2026, 4, 13, 15, 0, 0, 0, time.UTC),
+			Status:       "CONFIRMED",
+			RecurrenceID: "2026-04-13T09:00:00Z",
+		},
+	}
+	data, err := ExportEvents(events, "Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := recurrenceIDLine(string(data))
+	if line == "" {
+		t.Fatal("missing RECURRENCE-ID")
+	}
+	if strings.Contains(line, "VALUE=DATE") {
+		t.Errorf("timed override RECURRENCE-ID must not carry VALUE=DATE, got %q", line)
+	}
+	if !strings.Contains(recurrenceIDValue(line), "T") {
+		t.Errorf("timed override RECURRENCE-ID must keep its time component, got %q", line)
+	}
+}
+
+func TestExport_AllDayTodoOverrideRecurrenceIDIsDate(t *testing.T) {
+	t.Parallel()
+	todos := []todo.Todo{
+		{
+			UID:          "allday-todo-recurring",
+			Summary:      "Daily Task (moved)",
+			DueDate:      "2026-04-15",
+			RecurrenceID: "2026-04-15T00:00:00Z",
+		},
+	}
+	data, err := ExportTodos(todos, "Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := recurrenceIDLine(string(data))
+	if line == "" {
+		t.Fatal("missing RECURRENCE-ID")
+	}
+	if !strings.Contains(line, "VALUE=DATE") {
+		t.Errorf("all-day todo override RECURRENCE-ID must carry VALUE=DATE, got %q", line)
+	}
+	if strings.Contains(recurrenceIDValue(line), "T") {
+		t.Errorf("all-day todo override RECURRENCE-ID must be date-only, got %q", line)
+	}
+}
+
+func TestExport_AllDayJournalOverrideRecurrenceIDIsDate(t *testing.T) {
+	t.Parallel()
+	journals := []journal.Journal{
+		{
+			UID:          "allday-journal-recurring",
+			Summary:      "Daily Note (moved)",
+			StartDate:    "2026-04-15",
+			RecurrenceID: "2026-04-15T00:00:00Z",
+		},
+	}
+	data, err := ExportJournals(journals, "Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := recurrenceIDLine(string(data))
+	if line == "" {
+		t.Fatal("missing RECURRENCE-ID")
+	}
+	if !strings.Contains(line, "VALUE=DATE") {
+		t.Errorf("all-day journal override RECURRENCE-ID must carry VALUE=DATE, got %q", line)
+	}
+	if strings.Contains(recurrenceIDValue(line), "T") {
+		t.Errorf("all-day journal override RECURRENCE-ID must be date-only, got %q", line)
+	}
+}


### PR DESCRIPTION
Fixes #100

## Root cause
iCal export always emitted `RECURRENCE-ID` as a UTC `DATE-TIME`
(`YYYYMMDDTHHMMSSZ`) via `SetDateTime`, with no `VALUE=DATE` branch — even when
the master component was all-day (`DTSTART;VALUE=DATE`). RFC 5545 requires the
`RECURRENCE-ID` value type to match the master's `DTSTART`. The `DATE` →
`DATE-TIME` mismatch means external CalDAV servers cannot bind an all-day
override to its master, orphaning or rejecting the instance.

## Fix
Added a shared `emitRecurrenceID(props, recurrenceID, allDay)` helper in
`internal/ical/export.go` that emits `VALUE=DATE` (`YYYYMMDD`) for all-day
components and a UTC `DATE-TIME` otherwise. The event, todo, and journal export
paths now route through it:
- events: all-day from `event.AllDay`
- todos: all-day from a date-only recurrence anchor (`DTSTART`, else `DUE`) via `timeutil.IsDateOnly`
- journals: all-day from a date-only `DTSTART`

This also consolidates three near-identical inline `time.Parse` + `SetDateTime`
blocks into one helper. Import needs no change: it already parses `VALUE=DATE`
values into the canonical midnight-UTC RFC 3339 form, which round-trips
correctly through the new export.

## Tests
New tests in `internal/ical/export_test.go`:
- `TestExport_AllDayOverrideRecurrenceIDIsDate` — all-day event override emits `RECURRENCE-ID;VALUE=DATE:YYYYMMDD` with no time component (failed before the fix)
- `TestExport_TimedOverrideRecurrenceIDIsDateTime` — timed override keeps the `DATE-TIME` form (regression guard)
- `TestExport_AllDayTodoOverrideRecurrenceIDIsDate` and `TestExport_AllDayJournalOverrideRecurrenceIDIsDate` — same for VTODO/VJOURNAL

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
