### PR TITLE
fix(alarm): resolve recurring-instance times for snooze

### DIFF
--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -341,6 +341,93 @@ func computeTriggerTimeForInstance(expEvt recurrence.ExpandedEvent, alarm model.
 	return model.ParseAbsoluteTime(trigger, expEvt.Timezone)
 }
 
+// resolveStateEvent returns the event whose start/end times correspond to the
+// specific occurrence an alarm_state fired for.
+//
+// alarm_state stores the master row's event_id (whose StartTime/EndTime are the
+// first occurrence) plus the instance's trigger_at. For a recurring series the
+// master times are wrong for any occurrence past the first, so we re-expand the
+// series and pick the instance whose computed trigger (including repeats) equals
+// the stored trigger_at. Non-recurring events, and any case where no instance
+// matches, fall back to the stored master event.
+func (s *Service) resolveStateEvent(ctx context.Context, st storage.AlarmState) (event.Event, error) {
+	master, err := s.events.Get(ctx, st.EventID)
+	if err != nil {
+		return event.Event{}, err
+	}
+	if master.RecurrenceRule == "" {
+		return master, nil
+	}
+
+	// Find the alarm definition that fired so we can replay its trigger math.
+	alarms, err := s.events.ListAlarms(ctx, master.ID)
+	if err != nil {
+		return master, nil // best effort: fall back to the master row
+	}
+	var matched model.Alarm
+	for _, a := range alarms {
+		if a.ID == st.AlarmID {
+			matched = a
+			break
+		}
+	}
+	if matched.ID == 0 {
+		return master, nil
+	}
+
+	triggerAt, err := time.Parse(time.RFC3339, st.TriggerAt)
+	if err != nil {
+		return master, nil
+	}
+
+	// Bound the expansion window to comfortably contain the instance: the
+	// trigger sits at most |offset| (+ the event span, for RELATED=END alarms)
+	// away from the occurrence it belongs to.
+	radius := triggerSearchRadius(matched, master.Span(), triggerAt)
+	recurSvc := recurrence.NewService(s.db, s.q)
+	expanded, err := recurSvc.ListExpandedEvents(ctx, triggerAt.Add(-radius), triggerAt.Add(radius), recurrence.SkipCategories())
+	if err != nil {
+		return master, nil
+	}
+	for _, expEvt := range expanded {
+		if expEvt.ID != master.ID {
+			continue
+		}
+		base, err := computeTriggerTimeForInstance(expEvt, matched)
+		if err != nil {
+			continue
+		}
+		for _, t := range buildRepeatTriggers(base, matched.Repeat, matched.Duration) {
+			if t.Equal(triggerAt) {
+				inst := expEvt.Event
+				inst.StartTime = expEvt.InstanceTime
+				inst.EndTime = expEvt.InstanceTime.Add(expEvt.Span())
+				return inst, nil
+			}
+		}
+	}
+	return master, nil
+}
+
+// triggerSearchRadius returns a window half-width around a stored trigger_at
+// guaranteed to contain the occurrence the alarm fired for. It accounts for the
+// alarm's lead time, the event span (RELATED=END alarms anchor on the end), and
+// always leaves StaleThreshold+24h of slack.
+func triggerSearchRadius(a model.Alarm, span time.Duration, ref time.Time) time.Duration {
+	radius := StaleThreshold + 24*time.Hour
+	if span > 0 {
+		radius += span
+	}
+	if duration.Validate(a.TriggerValue) == nil {
+		offset := duration.Add(ref, a.TriggerValue).Sub(ref)
+		if offset < 0 {
+			offset = -offset
+		}
+		radius += offset
+	}
+	return radius
+}
+
 // ListExpiredSnoozed returns snoozed alarms whose snooze-until time is at or
 // before now. The caller should re-fire and mark them via MarkRefired.
 func (s *Service) ListExpiredSnoozed(ctx context.Context, now time.Time) ([]DueAlarm, error) {
@@ -352,7 +439,7 @@ func (s *Service) ListExpiredSnoozed(ctx context.Context, now time.Time) ([]DueA
 
 	var due []DueAlarm
 	for _, st := range states {
-		evt, err := s.events.Get(ctx, st.EventID)
+		evt, err := s.resolveStateEvent(ctx, st)
 		if err != nil {
 			continue // event may have been deleted
 		}
@@ -487,7 +574,7 @@ func (s *Service) ComputeSnooze(ctx context.Context, stateID int64, dur time.Dur
 		return SnoozeResult{}, fmt.Errorf("alarm state %d is already dismissed", stateID)
 	}
 
-	evt, err := s.events.Get(ctx, st.EventID)
+	evt, err := s.resolveStateEvent(ctx, st)
 	if err != nil {
 		return SnoozeResult{}, fmt.Errorf("get event %d: %w", st.EventID, err)
 	}
@@ -533,7 +620,7 @@ func (s *Service) SnoozeUntilStart(ctx context.Context, stateID int64, now time.
 		return SnoozeResult{}, fmt.Errorf("alarm state %d is already dismissed", stateID)
 	}
 
-	evt, err := s.events.Get(ctx, st.EventID)
+	evt, err := s.resolveStateEvent(ctx, st)
 	if err != nil {
 		return SnoozeResult{}, fmt.Errorf("get event %d: %w", st.EventID, err)
 	}

--- a/internal/alarm/snooze_recurring_test.go
+++ b/internal/alarm/snooze_recurring_test.go
@@ -1,0 +1,121 @@
+package alarm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/testutil"
+)
+
+// firedInstanceAlarm fires every event alarm due at `now`, marks the one
+// matching wantTrigger as fired, and returns its state ID. It fails the test
+// if no such alarm is due.
+func firedInstanceAlarm(t *testing.T, svc *Service, eventID int64, now, wantTrigger time.Time) int64 {
+	t.Helper()
+	due, _, err := svc.Check(context.Background(), now)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	for _, da := range due {
+		if da.Event.ID == eventID && da.TriggerAt.Equal(wantTrigger) {
+			stateID, err := svc.MarkFired(context.Background(), da)
+			if err != nil {
+				t.Fatalf("mark fired: %v", err)
+			}
+			return stateID
+		}
+	}
+	t.Fatalf("no due alarm for event %d at trigger %v", eventID, wantTrigger)
+	return 0
+}
+
+// TestComputeSnooze_RecurringInstanceTimes guards against issue #97: snoozing
+// an alarm that fired for a later occurrence of a recurring event must use that
+// occurrence's start/end, not the master row's first-occurrence times.
+func TestComputeSnooze_RecurringInstanceTimes(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	ctx := context.Background()
+	eventsSvc := event.NewService(db, q)
+	svc := NewService(db, q, eventsSvc, nil)
+
+	// First occurrence a week before "now"; daily recurrence.
+	base := time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	evt, err := eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID:     1,
+		Title:          "Daily Standup",
+		StartTime:      base,
+		EndTime:        base.Add(30 * time.Minute),
+		RecurrenceRule: "FREQ=DAILY",
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	if err := eventsSvc.ReplaceAlarms(ctx, evt.ID, []model.Alarm{
+		{UID: "a1", Action: "DISPLAY", TriggerValue: "-PT15M", Description: "Standup soon"},
+	}); err != nil {
+		t.Fatalf("add alarm: %v", err)
+	}
+
+	// Today's instance starts 09:00; the -15m alarm fires at 08:45.
+	now := time.Date(2026, 6, 25, 8, 50, 0, 0, time.UTC)
+	wantTrigger := time.Date(2026, 6, 25, 8, 45, 0, 0, time.UTC)
+	stateID := firedInstanceAlarm(t, svc, evt.ID, now, wantTrigger)
+
+	res, err := svc.ComputeSnooze(ctx, stateID, 5*time.Minute, now)
+	if err != nil {
+		// Bug: events.Get(masterID) returns the first occurrence (Jun 18),
+		// which is before now, so ComputeSnooze rejects it as "already ended".
+		t.Fatalf("ComputeSnooze rejected a live recurring instance: %v", err)
+	}
+
+	wantStart := time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC)
+	if !res.EventStart.Equal(wantStart) {
+		t.Errorf("EventStart = %v, want %v (instance start, not master first occurrence)", res.EventStart, wantStart)
+	}
+	wantEnd := wantStart.Add(30 * time.Minute)
+	if !res.EventEnd.Equal(wantEnd) {
+		t.Errorf("EventEnd = %v, want %v (instance end, not master first occurrence)", res.EventEnd, wantEnd)
+	}
+}
+
+// TestSnoozeUntilStart_RecurringInstanceTimes covers the snooze-until-start
+// path of issue #97: it must target the fired occurrence's start time.
+func TestSnoozeUntilStart_RecurringInstanceTimes(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	ctx := context.Background()
+	eventsSvc := event.NewService(db, q)
+	svc := NewService(db, q, eventsSvc, nil)
+
+	base := time.Date(2026, 6, 18, 9, 0, 0, 0, time.UTC)
+	evt, err := eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID:     1,
+		Title:          "Daily Standup",
+		StartTime:      base,
+		EndTime:        base.Add(30 * time.Minute),
+		RecurrenceRule: "FREQ=DAILY",
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	if err := eventsSvc.ReplaceAlarms(ctx, evt.ID, []model.Alarm{
+		{UID: "a1", Action: "DISPLAY", TriggerValue: "-PT15M", Description: "Standup soon"},
+	}); err != nil {
+		t.Fatalf("add alarm: %v", err)
+	}
+
+	now := time.Date(2026, 6, 25, 8, 50, 0, 0, time.UTC)
+	wantTrigger := time.Date(2026, 6, 25, 8, 45, 0, 0, time.UTC)
+	stateID := firedInstanceAlarm(t, svc, evt.ID, now, wantTrigger)
+
+	res, err := svc.SnoozeUntilStart(ctx, stateID, now)
+	if err != nil {
+		t.Fatalf("SnoozeUntilStart rejected a live recurring instance: %v", err)
+	}
+	wantStart := time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC)
+	if !res.Until.Equal(wantStart) {
+		t.Errorf("Until = %v, want %v (instance start)", res.Until, wantStart)
+	}
+}


### PR DESCRIPTION
Fixes #97

## Root cause
`MarkFired` persists `event_id = da.Event.ID`, which for an expanded recurring
instance is the **master** row ID. `ComputeSnooze`, `SnoozeUntilStart`, and
`ListExpiredSnoozed` then called `events.Get(masterID)`, whose `StartTime` /
`EndTime` are the series' **first** occurrence. For any occurrence past the
first, snoozing was rejected (`evt.EndTime.Before(now)` → "event has already
ended"; `now.After(evt.StartTime)` → "already started"), and re-fired snoozed
alarms rendered the wrong first-occurrence time. `alarm_state` only stores
`event_id` + `trigger_at`, so the instance had to be recovered.

## Fix
Add `resolveStateEvent`, which:
- returns the stored event unchanged for non-recurring events (and as a safe
  fallback on any miss/error), and
- for a recurring master, re-expands the series in a bounded window around the
  stored `trigger_at` and selects the instance whose computed trigger time
  (including repeat firings) equals `trigger_at`, returning that occurrence's
  start/end.

The three snooze paths now resolve the event through this helper. The search
window (`triggerSearchRadius`) is sized from the alarm lead time and event span
plus `StaleThreshold + 24h` of slack, so high-frequency series expand only a
handful of instances.

## Tests
`internal/alarm/snooze_recurring_test.go`:
- `TestComputeSnooze_RecurringInstanceTimes` — a daily event whose first
  occurrence is a week before `now`; the alarm fires for today's instance.
  Asserts `ComputeSnooze` no longer rejects it and that `EventStart`/`EventEnd`
  are today's instance times, not the first occurrence.
- `TestSnoozeUntilStart_RecurringInstanceTimes` — same setup; asserts
  `SnoozeUntilStart` targets today's instance start.

Both fail on `master` for the exact reasons in the issue and pass with the fix.
`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` are all green.
