### PR TITLE
fix(sync): withhold sync-token when a fetched resource fails to persist

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -768,17 +768,21 @@ func (p *pendingDeletions) apply(ctx context.Context, e *Engine, calendarID int6
 
 // absenceWithholdReason describes why an absence sweep was (or wasn't) safe,
 // for the withhold log line.
-func absenceWithholdReason(truncated bool, multigetMisses int) string {
-	switch {
-	case truncated && multigetMisses > 0:
-		return fmt.Sprintf("response truncated and %d multiget miss(es)", multigetMisses)
-	case truncated:
-		return "response truncated (RFC 6578 §3.6)"
-	case multigetMisses > 0:
-		return fmt.Sprintf("%d multiget miss(es)", multigetMisses)
-	default:
+func absenceWithholdReason(truncated bool, multigetMisses, persistFailures int) string {
+	var parts []string
+	if truncated {
+		parts = append(parts, "response truncated (RFC 6578 §3.6)")
+	}
+	if multigetMisses > 0 {
+		parts = append(parts, fmt.Sprintf("%d multiget miss(es)", multigetMisses))
+	}
+	if persistFailures > 0 {
+		parts = append(parts, fmt.Sprintf("%d persist failure(s)", persistFailures))
+	}
+	if len(parts) == 0 {
 		return "complete"
 	}
+	return strings.Join(parts, " and ")
 }
 
 // applySyncCollection consumes the change list from a sync-collection REPORT,
@@ -788,6 +792,7 @@ func absenceWithholdReason(truncated bool, multigetMisses int) string {
 func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client, calendarID int64, remoteURL string, cal storage.Calendar, syncResult *caldav.SyncCollectionResult, initialSnapshot bool) (*pullResult, error) {
 	result := &pullResult{}
 	multigetMisses := 0
+	persistFailures := 0
 
 	tombstones, err := e.q.ListTombstonesByCalendar(ctx, calendarID)
 	if err != nil {
@@ -914,6 +919,14 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 			}
 			ownerType := detectOwnerType(importResult)
 			if persistErr := e.persistImported(ctx, calendarID, importResult); persistErr != nil {
+				// A changed body we fetched but couldn't store (transient
+				// SQLite busy/lock, or a malformed component a Replace*
+				// rejects). Leave the sync_resource on its old etag and count
+				// the failure so the inventory is treated as incomplete: the
+				// token is withheld and the next REPORT re-lists this change
+				// for another attempt. Advancing the token here would skip the
+				// change permanently until the server touches it again.
+				persistFailures++
 				e.logger.Error("persist imported resource", "uid", uid, "path", res.Path, "error", persistErr)
 				continue
 			}
@@ -949,9 +962,10 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 
 	// All deletions funnel through one chokepoint (see pendingDeletions).
 	// The inventory is "complete" only when nothing limited our view of the
-	// server's resources: the response wasn't truncated and every changed
-	// body was fetched.
-	inventoryComplete := !syncResult.Truncated && multigetMisses == 0
+	// server's resources: the response wasn't truncated, every changed body
+	// was fetched, and every fetched body persisted. A persist failure leaves
+	// the local copy behind the server, so the token must be withheld too.
+	inventoryComplete := !syncResult.Truncated && multigetMisses == 0 && persistFailures == 0
 	deletions := newPendingDeletions(e.logger)
 
 	// Explicit deletions: the server returned a top-level 404 for these
@@ -977,7 +991,7 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 	// fetched.
 	if initialSnapshot {
 		deletions.inferFromAbsence(calendarID, localResources, seenUIDs,
-			inventoryComplete, absenceWithholdReason(syncResult.Truncated, multigetMisses))
+			inventoryComplete, absenceWithholdReason(syncResult.Truncated, multigetMisses, persistFailures))
 	}
 
 	result.deleted += deletions.apply(ctx, e, calendarID)
@@ -991,15 +1005,17 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 		}); err != nil {
 			e.logger.Warn("update sync token", "calendar_id", calendarID, "error", err)
 		}
-	} else if multigetMisses > 0 {
+	} else if multigetMisses > 0 || persistFailures > 0 {
 		// Pull made partial progress: some hrefs the server reported in
-		// sync-collection 404'd on multiget. We don't know if those are
-		// real deletions or transient errors, so we don't soft-delete
-		// them. We also don't advance the sync-token, so the next sync
-		// re-lists the same change set and gets another shot at fetching
-		// the missing bodies. Slow but safe.
-		e.logger.Warn("not advancing sync-token: multiget had missing paths",
-			"calendar_id", calendarID, "missing", multigetMisses)
+		// sync-collection 404'd on multiget, or a fetched body failed to
+		// persist locally. We don't know if the 404s are real deletions or
+		// transient errors, so we don't soft-delete them; and the persist
+		// failures left those resources behind the server. We don't advance
+		// the sync-token, so the next sync re-lists the same change set and
+		// gets another shot at fetching and storing the bodies. Slow but safe.
+		e.logger.Warn("not advancing sync-token: incomplete pull",
+			"calendar_id", calendarID, "multiget_misses", multigetMisses,
+			"persist_failures", persistFailures)
 	}
 
 	return result, nil

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2200,3 +2200,114 @@ END:VCALENDAR
 		t.Fatalf("alarms after server-side removal = %d, want 0 (stale alarm not cleared)", len(alarms))
 	}
 }
+
+// TestEnginePullWithholdsTokenOnPersistFailure covers issue #103: when a
+// fetched resource is successfully multiget'd but fails to persist locally
+// (a transient SQLite busy/lock or a child-replace error), the pull must NOT
+// advance the sync-token. Otherwise the token moves past the failed change
+// and the next REPORT never re-lists it, so the server-side update is lost
+// from the local copy indefinitely. The resource's old etag and the calendar
+// sync-token must both stay put so the next sync re-lists and retries.
+func TestEnginePullWithholdsTokenOnPersistFailure(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	// A locally-tracked event the server has just updated. Its multiget body
+	// carries a VALARM; dropping event_alarms below makes persistImported fail
+	// on ReplaceAlarms after the parent upsert, simulating a transient persist
+	// error mid-pull.
+	insertTestEvent(t, db, calendarID, "victim")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID: calendarID, Uid: "victim", OwnerType: "event",
+		RemoteUrl: "/calendar/victim.ics", Etag: "old", Dirty: 0, SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource victim: %v", err)
+	}
+
+	const syncBody = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/calendar/victim.ics</d:href>
+    <d:propstat><d:prop><d:getetag>&quot;new&quot;</d:getetag></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:sync-token>https://example.com/sync/t1</d:sync-token>
+</d:multistatus>`
+
+	const victimICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//chroncal//tests//EN
+BEGIN:VEVENT
+UID:victim
+DTSTAMP:20260403T120000Z
+DTSTART:20260403T120000Z
+DTEND:20260403T130000Z
+SUMMARY:Updated meeting
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT15M
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+`
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		raw, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(raw), "calendar-multiget") {
+			return &http.Response{StatusCode: http.StatusMultiStatus, Status: "207 Multi-Status",
+				Header: http.Header{"Content-Type": []string{"application/xml"}},
+				Body:   io.NopCloser(strings.NewReader(syncBody)), Request: r}, nil
+		}
+		multigetBody := `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/calendar/victim.ics</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>&quot;new&quot;</d:getetag>
+        <cal:calendar-data>` + victimICS + `</cal:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+		return &http.Response{StatusCode: http.StatusMultiStatus, Status: "207 Multi-Status",
+			Header: http.Header{"Content-Type": []string{"application/xml"}},
+			Body:   io.NopCloser(strings.NewReader(multigetBody)), Request: r}, nil
+	})
+
+	// Force the persist to fail: drop event_alarms so ReplaceAlarms errors
+	// after the parent event upsert succeeds.
+	if _, err := db.ExecContext(ctx, "DROP TABLE event_alarms"); err != nil {
+		t.Fatalf("drop event_alarms table: %v", err)
+	}
+
+	if _, err := engine.pull(ctx, client, calendarID, "/calendar/"); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+
+	// Token must be held back so the next sync re-lists the failed change.
+	calRow, err := q.GetCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if tok := storage.NullableToString(calRow.SyncToken); tok != "" {
+		t.Fatalf("sync_token = %q, want empty (held back on persist failure)", tok)
+	}
+
+	// The resource's etag must stay old so the next REPORT still sees a diff.
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: calendarID, Uid: "victim"})
+	if err != nil {
+		t.Fatalf("GetSyncResource victim: %v", err)
+	}
+	if res.Etag != "old" {
+		t.Fatalf("victim etag = %q, want old preserved (persist failed)", res.Etag)
+	}
+}


### PR DESCRIPTION
Fixes #103

## Root cause
In `applySyncCollection` (`internal/sync/engine.go`), when `persistImported`
failed for a fetched resource the code logged the error and `continue`d
without recording the failure. `inventoryComplete` was gated only on
`!syncResult.Truncated && multigetMisses == 0`, so it stayed `true` and the
new sync-token was stored. The failed resource kept its old etag, and because
the token advanced past it, the next sync-collection REPORT would not re-list
it until the server changed it again — silently dropping that one server-side
update (e.g. an updated meeting) from the local copy indefinitely. A transient
SQLite busy/lock or a single malformed component rejected by a `Replace*` call
during a steady-state pull was enough to trigger it. The full-snapshot path was
unaffected because it re-diffs by etag every run.

## Fix
Track persist failures with a `persistFailures` counter, parallel to the
existing `multigetMisses`, and fold it into the `inventoryComplete` gate. A
persist failure now withholds both the sync-token advance and any
absence-deletion sweep, so the next sync re-lists the same change set and
retries. The withhold log line and `absenceWithholdReason` were extended to
report persist failures too.

## Test coverage
`TestEnginePullWithholdsTokenOnPersistFailure` drives a full `pull`: the
sync-collection REPORT lists one changed resource, the multiget returns its
body successfully (with a VALARM), and `event_alarms` is dropped so
`persistImported` fails on `ReplaceAlarms` after the parent upsert. It asserts
the calendar sync-token stays empty and the resource's etag stays `old`, so the
next REPORT still sees a diff. The test fails on `master` (token advances to
`t1`) and passes with the fix.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.

Assisted-by: Claude Code:claude-opus-4-8
