### PR TITLE
fix(alarm): size alarm expansion window from longest lead time

### DIFF
--- a/db/queries/alarms.sql
+++ b/db/queries/alarms.sql
@@ -5,6 +5,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 -- name: ListAlarmsByEventID :many
 SELECT * FROM event_alarms WHERE event_id = ? ORDER BY id;
 
+-- name: ListDistinctAlarmTriggers :many
+SELECT DISTINCT trigger_value FROM event_alarms;
+
 -- name: ListAlarmsByEventIDs :many
 SELECT * FROM event_alarms WHERE event_id IN (sqlc.slice(event_ids)) ORDER BY event_id, id;
 

--- a/db/queries/todo_alarms.sql
+++ b/db/queries/todo_alarms.sql
@@ -5,6 +5,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 -- name: ListTodoAlarmsByTodoID :many
 SELECT * FROM todo_alarms WHERE todo_id = ? ORDER BY id;
 
+-- name: ListDistinctTodoAlarmTriggers :many
+SELECT DISTINCT trigger_value FROM todo_alarms;
+
 -- name: DeleteTodoAlarmsByTodoID :exec
 DELETE FROM todo_alarms WHERE todo_id = ?;
 

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -18,6 +18,35 @@ import (
 // StaleThreshold is the maximum age of an unfired alarm before it is skipped.
 const StaleThreshold = 24 * time.Hour
 
+// baseForwardWindow is the minimum distance past `now` that the expansion
+// window reaches, before accounting for configured alarm lead times. It covers
+// the common short reminders (-PT15M, -P1D, …) without a DB scan and provides
+// a safety margin for DST/day-arithmetic drift in the lead-time estimate.
+const baseForwardWindow = StaleThreshold + 24*time.Hour
+
+// maxLeadTime returns how far in the future an event/todo instance may sit and
+// still have an alarm due now, derived from the configured trigger durations.
+// triggerAt = instanceTime + offset, so an alarm is due now (triggerAt ~= now)
+// when instanceTime = now - offset; only negative offsets ("N before") push the
+// instance into the future, and the largest such magnitude bounds the window.
+// Absolute (RFC 3339) and zero/positive triggers contribute nothing. RELATED=END
+// is ignored because it only ever needs a *smaller* forward window than START
+// (the event end is later than its start), so treating every trigger as START
+// is a safe over-estimate.
+func maxLeadTime(triggers []string) time.Duration {
+	ref := time.Now()
+	var longest time.Duration
+	for _, trig := range triggers {
+		if duration.Validate(trig) != nil {
+			continue // absolute or malformed trigger: not a relative lead time
+		}
+		if lead := ref.Sub(duration.Add(ref, trig)); lead > longest {
+			longest = lead
+		}
+	}
+	return longest
+}
+
 // DueAlarm represents an alarm that should fire now.
 type DueAlarm struct {
 	Event     event.Event
@@ -73,7 +102,19 @@ type MissedTodoAlarm struct {
 // (no alarm_state / todo_alarm_state entry) and are past the stale threshold.
 func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.Duration) ([]MissedAlarm, []MissedTodoAlarm, error) {
 	windowStart := now.Add(-lookback)
-	windowEnd := now
+
+	// Extend windowEnd by the longest alarm lead time so a still-future event
+	// whose (now-stale) trigger already passed is expanded and reported missed.
+	// Future triggers are filtered out downstream by collectMissedTriggers.
+	eventTriggers, err := s.q.ListDistinctAlarmTriggers(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	todoTriggers, err := s.q.ListDistinctTodoAlarmTriggers(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	windowEnd := now.Add(maxLeadTime(append(eventTriggers, todoTriggers...)))
 
 	// --- Event alarms ---
 	recurSvc := recurrence.NewService(s.db, s.q)
@@ -216,8 +257,15 @@ func (s *Service) todoAlarmStateExists(ctx context.Context, alarmID int64, trigg
 
 // checkEventAlarms finds due event alarms
 func (s *Service) checkEventAlarms(ctx context.Context, now time.Time) ([]DueAlarm, error) {
+	// Size the forward window so events whose alarm lead time exceeds the base
+	// window (e.g. -P1W on an event 7 days out) are still expanded and fire.
+	triggers, err := s.q.ListDistinctAlarmTriggers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list alarm triggers: %w", err)
+	}
+	forward := baseForwardWindow + maxLeadTime(triggers)
 	windowStart := now.Add(-StaleThreshold - 24*time.Hour)
-	windowEnd := now.Add(StaleThreshold + 24*time.Hour)
+	windowEnd := now.Add(forward)
 
 	recurSvc := recurrence.NewService(s.db, s.q)
 	expandedEvents, err := recurSvc.ListExpandedEvents(ctx, windowStart, windowEnd, recurrence.SkipCategories())

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -1096,6 +1096,44 @@ func TestCheckMissed_SkipsNotYetStaleTodo(t *testing.T) {
 	}
 }
 
+// TestCheck_FiresLongLeadTimeAlarm guards issue #98: an alarm with a lead time
+// beyond the fixed 48h expansion window (e.g. -P1W on an event 7 days out)
+// must still fire when its trigger time arrives. The event instance sits far
+// past now+48h, so a fixed window silently drops it.
+func TestCheck_FiresLongLeadTimeAlarm(t *testing.T) {
+	svc, evtSvc := newTestServices(t)
+	ctx := context.Background()
+
+	// Event starts in exactly 7 days; a "1 week before" alarm is due now.
+	start := time.Now().Add(7 * 24 * time.Hour)
+	e, err := evtSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Far Meeting",
+		StartTime:  start,
+		EndTime:    start.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-P1W", Description: "1 week reminder"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	due, _, err := svc.Check(ctx, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("got %d due alarms, want 1 (long-lead-time alarm missed)", len(due))
+	}
+	if due[0].Event.ID != e.ID {
+		t.Errorf("event ID = %d, want %d", due[0].Event.ID, e.ID)
+	}
+}
+
 func mustLoadLocation(name string) *time.Location {
 	loc, err := time.LoadLocation(name)
 	if err != nil {

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -46,8 +46,15 @@ func NewTodoService(db *sql.DB, q *storage.Queries, todos TodoAlarmLister) *Todo
 // CheckTodos finds due alarms for todos within the stale threshold window.
 // Recurring todos are expanded via RRULE so alarms fire for each occurrence.
 func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueAlarm, error) {
+	// Widen the forward window for lead times beyond the base window so todos
+	// far in the future (e.g. -P1W on a todo due in 7 days) still fire.
+	triggers, err := s.q.ListDistinctTodoAlarmTriggers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list todo alarm triggers: %w", err)
+	}
+	forward := baseForwardWindow + maxLeadTime(triggers)
 	windowStart := now.Add(-StaleThreshold - 24*time.Hour)
-	windowEnd := now.Add(StaleThreshold + 24*time.Hour)
+	windowEnd := now.Add(forward)
 
 	rows, err := s.q.ListAllTodos(ctx)
 	if err != nil {

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -328,3 +328,37 @@ func TestListExpiredTodoSnoozed(t *testing.T) {
 		t.Errorf("expired snoozed = %d, want 1", len(expired))
 	}
 }
+
+// TestCheckTodos_FiresLongLeadTimeAlarm guards issue #98 on the todo path: a
+// todo due 7 days out with a "1 week before" alarm must fire now even though
+// the todo instance is far past the base forward window. Uses the real todo
+// service so the DB-backed trigger scan that sizes the window is exercised.
+func TestCheckTodos_FiresLongLeadTimeAlarm(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	todoSvc := todo.NewService(db, q)
+	ctx := context.Background()
+
+	due := time.Now().Add(7 * 24 * time.Hour)
+	td, err := todoSvc.Create(ctx, todo.CreateParams{
+		CalendarID: 1,
+		Summary:    "Far Deadline",
+		DueDate:    due.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create todo: %v", err)
+	}
+	if err := todoSvc.ReplaceAlarms(ctx, td.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-P1W", Description: "1 week reminder"},
+	}); err != nil {
+		t.Fatalf("replace alarms: %v", err)
+	}
+
+	todoAlarmSvc := NewTodoService(db, q, todoSvc)
+	got, err := todoAlarmSvc.CheckTodos(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("check todos: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d due todo alarms, want 1 (long-lead-time alarm missed)", len(got))
+	}
+}

--- a/internal/storage/alarms.sql.go
+++ b/internal/storage/alarms.sql.go
@@ -215,6 +215,33 @@ func (q *Queries) ListAlarmsWithEmptyUID(ctx context.Context) ([]EventAlarm, err
 	return items, nil
 }
 
+const listDistinctAlarmTriggers = `-- name: ListDistinctAlarmTriggers :many
+SELECT DISTINCT trigger_value FROM event_alarms
+`
+
+func (q *Queries) ListDistinctAlarmTriggers(ctx context.Context) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listDistinctAlarmTriggers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var trigger_value string
+		if err := rows.Scan(&trigger_value); err != nil {
+			return nil, err
+		}
+		items = append(items, trigger_value)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateAlarmAcknowledged = `-- name: UpdateAlarmAcknowledged :exec
 UPDATE event_alarms SET acknowledged = ? WHERE id = ? AND event_id = ?
 `

--- a/internal/storage/todo_alarms.sql.go
+++ b/internal/storage/todo_alarms.sql.go
@@ -81,6 +81,33 @@ func (q *Queries) DeleteTodoAlarmsByTodoID(ctx context.Context, todoID int64) er
 	return err
 }
 
+const listDistinctTodoAlarmTriggers = `-- name: ListDistinctTodoAlarmTriggers :many
+SELECT DISTINCT trigger_value FROM todo_alarms
+`
+
+func (q *Queries) ListDistinctTodoAlarmTriggers(ctx context.Context) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listDistinctTodoAlarmTriggers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var trigger_value string
+		if err := rows.Scan(&trigger_value); err != nil {
+			return nil, err
+		}
+		items = append(items, trigger_value)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTodoAlarmsByTodoID = `-- name: ListTodoAlarmsByTodoID :many
 SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype FROM todo_alarms WHERE todo_id = ? ORDER BY id
 `


### PR DESCRIPTION
Fixes #98

## Root cause
Alarm checks expanded events/todos only within a fixed window of
`[now-48h, now+48h]` (`StaleThreshold + 24h` on each side). An alarm is due
now when `triggerAt = instanceTime + offset ~= now`, i.e. the event sits at
`now + |offset|`. For lead times >= 48h (e.g. `TRIGGER:-P1W` on an event 7
days out) the event instance falls outside the forward edge of the window, so
it is never expanded and the alarm is silently skipped forever. The exact
`-P2D` boundary case was also dropped by half-open `[start, end)` expansion.

## Fix
Size the forward edge of the expansion window from the longest configured
alarm lead time. New queries `ListDistinctAlarmTriggers` /
`ListDistinctTodoAlarmTriggers` return the distinct trigger durations; a
helper `maxLeadTime` parses them and returns the largest "before" magnitude
(absolute/positive triggers contribute nothing; `RELATED=END` is a safe
over-estimate when treated as START). `checkEventAlarms` and `CheckTodos` add
this to the base window; `CheckMissed` widens its forward edge likewise so
still-future, already-stale triggers are reported. With no alarms the window
is unchanged from before, so there is no regression.

## Tests
- `TestCheck_FiresLongLeadTimeAlarm` — event 7 days out with a `-P1W` alarm
  must be due now (fails before the fix: 0 due alarms).
- `TestCheckTodos_FiresLongLeadTimeAlarm` — same on the todo path, using the
  real todo service so the DB-backed trigger scan is exercised.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
