### PR TITLE
fix(config): honor purge_days=0 as "disable auto-purge"

### DIFF
--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/douglasdemoura/chroncal/internal/alarm"
 	"github.com/douglasdemoura/chroncal/internal/app"
-	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/notify"
 	"github.com/douglasdemoura/chroncal/internal/storage"
@@ -894,10 +893,10 @@ system was not running when they became due.`,
 			// but the maintenance purge deletes acknowledged rows older
 			// than the soft-delete retention — beyond that horizon a
 			// dismissed alarm is indistinguishable from a missed one.
+			// config.Load already resolved the default; PurgeDays<=0 means
+			// purging is disabled, so history is retained indefinitely and
+			// no retention warning applies.
 			retentionDays := cfg.SoftDelete.PurgeDays
-			if retentionDays == 0 {
-				retentionDays = config.DefaultSoftDeletePurgeDays
-			}
 			if retentionDays > 0 && days > retentionDays {
 				fmt.Fprintf(os.Stderr, "chroncal: warning: lookback of %d days exceeds the %d-day alarm-history retention; results older than %d days may include alarms that were actually dismissed\n",
 					days, retentionDays, retentionDays)

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -216,14 +216,11 @@ Helpful conventions:
 		defer a.Close()
 
 		// Kick off the soft-delete purge loop for long-running TUI sessions.
-		// PurgeDays=0 (or negative) disables; otherwise runs once up front
-		// then every 24h. Detached goroutine — ctx is bound to process
+		// config.Load already resolved the default; PurgeDays=0 (or negative)
+		// means the user disabled purging, so leave it off. Otherwise run once
+		// up front then every 24h. Detached goroutine — ctx is bound to process
 		// lifetime via the signal handler in the TUI loop below.
-		purgeDays := cfg.SoftDelete.PurgeDays
-		if purgeDays == 0 {
-			purgeDays = config.DefaultSoftDeletePurgeDays
-		}
-		if purgeDays > 0 {
+		if purgeDays := cfg.SoftDelete.PurgeDays; purgeDays > 0 {
 			purger := maintenance.NewPurger(a.Trash, a.Queries, purgeDays, nil)
 			go purger.RunDaily(context.Background())
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,8 +54,9 @@ type Config struct {
 	UI         UIConfig         `mapstructure:"ui"`
 }
 
-// DefaultSoftDeletePurgeDays is applied when SoftDelete.PurgeDays is zero or
-// unset (viper Unmarshal leaves unset ints at zero).
+// DefaultSoftDeletePurgeDays is applied by Load when the purge_days key is
+// genuinely unset. An explicit purge_days=0 is preserved as 0 (disabled) per
+// the SoftDeleteConfig contract.
 const DefaultSoftDeletePurgeDays = 30
 
 // DefaultSMTPPort is applied when SMTP.Port is unset, matching the
@@ -77,6 +78,13 @@ func Load() Config {
 	v.Unmarshal(&cfg) //nolint:errcheck // best-effort; zero-value Config is safe
 	if cfg.SMTP.Port == 0 {
 		cfg.SMTP.Port = DefaultSMTPPort
+	}
+	// Apply the purge-days default only when the key is genuinely unset.
+	// An explicit purge_days=0 means "disable automatic purging" per the
+	// documented contract, so it must survive as 0 rather than be rewritten
+	// to the default. viper.IsSet distinguishes unset from an explicit 0.
+	if !v.IsSet("soft_delete.purge_days") {
+		cfg.SoftDelete.PurgeDays = DefaultSoftDeletePurgeDays
 	}
 	return cfg
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -171,6 +171,46 @@ allow_unsafe_alarm_email_attendees = true
 	}
 }
 
+func TestLoad_PurgeDaysDefaultsWhenUnset(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no config file
+	t.Setenv("CHRONCAL_SOFT_DELETE_PURGE_DAYS", "")
+	cfg := Load()
+	if cfg.SoftDelete.PurgeDays != DefaultSoftDeletePurgeDays {
+		t.Errorf("PurgeDays = %d, want %d when unset", cfg.SoftDelete.PurgeDays, DefaultSoftDeletePurgeDays)
+	}
+}
+
+func TestLoad_PurgeDaysZeroDisables(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "chroncal")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[soft_delete]\npurge_days = 0\n"), 0o644)
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_SOFT_DELETE_PURGE_DAYS", "")
+
+	cfg := Load()
+	if cfg.SoftDelete.PurgeDays != 0 {
+		t.Errorf("PurgeDays = %d, want 0 (explicit 0 must stay disabled, not default to %d)",
+			cfg.SoftDelete.PurgeDays, DefaultSoftDeletePurgeDays)
+	}
+}
+
+func TestLoad_PurgeDaysExplicitValue(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "chroncal")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[soft_delete]\npurge_days = 7\n"), 0o644)
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_SOFT_DELETE_PURGE_DAYS", "")
+
+	cfg := Load()
+	if cfg.SoftDelete.PurgeDays != 7 {
+		t.Errorf("PurgeDays = %d, want 7", cfg.SoftDelete.PurgeDays)
+	}
+}
+
 func TestLoad_SMTPPortDefaultsWhenUnset(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no config file
 	t.Setenv("CHRONCAL_SMTP_PORT", "")


### PR DESCRIPTION
Fixes #99

## Root cause
`SoftDeleteConfig.PurgeDays` is documented as "Zero disables automatic purging,"
and `Purger.RunOnce/RunDaily` honor it (`days <= 0` is a no-op). But the default
was applied per-caller via a `0 -> DefaultSoftDeletePurgeDays (30)` rewrite in
both the TUI startup path (`cmd/chroncal/main.go`) and the `alarm missed` command
(`cmd/chroncal/alarm.go`). That silently overrode an explicit `purge_days = 0`,
so a user expecting trash retention still got soft-deleted rows and alarm-state
history hard-deleted after 30 days — contradicting the documented contract. Only
a negative (undocumented) value actually disabled it.

## Fix
Resolve the default centrally in `config.Load` using `viper.IsSet`, which
distinguishes a genuinely unset key (apply the 30-day default) from an explicit
`0` (preserve as disabled). Both per-caller `0 -> 30` rewrites are removed, so
callers read the resolved `cfg.SoftDelete.PurgeDays` directly. Negative values
remain disabled as before.

Removing the `alarm missed` rewrite also fixes a now-inconsistent warning: with
purging disabled, acknowledged alarm history is never purged, so the
"results may include alarms that were actually dismissed" warning correctly no
longer fires.

## Tests
New `internal/config` tests covering the resolution contract:
- `TestLoad_PurgeDaysDefaultsWhenUnset` — unset key resolves to 30 (failed before the fix)
- `TestLoad_PurgeDaysZeroDisables` — explicit `purge_days = 0` stays 0 (disabled)
- `TestLoad_PurgeDaysExplicitValue` — explicit positive value is preserved

`make fmt`, `go vet ./...`, and `go test ./internal/... ./cmd/...` all pass.
