### PR TITLE
fix(tui): filter hidden calendars in day-popup navigation

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2072,7 +2072,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					SetSize(m.width, m.height)
 				return m, m.loadEvents()
 			}
-			dayEvents := eventsOn(m.events, msg.Day)
+			dayEvents := eventsOn(filterVisibleEvents(m.events, m.hiddenCalendars), msg.Day)
 			m.dialog = NewEventDialogModel(msg.Day, dayEvents, m.calendars, newThemedHelp(m.theme)).
 				SetSelectedColor(m.theme.Selected).
 				SetSize(m.width, m.height)
@@ -2087,7 +2087,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					SetSize(m.width, m.height)
 				return m, m.loadEvents()
 			}
-			dayEvents := eventsOn(m.events, msg.Day)
+			dayEvents := eventsOn(filterVisibleEvents(m.events, m.hiddenCalendars), msg.Day)
 			m.dialog = NewEventDialogModel(msg.Day, dayEvents, m.calendars, newThemedHelp(m.theme)).
 				SetSelectedColor(m.theme.Selected).
 				SetSize(m.width, m.height)
@@ -2101,7 +2101,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				SetSize(m.width, m.height)
 			return m, m.loadEvents()
 		}
-		dayEvents := eventsOn(m.events, msg.Day)
+		dayEvents := eventsOn(filterVisibleEvents(m.events, m.hiddenCalendars), msg.Day)
 		m.dialog = NewEventDialogModel(msg.Day, dayEvents, m.calendars, newThemedHelp(m.theme)).
 			SetSelectedColor(m.theme.Selected).
 			SetSize(m.width, m.height)

--- a/internal/tui/app_day_popup_filter_test.go
+++ b/internal/tui/app_day_popup_filter_test.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+)
+
+// TestDialogDayChanged_HonorsHiddenCalendars guards against a regression where
+// the day-events popup, when navigating to another day within the already
+// loaded period, rebuilt its list from the unfiltered event cache. That made
+// events from calendars hidden in the sidebar reappear in the popup.
+//
+// See issue #108.
+func TestDialogDayChanged_HonorsHiddenCalendars(t *testing.T) {
+	target := time.Date(2026, 6, 11, 0, 0, 0, 0, time.Local)
+
+	visible := event.Event{
+		ID:         1,
+		CalendarID: 1,
+		Title:      "Visible meeting",
+		StartTime:  time.Date(2026, 6, 11, 9, 0, 0, 0, time.Local),
+		EndTime:    time.Date(2026, 6, 11, 10, 0, 0, 0, time.Local),
+	}
+	hidden := event.Event{
+		ID:         2,
+		CalendarID: 2,
+		Title:      "Hidden meeting",
+		StartTime:  time.Date(2026, 6, 11, 11, 0, 0, 0, time.Local),
+		EndTime:    time.Date(2026, 6, 11, 12, 0, 0, 0, time.Local),
+	}
+
+	m := Model{
+		theme:    LoadTheme("", true),
+		width:    100,
+		height:   40,
+		viewMode: viewMonth,
+		calendar: NewCalendarModel(time.Date(2026, 6, 10, 0, 0, 0, 0, time.Local)),
+		events:   []event.Event{visible, hidden},
+		calendars: map[int64]CalendarInfo{
+			1: {Name: "Personal", Color: "#7C3AED"},
+			2: {Name: "Work", Color: "#a6e3a1"},
+		},
+		hiddenCalendars: map[int64]bool{2: true},
+	}
+
+	updated, _ := m.Update(DialogDayChangedMsg{Day: target})
+	got := updated.(Model)
+
+	for _, ev := range got.dialog.events {
+		if ev.CalendarID == 2 {
+			t.Fatalf("day popup includes event %q from hidden calendar %d", ev.Title, ev.CalendarID)
+		}
+	}
+	if len(got.dialog.events) != 1 {
+		t.Fatalf("expected 1 visible event in popup, got %d", len(got.dialog.events))
+	}
+}


### PR DESCRIPTION
Fixes #108.

## Root cause
The `DialogDayChangedMsg` handler in `internal/tui/app.go` rebuilt the day-events
popup from the **unfiltered** event cache (`eventsOn(m.events, msg.Day)`) when the
user navigated to another day within the already-loaded period. Every other path
(initial open, sidebar visibility toggle, post-load refresh) runs the events
through `filterVisibleEvents(m.events, m.hiddenCalendars)` first. As a result,
pressing the popup's prev/next-day keys to a day in the loaded range made events
from calendars hidden in the sidebar reappear.

## Fix
Wrap the three `eventsOn(m.events, msg.Day)` calls (the day, week, and month view
branches) in `filterVisibleEvents(m.events, m.hiddenCalendars)`, matching the
established call sites.

## Test
`TestDialogDayChanged_HonorsHiddenCalendars` builds a month-view `Model` with two
events on the same day — one in a visible calendar, one in a hidden calendar —
sends a `DialogDayChangedMsg` to that day (within the loaded month, so no reload),
and asserts the rebuilt popup contains only the visible event. The test fails
before the fix and passes after.

Verified: `make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.
