### PR TITLE
fix(tui): preserve attendee role/RSVP/CN across event edits

### DIFF
--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -162,6 +162,12 @@ type EventFormModel struct {
 	alarmEditor        AlarmListEditorModel
 	alarmEditorOpen    bool
 
+	// origAttendees retains the full attendee structs from the event being
+	// edited. The People field only surfaces email addresses, so on save we
+	// re-attach each email's original Role/RSVPStatus/CUType/CN instead of
+	// flattening everyone back to defaults (issue #109).
+	origAttendees []model.Attendee
+
 	// Mini-month models for date picker overlays
 	datePicker          MiniMonthModel
 	endsDatePickerModel MiniMonthModel
@@ -445,6 +451,7 @@ func NewEventFormModelForEditInstance(ev event.Event, instanceTime time.Time, ca
 
 	// Pre-fill attendees.
 	if len(ev.Attendees) > 0 {
+		m.origAttendees = append([]model.Attendee(nil), ev.Attendees...)
 		emails := make([]string, 0, len(ev.Attendees))
 		for _, a := range ev.Attendees {
 			emails = append(emails, a.Email)
@@ -1609,19 +1616,37 @@ func (m EventFormModel) save(f *Form) tea.Cmd {
 	title := strings.TrimSpace(m.titleField.Value())
 	tzName := m.timezoneField.Value()
 
-	// Parse comma-separated emails into attendees.
+	// Parse comma-separated emails into attendees. The People field only
+	// exposes email addresses, so re-attach each email's original participation
+	// metadata (Role/RSVPStatus/CUType/CN, etc.) instead of overwriting it with
+	// defaults. New emails get the standard defaults (issue #109).
+	orig := make(map[string]model.Attendee, len(m.origAttendees))
+	for _, a := range m.origAttendees {
+		orig[strings.ToLower(a.Email)] = a
+	}
 	var attendees []model.Attendee
 	if raw := strings.TrimSpace(m.peopleField.Value()); raw != "" {
+		seen := make(map[string]bool)
 		for _, part := range strings.Split(raw, ",") {
 			email := strings.TrimSpace(part)
-			if email != "" {
-				attendees = append(attendees, model.Attendee{
-					Email:      email,
-					Role:       "REQ-PARTICIPANT",
-					RSVPStatus: "NEEDS-ACTION",
-					CUType:     "INDIVIDUAL",
-				})
+			if email == "" {
+				continue
 			}
+			key := strings.ToLower(email)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			if prev, ok := orig[key]; ok {
+				attendees = append(attendees, prev)
+				continue
+			}
+			attendees = append(attendees, model.Attendee{
+				Email:      email,
+				Role:       "REQ-PARTICIPANT",
+				RSVPStatus: "NEEDS-ACTION",
+				CUType:     "INDIVIDUAL",
+			})
 		}
 	}
 

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -395,4 +396,56 @@ func TestEventForm_EnterOnAllDayDisablesTimeImmediately(t *testing.T) {
 
 	assert.True(t, m.allDayField.Checked())
 	assert.False(t, m.timeField.IsFocusable())
+}
+
+// TestEventForm_EditPreservesAttendeeMetadata guards against issue #109:
+// editing an event must not flatten attendee Role/RSVPStatus/CUType/CN back to
+// defaults. A CHAIR who has ACCEPTED must remain a CHAIR who has ACCEPTED after
+// an unrelated title edit, and unchanged attendees must keep their display name.
+func TestEventForm_EditPreservesAttendeeMetadata(t *testing.T) {
+	m, _ := NewEventFormModelForEdit(event.Event{
+		ID:         7,
+		CalendarID: 1,
+		Title:      "Standup",
+		Attendees: []model.Attendee{
+			{
+				Email:      "chair@example.com",
+				Name:       "Chair Person",
+				Role:       "CHAIR",
+				RSVPStatus: "ACCEPTED",
+				CUType:     "INDIVIDUAL",
+			},
+			{
+				Email:      "room@example.com",
+				Name:       "Big Room",
+				Role:       "OPT-PARTICIPANT",
+				RSVPStatus: "TENTATIVE",
+				CUType:     "ROOM",
+			},
+		},
+	}, testEventFormCalendars(), Theme{})
+
+	m.titleField.SetValue("Standup (renamed)")
+
+	cmd := m.save(&m.form)
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(EventFormSaveMsg)
+	require.True(t, ok)
+
+	require.Len(t, msg.Attendees, 2)
+	byEmail := map[string]model.Attendee{}
+	for _, a := range msg.Attendees {
+		byEmail[a.Email] = a
+	}
+
+	chair := byEmail["chair@example.com"]
+	assert.Equal(t, "CHAIR", chair.Role)
+	assert.Equal(t, "ACCEPTED", chair.RSVPStatus)
+	assert.Equal(t, "Chair Person", chair.Name)
+
+	room := byEmail["room@example.com"]
+	assert.Equal(t, "OPT-PARTICIPANT", room.Role)
+	assert.Equal(t, "TENTATIVE", room.RSVPStatus)
+	assert.Equal(t, "ROOM", room.CUType)
+	assert.Equal(t, "Big Room", room.Name)
 }


### PR DESCRIPTION
Fixes #109

## Root cause
The event form only exposes attendees as a comma-joined list of email
addresses. On load it threw away every attendee's `Role`, `RSVPStatus`,
`CUType`, `CN`, and remaining RFC 5545 params, keeping only the email. On save
it rebuilt each attendee from that email string with hardcoded
`Role=REQ-PARTICIPANT`, `RSVPStatus=NEEDS-ACTION`, `CUType=INDIVIDUAL`. So any
unrelated edit (e.g. changing the title) silently downgraded a CHAIR who had
ACCEPTED to a needs-action required participant and dropped their display name.

## Fix
- Retain the original `[]model.Attendee` on the form model
  (`origAttendees`) when loading an event for edit.
- On save, re-attach each surviving email's original struct (matched
  case-insensitively) and only mint default metadata for newly typed emails.
- Dedup repeated emails so a typo can't create duplicate attendee rows.

`ReplaceAttendees` rewrites rows using the target event ID, so carrying the
original struct (with its stale row ID) through is safe.

## Test coverage
`TestEventForm_EditPreservesAttendeeMetadata` loads an event with a CHAIR
(ACCEPTED, named) and a ROOM resource (OPT-PARTICIPANT, TENTATIVE, named),
performs an unrelated title edit, saves, and asserts every attendee's Role,
RSVPStatus, CUType, and CN survive. It failed before the fix and passes after.

## Verification
`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.
