### PR TITLE
fix(tui): bound agenda auto-fill on sparse calendars

### DIFF
--- a/internal/tui/agenda_expand_test.go
+++ b/internal/tui/agenda_expand_test.go
@@ -216,6 +216,48 @@ func TestMaybeFillViewport_TriggersForwardExpansionWhenUnderfilled(t *testing.T)
 	}
 }
 
+// TestMaybeFillViewport_StopsExpandingWhenNoNewRows reproduces issue #93:
+// on a sparse calendar whose few rows never fill a tall viewport, the host
+// re-queries the same event set after each forward expansion, so the
+// auto-fill must settle instead of growing windowEnd forward without bound.
+func TestMaybeFillViewport_StopsExpandingWhenNoNewRows(t *testing.T) {
+	jumpDay := time.Date(2026, 4, 1, 0, 0, 0, 0, time.Local)
+	// A handful of events, all inside the initial window — more than zero
+	// rows but far fewer than the viewport height (38), so every load is
+	// "underfilled" yet no future expansion can ever add a row.
+	events := []event.Event{
+		{ID: 1, Title: "A", StartTime: jumpDay.Add(9 * time.Hour), EndTime: jumpDay.Add(10 * time.Hour)},
+		{ID: 2, Title: "B", StartTime: jumpDay.AddDate(0, 0, 2).Add(9 * time.Hour), EndTime: jumpDay.AddDate(0, 0, 2).Add(10 * time.Hour)},
+		{ID: 3, Title: "C", StartTime: jumpDay.AddDate(0, 0, 4).Add(9 * time.Hour), EndTime: jumpDay.AddDate(0, 0, 4).Add(10 * time.Hour)},
+	}
+	m := NewAgendaModel(jumpDay).SetSize(80, 40).SetTheme(NewTheme(true))
+	m = m.ResetWindow(jumpDay)
+	m = m.SetEvents(events, nil)
+
+	// Simulate the host loop: each non-nil MaybeFillViewport command grows
+	// the window and triggers a reload that replays the same events. The
+	// loop must terminate; an unbounded auto-fill never returns nil.
+	const maxSteps = 50
+	steps := 0
+	for {
+		cmd := m.MaybeFillViewport()
+		if cmd == nil {
+			break
+		}
+		if _, ok := cmd().(AgendaReloadMsg); !ok {
+			t.Fatalf("expected AgendaReloadMsg, got %T", cmd())
+		}
+		steps++
+		if steps > maxSteps {
+			t.Fatalf("auto-fill never settled: still expanding after %d steps "+
+				"(windowEnd=%v) — runaway forward expansion (issue #93)",
+				steps, m.WindowEnd().Format("2006-01-02"))
+		}
+		// Host re-queries the (unchanged) event set over the grown window.
+		m = m.SetEvents(events, nil)
+	}
+}
+
 // TestMaybeFillViewport_NoopWhenFull verifies the auto-fill doesn't fire
 // when rows already fill the viewport — otherwise every load would spawn
 // a pointless reload round-trip.

--- a/internal/tui/agenda_model.go
+++ b/internal/tui/agenda_model.go
@@ -126,6 +126,13 @@ type AgendaModel struct {
 	// reloadPending prevents firing a second AgendaReloadMsg while the
 	// previous one is still in-flight; it's cleared by SetEvents.
 	reloadPending bool
+	// fillExpandRows bounds the underfill-driven auto-fill (see
+	// MaybeFillViewport). It records len(rows) at the last auto-fill
+	// expansion so the next one is suppressed unless the row count actually
+	// grew — otherwise a sparse calendar in a tall terminal would extend
+	// windowEnd forward without bound. -1 means "no auto-fill yet"; reset
+	// to -1 on a jump (ResetWindow) or once the viewport fills.
+	fillExpandRows int
 	// showEmptyDays, when true, renders a placeholder row for each day
 	// in the window that has no events. Toggled by the "o" key.
 	showEmptyDays bool
@@ -139,12 +146,13 @@ type AgendaModel struct {
 func NewAgendaModel(today time.Time) AgendaModel {
 	t := dayAligned(today.Local())
 	return AgendaModel{
-		cursor:      t,
-		today:       t,
-		windowStart: t,
-		windowEnd:   t.AddDate(0, 0, AgendaWindowDays),
-		selected:    -1,
-		keys:        defaultAgendaKeys(),
+		cursor:         t,
+		today:          t,
+		windowStart:    t,
+		windowEnd:      t.AddDate(0, 0, AgendaWindowDays),
+		selected:       -1,
+		keys:           defaultAgendaKeys(),
+		fillExpandRows: -1,
 	}
 }
 
@@ -168,6 +176,7 @@ func (m AgendaModel) ResetWindow(day time.Time) AgendaModel {
 	m.windowEnd = d.AddDate(0, 0, AgendaWindowDays)
 	m.anchorDay = time.Time{}
 	m.reloadPending = false
+	m.fillExpandRows = -1
 	m.selected = -1
 	return m
 }
@@ -715,8 +724,42 @@ func (m AgendaModel) maxScroll(viewportH int) int {
 // rows don't fill the visible area — used by the host after a fresh
 // SetEvents (e.g. after `[`/`]` jumps) so sparse months automatically
 // pull in the next month's events instead of leaving blank rows below.
+//
+// The host calls this after every load, including the load it triggers,
+// so it must self-terminate. Unlike scroll-driven expansion there's no
+// scroll position to bound it; instead it stops once an expansion fails
+// to add rows. Without that guard a calendar with a few events in a tall
+// terminal — underfilled but non-empty — would grow windowEnd forward
+// without bound, re-querying an ever-larger range on every step.
 func (m *AgendaModel) MaybeFillViewport() tea.Cmd {
-	return m.maybeExpandForward()
+	if m.reloadPending || len(m.rows) == 0 {
+		return nil
+	}
+	if len(m.rows) >= m.viewportH() {
+		// Viewport is full; nothing to auto-fill. Clear the guard so a
+		// later jump to another sparse month can auto-fill afresh.
+		m.fillExpandRows = -1
+		return nil
+	}
+	// Underfilled: pull in the next step, but only while each expansion
+	// keeps adding rows. Once the row count stops growing, the future is
+	// empty (or sparse enough that no step adds anything) — stop.
+	if m.fillExpandRows >= 0 && len(m.rows) <= m.fillExpandRows {
+		return nil
+	}
+	m.fillExpandRows = len(m.rows)
+	m.windowEnd = m.windowEnd.AddDate(0, 0, AgendaExpandStep)
+	return m.requestReload()
+}
+
+// requestReload stamps the scroll anchor, marks a reload in flight, and
+// returns the command that asks the host to re-query the current window.
+// All three window-growth paths funnel through here so the reloadPending
+// handshake (cleared by SetEvents) is asserted in exactly one place.
+func (m *AgendaModel) requestReload() tea.Cmd {
+	m.stampAnchor()
+	m.reloadPending = true
+	return func() tea.Msg { return AgendaReloadMsg{} }
 }
 
 // ScrollBy advances the viewport by delta rows (positive scrolls down,
@@ -753,33 +796,29 @@ func (m *AgendaModel) maybeExpandBackward() tea.Cmd {
 		return nil
 	}
 	m.windowStart = m.windowStart.AddDate(0, 0, -AgendaExpandStep)
-	m.stampAnchor()
-	m.reloadPending = true
-	return func() tea.Msg { return AgendaReloadMsg{} }
+	return m.requestReload()
 }
 
 // maybeExpandForward is the mirror of maybeExpandBackward for the
 // bottom edge — the near edge (windowStart) is held fixed for the same
-// reason. It also fires when the loaded rows don't fill the viewport
-// (e.g. after `[`/`]` jumps land on a sparse month), so the next month
-// flows in automatically instead of waiting for the user to navigate.
+// reason. It fires when the scroll or selection is within
+// AgendaPreloadRows of the last row, so infinite scroll keeps feeding the
+// next month in as the user moves down. (The underfill case — a sparse
+// month that never fills the viewport — is handled by MaybeFillViewport,
+// which bounds itself so it can't loop forever.)
 func (m *AgendaModel) maybeExpandForward() tea.Cmd {
 	if m.reloadPending || len(m.rows) == 0 {
 		return nil
 	}
 	viewportH := m.viewportH()
-	underfilled := len(m.rows) < viewportH
 	maxScroll := m.maxScroll(viewportH)
-	atBottom := underfilled ||
-		(maxScroll > 0 && m.scroll >= maxScroll-AgendaPreloadRows) ||
+	atBottom := (maxScroll > 0 && m.scroll >= maxScroll-AgendaPreloadRows) ||
 		(m.selected >= 0 && m.selected >= len(m.rows)-AgendaPreloadRows)
 	if !atBottom {
 		return nil
 	}
 	m.windowEnd = m.windowEnd.AddDate(0, 0, AgendaExpandStep)
-	m.stampAnchor()
-	m.reloadPending = true
-	return func() tea.Msg { return AgendaReloadMsg{} }
+	return m.requestReload()
 }
 
 func (m *AgendaModel) stampAnchor() {


### PR DESCRIPTION
Fixes #93

## Root cause

After every agenda `eventsLoadedMsg`, the host (`app.go:1690`) calls
`MaybeFillViewport()`, which delegated to `maybeExpandForward`. That fired
whenever the loaded rows underfilled the viewport (`len(rows) < viewportH`),
growing `windowEnd` by 30 days and emitting `AgendaReloadMsg`. The reload
produced another load, which called `MaybeFillViewport` again. The only
termination was `len(rows) == 0`. Any user with a few upcoming events in a
tall terminal (rows > 0 but < viewport height) triggered an endless chain:
the window extended 30 days forward on every step, each running a
recurrence-expanded DB query over an ever-larger range, never settling.

## Fix

- `MaybeFillViewport` now has its own self-terminating logic: it no-ops once
  the viewport is full, and otherwise expands forward only while each step
  actually adds rows — tracked via a new `fillExpandRows` field (records the
  row count at the last auto-fill expansion; reset to `-1` on a jump via
  `ResetWindow` and once the viewport fills).
- The `underfilled` trigger is removed from `maybeExpandForward`, which now
  handles only scroll/selection-driven infinite scroll. That path is bounded
  by the user's actual scroll/selection position, so it can't loop.
- The shared stamp-anchor / mark-pending / emit-`AgendaReloadMsg` tail (now
  used by all three window-growth paths) is centralized in a `requestReload`
  helper.

## Test

`TestMaybeFillViewport_StopsExpandingWhenNoNewRows` reproduces the bug: it
loads a sparse 3-event set into a 38-row viewport and drives the host loop —
each non-nil `MaybeFillViewport` command grows the window and triggers a
reload that replays the same events. Before the fix the loop never returns
nil (windowEnd runs out to 2030+ within 50 steps); after the fix it settles.
The existing agenda expand/sticky-title tests still pass.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` are all
green.
