### PR TITLE
fix(cmd): default --to to from+30 to avoid inverted date range

### DIFF
--- a/cmd/chroncal/date_range_test.go
+++ b/cmd/chroncal/date_range_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseDateRangeFromBeyondDefaultWindow guards against issue #111:
+// when --to is omitted and --from is more than 30 days in the future, the
+// default `to` must follow `from` (from+30), not stay anchored to today+30,
+// which would produce an inverted, silently-empty range.
+func TestParseDateRangeFromBeyondDefaultWindow(t *testing.T) {
+	now := time.Now()
+	fromStr := now.AddDate(0, 0, 60).Format("2006-01-02")
+
+	from, to, err := parseDateRange(fromStr, "")
+	if err != nil {
+		t.Fatalf("parseDateRange returned error: %v", err)
+	}
+	if !to.After(from) {
+		t.Fatalf("expected to (%s) to be after from (%s); inverted range", to, from)
+	}
+}
+
+func TestParseDateRangeDefaultToFollowsFrom(t *testing.T) {
+	from, to, err := parseDateRange("2026-09-01", "")
+	if err != nil {
+		t.Fatalf("parseDateRange returned error: %v", err)
+	}
+	wantTo := from.AddDate(0, 0, 30)
+	if !to.Equal(wantTo) {
+		t.Fatalf("default to = %s, want %s (from+30)", to, wantTo)
+	}
+}

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -354,7 +354,6 @@ func resolveJournal(ctx context.Context, a *app.App, ref, recurrenceID string) (
 func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
 	now := time.Now()
 	from := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
-	to := from.AddDate(0, 0, 30)
 
 	if fromStr != "" {
 		var err error
@@ -363,6 +362,10 @@ func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
 			return time.Time{}, time.Time{}, err
 		}
 	}
+	// Default the window end to 30 days after `from` (not after today), so a
+	// `--from` far in the future without `--to` still yields a forward,
+	// non-empty range instead of an inverted one (issue #111).
+	to := from.AddDate(0, 0, 30)
 	if toStr != "" {
 		var err error
 		to, err = parseCLIDate("to", toStr, time.Local)


### PR DESCRIPTION
Fixes #111

## Root cause
`parseDateRange` (cmd/chroncal/main.go) computed the default `to` as
today+30 *before* overriding `from` from `--from`. When `--to` was omitted
and `--from` pointed more than ~30 days into the future, `to` stayed
anchored to today+30, producing `from > to`. The half-open `[from, to)`
query then matched zero rows with no error, so the user saw "No events
found." for events that actually exist. This affected event/todo/journal
`list` and ical export.

## Fix
Move the `to := from.AddDate(0, 0, 30)` default so it runs *after* `from`
is parsed. The default window now always extends 30 days past the requested
start, never inverts. The `--to` override path and the all-empty default
(today .. today+30) are unchanged.

## Test coverage
`cmd/chroncal/date_range_test.go`:
- `TestParseDateRangeFromBeyondDefaultWindow` — `--from` 60 days out, no
  `--to`: asserts `to.After(from)` (failed before the fix with an inverted
  range).
- `TestParseDateRangeDefaultToFollowsFrom` — asserts the default `to`
  equals `from+30`.

`make fmt`, `go vet ./...`, and `go test ./internal/... ./cmd/...` all pass.
