### PR TITLE
fix(retry): honor Retry-After header on 429/503 responses

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/retry"
 	"github.com/emersion/go-ical"
 	"github.com/emersion/go-webdav"
 	"github.com/emersion/go-webdav/caldav"
@@ -450,10 +452,55 @@ func httpError(resp *http.Response) error {
 		}
 	}
 
+	var err error
 	if bodyText == "" {
-		return fmt.Errorf("HTTP %s", status)
+		err = fmt.Errorf("HTTP %s", status)
+	} else {
+		err = fmt.Errorf("HTTP %s: %s", status, bodyText)
 	}
-	return fmt.Errorf("HTTP %s: %s", status, bodyText)
+
+	// Servers ask clients to back off via Retry-After (typically on 429 or
+	// 503). Thread that hint out as a typed transient error so the retry
+	// layer can honor it as a floor instead of hammering with fixed backoff.
+	if isRetryableStatus(resp.StatusCode) {
+		if d, ok := parseRetryAfter(resp.Header.Get("Retry-After"), time.Now()); ok {
+			return &retry.TransientError{Err: err, RetryAfter: d}
+		}
+	}
+	return err
+}
+
+// isRetryableStatus reports whether an HTTP status is worth retrying and may
+// carry a Retry-After hint.
+func isRetryableStatus(code int) bool {
+	switch code {
+	case http.StatusRequestTimeout, http.StatusTooEarly, http.StatusTooManyRequests:
+		return true
+	}
+	return code >= 500
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value, which is either a
+// non-negative delay in seconds or an HTTP-date. It returns the delay relative
+// to now, clamped to be non-negative, and whether the value was understood.
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(value); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		if d := t.Sub(now); d > 0 {
+			return d, true
+		}
+		return 0, true
+	}
+	return 0, false
 }
 
 func normalizeETag(etag string) string {

--- a/internal/caldav/multiget.go
+++ b/internal/caldav/multiget.go
@@ -54,7 +54,7 @@ func (c *Client) MultiGetTolerant(ctx context.Context, calendarPath string, href
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusMultiStatus && resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("REPORT calendar-multiget: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("REPORT calendar-multiget: %w", httpError(resp))
 	}
 
 	var ms multiGetMultiStatus

--- a/internal/caldav/retry_after_test.go
+++ b/internal/caldav/retry_after_test.go
@@ -1,0 +1,82 @@
+package caldav
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/retry"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+		ok    bool
+	}{
+		{name: "seconds", value: "30", want: 30 * time.Second, ok: true},
+		{name: "zero seconds", value: "0", want: 0, ok: true},
+		{name: "whitespace", value: "  15 ", want: 15 * time.Second, ok: true},
+		{name: "http date future", value: now.Add(45 * time.Second).UTC().Format(http.TimeFormat), want: 45 * time.Second, ok: true},
+		{name: "http date past", value: now.Add(-time.Minute).UTC().Format(http.TimeFormat), want: 0, ok: true},
+		{name: "empty", value: "", want: 0, ok: false},
+		{name: "negative", value: "-5", want: 0, ok: false},
+		{name: "garbage", value: "soon", want: 0, ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseRetryAfter(tt.value, now)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("parseRetryAfter(%q) = (%v, %v), want (%v, %v)", tt.value, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestHTTPErrorThreadsRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Status:     "429 Too Many Requests",
+		Header:     http.Header{"Retry-After": {"30"}},
+	}
+	err := httpError(resp)
+
+	if !retry.IsTransient(err) {
+		t.Fatalf("httpError(429) not classified transient: %v", err)
+	}
+	var te *retry.TransientError
+	if !errors.As(err, &te) {
+		t.Fatalf("httpError(429 + Retry-After) = %T, want *retry.TransientError", err)
+	}
+	if te.RetryAfter != 30*time.Second {
+		t.Fatalf("RetryAfter = %v, want 30s", te.RetryAfter)
+	}
+}
+
+func TestHTTPErrorNoRetryAfterStaysPlain(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     "503 Service Unavailable",
+		Header:     http.Header{},
+	}
+	err := httpError(resp)
+
+	var te *retry.TransientError
+	if errors.As(err, &te) {
+		t.Fatalf("httpError(503 without Retry-After) wrapped as TransientError unexpectedly")
+	}
+	// Still retryable via status-code classification.
+	if !retry.IsTransient(err) {
+		t.Fatalf("httpError(503) should still be transient: %v", err)
+	}
+}

--- a/internal/caldav/sync_collection.go
+++ b/internal/caldav/sync_collection.go
@@ -94,7 +94,7 @@ func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncTo
 		// should fall back to a full QueryAll.
 		return nil, ErrSyncCollectionUnsupported
 	default:
-		return nil, fmt.Errorf("REPORT sync-collection: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("REPORT sync-collection: %w", httpError(resp))
 	}
 
 	var ms syncCollectionMultiStatus

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -31,6 +31,11 @@ func Retry[T any](ctx context.Context, opts RetryOptions, fn func(context.Contex
 		}
 
 		delay := retryDelay(opts, attempt-1)
+		// Honor a server-requested Retry-After as a floor: never retry
+		// sooner than the server asked, even if it exceeds MaxDelay.
+		if floor := retryAfter(err); floor > delay {
+			delay = floor
+		}
 		select {
 		case <-time.After(delay):
 		case <-ctx.Done():

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestRetryRetriesTransientErrors(t *testing.T) {
@@ -46,5 +47,42 @@ func TestRetryStopsOnNonTransientError(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Fatalf("Retry attempts = %d, want 1", attempts)
+	}
+}
+
+func TestRetryHonorsRetryAfterAsFloor(t *testing.T) {
+	t.Parallel()
+
+	const retryAfter = 60 * time.Millisecond
+	attempts := 0
+	start := time.Now()
+	_, err := Retry(context.Background(), RetryOptions{
+		MaxAttempts: 2,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    time.Millisecond,
+	}, func(ctx context.Context) (string, error) {
+		attempts++
+		if attempts == 1 {
+			return "", &TransientError{
+				Err:        errors.New("429 Too Many Requests"),
+				RetryAfter: retryAfter,
+			}
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < retryAfter {
+		t.Fatalf("Retry waited %v, want >= %v (Retry-After floor ignored)", elapsed, retryAfter)
+	}
+}
+
+func TestTransientErrorIsTransient(t *testing.T) {
+	t.Parallel()
+
+	err := &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: time.Second}
+	if !IsTransient(err) {
+		t.Fatalf("IsTransient(TransientError) = false, want true")
 	}
 }

--- a/internal/retry/transient.go
+++ b/internal/retry/transient.go
@@ -6,14 +6,51 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var httpStatusPattern = regexp.MustCompile(`\b([1-5][0-9][0-9])\b`)
+
+// TransientError marks an error as retryable and optionally carries a
+// server-requested minimum delay before the next attempt, such as the value
+// of an HTTP Retry-After header on a 429 or 503 response. A zero RetryAfter
+// means the server gave no hint and normal exponential backoff applies.
+type TransientError struct {
+	Err        error
+	RetryAfter time.Duration
+}
+
+func (e *TransientError) Error() string {
+	if e == nil || e.Err == nil {
+		return "transient error"
+	}
+	return e.Err.Error()
+}
+
+func (e *TransientError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// retryAfter returns the server-requested minimum delay carried by err, if any.
+func retryAfter(err error) time.Duration {
+	var te *TransientError
+	if errors.As(err, &te) && te.RetryAfter > 0 {
+		return te.RetryAfter
+	}
+	return 0
+}
 
 // IsTransient reports whether err is worth retrying.
 func IsTransient(err error) bool {
 	if err == nil {
 		return false
+	}
+	var te *TransientError
+	if errors.As(err, &te) {
+		return true
 	}
 	if errors.Is(err, context.Canceled) {
 		return false


### PR DESCRIPTION
Fixes #105

## Root cause
429 and 5xx responses were classified transient and retried with exponential full-jitter backoff capped at `MaxDelay` (default 2s). The server's `Retry-After` header never reached the retry logic because only the stringified error was available downstream (`caldav/httpError` dropped response headers). Google/Fastmail return `429` with `Retry-After: 30`, so the client retried ~3 times within seconds, ignoring the requested delay and likely extending the rate-limit window.

## Fix
- Add a typed `retry.TransientError` carrying an optional `RetryAfter` duration. `IsTransient` recognizes it, and the retry loop honors `RetryAfter` as a **floor** — it never retries sooner than the server asked, even when that exceeds `MaxDelay`. Cancellation via `ctx.Done()` is preserved.
- `caldav.httpError` parses `Retry-After` (delta-seconds or HTTP-date) and wraps the error as a `TransientError` for retryable statuses (408/425/429/5xx).
- Route the `sync-collection` and `calendar-multiget` non-2xx error paths through `httpError` so those retried REPORTs carry the hint too.

## Tests
- `TestParseRetryAfter`: delta-seconds, whitespace, future/past HTTP-date, empty, negative, garbage.
- `TestHTTPErrorThreadsRetryAfter` / `TestHTTPErrorNoRetryAfterStaysPlain`: `httpError` wraps a 429+`Retry-After` as `TransientError` with the right delay, and a 503 without the header stays a plain (but still transient) error.
- `TestRetryHonorsRetryAfterAsFloor`: the retry loop waits at least the requested `Retry-After` even with `MaxDelay` set to 1ms (fails before the fix).
- `TestTransientErrorIsTransient`: `IsTransient` recognizes the typed error.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
