### PR TITLE
fix(cmd): make sync reset fail loudly on unknown or local-only calendar

### DIFF
--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -319,18 +319,34 @@ This does not delete your local calendars or entries.`,
 				return err
 			}
 
+			var nameFound, connected, failed int
 			for _, c := range cals {
 				if calendarName != "" && c.Name != calendarName {
 					continue
 				}
+				nameFound++
 				if c.AccountID == 0 {
 					continue
 				}
+				connected++
 				if err := svc.ResetCalendar(ctx, c.ID); err != nil {
+					failed++
 					fmt.Fprintf(os.Stderr, "reset %s: %s\n", safeText(c.Name), safeText(err.Error()))
 					continue
 				}
 				fmt.Printf("Reset sync state for %q\n", safeText(c.Name))
+			}
+
+			if calendarName != "" {
+				if nameFound == 0 {
+					return &cliError{Code: "not_found", Msg: fmt.Sprintf("calendar %q not found", calendarName)}
+				}
+				if connected == 0 {
+					return &cliError{Code: "invalid_input", Msg: fmt.Sprintf("calendar %q is not connected to a remote; no sync state to reset", calendarName)}
+				}
+			}
+			if failed > 0 {
+				return &cliError{Code: "error", Msg: fmt.Sprintf("failed to reset %d calendar(s)", failed)}
 			}
 			return nil
 		},

--- a/cmd/chroncal/sync_reset_cli_test.go
+++ b/cmd/chroncal/sync_reset_cli_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A typo'd / non-existent calendar name must fail loudly rather than
+// silently exiting 0, so the user knows nothing was reset.
+func TestSyncResetUnknownCalendarFails(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	_, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "Wrok")
+	if err == nil {
+		t.Fatalf("sync reset with unknown calendar exited 0; want non-zero. stderr=%q", stderr)
+	}
+	if !strings.Contains(strings.ToLower(stderr), "not found") {
+		t.Fatalf("sync reset stderr = %q, want a not-found message", stderr)
+	}
+}
+
+// A calendar that exists but is local-only (not connected to a remote)
+// has no sync state to reset; the command must say so instead of a
+// silent no-op.
+func TestSyncResetLocalOnlyCalendarReportsNotConnected(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	_, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "Work")
+	if err == nil {
+		t.Fatalf("sync reset on local-only calendar exited 0; want non-zero. stderr=%q", stderr)
+	}
+	if !strings.Contains(strings.ToLower(stderr), "not connected") {
+		t.Fatalf("sync reset stderr = %q, want a not-connected message", stderr)
+	}
+}


### PR DESCRIPTION
Fixes #113

## Root cause
`syncResetCmd` looped over calendars, `continue`-ing past names that
didn't match `--calendar` and past calendars with `AccountID == 0`
(local-only / not connected), without ever tracking whether anything
matched. A typo'd or local-only calendar name therefore produced a
successful, silent no-op — the user believed sync state was reset.

## Fix
Track `nameFound` / `connected` / `failed` counts. When `--calendar`
is supplied:
- no calendar matches the name → `not_found` cliError (exit 1)
- the name matches but the calendar isn't connected to a remote →
  `invalid_input` cliError with a clear "not connected" message (exit 1)

A reset that errors on a connected calendar now also yields a non-zero
exit instead of only logging to stderr.

## Test coverage
`cmd/chroncal/sync_reset_cli_test.go` adds two CLI-level tests that run
the real binary via the helper-process harness:
- `TestSyncResetUnknownCalendarFails` — typo'd name exits non-zero with
  a "not found" message.
- `TestSyncResetLocalOnlyCalendarReportsNotConnected` — local-only
  calendar exits non-zero with a "not connected" message.

Both failed before the fix (exit 0, empty stderr) and pass after.
