### PR TITLE
fix(tui): block empty/zero recurrence count from persisting invalid RRULE

### DIFF
--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -281,6 +281,7 @@ func NewEventFormModel(day time.Time, calendars map[int64]CalendarInfo, theme Th
 	m.endsCountField.SetCharLimit(4)
 	m.endsCountField.SetDigitsOnly()
 	m.endsCountField.suffix = "times"
+	m.endsCountField.SetValidate(validatePositiveInt)
 
 	if len(calOpts) > 1 {
 		calSelectOpts := make([]SelectOption, len(calOpts))

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -279,6 +279,20 @@ func TestEventForm_MouseWheelScrollSurvivesRender(t *testing.T) {
 	assert.Contains(t, out, "↑ more")
 }
 
+func TestEventForm_EndsAfterBlocksEmptyAndZeroCount(t *testing.T) {
+	for _, count := range []string{"", "0"} {
+		m, _ := NewEventFormModel(time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), testEventFormCalendars(), Theme{})
+		m.titleField.SetValue("Standup")
+		m.repeatField.SetSelected(1) // a recurring preset
+		m.endsField.SetSelected(int(endsAfter))
+		m.rebuildDialog() // rebuild items so the count field is present
+		m.endsCountField.SetValue(count)
+
+		_, valid := m.form.validate()
+		assert.Falsef(t, valid, "Ends=After with count %q must block submit", count)
+	}
+}
+
 func TestEventForm_SaveIncludesShowAsAndVisibility(t *testing.T) {
 	m, _ := NewEventFormModel(time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), testEventFormCalendars(), Theme{})
 	m.titleField.SetValue("Planning")

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -45,6 +45,7 @@ type TextField struct {
 	suffix   string
 	disabled bool
 	dimStyle lipgloss.Style
+	validate func(string) string
 }
 
 func NewTextField(placeholder string) *TextField {
@@ -76,6 +77,21 @@ func (f *TextField) SetCharLimit(n int)      { f.input.CharLimit = n }
 func (f *TextField) Position() int           { return f.input.Position() }
 func (f *TextField) SetCursor(pos int)       { f.input.SetCursor(pos) }
 func (f *TextField) SetSuffix(s string)      { f.suffix = s }
+
+// SetValidate installs a validation hook run by Form.validate before
+// submit. The hook receives the trimmed field value and returns an error
+// message, or "" when the value is acceptable. When no hook is set the
+// field always validates.
+func (f *TextField) SetValidate(fn func(string) string) { f.validate = fn }
+
+// Validate implements the validator interface. It delegates to the hook
+// installed via SetValidate, returning "" (valid) when none is set.
+func (f *TextField) Validate() string {
+	if f.validate == nil {
+		return ""
+	}
+	return f.validate(strings.TrimSpace(f.input.Value()))
+}
 
 // SetFilter sets a function that gates printable keystrokes. When set, a key
 // with non-empty Text is forwarded to the underlying input only if fn returns
@@ -538,7 +554,14 @@ func (f *QuantitySelectField) HandleClickTarget(target string) tea.Cmd {
 }
 
 func (f *QuantitySelectField) Validate() string {
-	raw := strings.TrimSpace(f.amount.Value())
+	return validatePositiveInt(strings.TrimSpace(f.amount.Value()))
+}
+
+// validatePositiveInt reports an error message when raw is not a whole
+// number greater than zero, or "" when it is. Shared by the quantity
+// field and the recurrence "Ends: After N times" count fields so an
+// empty or zero count can never persist an unbounded or invalid RRULE.
+func validatePositiveInt(raw string) string {
 	n, err := strconv.Atoi(raw)
 	if err != nil {
 		return "Value must be a whole number"

--- a/internal/tui/recurrence_editor.go
+++ b/internal/tui/recurrence_editor.go
@@ -84,6 +84,7 @@ func NewRecurrenceEditorModel(startDate time.Time, w, h int, theme Theme) Recurr
 	endsCountField.SetDigitsOnly()
 	endsCountField.SetSuffix("times")
 	endsCountField.SetValue("1")
+	endsCountField.SetValidate(validatePositiveInt)
 
 	m := RecurrenceEditorModel{
 		startDate:      startDate,

--- a/internal/tui/recurrence_editor_test.go
+++ b/internal/tui/recurrence_editor_test.go
@@ -49,6 +49,18 @@ func TestRecurrenceEditor_EndsAfterIncludesCount(t *testing.T) {
 	assert.Equal(t, "FREQ=WEEKLY;BYDAY=FR;COUNT=10", m.BuildRule())
 }
 
+func TestRecurrenceEditor_EndsAfterBlocksEmptyAndZeroCount(t *testing.T) {
+	for _, count := range []string{"", "0"} {
+		m := NewRecurrenceEditorModel(time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC), 120, 40, Theme{})
+		m.endsField.SetSelected(int(endsAfter))
+		m.syncFromForm() // rebuild items so the count field is present
+		m.endsCountField.SetValue(count)
+
+		_, valid := m.form.validate()
+		assert.Falsef(t, valid, "Ends=After with count %q must block submit", count)
+	}
+}
+
 func TestRecurrenceEditor_MonthlyOnFieldUpdatesRule(t *testing.T) {
 	m := NewRecurrenceEditorModel(time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC), 120, 40, Theme{})
 	m.eachField.SetSelected(2)


### PR DESCRIPTION
Fixes #110

## Root cause
The recurrence "Ends: After N times" count field (`endsCountField`) is
digits-only but had no validator, and the Form's `validate()` path never
checked it. When the user picked Ends=After but left the count blank,
`buildRecurrenceRule`/`BuildRule` omitted `COUNT` entirely, turning the rule
into a never-ending recurrence. Typing `0` produced `...;COUNT=0`, an invalid
RRULE that got persisted.

## Fix
- Add an optional validation hook to `TextField` (`SetValidate` / `Validate`)
  so any text field can opt into Form-level validation, returning "" (valid)
  when no hook is set — other text fields are unaffected.
- Extract the positive-integer check into a shared `validatePositiveInt`
  helper, reused by `QuantitySelectField.Validate`.
- Wire `validatePositiveInt` into both count fields (event form and recurrence
  editor). `Form.validate()` (on the submit path via `submitIfValid`) now
  blocks submit with "Value must be greater than 0" / "Value must be a whole
  number" before the rule is built or persisted.

## Tests
- `TestRecurrenceEditor_EndsAfterBlocksEmptyAndZeroCount` and
  `TestEventForm_EndsAfterBlocksEmptyAndZeroCount` assert that, with
  Ends=After and the count set to `""` or `"0"`, `form.validate()` returns
  `valid == false`. Both fail before the fix and pass after.
- `make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` are all green.

Assisted-by: Claude Code:claude-opus-4-8
