### PR TITLE
fix(ical): preserve commas inside category values on round-trip

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -676,7 +676,7 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 	}
 
 	e := fromStorage(r)
-	e.Categories = strings.Join(carriedCats, ",")
+	e.Categories = timeutil.JoinCategoryList(carriedCats)
 	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
 	return e, nil
 }
@@ -857,7 +857,7 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 	}
 
 	e := fromStorage(r)
-	e.Categories = strings.Join(carriedCats, ",")
+	e.Categories = timeutil.JoinCategoryList(carriedCats)
 	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
 	_ = storage.MarkResourceDirty(ctx, s.db, p.CalendarID, newUID, "event")
 	return e, nil
@@ -1594,7 +1594,7 @@ func (s *Service) populateSingleCategories(ctx context.Context, e *Event) {
 		log.Printf("populateSingleCategories failed for event %d: %v", e.ID, err)
 		return
 	}
-	e.Categories = strings.Join(cats, ",")
+	e.Categories = timeutil.JoinCategoryList(cats)
 }
 
 func (s *Service) populateCategories(ctx context.Context, events []Event) {
@@ -1616,7 +1616,7 @@ func (s *Service) populateCategories(ctx context.Context, events []Event) {
 	}
 	for i := range events {
 		if cats, ok := catMap[events[i].ID]; ok {
-			events[i].Categories = strings.Join(cats, ",")
+			events[i].Categories = timeutil.JoinCategoryList(cats)
 		}
 	}
 }

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -99,7 +99,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 			// SetTextList handles escaping within individual values and
 			// uses unescaped commas as separators per RFC 5545 Section 3.8.1.2.
 			catProp := &ical.Prop{Name: ical.PropCategories}
-			catProp.SetTextList(strings.Split(e.Categories, ","))
+			catProp.SetTextList(e.ParseCategories())
 			vevent.Props.Set(catProp)
 		}
 
@@ -432,7 +432,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 
 		if t.Categories != "" {
 			catProp := &ical.Prop{Name: ical.PropCategories}
-			catProp.SetTextList(strings.Split(t.Categories, ","))
+			catProp.SetTextList(t.ParseCategories())
 			vtodo.Props.Set(catProp)
 		}
 
@@ -1018,7 +1018,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 
 		if j.Categories != "" {
 			catProp := &ical.Prop{Name: ical.PropCategories}
-			catProp.SetTextList(strings.Split(j.Categories, ","))
+			catProp.SetTextList(j.ParseCategories())
 			vjournal.Props.Set(catProp)
 		}
 

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -19,6 +19,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/freebusy"
 	"github.com/douglasdemoura/chroncal/internal/journal"
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
@@ -533,14 +534,13 @@ func parseCategories(ve ical.Event) string {
 		// handling both RFC-correct "CATEGORIES:a,b" and legacy
 		// escaped "CATEGORIES:a\,b" inputs.
 		if list, err := prop.TextList(); err == nil {
-			for _, s := range list {
-				if s = strings.TrimSpace(s); s != "" {
-					cats = append(cats, s)
-				}
-			}
+			cats = append(cats, list...)
 		}
 	}
-	return strings.Join(cats, ",")
+	// Join with comma-escaping so a category value that itself contains a
+	// comma (e.g. "Foo, Bar") stays a single value through the in-memory
+	// comma-joined representation instead of fragmenting on round-trip.
+	return timeutil.JoinCategoryList(cats)
 }
 
 // parseAlarm extracts a model.Alarm from a VALARM component.
@@ -713,14 +713,10 @@ func parseCategoriesFromProps(props ical.Props) string {
 	var cats []string
 	for _, prop := range props.Values(ical.PropCategories) {
 		if list, err := prop.TextList(); err == nil {
-			for _, s := range list {
-				if s = strings.TrimSpace(s); s != "" {
-					cats = append(cats, s)
-				}
-			}
+			cats = append(cats, list...)
 		}
 	}
-	return strings.Join(cats, ",")
+	return timeutil.JoinCategoryList(cats)
 }
 
 func parseDateListFromProps(props ical.Props, propName string) string {

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -2204,3 +2204,53 @@ func TestRoundtrip_Journal(t *testing.T) {
 		}
 	}
 }
+
+// TestRoundtrip_CategoryWithEmbeddedComma guards against fragmenting a single
+// CATEGORIES value that legitimately contains a comma (issue #101). A category
+// like "Foo, Bar" must survive import -> store -> export -> import as one value,
+// not be split into two categories on every round-trip.
+func TestRoundtrip_CategoryWithEmbeddedComma(t *testing.T) {
+	t.Parallel()
+	const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:cat-comma
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T140000Z
+DTEND:20260401T150000Z
+SUMMARY:Comma Category
+CATEGORIES:Foo\, Bar,Baz
+END:VEVENT
+END:VCALENDAR`
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("imported %d events, want 1", len(result.Events))
+	}
+	if got := result.Events[0].ParseCategories(); len(got) != 2 ||
+		got[0] != "Foo, Bar" || got[1] != "Baz" {
+		t.Fatalf("imported categories = %v, want [\"Foo, Bar\" \"Baz\"]", got)
+	}
+
+	// Round-trip through export and re-import: the comma-bearing category must
+	// still be a single value.
+	data, err := ExportEvents(result.Events, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	reimported, err := ImportFile(strings.NewReader(string(data)))
+	if err != nil {
+		t.Fatalf("reimport: %v", err)
+	}
+	if len(reimported.Events) != 1 {
+		t.Fatalf("reimported %d events, want 1", len(reimported.Events))
+	}
+	got := reimported.Events[0].ParseCategories()
+	if len(got) != 2 || got[0] != "Foo, Bar" || got[1] != "Baz" {
+		t.Fatalf("round-tripped categories = %v, want [\"Foo, Bar\" \"Baz\"]", got)
+	}
+}

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -752,7 +752,7 @@ func (s *Service) populateSingleCategories(ctx context.Context, j *Journal) {
 	for i, r := range rows {
 		cats[i] = r.Category
 	}
-	j.Categories = strings.Join(cats, ",")
+	j.Categories = timeutil.JoinCategoryList(cats)
 }
 
 func (s *Service) populateCategories(ctx context.Context, journals []Journal) {
@@ -773,7 +773,7 @@ func (s *Service) populateCategories(ctx context.Context, journals []Journal) {
 	}
 	for i := range journals {
 		if cats, ok := catMap[journals[i].ID]; ok {
-			journals[i].Categories = strings.Join(cats, ",")
+			journals[i].Categories = timeutil.JoinCategoryList(cats)
 		}
 	}
 }

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -368,7 +368,7 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 				}
 				for i := range results {
 					if c, ok := catMap[results[i].ID]; ok {
-						results[i].Categories = strings.Join(c, ",")
+						results[i].Categories = timeutil.JoinCategoryList(c)
 					}
 				}
 			}
@@ -660,7 +660,7 @@ func (s *Service) populateEventCategories(ctx context.Context, events []event.Ev
 	}
 	for i := range events {
 		if cats, ok := catMap[events[i].ID]; ok {
-			events[i].Categories = strings.Join(cats, ",")
+			events[i].Categories = timeutil.JoinCategoryList(cats)
 		}
 	}
 }
@@ -683,7 +683,7 @@ func (s *Service) populateTodoCategories(ctx context.Context, todos []todo.Todo)
 	}
 	for i := range todos {
 		if cats, ok := catMap[todos[i].ID]; ok {
-			todos[i].Categories = strings.Join(cats, ",")
+			todos[i].Categories = timeutil.JoinCategoryList(cats)
 		}
 	}
 }
@@ -1115,7 +1115,7 @@ func (s *Service) populateJournalCategories(ctx context.Context, journals []jour
 	}
 	for i := range journals {
 		if cats, ok := catMap[journals[i].ID]; ok {
-			journals[i].Categories = strings.Join(cats, ",")
+			journals[i].Categories = timeutil.JoinCategoryList(cats)
 		}
 	}
 }

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -116,17 +116,64 @@ func SerializeTimeList(times []time.Time) string {
 	return strings.Join(parts, ",")
 }
 
-// ParseCategoryList splits a comma-separated string into trimmed non-empty values.
+// JoinCategoryList joins category values into a single comma-separated string,
+// backslash-escaping any backslash or comma inside an individual value so the
+// result is an exact inverse of ParseCategoryList. This keeps a category that
+// legitimately contains a comma (e.g. "Foo, Bar") as one value across the
+// in-memory comma-joined representation. Empty/whitespace-only values are
+// dropped.
+func JoinCategoryList(cats []string) string {
+	parts := make([]string, 0, len(cats))
+	for _, c := range cats {
+		if c = strings.TrimSpace(c); c != "" {
+			parts = append(parts, escapeCategory(c))
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+func escapeCategory(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, ",", `\,`)
+	return s
+}
+
+// ParseCategoryList splits a comma-separated string produced by
+// JoinCategoryList into trimmed non-empty values. Commas escaped as "\," are
+// treated as part of a value rather than separators, and "\\" decodes to a
+// single backslash.
 func ParseCategoryList(s string) []string {
 	if s == "" {
 		return nil
 	}
-	parts := strings.Split(s, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if v := strings.TrimSpace(p); v != "" {
+	var (
+		out     []string
+		b       strings.Builder
+		escaped bool
+	)
+	flush := func() {
+		if v := strings.TrimSpace(b.String()); v != "" {
 			out = append(out, v)
 		}
+		b.Reset()
 	}
+	for _, r := range s {
+		switch {
+		case escaped:
+			b.WriteRune(r)
+			escaped = false
+		case r == '\\':
+			escaped = true
+		case r == ',':
+			flush()
+		default:
+			b.WriteRune(r)
+		}
+	}
+	if escaped {
+		// Trailing lone backslash: preserve it literally.
+		b.WriteByte('\\')
+	}
+	flush()
 	return out
 }

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -1,0 +1,74 @@
+package timeutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCategoryListRoundtrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cats []string
+	}{
+		{"plain", []string{"work", "meeting", "urgent"}},
+		{"embedded comma", []string{"Foo, Bar", "Baz"}},
+		{"embedded backslash", []string{`a\b`, "c"}},
+		{"comma and backslash", []string{`x\, y`, "z"}},
+		{"only comma value", []string{"a,b,c"}},
+		{"empty", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ParseCategoryList(JoinCategoryList(tc.cats))
+			if len(tc.cats) == 0 {
+				if len(got) != 0 {
+					t.Fatalf("got %v, want empty", got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.cats) {
+				t.Fatalf("round-trip = %v, want %v", got, tc.cats)
+			}
+		})
+	}
+}
+
+func TestParseCategoryList_LegacyAndEdgeCases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"a,b", []string{"a", "b"}},
+		{" a , b ", []string{"a", "b"}},      // trimmed
+		{"a,,b", []string{"a", "b"}},         // empty segment dropped
+		{`Foo\, Bar`, []string{"Foo, Bar"}},  // escaped comma kept
+		{`a\\b`, []string{`a\b`}},            // escaped backslash decoded
+		{`trailing\`, []string{`trailing\`}}, // lone trailing backslash preserved
+	}
+	for _, tc := range cases {
+		got := ParseCategoryList(tc.in)
+		if len(tc.want) == 0 {
+			if len(got) != 0 {
+				t.Errorf("ParseCategoryList(%q) = %v, want empty", tc.in, got)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("ParseCategoryList(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestJoinCategoryList_EscapesAndDropsEmpty(t *testing.T) {
+	t.Parallel()
+	if got := JoinCategoryList([]string{"Foo, Bar", "Baz"}); got != `Foo\, Bar,Baz` {
+		t.Errorf("JoinCategoryList = %q, want %q", got, `Foo\, Bar,Baz`)
+	}
+	if got := JoinCategoryList([]string{"a", "  ", "", "b"}); got != "a,b" {
+		t.Errorf("JoinCategoryList dropped-empty = %q, want %q", got, "a,b")
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -1246,7 +1246,7 @@ func (s *Service) populateSingleCategories(ctx context.Context, t *Todo) {
 	for j, r := range rows {
 		cats[j] = r.Category
 	}
-	t.Categories = strings.Join(cats, ",")
+	t.Categories = timeutil.JoinCategoryList(cats)
 }
 
 func (s *Service) populateCategories(ctx context.Context, todos []Todo) {
@@ -1267,7 +1267,7 @@ func (s *Service) populateCategories(ctx context.Context, todos []Todo) {
 	}
 	for i := range todos {
 		if cats, ok := catMap[todos[i].ID]; ok {
-			todos[i].Categories = strings.Join(cats, ",")
+			todos[i].Categories = timeutil.JoinCategoryList(cats)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #101

## Root cause
A single `CATEGORIES` value containing a comma (e.g. `Foo, Bar`) was silently fragmented into multiple categories on every round-trip. Import used `prop.TextList()`, which correctly unescapes `\,` into one value, but the per-domain `Categories string` then joined all categories with a plain comma. Export (and the storage layer) split that field on **every** comma, so an embedded comma was indistinguishable from a separator: `CATEGORIES:Foo\, Bar` imported as one category, was stored/joined as `"Foo, Bar"`, and re-exported as two categories.

## Fix
Make the comma-joined `Categories` representation lossless by adding a matched escape-aware pair in `internal/timeutil`:
- `JoinCategoryList` backslash-escapes commas and backslashes inside each value and drops empties.
- `ParseCategoryList` is rewritten as its exact inverse (splits on unescaped commas, decodes `\,` and `\\`).

Every category **join** site (event/todo/journal/recurrence services and ical import) now goes through `JoinCategoryList`, and the ical export **split** sites reuse the existing `Event/Todo/Journal.ParseCategories()` accessors (which delegate to `ParseCategoryList`). The DB continues to store clean per-row category values, so search/FTS is unaffected — only the transient joined string carries escapes.

Tradeoff (the approach the issue suggested): a category that literally contains a comma or backslash now shows its escaped form in transient JSON/TUI display. The common no-special-character case is byte-for-byte unchanged.

## Test coverage
- New `TestRoundtrip_CategoryWithEmbeddedComma` in `internal/ical/roundtrip_test.go`: imports `CATEGORIES:Foo\, Bar,Baz`, asserts two categories, then exports and re-imports asserting the comma-bearing category stays a single value. Fails on `master` (`[Foo Bar Baz]`), passes with the fix.
- New `internal/timeutil/timeutil_test.go`: round-trip and edge-case tests for the `JoinCategoryList`/`ParseCategoryList` inverse pair (embedded commas, backslashes, legacy escaped input, trimming, empty segments).

Verification: `make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.
