### PR TITLE
fix(cmd): reject numeric ID combined with --recurrence-id

### DIFF
--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -290,6 +290,15 @@ func resolveRef[T any](
 	var v T
 	var err error
 	if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
+		// A numeric ref addresses a single row by its unique ID. A
+		// recurrence-id can only narrow a UID to one instance, so pairing it
+		// with an ID is contradictory: honoring the ID would silently drop the
+		// recurrence-id (and, for delete/update, act on the master while the
+		// prompt claims to touch one occurrence). Reject instead of guessing.
+		// To target an override by recurrence-id, pass the series UID. See #114.
+		if recurrenceID != "" {
+			return v, errInvalidInputf("--recurrence-id cannot be combined with a numeric %s ID %q; use the series UID to address an override instance", kind, ref)
+		}
 		v, err = getByID(ctx, id)
 	} else if recurrenceID != "" {
 		v, err = getByUIDAndRecurrenceID(ctx, ref, recurrenceID)

--- a/cmd/chroncal/resolve_ref_test.go
+++ b/cmd/chroncal/resolve_ref_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// When a reference is a numeric ID, the master row is resolved directly and a
+// non-empty --recurrence-id cannot be honored (IDs are unique per row, so the
+// override would have to be addressed by its own ID). Silently dropping the
+// recurrence-id let `event delete 42 --recurrence-id ...` render an
+// override-specific confirm prompt and then soft-delete the master. Reject the
+// combination instead. See issue #114.
+func TestResolveRefNumericWithRecurrenceIDRejected(t *testing.T) {
+	idCalled := false
+	getByID := func(context.Context, int64) (int, error) {
+		idCalled = true
+		return 42, nil
+	}
+	getByUID := func(context.Context, string) (int, error) {
+		t.Fatalf("getByUID should not be called for a numeric ref")
+		return 0, nil
+	}
+	getByUIDAndRecurrenceID := func(context.Context, string, string) (int, error) {
+		t.Fatalf("getByUIDAndRecurrenceID should not be called for a numeric ref")
+		return 0, nil
+	}
+
+	_, err := resolveRef(context.Background(), "42", "2026-04-07T12:00:00Z", "event",
+		getByID, getByUID, getByUIDAndRecurrenceID)
+	if err == nil {
+		t.Fatalf("expected error for numeric ref + recurrence-id, got nil")
+	}
+	if idCalled {
+		t.Fatalf("getByID must not resolve the master when recurrence-id is set")
+	}
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "invalid_input" {
+		t.Fatalf("expected invalid_input cliError, got %#v", err)
+	}
+}
+
+// A numeric ID with no recurrence-id still resolves the master row directly.
+func TestResolveRefNumericWithoutRecurrenceID(t *testing.T) {
+	getByID := func(context.Context, int64) (int, error) { return 42, nil }
+	fail2 := func(context.Context, string) (int, error) {
+		t.Fatalf("getByUID should not be called for a numeric ref")
+		return 0, nil
+	}
+	fail3 := func(context.Context, string, string) (int, error) {
+		t.Fatalf("getByUIDAndRecurrenceID should not be called for a numeric ref")
+		return 0, nil
+	}
+
+	got, err := resolveRef(context.Background(), "42", "", "event", getByID, fail2, fail3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+}


### PR DESCRIPTION
Fixes #114

## Root cause
`resolveRef` (in `cmd/chroncal/main.go`) parsed any integer reference via
`getByID` and ignored a non-empty `--recurrence-id`. For
`chroncal event delete 42 --recurrence-id 2026-04-07T12:00:00Z` (42 = master),
the delete command's confirm text still branched on `recurrenceID != ""` and
claimed to delete a single override instance, but `Delete(ctx, e.ID)` then
soft-deleted the master row. The same silent-ignore affected `update`/`get`
and `todo complete`.

## Fix
When a reference parses as a numeric ID and `--recurrence-id` is set, return an
`invalid_input` error before any lookup or prompt rendering, instead of
silently dropping the recurrence-id. A numeric ID addresses one unique row, so
pairing it with a recurrence-id is contradictory. To target an override, pass
the series UID together with `--recurrence-id`, as before. The fix lives in the
shared resolver, so it covers event/todo/journal get/update/delete and todo
complete uniformly.

## Test coverage
`cmd/chroncal/resolve_ref_test.go`:
- `TestResolveRefNumericWithRecurrenceIDRejected` — numeric ref + recurrence-id
  returns an `invalid_input` `cliError` and never calls any lookup function
  (so the master is never resolved/deleted). Fails on the old code.
- `TestResolveRefNumericWithoutRecurrenceID` — a plain numeric ID still
  resolves the master directly (no regression).

## Verification
`make fmt`, `go vet ./...`, `go test ./internal/... ./cmd/... -count=1` all green.