### PR TITLE
fix(cmd): match sync --calendar case-insensitively

### DIFF
--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -104,17 +104,11 @@ run to a single local calendar.`,
 
 			var results []*syncPkg.SyncResult
 			if calendarName != "" {
-				var calID int64
-				for _, c := range cals {
-					if c.Name == calendarName {
-						calID = c.ID
-						break
-					}
+				target, err := findCalendarByRef(cals, calendarName)
+				if err != nil {
+					return &cliError{Code: "not_found", Msg: err.Error()}
 				}
-				if calID == 0 {
-					return &cliError{Code: "not_found", Msg: fmt.Sprintf("calendar %q not found", calendarName)}
-				}
-				r, err := svc.SyncCalendar(ctx, calID, strategy)
+				r, err := svc.SyncCalendar(ctx, target.ID, strategy)
 				if err != nil {
 					return classifySyncError(err)
 				}
@@ -320,8 +314,19 @@ This does not delete your local calendars or entries.`,
 			}
 
 			var nameFound, connected, failed int
+			// Resolve --calendar the same way every other command does
+			// (by ID or case-insensitive name) so behavior is uniform.
+			var targetID int64
+			if calendarName != "" {
+				target, err := findCalendarByRef(cals, calendarName)
+				if err != nil {
+					return &cliError{Code: "not_found", Msg: err.Error()}
+				}
+				targetID = target.ID
+			}
+
 			for _, c := range cals {
-				if calendarName != "" && c.Name != calendarName {
+				if targetID != 0 && c.ID != targetID {
 					continue
 				}
 				nameFound++

--- a/cmd/chroncal/sync_cli_test.go
+++ b/cmd/chroncal/sync_cli_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSyncResetMatchesCalendarCaseInsensitively guards against issue #112:
+// `sync reset --calendar work` must match a calendar named "Work" the same
+// way every other command's --calendar flag does (case-insensitive,
+// strings.EqualFold). Before the fix the reset loop compared names with ==,
+// so a case-mismatched name silently matched nothing.
+func TestSyncResetMatchesCalendarCaseInsensitively(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	createLinkedCalendarForTest(t, dbPath)
+
+	stdout, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "work")
+	if err != nil {
+		t.Fatalf("sync reset --calendar work: %v (stderr: %s)", err, stderr)
+	}
+	if !strings.Contains(stdout, "Reset sync state") {
+		t.Fatalf("sync reset --calendar work did not reset the %q calendar; stdout = %q", "Work", stdout)
+	}
+}
+
+// TestSyncRunMatchesCalendarCaseInsensitively guards against issue #112:
+// `sync run --calendar work` must resolve a calendar named "Work"
+// case-insensitively. Before the fix the run loop compared names with ==,
+// so it reported `calendar "work" not found`.
+func TestSyncRunMatchesCalendarCaseInsensitively(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	createLinkedCalendarForTest(t, dbPath)
+
+	// The run will still fail downstream (no stored credentials), but it must
+	// not fail with the case-sensitive "not found" resolution error.
+	_, stderr, err := runChroncalCommand(t, "sync", "run", "--calendar", "work")
+	if err == nil {
+		return // resolved and ran; resolution is clearly case-insensitive
+	}
+	if strings.Contains(stderr, `calendar "work" not found`) {
+		t.Fatalf("sync run --calendar work failed to resolve %q case-insensitively; stderr = %q", "Work", stderr)
+	}
+}


### PR DESCRIPTION
Fixes #112

## Root cause
`sync run` (`cmd/chroncal/sync.go:109`) and `sync reset` (`sync.go:323`)
compared calendar names with `c.Name == calendarName` (exact, case-sensitive),
while every other command resolves `--calendar` via `findCalendarByRef` /
`resolveCalendarID` using `strings.EqualFold`. So with a calendar named
"Work", `sync run --calendar work` returned `calendar "work" not found` and
`sync reset --calendar work` silently matched nothing.

## Fix
Route both sites through the existing `findCalendarByRef(cals, ...)` helper,
which matches a calendar by numeric ID or case-insensitive name. `sync reset`
now resolves the target once up front and filters the loop by ID; as a side
benefit it reports "calendar not found" instead of silently doing nothing when
the name is wrong.

## Test coverage
`cmd/chroncal/sync_cli_test.go` adds two CLI-level tests against a connected
"Work" calendar:
- `TestSyncResetMatchesCalendarCaseInsensitively` — `sync reset --calendar work`
  must reset the calendar (prints "Reset sync state"); failed before the fix.
- `TestSyncRunMatchesCalendarCaseInsensitively` — `sync run --calendar work`
  must not fail with the `calendar "work" not found` resolution error.

Both failed before the change for the stated reason and pass after.
`make fmt`, `go vet ./...`, `go test ./internal/... ./cmd/... -count=1` all green.
