### PR TITLE
fix(event): emit DATE-valued UNTIL when truncating all-day recurring series

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -548,7 +548,7 @@ func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTi
 
 	prevRRule := storage.NullableToString(master.RecurrenceRule)
 	until := instanceTime.UTC().Add(-time.Second)
-	rule := setRRuleUntil(prevRRule, until)
+	rule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -776,7 +776,7 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 
 	prevRRule := storage.NullableToString(master.RecurrenceRule)
 	until := instanceTime.UTC().Add(-time.Second)
-	truncatedRule := setRRuleUntil(prevRRule, until)
+	truncatedRule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -864,8 +864,18 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 }
 
 // setRRuleUntil adds or replaces the UNTIL parameter in an RRULE string.
-func setRRuleUntil(rule string, until time.Time) string {
-	untilStr := "UNTIL=" + until.UTC().Format("20060102T150405Z")
+//
+// RFC 5545 requires UNTIL's value type to match DTSTART: a DATE-valued
+// (all-day) series must use a DATE UNTIL (YYYYMMDD), while a DATE-TIME series
+// uses a UTC DATE-TIME (YYYYMMDDTHHMMSSZ). Emitting a DATE-TIME UNTIL on an
+// all-day series produces a type-mismatched RRULE that strict CalDAV servers
+// reject.
+func setRRuleUntil(rule string, until time.Time, allDay bool) string {
+	layout := "20060102T150405Z"
+	if allDay {
+		layout = "20060102"
+	}
+	untilStr := "UNTIL=" + until.UTC().Format(layout)
 	parts := strings.Split(rule, ";")
 	out := parts[:0]
 	for _, p := range parts {

--- a/internal/event/update_scope_test.go
+++ b/internal/event/update_scope_test.go
@@ -202,6 +202,60 @@ func TestUpdateFromInstance_SoftDeletesFutureOverrides(t *testing.T) {
 	}
 }
 
+// Truncating an all-day recurring series must emit a DATE-valued UNTIL
+// (YYYYMMDD) so the RRULE's UNTIL value type matches its DATE-valued DTSTART,
+// as RFC 5545 requires. A DATE-TIME UNTIL on an all-day series is rejected or
+// mis-handled by strict CalDAV servers.
+func TestDeleteFromInstance_AllDayEmitsDateOnlyUntil(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "allday-trunc-1",
+		CalendarID:     1,
+		Title:          "Daily all-day",
+		StartTime:      time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC),
+		AllDay:         true,
+		RecurrenceRule: "FREQ=DAILY",
+	})
+	if err != nil {
+		t.Fatalf("upsert all-day master: %v", err)
+	}
+
+	// Drop the May 20 occurrence and everything after it; May 19 is the last
+	// kept instance.
+	cutoff := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	if err := svc.DeleteFromInstance(ctx, master.UID, cutoff); err != nil {
+		t.Fatalf("DeleteFromInstance: %v", err)
+	}
+
+	fresh, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get truncated master: %v", err)
+	}
+
+	until := rruleParamValue(fresh.RecurrenceRule, "UNTIL")
+	if until == "" {
+		t.Fatalf("expected UNTIL on truncated master, got %q", fresh.RecurrenceRule)
+	}
+	if strings.Contains(until, "T") || strings.Contains(until, "Z") {
+		t.Errorf("all-day series must use DATE UNTIL, got %q in %q", until, fresh.RecurrenceRule)
+	}
+	if until != "20260519" {
+		t.Errorf("UNTIL = %q, want last kept day 20260519", until)
+	}
+}
+
+func rruleParamValue(rule, name string) string {
+	for _, p := range strings.Split(rule, ";") {
+		if strings.HasPrefix(strings.ToUpper(p), name+"=") {
+			return p[len(name)+1:]
+		}
+	}
+	return ""
+}
+
 // Caller is the source of truth for categories. Empty Categories on update
 // means "no categories" — UpdateInstance/UpdateFromInstance no longer inherit
 // from master, so users can clear tags via the form and have it persist.


### PR DESCRIPTION
Fixes #117

## Root cause
`setRRuleUntil` (`internal/event/service.go`) formatted the RRULE `UNTIL`
unconditionally as a DATE-TIME (`YYYYMMDDTHHMMSSZ`). RFC 5545 requires the
`UNTIL` value type to match `DTSTART`, so an all-day (DATE-valued) recurring
series must use a DATE `UNTIL` (`YYYYMMDD`). Truncating an all-day series via
`DeleteFromInstance` or `UpdateFromInstance` ("this and following") therefore
wrote a type-mismatched RRULE like `FREQ=DAILY;UNTIL=20260519T235959Z`, which
strict CalDAV servers reject or mis-handle.

## Fix
Thread the master event's all-day flag into `setRRuleUntil` and pick a
date-only layout (`20060102`) when the series is all-day; DATE-TIME series are
unchanged. Both truncation call sites pass `master.AllDay == 1`.

## Test coverage
`TestDeleteFromInstance_AllDayEmitsDateOnlyUntil` creates an all-day daily
recurring master, truncates it, and asserts the stored RRULE carries a
DATE-only `UNTIL` (`20260519`, the last kept day) with no `T`/`Z`. It fails
before the fix (`UNTIL=20260519T235959Z`) and passes after.

## Verification
`make fmt`, `go vet ./...`, and `go test ./internal/... ./cmd/... -count=1` all
pass.
