### PR TITLE
fix(calendar): roll back keyring on failed re-link transaction

### DIFF
--- a/internal/calendar/remote.go
+++ b/internal/calendar/remote.go
@@ -43,9 +43,6 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 		existing, err := s.q.GetAccount(ctx, cal.AccountID)
 		if err == nil && strings.HasPrefix(existing.Name, hiddenAccountPrefix) {
 			cred.AccountID = existing.ID
-			if err := credStore.Set(cred); err != nil {
-				return fmt.Errorf("store credentials: %w", err)
-			}
 
 			tx, err := s.db.BeginTx(ctx, nil)
 			if err != nil {
@@ -75,7 +72,23 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 			// same save (Update set color_dirty=1), and the next sync's
 			// syncCalendarMetadata reconciles colors with proper dirty-flag
 			// handling. Seeding here would clobber the local edit.
+			//
+			// Capture the prior credential so a failed commit can roll the
+			// keyring back to it; otherwise the account row keeps its old
+			// settings while the keyring holds the new secret -- a mismatch
+			// that breaks the next sync. Write the new credential only after
+			// the DB writes succeed, mirroring the new-account path below.
+			prevCred, prevErr := credStore.Get(existing.ID)
+			if err := credStore.Set(cred); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("store credentials: %w", err)
+			}
 			if err := tx.Commit(); err != nil {
+				if prevErr == nil {
+					_ = credStore.Set(prevCred)
+				} else {
+					_ = credStore.Delete(existing.ID)
+				}
 				return fmt.Errorf("commit remote calendar link: %w", err)
 			}
 			return nil

--- a/internal/calendar/remote_test.go
+++ b/internal/calendar/remote_test.go
@@ -130,6 +130,74 @@ func TestConnect_RelinkDoesNotClobberLocalColorEdit(t *testing.T) {
 	}
 }
 
+func TestConnect_RelinkRestoresCredentialOnTxFailure(t *testing.T) {
+	svc, q, _ := newTestServiceWithDB(t)
+	ctx := context.Background()
+
+	// Calendar 1 is linked to a hidden account whose name differs from the
+	// name Connect will rename it to (hiddenAccountName(1) == "__calendar_1").
+	account, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      "__calendar_99",
+		ServerUrl: "https://example.com",
+		AuthType:  "basic",
+		Username:  "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		ID:        1,
+		AccountID: &account.ID,
+		RemoteUrl: storage.StringToNullable("https://example.com/dav/calendars/work/"),
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+
+	// A second hidden account already owns the name Connect will try to rename
+	// the first account to, so UpdateAccount hits a UNIQUE(name) violation and
+	// the re-link transaction fails after credStore.Set would have run.
+	if _, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      "__calendar_1",
+		ServerUrl: "https://other.example.com",
+		AuthType:  "basic",
+		Username:  "user",
+	}); err != nil {
+		t.Fatalf("CreateAccount (collision): %v", err)
+	}
+
+	// The keyring already holds the old credential for the linked account.
+	store := &memCredStore{}
+	oldCred := auth.Credential{AccountID: account.ID, Username: "user", Password: "old-pass"}
+	if err := store.Set(oldCred); err != nil {
+		t.Fatalf("seed old credential: %v", err)
+	}
+
+	cal, err := svc.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	link := RemoteLink{
+		RemoteURL:     "https://example.com/dav/calendars/work/",
+		Username:      "user",
+		AuthType:      "basic",
+		AllowInsecure: false,
+	}
+	newCred := auth.Credential{Username: "user", Password: "new-pass"}
+
+	if err := svc.Connect(ctx, cal, link, newCred, store); err == nil {
+		t.Fatal("Connect: expected error from UNIQUE(name) collision, got nil")
+	}
+
+	got, err := store.Get(account.ID)
+	if err != nil {
+		t.Fatalf("Get credential after failed Connect: %v", err)
+	}
+	if got.Password != "old-pass" {
+		t.Errorf("stored password = %q, want %q: a failed re-link must not leave the keyring holding the new credential", got.Password, "old-pass")
+	}
+}
+
 func TestConnect_NoRemoteColor_LeavesLocalColor(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #118

## Root cause
`calendar.Service.Connect`'s existing-hidden-account (re-link) branch called
`credStore.Set(cred)` before `BeginTx`, with no compensating delete/restore if
`UpdateAccount`, `LinkCalendarToAccount`, or `tx.Commit` later failed. The
new-account branch already handles this correctly (Set after the DB writes,
Delete on commit failure). When a user edited the remote URL/auth of an
already-linked calendar and the transaction failed to commit, the account row
kept its old server URL/auth while the keyring held the new credential — a
persistent mismatch that can break the next sync.

## Fix
Mirror the new-account path in the re-link branch:
- Move `credStore.Set` to after the in-transaction DB writes succeed, so a
  failed `UpdateAccount`/`LinkCalendarToAccount` rolls back before any keyring
  write.
- Capture the prior credential via `credStore.Get` first; on commit failure,
  restore it (or `Delete` the just-written secret when no prior credential
  existed). Production stores (Keyring, Plaintext) return a not-found error, so
  the absence of a prior credential is detected reliably.

## Test
`TestConnect_RelinkRestoresCredentialOnTxFailure` links calendar 1 to a hidden
account, seeds an old credential, then creates a second account that already
owns the name the re-link will rename to. The rename hits a `UNIQUE(name)`
violation, the transaction fails, and the test asserts the keyring still holds
the old credential. The test fails on the pre-fix code (keyring held the new
secret) and passes after the fix.

Assisted-by: Claude Code:claude-opus-4-8
