### PR TITLE
fix(storage): remove dead lower_unicode SQLite function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ CLI commands live in `cmd/chroncal/`, one file per resource group. Each exports 
 ## Gotchas
 
 ### Database
-- `lower_unicode` is a custom SQLite function registered in `connect.go` for case-insensitive Unicode search. SQL queries reference it directly.
+- Case-insensitive Unicode search goes through FTS5 (`unicode61 remove_diacritics 2` tokenizer); see the `*_fts` virtual tables in `db/migrations/`. There is no custom `lower_unicode` SQLite function — a stale registration that no query referenced was removed. Do not reintroduce `strings.ToLower`-backed folding: it is simple case folding only and would not match the FTS tokenizer's diacritic-insensitive behavior.
 - `backfillAlarmUIDs` in `connect.go` assigns UUIDs to alarms from the pre-UID schema. Runs on every startup, no-ops when all alarms have UIDs.
 - SQLite pragmas set in `connect.go:Open()`: WAL mode, foreign keys ON, 5s busy timeout, synchronous=NORMAL.
 

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -3,30 +3,15 @@ package storage
 import (
 	"context"
 	"database/sql"
-	"database/sql/driver"
 	"fmt"
 	"io/fs"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/pressly/goose/v3"
-	sqlite "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
 
 	"github.com/douglasdemoura/chroncal/db"
 )
-
-func init() {
-	sqlite.MustRegisterFunction("lower_unicode", &sqlite.FunctionImpl{
-		NArgs:         1,
-		Deterministic: true,
-		Scalar: func(ctx *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
-			if s, ok := args[0].(string); ok {
-				return strings.ToLower(s), nil
-			}
-			return args[0], nil
-		},
-	})
-}
 
 func Open(dbPath string) (*sql.DB, *Queries, error) {
 	// Encode pragmas in the DSN so every pooled connection gets them,


### PR DESCRIPTION
Fixes #122

## Root cause
The custom `lower_unicode` SQLite scalar was registered in `internal/storage/connect.go`'s `init()` on every process start, but a repo-wide grep finds zero references to it in any `.sql`, `.sql.go`, or Go file. Case-insensitive Unicode search is handled entirely by FTS5 (`unicode61 remove_diacritics 2` tokenizer in the `*_fts` virtual tables). The registration was dead — harmless at runtime but misleading, since the AGENTS.md note claimed "SQL queries reference it directly." Its `strings.ToLower` backing is also only simple case folding and would not reproduce the FTS tokenizer's diacritic-insensitive behavior if someone reintroduced it.

## Fix
- Remove the `lower_unicode` registration `init()` and its now-unused `database/sql/driver` and `strings` imports.
- Keep `modernc.org/sqlite` as a blank import (`_`) so the `sqlite` database/sql driver is still registered for `sql.Open`.
- Update the stale AGENTS.md "Database" gotcha to describe the FTS5 search path and warn against reintroducing `strings.ToLower`-backed folding.

## Test coverage
No new test is needed — the corrected invariant is already asserted at runtime by the existing case- and diacritic-insensitive search tests (`TestService_Search` in `internal/event`, `internal/todo`, `internal/journal`), e.g. query `CAFÉ` matching `Réunion café`. These exercise diacritic-insensitive matching that only FTS5 provides (not `strings.ToLower`) and pass unchanged after the function is removed, proving search behavior never depended on `lower_unicode`. A dedicated "function is not registered" assertion is not meaningful: modernc/sqlite offers no public lookup and would panic only on a duplicate registration.

## Verification
`make fmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/... -count=1` all green.