### PR TITLE
fix(storage): skip punctuation-only terms in FTSQuery

### DIFF
--- a/internal/storage/fts.go
+++ b/internal/storage/fts.go
@@ -3,20 +3,39 @@ package storage
 import (
 	"context"
 	"strings"
+	"unicode"
 )
+
+// hasFTSToken reports whether w contains at least one character the FTS5
+// unicode61 tokenizer treats as part of a token (a letter or a digit).
+// Tokens made up solely of separators/punctuation produce no tokens once
+// indexed, so quoting them yields an empty MATCH phrase.
+func hasFTSToken(w string) bool {
+	for _, r := range w {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return true
+		}
+	}
+	return false
+}
 
 // FTSQuery converts a user search string into safe FTS5 query syntax.
 // Each word gets quoted and suffixed with * for prefix matching, approximating
 // the old LIKE '%word%' behaviour at token boundaries.
+//
+// Words that carry no FTS-significant characters (e.g. "-" or "!") are
+// skipped: quoting them would emit an empty phrase ("-"*) that FTS5 matches
+// against nothing or rejects as a syntax error. When every word is dropped
+// the result is "", letting the caller bypass FTS entirely.
 func FTSQuery(input string) string {
 	words := strings.Fields(input)
-	if len(words) == 0 {
-		return ""
-	}
-	parts := make([]string, len(words))
-	for i, w := range words {
+	parts := make([]string, 0, len(words))
+	for _, w := range words {
+		if !hasFTSToken(w) {
+			continue
+		}
 		w = strings.ReplaceAll(w, "\"", "\"\"")
-		parts[i] = "\"" + w + "\"" + "*"
+		parts = append(parts, "\""+w+"\""+"*")
 	}
 	return strings.Join(parts, " ")
 }

--- a/internal/storage/fts_test.go
+++ b/internal/storage/fts_test.go
@@ -1,0 +1,53 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFTSQuery_PunctuationOnly(t *testing.T) {
+	// Tokens made up entirely of separator characters carry no
+	// FTS-significant tokens. They must not be emitted as an empty
+	// quoted phrase ("-"*) which FTS5 rejects as a syntax error.
+	cases := []string{"-", "!", "?", "--", "-!?", "   -   ", "''"}
+	for _, in := range cases {
+		if got := FTSQuery(in); got != "" {
+			t.Errorf("FTSQuery(%q) = %q, want \"\"", in, got)
+		}
+	}
+}
+
+func TestFTSQuery_MixedDropsPunctuation(t *testing.T) {
+	// A real word combined with punctuation-only tokens keeps the word.
+	got := FTSQuery("foo - bar")
+	if !strings.Contains(got, "\"foo\"*") || !strings.Contains(got, "\"bar\"*") {
+		t.Errorf("FTSQuery(%q) = %q, want it to contain both words", "foo - bar", got)
+	}
+	if strings.Contains(got, "\"-\"*") {
+		t.Errorf("FTSQuery(%q) = %q, should not contain empty-phrase token", "foo - bar", got)
+	}
+}
+
+// TestFTSQuery_MatchesAgainstFTS5 exercises the produced MATCH expression
+// against a real FTS5 table to ensure it never triggers a syntax error.
+func TestFTSQuery_MatchesAgainstFTS5(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	_ = q
+
+	for _, in := range []string{"-", "!", "-!?", "foo", "foo-bar"} {
+		fts := FTSQuery(in)
+		if fts == "" {
+			// Caller bypasses FTS entirely for empty queries.
+			continue
+		}
+		var rowid int
+		err := db.QueryRow("SELECT rowid FROM events_fts WHERE events_fts MATCH ?", fts).Scan(&rowid)
+		if err != nil && err.Error() != "sql: no rows in result set" {
+			t.Errorf("MATCH for input %q (query %q) errored: %v", in, fts, err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #124

## Root cause
`storage.FTSQuery` quoted every whitespace-separated word and appended `*`
for prefix matching. A word consisting solely of separator/punctuation
characters (e.g. `-`, `!`, `-!?`) became the MATCH phrase `"-"*`. After
unicode61 tokenization that phrase contains no tokens, so FTS5 either
rejects it as a syntax error or matches nothing — surfacing a
punctuation-only search as a failed search rather than a clean empty result.

## Fix
Skip words that contain no FTS-significant character (no Unicode letter or
digit) via a small `hasFTSToken` helper. When every word is dropped,
`FTSQuery` returns `""`. The event, todo, and journal `Search` methods
already treat an empty FTS query as "bypass FTS, return no results", so no
caller changes are needed.

## Tests
`internal/storage/fts_test.go` adds:
- `TestFTSQuery_PunctuationOnly` — punctuation-only inputs return `""`.
- `TestFTSQuery_MixedDropsPunctuation` — a real word mixed with punctuation
  keeps the word and drops the empty-phrase token.
- `TestFTSQuery_MatchesAgainstFTS5` — the produced MATCH expression runs
  against a real in-memory FTS5 table without erroring.

All three failed (or the function emitted the bad phrase) before the fix and
pass after. `make fmt`, `go vet ./...`, and `go test ./internal/...` are green.
