### PR TITLE
fix(soft-delete): propagate tombstone-clear error on restore

### DIFF
--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -458,11 +458,15 @@ func (s *Service) restoreFromInstance(ctx context.Context, meta UndoMeta) error 
 // Override rows don't own a sync_resource; callers pass the master's UID so
 // the master is marked dirty instead, which covers the override on push.
 func (s *Service) reconcileSyncAfterRestore(ctx context.Context, calendarID int64, uid string) error {
-	_ = s.q.DeleteTombstonesByCalendarAndUID(ctx, storage.DeleteTombstonesByCalendarAndUIDParams{
+	if err := s.q.DeleteTombstonesByCalendarAndUID(ctx, storage.DeleteTombstonesByCalendarAndUIDParams{
 		CalendarID: calendarID,
 		Uid:        uid,
-	})
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
+	}); err != nil {
+		return fmt.Errorf("clear tombstone after restore: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event"); err != nil {
+		return fmt.Errorf("mark resource dirty after restore: %w", err)
+	}
 	return nil
 }
 

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -629,3 +629,25 @@ func TestSoftDelete_RestoreByUIDPreservesImportedEXDATE(t *testing.T) {
 		t.Fatalf("EXDATE count after RestoreByUID = %d, want 1 (imported exclusion preserved) (%q)", got, restoredMaster.ExDates)
 	}
 }
+
+// TestSoftDelete_RestoreSurfacesTombstoneClearError verifies that a failure
+// to clear the queued tombstone during restore is propagated to the caller
+// instead of being silently swallowed. Regression test for #121.
+func TestSoftDelete_RestoreSurfacesTombstoneClearError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	e := createEvent(t, svc)
+
+	if err := svc.Delete(ctx, e.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Force the tombstone-clear inside reconcileSyncAfterRestore to fail.
+	if _, err := svc.db.ExecContext(ctx, "DROP TABLE tombstones"); err != nil {
+		t.Fatalf("drop tombstones: %v", err)
+	}
+
+	if err := svc.RestoreByID(ctx, e.ID); err == nil {
+		t.Fatal("RestoreByID returned nil, want error when tombstone clear fails")
+	}
+}

--- a/internal/journal/soft_delete.go
+++ b/internal/journal/soft_delete.go
@@ -239,10 +239,14 @@ func (s *Service) PurgeByID(ctx context.Context, id int64) error {
 // marks the resource dirty so the next push re-CREATEs it server-side if
 // the sync_resource was already swept out.
 func (s *Service) reconcileSyncAfterRestore(ctx context.Context, calendarID int64, uid string) error {
-	_ = s.q.DeleteTombstonesByCalendarAndUID(ctx, storage.DeleteTombstonesByCalendarAndUIDParams{
+	if err := s.q.DeleteTombstonesByCalendarAndUID(ctx, storage.DeleteTombstonesByCalendarAndUIDParams{
 		CalendarID: calendarID,
 		Uid:        uid,
-	})
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "journal")
+	}); err != nil {
+		return fmt.Errorf("clear tombstone after restore: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "journal"); err != nil {
+		return fmt.Errorf("mark resource dirty after restore: %w", err)
+	}
 	return nil
 }

--- a/internal/journal/soft_delete_test.go
+++ b/internal/journal/soft_delete_test.go
@@ -379,3 +379,25 @@ func TestSoftDelete_SequenceBumpedOnRestore(t *testing.T) {
 		t.Fatalf("Sequence not bumped: before=%d after=%d", originalSeq, restored.Sequence)
 	}
 }
+
+// TestSoftDelete_RestoreSurfacesTombstoneClearError verifies that a failure
+// to clear the queued tombstone during restore is propagated to the caller
+// instead of being silently swallowed. Regression test for #121.
+func TestSoftDelete_RestoreSurfacesTombstoneClearError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	j := createJournal(t, svc)
+
+	if err := svc.Delete(ctx, j.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Force the tombstone-clear inside reconcileSyncAfterRestore to fail.
+	if _, err := svc.db.ExecContext(ctx, "DROP TABLE tombstones"); err != nil {
+		t.Fatalf("drop tombstones: %v", err)
+	}
+
+	if err := svc.RestoreByID(ctx, j.ID); err == nil {
+		t.Fatal("RestoreByID returned nil, want error when tombstone clear fails")
+	}
+}

--- a/internal/todo/soft_delete.go
+++ b/internal/todo/soft_delete.go
@@ -245,10 +245,14 @@ func (s *Service) PurgeByID(ctx context.Context, id int64) error {
 // marks the resource dirty so the next push re-CREATEs it server-side if
 // the sync_resource was already swept out.
 func (s *Service) reconcileSyncAfterRestore(ctx context.Context, calendarID int64, uid string) error {
-	_ = s.q.DeleteTombstonesByCalendarAndUID(ctx, storage.DeleteTombstonesByCalendarAndUIDParams{
+	if err := s.q.DeleteTombstonesByCalendarAndUID(ctx, storage.DeleteTombstonesByCalendarAndUIDParams{
 		CalendarID: calendarID,
 		Uid:        uid,
-	})
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "todo")
+	}); err != nil {
+		return fmt.Errorf("clear tombstone after restore: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "todo"); err != nil {
+		return fmt.Errorf("mark resource dirty after restore: %w", err)
+	}
 	return nil
 }

--- a/internal/todo/soft_delete_test.go
+++ b/internal/todo/soft_delete_test.go
@@ -406,3 +406,29 @@ func TestSoftDelete_SequenceBumpedOnRestore(t *testing.T) {
 		t.Fatalf("Sequence not bumped: before=%d after=%d", originalSeq, restored.Sequence)
 	}
 }
+
+// TestSoftDelete_RestoreSurfacesTombstoneClearError verifies that a failure
+// to clear the queued tombstone during restore is propagated to the caller
+// instead of being silently swallowed. Regression test for #121: a swallowed
+// tombstone-clear error left a DELETE tombstone in place after a "successful"
+// restore, so the next sync push could re-delete the restored todo on the
+// server. We inject the fault by dropping the tombstones table after the
+// soft-delete so the in-restore DELETE fails.
+func TestSoftDelete_RestoreSurfacesTombstoneClearError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	td := createTodo(t, svc)
+
+	if err := svc.Delete(ctx, td.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Force the tombstone-clear inside reconcileSyncAfterRestore to fail.
+	if _, err := svc.db.ExecContext(ctx, "DROP TABLE tombstones"); err != nil {
+		t.Fatalf("drop tombstones: %v", err)
+	}
+
+	if err := svc.RestoreByID(ctx, td.ID); err == nil {
+		t.Fatal("RestoreByID returned nil, want error when tombstone clear fails")
+	}
+}


### PR DESCRIPTION
Fixes #121

## Root cause
`reconcileSyncAfterRestore` (event / todo / journal services) discarded the
results of `DeleteTombstonesByCalendarAndUID` and `MarkResourceDirty` with
`_ = ...`. When clearing the queued DELETE tombstone failed (e.g. a transient
DB error), restore still reported success while the tombstone stayed queued.
A subsequent CalDAV push would then re-CREATE the dirty resource and DELETE it
via the leftover tombstone, removing the just-restored item from the server.

## Fix
Propagate both errors (wrapped with context) so restore surfaces the
inconsistent sync state instead of silently succeeding. Applied to the
identical helper in all three services (event, todo, journal) for consistency.

## Tests
Added `TestSoftDelete_RestoreSurfacesTombstoneClearError` to each of the event,
todo, and journal soft-delete test suites. Each soft-deletes a row, drops the
`tombstones` table to force the in-restore tombstone DELETE to fail, then
asserts `RestoreByID` returns an error. All three fail before the fix
(restore returns nil) and pass after.

## Verification
- `make fmt`, `go vet ./...` clean
- `go test ./internal/... -count=1` all green

Assisted-by: Claude Code:claude-opus-4-8
