### PR TITLE
fix(delete): fail override delete on malformed recurrence_id

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -438,23 +438,28 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		if err == nil {
 			existing := ParseTimeList(storage.NullableToString(master.Exdates))
 			recIDTime, parseErr := timeutil.ParseRecurrenceID(evt.RecurrenceID)
-			if parseErr == nil {
-				existing = append(existing, recIDTime)
-				if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
-					Exdates: storage.StringToNullable(SerializeTimeList(existing)),
-					ID:      master.ID,
-				}); err != nil {
-					return fmt.Errorf("update exdates: %w", err)
-				}
-				// Record provenance so restore knows this EXDATE was
-				// delete-added (and may be stripped) rather than imported.
-				if err := qtx.RecordEventExdateDelete(ctx, storage.RecordEventExdateDeleteParams{
-					CalendarID:   master.CalendarID,
-					Uid:          evt.UID,
-					RecurrenceID: evt.RecurrenceID,
-				}); err != nil {
-					return fmt.Errorf("record exdate delete: %w", err)
-				}
+			if parseErr != nil {
+				// A malformed recurrence_id can't be excluded from the
+				// master, so soft-deleting the override would resurrect the
+				// occurrence via series expansion. Fail loudly instead — the
+				// restore path treats the same parse failure as fatal.
+				return fmt.Errorf("parse recurrence_id %q: %w", evt.RecurrenceID, parseErr)
+			}
+			existing = append(existing, recIDTime)
+			if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
+				Exdates: storage.StringToNullable(SerializeTimeList(existing)),
+				ID:      master.ID,
+			}); err != nil {
+				return fmt.Errorf("update exdates: %w", err)
+			}
+			// Record provenance so restore knows this EXDATE was
+			// delete-added (and may be stripped) rather than imported.
+			if err := qtx.RecordEventExdateDelete(ctx, storage.RecordEventExdateDeleteParams{
+				CalendarID:   master.CalendarID,
+				Uid:          evt.UID,
+				RecurrenceID: evt.RecurrenceID,
+			}); err != nil {
+				return fmt.Errorf("record exdate delete: %w", err)
 			}
 		}
 

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -157,6 +157,57 @@ func TestSoftDelete_RestoreOverrideByIDClearsMasterEXDATE(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_MalformedRecurrenceID is the regression test for
+// issue #120: deleting an override whose recurrence_id cannot be parsed
+// must fail loudly rather than soft-delete the row while silently
+// skipping the EXDATE addition. Otherwise the override is hidden but the
+// master keeps expanding the occurrence, resurrecting the "deleted" slot.
+// The restore path already propagates this parse error; delete must too.
+func TestSoftDelete_MalformedRecurrenceID(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "malformed-recid",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Review (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: "2026-04-08T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Simulate corrupt/imported data: a non-parseable recurrence_id.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET recurrence_id = ? WHERE id = ?", "not-a-date", override.ID); err != nil {
+		t.Fatalf("corrupt recurrence_id: %v", err)
+	}
+
+	// Delete must fail rather than silently skip the EXDATE addition.
+	if err := svc.Delete(ctx, override.ID); err == nil {
+		t.Fatal("Delete with malformed recurrence_id should fail, got nil")
+	}
+
+	// The override must remain live (transaction rolled back), so the
+	// occurrence is still represented by the override and not resurrected.
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("override should still be live after failed delete: %v", err)
+	}
+}
+
 func TestSoftDelete_RestoreByUIDClearsOverrideEXDATEs(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -366,23 +366,28 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		if err == nil {
 			existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
 			recIDTime, parseErr := timeutil.ParseRecurrenceID(j.RecurrenceID)
-			if parseErr == nil {
-				existing = append(existing, recIDTime)
-				if err := qtx.UpdateJournalExdates(ctx, storage.UpdateJournalExdatesParams{
-					Exdates: storage.StringToNullable(timeutil.SerializeTimeList(existing)),
-					ID:      master.ID,
-				}); err != nil {
-					return fmt.Errorf("update exdates: %w", err)
-				}
-				// Record provenance so restore knows this EXDATE was
-				// delete-added (and may be stripped) rather than imported.
-				if err := qtx.RecordJournalExdateDelete(ctx, storage.RecordJournalExdateDeleteParams{
-					CalendarID:   master.CalendarID,
-					Uid:          j.UID,
-					RecurrenceID: j.RecurrenceID,
-				}); err != nil {
-					return fmt.Errorf("record exdate delete: %w", err)
-				}
+			if parseErr != nil {
+				// A malformed recurrence_id can't be excluded from the
+				// master, so soft-deleting the override would resurrect the
+				// occurrence via series expansion. Fail loudly instead — the
+				// restore path treats the same parse failure as fatal.
+				return fmt.Errorf("parse recurrence_id %q: %w", j.RecurrenceID, parseErr)
+			}
+			existing = append(existing, recIDTime)
+			if err := qtx.UpdateJournalExdates(ctx, storage.UpdateJournalExdatesParams{
+				Exdates: storage.StringToNullable(timeutil.SerializeTimeList(existing)),
+				ID:      master.ID,
+			}); err != nil {
+				return fmt.Errorf("update exdates: %w", err)
+			}
+			// Record provenance so restore knows this EXDATE was
+			// delete-added (and may be stripped) rather than imported.
+			if err := qtx.RecordJournalExdateDelete(ctx, storage.RecordJournalExdateDeleteParams{
+				CalendarID:   master.CalendarID,
+				Uid:          j.UID,
+				RecurrenceID: j.RecurrenceID,
+			}); err != nil {
+				return fmt.Errorf("record exdate delete: %w", err)
 			}
 		}
 

--- a/internal/journal/soft_delete_test.go
+++ b/internal/journal/soft_delete_test.go
@@ -217,6 +217,51 @@ func TestSoftDelete_RestoreOverrideClearsExdate(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_MalformedRecurrenceID is the regression test for
+// issue #120: deleting an override whose recurrence_id cannot be parsed
+// must fail loudly rather than soft-delete the row while silently
+// skipping the EXDATE addition. Otherwise the override is hidden but the
+// master keeps expanding the occurrence, resurrecting the "deleted" slot.
+// The restore path already propagates this parse error; delete must too.
+func TestSoftDelete_MalformedRecurrenceID(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "daily-uid", CalendarID: 1, Summary: "Daily Journal",
+		StartDate:      "2026-04-01",
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: master.UID, CalendarID: 1, Summary: "Daily Journal (amended)",
+		StartDate:    "2026-04-03",
+		RecurrenceID: time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Simulate corrupt/imported data: a non-parseable recurrence_id.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE journals SET recurrence_id = ? WHERE id = ?", "not-a-date", override.ID); err != nil {
+		t.Fatalf("corrupt recurrence_id: %v", err)
+	}
+
+	// Delete must fail rather than silently skip the EXDATE addition.
+	if err := svc.Delete(ctx, override.ID); err == nil {
+		t.Fatal("Delete with malformed recurrence_id should fail, got nil")
+	}
+
+	// The override must remain live (transaction rolled back), so the
+	// occurrence is still represented by the override and not resurrected.
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("override should still be live after failed delete: %v", err)
+	}
+}
+
 // TestSoftDelete_RestoreByUIDClearsExdate is the regression test for
 // issue #72: restoring a recurring series by UID must strip the EXDATEs
 // the instance-delete path added to the master, just like RestoreByID

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -472,23 +472,28 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		if err == nil {
 			existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
 			recIDTime, parseErr := timeutil.ParseRecurrenceID(td.RecurrenceID)
-			if parseErr == nil {
-				existing = append(existing, recIDTime)
-				if err := qtx.UpdateTodoExdates(ctx, storage.UpdateTodoExdatesParams{
-					Exdates: storage.StringToNullable(timeutil.SerializeTimeList(existing)),
-					ID:      master.ID,
-				}); err != nil {
-					return fmt.Errorf("update exdates: %w", err)
-				}
-				// Record provenance so restore knows this EXDATE was
-				// delete-added (and may be stripped) rather than imported.
-				if err := qtx.RecordTodoExdateDelete(ctx, storage.RecordTodoExdateDeleteParams{
-					CalendarID:   master.CalendarID,
-					Uid:          td.UID,
-					RecurrenceID: td.RecurrenceID,
-				}); err != nil {
-					return fmt.Errorf("record exdate delete: %w", err)
-				}
+			if parseErr != nil {
+				// A malformed recurrence_id can't be excluded from the
+				// master, so soft-deleting the override would resurrect the
+				// occurrence via series expansion. Fail loudly instead — the
+				// restore path treats the same parse failure as fatal.
+				return fmt.Errorf("parse recurrence_id %q: %w", td.RecurrenceID, parseErr)
+			}
+			existing = append(existing, recIDTime)
+			if err := qtx.UpdateTodoExdates(ctx, storage.UpdateTodoExdatesParams{
+				Exdates: storage.StringToNullable(timeutil.SerializeTimeList(existing)),
+				ID:      master.ID,
+			}); err != nil {
+				return fmt.Errorf("update exdates: %w", err)
+			}
+			// Record provenance so restore knows this EXDATE was
+			// delete-added (and may be stripped) rather than imported.
+			if err := qtx.RecordTodoExdateDelete(ctx, storage.RecordTodoExdateDeleteParams{
+				CalendarID:   master.CalendarID,
+				Uid:          td.UID,
+				RecurrenceID: td.RecurrenceID,
+			}); err != nil {
+				return fmt.Errorf("record exdate delete: %w", err)
 			}
 		}
 

--- a/internal/todo/soft_delete_test.go
+++ b/internal/todo/soft_delete_test.go
@@ -236,6 +236,51 @@ func TestSoftDelete_RestoreOverrideClearsExdate(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_MalformedRecurrenceID is the regression test for
+// issue #120: deleting an override whose recurrence_id cannot be parsed
+// must fail loudly rather than soft-delete the row while silently
+// skipping the EXDATE addition. Otherwise the override is hidden but the
+// master keeps expanding the occurrence, resurrecting the "deleted" slot.
+// The restore path already propagates this parse error; delete must too.
+func TestSoftDelete_MalformedRecurrenceID(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "weekly-uid", CalendarID: 1, Summary: "Weekly Review",
+		DueDate:        time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: master.UID, CalendarID: 1, Summary: "Weekly Review (moved)",
+		DueDate:      time.Date(2026, 4, 15, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceID: time.Date(2026, 4, 15, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Simulate corrupt/imported data: a non-parseable recurrence_id.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE todos SET recurrence_id = ? WHERE id = ?", "not-a-date", override.ID); err != nil {
+		t.Fatalf("corrupt recurrence_id: %v", err)
+	}
+
+	// Delete must fail rather than silently skip the EXDATE addition.
+	if err := svc.Delete(ctx, override.ID); err == nil {
+		t.Fatal("Delete with malformed recurrence_id should fail, got nil")
+	}
+
+	// The override must remain live (transaction rolled back), so the
+	// occurrence is still represented by the override and not resurrected.
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("override should still be live after failed delete: %v", err)
+	}
+}
+
 // TestSoftDelete_RestoreByUIDClearsExdate is the regression test for
 // issue #72: restoring a recurring series by UID must strip the EXDATEs
 // the instance-delete path added to the master, just like RestoreByID


### PR DESCRIPTION
Fixes #120

## Root cause

On instance (override) delete, `Delete` parses the override's `recurrence_id`
to add a matching EXDATE to the master so the occurrence stops being expanded.
If `timeutil.ParseRecurrenceID` failed (corrupt/imported data), the error was
silently swallowed via `if parseErr == nil` — yet the override row was still
soft-deleted. The result: the hidden override no longer represents the
occurrence, but the master keeps expanding it, so the "deleted" instance
reappears via series expansion. The restore path (`clearMasterEXDATE`) already
treats the same parse failure as a fatal data-integrity error, making the two
sides asymmetric.

## Fix

Propagate the parse error and abort the delete. Since the EXDATE update and
soft-delete run in one transaction, the rollback leaves the override live and
the master untouched, so the occurrence is never resurrected. Applied
symmetrically to `event`, `todo`, and `journal`, which share the
reversible-delete contract (the issue named todo/journal; event had the
identical bug).

## Test coverage

Added `TestSoftDelete_MalformedRecurrenceID` to each of the three packages.
Each creates a recurring master + a valid override, corrupts the override's
`recurrence_id` to a non-parseable value via raw SQL, then asserts:

- `Delete` returns an error rather than `nil`.
- The override row is still live afterward (transaction rolled back), so the
  occurrence is not resurrected.

All three tests fail before the fix (`Delete ... should fail, got nil`) and
pass after. `make fmt`, `go vet ./...`, and `go test ./internal/... ./cmd/...`
are all green.
