### PR TITLE
fix(cmd): opportunistically push todo/journal/import writes to CalDAV

### DIFF
--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -122,6 +122,13 @@ again updates existing items instead of blindly duplicating them.`,
 				}
 			}
 
+			// Opportunistically push whatever landed to a CalDAV-linked
+			// calendar, mirroring the event/todo/journal write paths, so an
+			// import doesn't wait for the next `service run` tick (issue #115).
+			if len(summary.events)+len(summary.todos)+len(summary.journals) > 0 {
+				pushCalendarAfterWrite(a, calID, w)
+			}
+
 			// A non-zero exit signals that the import was partial, but the
 			// summary above still reports exactly what landed so the caller
 			// can retry only the failed components.

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -338,9 +339,14 @@ Defaults: status=FINAL, class=PUBLIC, calendar=Personal.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONJournal(j))
+				if err := printOutput(w, toJSONJournal(j)); err != nil {
+					return err
+				}
+				pushCalendarAfterWrite(a, j.CalendarID, io.Discard)
+				return nil
 			}
 			printJournal(w, j)
+			pushCalendarAfterWrite(a, j.CalendarID, w)
 			return nil
 		},
 	}
@@ -566,9 +572,14 @@ Repeatable flags (--attendee, --comment, --contact, --attach,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONJournal(j))
+				if err := printOutput(w, toJSONJournal(j)); err != nil {
+					return err
+				}
+				pushCalendarAfterWrite(a, j.CalendarID, io.Discard)
+				return nil
 			}
 			printJournal(w, j)
+			pushCalendarAfterWrite(a, j.CalendarID, w)
 			return nil
 		},
 	}
@@ -647,9 +658,14 @@ entire recurring series.`,
 				}
 				w := cmd.OutOrStdout()
 				if outputFmt != "text" {
-					return printOutput(w, map[string]any{"deleted": true, "uid": j.UID, "series": true})
+					if err := printOutput(w, map[string]any{"deleted": true, "uid": j.UID, "series": true}); err != nil {
+						return err
+					}
+					pushCalendarAfterWrite(a, j.CalendarID, io.Discard)
+					return nil
 				}
 				fmt.Fprintf(w, "Deleted journal series %q.\n", safeText(j.UID))
+				pushCalendarAfterWrite(a, j.CalendarID, w)
 				return nil
 			}
 
@@ -659,9 +675,14 @@ entire recurring series.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, map[string]any{"deleted": true, "id": j.ID})
+				if err := printOutput(w, map[string]any{"deleted": true, "id": j.ID}); err != nil {
+					return err
+				}
+				pushCalendarAfterWrite(a, j.CalendarID, io.Discard)
+				return nil
 			}
 			fmt.Fprintf(w, "Deleted journal %d.\n", j.ID)
+			pushCalendarAfterWrite(a, j.CalendarID, w)
 			return nil
 		},
 	}

--- a/cmd/chroncal/push.go
+++ b/cmd/chroncal/push.go
@@ -19,7 +19,11 @@ const opportunisticPushTimeout = 30 * time.Second
 // reported to w but do not affect the command's exit status — the dirty
 // flag survives and the periodic `chroncal service run` tick will retry.
 // Local-only calendars (no CalDAV account linked) are silent no-ops.
-func pushCalendarAfterWrite(a *app.App, calendarID int64, w io.Writer) {
+//
+// It is a package var so tests can substitute a recording stub to assert
+// that write paths opportunistically push, without standing up a CalDAV
+// server.
+var pushCalendarAfterWrite = func(a *app.App, calendarID int64, w io.Writer) {
 	ctx, cancel := context.WithTimeout(context.Background(), opportunisticPushTimeout)
 	defer cancel()
 

--- a/cmd/chroncal/push_writepaths_test.go
+++ b/cmd/chroncal/push_writepaths_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/config"
+)
+
+// stubPushSeam replaces the opportunistic-push seam with a recorder that
+// captures the calendar IDs write paths attempt to push. It restores the
+// original on test cleanup.
+func stubPushSeam(t *testing.T) *[]int64 {
+	t.Helper()
+	pushed := &[]int64{}
+	prev := pushCalendarAfterWrite
+	pushCalendarAfterWrite = func(a *app.App, calendarID int64, w io.Writer) {
+		*pushed = append(*pushed, calendarID)
+	}
+	t.Cleanup(func() { pushCalendarAfterWrite = prev })
+	return pushed
+}
+
+// runWriteCommand executes one CLI command tree in-process against the test
+// DB. It wraps the resource command in a fresh parent so cfg is reloaded
+// from CHRONCAL_DB (mirroring rootCmd's PersistentPreRunE) and so each call
+// gets fresh flag closures.
+func runWriteCommand(t *testing.T, sub *cobra.Command, args ...string) error {
+	t.Helper()
+	root := &cobra.Command{
+		Use: "chroncal-test",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			cfg = config.Load()
+			return nil
+		},
+	}
+	root.AddCommand(sub)
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+// TestWritePathsOpportunisticallyPush asserts that todo, journal, and import
+// write paths invoke the opportunistic CalDAV push seam, matching event write
+// paths. Regression guard for issue #115.
+func TestWritePathsOpportunisticallyPush(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	t.Setenv("CHRONCAL_ASSUME_YES", "1")
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	ctx := context.Background()
+	cal, err := a.Calendars.Create(ctx, "Work", "#7C3AED", "")
+	if err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	calID := cal.ID
+	a.Close()
+
+	t.Run("todo add", func(t *testing.T) {
+		pushed := stubPushSeam(t)
+		if err := runWriteCommand(t, todoCmd(),
+			"todo", "add", "Ship release", "--calendar", "Work"); err != nil {
+			t.Fatalf("todo add: %v", err)
+		}
+		assertPushed(t, *pushed, calID)
+	})
+
+	t.Run("todo update", func(t *testing.T) {
+		pushed := stubPushSeam(t)
+		if err := runWriteCommand(t, todoCmd(),
+			"todo", "update", "1", "--summary", "Ship release v2"); err != nil {
+			t.Fatalf("todo update: %v", err)
+		}
+		assertPushed(t, *pushed, calID)
+	})
+
+	t.Run("todo complete", func(t *testing.T) {
+		pushed := stubPushSeam(t)
+		if err := runWriteCommand(t, todoCmd(),
+			"todo", "complete", "1"); err != nil {
+			t.Fatalf("todo complete: %v", err)
+		}
+		assertPushed(t, *pushed, calID)
+	})
+
+	t.Run("todo delete", func(t *testing.T) {
+		pushed := stubPushSeam(t)
+		if err := runWriteCommand(t, todoCmd(),
+			"todo", "delete", "1", "--yes"); err != nil {
+			t.Fatalf("todo delete: %v", err)
+		}
+		assertPushed(t, *pushed, calID)
+	})
+
+	t.Run("journal add", func(t *testing.T) {
+		pushed := stubPushSeam(t)
+		if err := runWriteCommand(t, journalCmd(),
+			"journal", "add", "Daily note", "--calendar", "Work"); err != nil {
+			t.Fatalf("journal add: %v", err)
+		}
+		assertPushed(t, *pushed, calID)
+	})
+
+	t.Run("journal update", func(t *testing.T) {
+		pushed := stubPushSeam(t)
+		if err := runWriteCommand(t, journalCmd(),
+			"journal", "update", "1", "--summary", "Daily note v2"); err != nil {
+			t.Fatalf("journal update: %v", err)
+		}
+		assertPushed(t, *pushed, calID)
+	})
+
+	t.Run("journal delete", func(t *testing.T) {
+		pushed := stubPushSeam(t)
+		if err := runWriteCommand(t, journalCmd(),
+			"journal", "delete", "1", "--yes"); err != nil {
+			t.Fatalf("journal delete: %v", err)
+		}
+		assertPushed(t, *pushed, calID)
+	})
+
+	t.Run("ical import", func(t *testing.T) {
+		icsPath := filepath.Join(t.TempDir(), "in.ics")
+		ics := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//chroncal//test//EN\r\n" +
+			"BEGIN:VTODO\r\nUID:import-todo-1\r\nSUMMARY:Imported task\r\nEND:VTODO\r\n" +
+			"END:VCALENDAR\r\n"
+		if err := os.WriteFile(icsPath, []byte(ics), 0o600); err != nil {
+			t.Fatalf("write ics: %v", err)
+		}
+		pushed := stubPushSeam(t)
+		if err := runWriteCommand(t, icalCmd(),
+			"ical", "import", icsPath, "--calendar", "Work"); err != nil {
+			t.Fatalf("ical import: %v", err)
+		}
+		assertPushed(t, *pushed, calID)
+	})
+}
+
+func assertPushed(t *testing.T, pushed []int64, want int64) {
+	t.Helper()
+	for _, id := range pushed {
+		if id == want {
+			return
+		}
+	}
+	t.Fatalf("write path did not opportunistically push calendar %d; pushed=%v", want, pushed)
+}

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -492,9 +493,14 @@ and percent-complete to 100.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONTodo(t))
+				if err := printOutput(w, toJSONTodo(t)); err != nil {
+					return err
+				}
+				pushCalendarAfterWrite(a, t.CalendarID, io.Discard)
+				return nil
 			}
 			printTodo(w, t)
+			pushCalendarAfterWrite(a, t.CalendarID, w)
 			return nil
 		},
 	}
@@ -836,9 +842,14 @@ a --progress value other than 100.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONTodo(t))
+				if err := printOutput(w, toJSONTodo(t)); err != nil {
+					return err
+				}
+				pushCalendarAfterWrite(a, t.CalendarID, io.Discard)
+				return nil
 			}
 			printTodo(w, t)
+			pushCalendarAfterWrite(a, t.CalendarID, w)
 			return nil
 		},
 	}
@@ -908,9 +919,14 @@ its progress to 100%.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONTodo(t))
+				if err := printOutput(w, toJSONTodo(t)); err != nil {
+					return err
+				}
+				pushCalendarAfterWrite(a, t.CalendarID, io.Discard)
+				return nil
 			}
 			fmt.Fprintf(w, "Completed: %s\n", safeText(t.Summary))
+			pushCalendarAfterWrite(a, t.CalendarID, w)
 			return nil
 		},
 	}
@@ -965,9 +981,14 @@ recurring series.`,
 				}
 				w := cmd.OutOrStdout()
 				if outputFmt != "text" {
-					return printOutput(w, map[string]any{"deleted": true, "uid": t.UID, "series": true})
+					if err := printOutput(w, map[string]any{"deleted": true, "uid": t.UID, "series": true}); err != nil {
+						return err
+					}
+					pushCalendarAfterWrite(a, t.CalendarID, io.Discard)
+					return nil
 				}
 				fmt.Fprintf(w, "Deleted todo series %q.\n", safeText(t.UID))
+				pushCalendarAfterWrite(a, t.CalendarID, w)
 				return nil
 			}
 
@@ -977,9 +998,14 @@ recurring series.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, map[string]any{"deleted": true, "id": t.ID})
+				if err := printOutput(w, map[string]any{"deleted": true, "id": t.ID}); err != nil {
+					return err
+				}
+				pushCalendarAfterWrite(a, t.CalendarID, io.Discard)
+				return nil
 			}
 			fmt.Fprintf(w, "Deleted todo %d.\n", t.ID)
+			pushCalendarAfterWrite(a, t.CalendarID, w)
 			return nil
 		},
 	}


### PR DESCRIPTION
Fixes #115

## Root cause

`pushCalendarAfterWrite` (cmd/chroncal/push.go) was invoked only from the
`event add/update/delete` paths. The todo and journal create/update/delete/
complete verbs and `ical import` never called it, even though the sync service
supports all three resource types. On a CalDAV-linked calendar, creating an
event uploaded immediately, but creating a todo/journal or importing an .ics
waited for the next `service run` tick -- an inconsistency between otherwise
symmetric verbs.

## Fix

Wire the opportunistic push into the missing write paths, mirroring the
existing event pattern exactly:

- `todo`: add, update, complete, delete (single + series)
- `journal`: add, update, delete (single + series)
- `ical import`: a single push for the target calendar when at least one item
  was imported

The JSON output branch pushes silently to `io.Discard`; the text branch
reports the sync result to the command writer. `printOutput` errors that were
previously dropped on these branches are now propagated.

`pushCalendarAfterWrite` becomes a package var so tests can substitute a
recording stub.

## Test coverage

`TestWritePathsOpportunisticallyPush` (cmd/chroncal/push_writepaths_test.go)
runs each write path in-process against a test DB with the push seam stubbed,
and asserts the target calendar ID is pushed. It covers todo add/update/
complete/delete, journal add/update/delete, and ical import. The test fails
on the pre-fix code (no path pushes) and passes after the fix.

## Verification

- `make fmt`, `go vet ./...`: clean
- `go test ./internal/... ./cmd/...`: all green
