### PR TITLE
fix(recurrence): bucket agenda sort by local calendar day

### DIFF
--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -395,13 +395,20 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 		}
 	}
 
-	// Order by instance day, placing all-day events before timed events on
-	// the same day, then timed events by start time. SQL-level ordering is
-	// not sufficient because recurring instances are generated in Go.
+	sortExpandedEvents(results)
+
+	return results, nil
+}
+
+// sortExpandedEvents orders instances by their local calendar day, placing
+// all-day events before timed events on the same day, then timed events by
+// start time. SQL-level ordering is not sufficient because recurring instances
+// are generated in Go.
+func sortExpandedEvents(results []ExpandedEvent) {
 	sort.SliceStable(results, func(i, j int) bool {
 		a, b := results[i], results[j]
-		ad := a.InstanceTime.Local().Truncate(24 * time.Hour)
-		bd := b.InstanceTime.Local().Truncate(24 * time.Hour)
+		ad := timeutil.LocalDay(a.InstanceTime)
+		bd := timeutil.LocalDay(b.InstanceTime)
 		if !ad.Equal(bd) {
 			return ad.Before(bd)
 		}
@@ -410,8 +417,6 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 		}
 		return a.InstanceTime.Before(b.InstanceTime)
 	})
-
-	return results, nil
 }
 
 func attendeeFromStorage(r storage.EventAttendee) model.Attendee {

--- a/internal/recurrence/sort_test.go
+++ b/internal/recurrence/sort_test.go
@@ -1,0 +1,46 @@
+package recurrence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+)
+
+// TestSortExpandedEvents_LocalDayBucket guards against issue #126: the day
+// bucket used for ordering must reflect the host's LOCAL calendar day, not
+// UTC midnight. Two instances on the same local day that straddle UTC midnight
+// must group together, with the all-day event ordered before the timed one.
+func TestSortExpandedEvents_LocalDayBucket(t *testing.T) {
+	// Pin the local zone to UTC-5 for the duration of the test so the bug is
+	// observable regardless of the host's real timezone.
+	orig := time.Local
+	time.Local = time.FixedZone("UTC-5", -5*60*60)
+	t.Cleanup(func() { time.Local = orig })
+
+	// Both instances fall on the local calendar day 2025-12-31 (UTC-5), but
+	// they sit on opposite sides of UTC midnight:
+	//   - all-day: 2026-01-01 00:00 UTC == 2025-12-31 19:00 local (stored as
+	//     midnight UTC, the canonical all-day representation)
+	//   - timed:   2025-12-31 15:00 UTC == 2025-12-31 10:00 local
+	// A UTC-midnight bucket (the bug) buckets the all-day event on Jan 1 and
+	// the timed event on Dec 31, so the timed event sorts first — wrong. A
+	// local-day bucket keeps them on Dec 31 with the all-day event first.
+	allDay := ExpandedEvent{
+		Event:        event.Event{Title: "all-day", AllDay: true},
+		InstanceTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	timed := ExpandedEvent{
+		Event:        event.Event{Title: "timed"},
+		InstanceTime: time.Date(2025, 12, 31, 15, 0, 0, 0, time.UTC),
+	}
+
+	// Start out of order so a correct sort must reorder them.
+	results := []ExpandedEvent{timed, allDay}
+	sortExpandedEvents(results)
+
+	if results[0].Title != "all-day" || results[1].Title != "timed" {
+		t.Fatalf("expected all-day before timed on the same local day, got [%s, %s]",
+			results[0].Title, results[1].Title)
+	}
+}

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -29,6 +29,17 @@ func IsDateOnly(s string) bool {
 	return err == nil
 }
 
+// LocalDay returns midnight at the start of t's local calendar day, in the
+// local location. Unlike t.Truncate(24*time.Hour) — which floors the absolute
+// instant to a multiple of 24h and therefore always aligns to UTC midnight
+// regardless of any preceding .Local() — this computes the day boundary from
+// the local Year/Month/Day, so two instants on the same local calendar day map
+// to the same value even when they straddle UTC midnight.
+func LocalDay(t time.Time) time.Time {
+	l := t.Local()
+	return time.Date(l.Year(), l.Month(), l.Day(), 0, 0, 0, 0, time.Local)
+}
+
 // ParseDate parses s as either a date-only string (YYYY-MM-DD) or an RFC 3339 datetime.
 // Returns zero time if s is empty.
 func ParseDate(s string) time.Time {


### PR DESCRIPTION
Fixes #126

## Root cause
`ListExpandedEvents` ordered agenda instances with a day-bucket key of
`InstanceTime.Local().Truncate(24 * time.Hour)`. `time.Truncate` floors the
absolute instant to a multiple of 24h, which aligns to **UTC** midnight no
matter the preceding `.Local()`. On a non-UTC host, two instances on the same
local calendar day that straddle UTC midnight fall into different buckets, so
the day grouping and the all-day-before-timed ordering near midnight are wrong.

## Fix
- Add `timeutil.LocalDay`, which derives the day boundary from the local
  `Year/Month/Day` via `time.Date(..., time.Local)` so instants on the same
  local day map to the same value even across UTC midnight.
- Extract the inline sort comparator into `sortExpandedEvents` and route it
  through `timeutil.LocalDay`.

## Test coverage
`TestSortExpandedEvents_LocalDayBucket` pins `time.Local` to UTC-5 and asserts
an all-day event stored at midnight UTC (local 19:00 the prior day) sorts
before a same-local-day timed event whose UTC instant lands on the prior UTC
day. The test fails against the old `.Truncate(24h)` key (the timed event sorts
first) and passes with the local-day bucket.

## Verification
`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
