### PR TITLE
fix(todo,journal): gate DeleteSeries dirty-mark on master existence

### DIFF
--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -413,8 +413,9 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 // next push sends DELETE to the server; the local rows stay in place
 // until purge so the user can restore them.
 func (s *Service) DeleteSeries(ctx context.Context, uid string) error {
-	master, err := s.q.GetJournalByUID(ctx, uid)
-	if err == nil {
+	master, mErr := s.q.GetJournalByUID(ctx, uid)
+	haveMaster := mErr == nil
+	if haveMaster {
 		_, _ = storage.CreateTombstoneIfSynced(ctx, s.db, master.CalendarID, uid)
 	}
 
@@ -431,7 +432,7 @@ func (s *Service) DeleteSeries(ctx context.Context, uid string) error {
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit delete series: %w", err)
 	}
-	if err == nil {
+	if haveMaster {
 		_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "journal")
 	}
 	return nil

--- a/internal/journal/soft_delete_test.go
+++ b/internal/journal/soft_delete_test.go
@@ -5,7 +5,58 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
+
+// TestDeleteSeries_DirtyMarkGatedOnMaster verifies that DeleteSeries on a
+// synced calendar marks the series resource dirty when the master exists,
+// and does NOT touch sync_resources (in particular no spurious calendar_id=0
+// row) when no master row exists for the UID. Regression test for the
+// master-existence guard being defeated by err reuse (issue #119).
+func TestDeleteSeries_DirtyMarkGatedOnMaster(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+	testutil.LinkCalendarToAccount(t, db)
+
+	// Master exists -> series should be marked dirty.
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "have-master", CalendarID: 1, Summary: "Weekly",
+		StartDate:      time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	if err := svc.DeleteSeries(ctx, master.UID); err != nil {
+		t.Fatalf("DeleteSeries (master): %v", err)
+	}
+	var dirty int
+	if err := db.QueryRow(
+		`SELECT dirty FROM sync_resources WHERE calendar_id = 1 AND uid = ?`, master.UID,
+	).Scan(&dirty); err != nil {
+		t.Fatalf("expected sync_resources row for master series: %v", err)
+	}
+	if dirty != 1 {
+		t.Errorf("master series dirty = %d, want 1", dirty)
+	}
+
+	// No master row for this UID -> must not write any sync_resources row,
+	// and in particular nothing keyed on calendar_id 0.
+	if err := svc.DeleteSeries(ctx, "ghost-uid"); err != nil {
+		t.Fatalf("DeleteSeries (ghost): %v", err)
+	}
+	var ghost int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sync_resources WHERE uid = 'ghost-uid' OR calendar_id = 0`,
+	).Scan(&ghost); err != nil {
+		t.Fatalf("count sync_resources: %v", err)
+	}
+	if ghost != 0 {
+		t.Errorf("spurious sync_resources rows for missing master = %d, want 0", ghost)
+	}
+}
 
 // TestSoftDelete_Standalone verifies:
 //   - Delete sets deleted_at, row stays in DB

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -18,3 +18,23 @@ func NewTestDB(t *testing.T) (*sql.DB, *storage.Queries) {
 	t.Cleanup(func() { db.Close() })
 	return db, q
 }
+
+// LinkCalendarToAccount creates an account and links calendar id 1 to it,
+// turning calendar 1 into a synced calendar so storage.MarkResourceDirty
+// (and related sync bookkeeping) actually writes sync_resources rows.
+func LinkCalendarToAccount(t *testing.T, db *sql.DB) {
+	t.Helper()
+	res, err := db.Exec(
+		`INSERT INTO accounts (name, server_url) VALUES ('Test', 'https://dav.example')`,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	if _, err := db.Exec(`UPDATE calendars SET account_id = ? WHERE id = 1`, accID); err != nil {
+		t.Fatalf("link calendar: %v", err)
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -519,8 +519,9 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 // the next push sends DELETE to the server; the local rows stay in
 // place until purge so the user can restore them.
 func (s *Service) DeleteSeries(ctx context.Context, uid string) error {
-	master, err := s.q.GetTodoByUID(ctx, uid)
-	if err == nil {
+	master, mErr := s.q.GetTodoByUID(ctx, uid)
+	haveMaster := mErr == nil
+	if haveMaster {
 		_, _ = storage.CreateTombstoneIfSynced(ctx, s.db, master.CalendarID, uid)
 	}
 
@@ -537,7 +538,7 @@ func (s *Service) DeleteSeries(ctx context.Context, uid string) error {
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit delete series: %w", err)
 	}
-	if err == nil {
+	if haveMaster {
 		_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "todo")
 	}
 	return nil

--- a/internal/todo/soft_delete_test.go
+++ b/internal/todo/soft_delete_test.go
@@ -5,7 +5,58 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
+
+// TestDeleteSeries_DirtyMarkGatedOnMaster verifies that DeleteSeries on a
+// synced calendar marks the series resource dirty when the master exists,
+// and does NOT touch sync_resources (in particular no spurious calendar_id=0
+// row) when no master row exists for the UID. Regression test for the
+// master-existence guard being defeated by err reuse (issue #119).
+func TestDeleteSeries_DirtyMarkGatedOnMaster(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+	testutil.LinkCalendarToAccount(t, db)
+
+	// Master exists -> series should be marked dirty.
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "have-master", CalendarID: 1, Summary: "Weekly",
+		DueDate:        time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	if err := svc.DeleteSeries(ctx, master.UID); err != nil {
+		t.Fatalf("DeleteSeries (master): %v", err)
+	}
+	var dirty int
+	if err := db.QueryRow(
+		`SELECT dirty FROM sync_resources WHERE calendar_id = 1 AND uid = ?`, master.UID,
+	).Scan(&dirty); err != nil {
+		t.Fatalf("expected sync_resources row for master series: %v", err)
+	}
+	if dirty != 1 {
+		t.Errorf("master series dirty = %d, want 1", dirty)
+	}
+
+	// No master row for this UID -> must not write any sync_resources row,
+	// and in particular nothing keyed on calendar_id 0.
+	if err := svc.DeleteSeries(ctx, "ghost-uid"); err != nil {
+		t.Fatalf("DeleteSeries (ghost): %v", err)
+	}
+	var ghost int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sync_resources WHERE uid = 'ghost-uid' OR calendar_id = 0`,
+	).Scan(&ghost); err != nil {
+		t.Fatalf("count sync_resources: %v", err)
+	}
+	if ghost != 0 {
+		t.Errorf("spurious sync_resources rows for missing master = %d, want 0", ghost)
+	}
+}
 
 // TestSoftDelete_Standalone verifies:
 //   - Delete sets deleted_at, row stays in DB


### PR DESCRIPTION
Fixes #119

## Root cause

In `todo` and `journal` `DeleteSeries`, the trailing
`if err == nil { storage.MarkResourceDirty(...) }` was intended to gate
on the master fetch (`master, err := s.q.Get*ByUID(...)`). But
`tx, err := s.db.BeginTx(...)` reassigns `err`, and the function returns
early when `BeginTx` fails — so by the time the trailing guard runs,
`err` is the (nil) result of a successful `tx.Commit()`. The
master-existence check was therefore always true, and on a UID with no
master row the dirty-mark ran with `master.CalendarID == 0`.

Note: the bug was *masked* at runtime because `storage.MarkResourceDirty`
returns early when `calendarID == 0`, so no spurious `sync_resources` row
was actually written. This is an intent/clarity correctness fix that also
hardens the path against that masking ever being relaxed. The matching
`event.DeleteSeries` does not have the bug (it omits the trailing
dirty-mark entirely).

## Fix

Capture the master fetch in a dedicated variable and gate both
`CreateTombstoneIfSynced` and `MarkResourceDirty` on a `haveMaster`
boolean instead of the reused `err`, in both `internal/todo/service.go`
and `internal/journal/service.go`.

## Test coverage

Adds `TestDeleteSeries_DirtyMarkGatedOnMaster` for both todo and journal
on a synced calendar, asserting:
- master present -> the series `sync_resources` row is marked `dirty=1`
  (the intended behavior is preserved by the fix), and
- UID with no master -> no `sync_resources` row is written, in particular
  nothing keyed on `calendar_id = 0`.

Also extracts a shared `testutil.LinkCalendarToAccount` helper.

## Verification

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
