### PR TITLE
fix(ical): parse optional seconds in UTC-OFFSET values

### DIFF
--- a/internal/ical/vtimezone.go
+++ b/internal/ical/vtimezone.go
@@ -88,8 +88,9 @@ func compPropText(c *goical.Component, name string) string {
 	return ""
 }
 
-// parseUTCOffset parses an RFC 5545 UTC-OFFSET value like "+0530" or "-0800"
-// and returns the offset in seconds.
+// parseUTCOffset parses an RFC 5545 UTC-OFFSET value like "+0530", "-0800",
+// or "+005258" (the optional trailing seconds component) and returns the
+// offset in seconds.
 func parseUTCOffset(s string) (int, error) {
 	s = strings.TrimSpace(s)
 	if len(s) < 5 {
@@ -103,8 +104,9 @@ func parseUTCOffset(s string) (int, error) {
 		sign = -1
 		s = s[1:]
 	}
-	if len(s) < 4 {
-		return 0, fmt.Errorf("utc-offset too short after sign: %q", s)
+	// After the sign, RFC 5545 allows "HHMM" or "HHMMSS".
+	if len(s) != 4 && len(s) != 6 {
+		return 0, fmt.Errorf("utc-offset has invalid length: %q", s)
 	}
 	hours, err := strconv.Atoi(s[:2])
 	if err != nil {
@@ -114,7 +116,14 @@ func parseUTCOffset(s string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return sign * (hours*3600 + minutes*60), nil
+	seconds := 0
+	if len(s) == 6 {
+		seconds, err = strconv.Atoi(s[4:6])
+		if err != nil {
+			return 0, err
+		}
+	}
+	return sign * (hours*3600 + minutes*60 + seconds), nil
 }
 
 // resolveComponentTZIDs rewrites TZID parameters on datetime properties

--- a/internal/ical/vtimezone_test.go
+++ b/internal/ical/vtimezone_test.go
@@ -1,0 +1,40 @@
+package ical
+
+import "testing"
+
+func TestParseUTCOffset(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{name: "positive hhmm", in: "+0530", want: 5*3600 + 30*60},
+		{name: "negative hhmm", in: "-0800", want: -(8 * 3600)},
+		{name: "zero", in: "+0000", want: 0},
+		{name: "positive with seconds", in: "+005258", want: 52*60 + 58},
+		{name: "negative with seconds", in: "-005258", want: -(52*60 + 58)},
+		{name: "negative offset with seconds", in: "-103730", want: -(10*3600 + 37*60 + 30)},
+		{name: "too short", in: "+05", wantErr: true},
+		{name: "bad minutes", in: "+05XY", wantErr: true},
+		{name: "bad seconds", in: "+0052ZZ", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUTCOffset(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseUTCOffset(%q) = %d, want error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseUTCOffset(%q) unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseUTCOffset(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #132

## Root cause
RFC 5545 UTC-OFFSET values permit an optional seconds component
(`+/-HHMMSS`), but `parseUTCOffset` in `internal/ical/vtimezone.go`
read only `s[:2]` (hours) and `s[2:4]` (minutes), silently discarding
any seconds. A VTIMEZONE whose `TZOFFSETTO` is a sub-minute historical
offset like `+005258` produced a fixed zone off by 58 seconds,
mis-shifting every datetime resolved through that custom zone.

## Fix
Parse the optional trailing `SS` group and add it into the returned
offset seconds. The post-sign length check is tightened from `len < 4`
to "exactly 4 or 6" so only valid `HHMM` / `HHMMSS` forms are accepted.

## Test coverage
New `internal/ical/vtimezone_test.go` (`TestParseUTCOffset`) covers
plus/minus `HHMM`, zero, plus/minus `HHMMSS` (including the issue's
`+005258` = 3178s and a full `-103730`), and malformed inputs (too
short, bad minutes, bad seconds). The seconds cases fail on the old
code and pass with the fix.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.

Assisted-by: Claude Code:claude-opus-4-8