### PR TITLE
fix(event): make UpsertByUID and TUI edit path atomic

### DIFF
--- a/internal/event/atomic_test.go
+++ b/internal/event/atomic_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
 
@@ -104,5 +105,94 @@ func TestUpdate_AtomicOnCategoryFailure(t *testing.T) {
 	}
 	if !got.StartTime.Equal(orig.StartTime) {
 		t.Fatalf("start time after failed Update = %v, want %v", got.StartTime, orig.StartTime)
+	}
+}
+
+// TestUpsertByUID_AtomicOnCategoryFailure asserts that when the category
+// child-write fails, UpsertByUID returns an error AND leaves no event row
+// behind. Before the fix the upsert committed the row in autocommit and only
+// then ran ReplaceCategories in a separate transaction, so a failure left an
+// orphan row (the sibling of issue #73, filed as issue #87).
+//
+// The failure is injected via duplicate categories: event_categories has a
+// PRIMARY KEY (event_id, category) and ParseCategoryList does not dedupe, so
+// inserting "dup,dup" fails on the second row. That isolates the failure to the
+// category child-write while the parent upsert row write succeeds — exactly the
+// partial-failure window the fix must close. (Dropping event_categories instead
+// would break the upsert statement itself: SQLite compiles the upsert's
+// ON CONFLICT UPDATE-branch trigger, which reads event_categories, at prepare
+// time.)
+func TestUpsertByUID_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	_, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:        "upsert-atomic-uid",
+		CalendarID: 1,
+		Title:      "Atomic Upsert",
+		StartTime:  time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Categories: "dup,dup",
+	})
+	if err == nil {
+		t.Fatal("UpsertByUID succeeded, want error from duplicate category write")
+	}
+
+	if n := countRows(t, db, `SELECT COUNT(*) FROM events`); n != 0 {
+		t.Fatalf("event rows persisted after failed UpsertByUID = %d, want 0", n)
+	}
+}
+
+// TestUpdateWithRelations_AtomicOnAttendeeFailure asserts that when the
+// attendee child-write fails, UpdateWithRelations returns an error AND leaves
+// the original event row unchanged. The TUI edit path previously called Update
+// and then ReplaceAttendees/ReplaceAlarms in separate transactions, so a
+// failure after the row update left a half-updated row (issue #87).
+//
+// Dropping event_attendees isolates the failure to the attendee write: no
+// trigger on events references that table, so the event row UPDATE still runs;
+// only the in-tx attendee replacement fails, which must roll the row back.
+func TestUpdateWithRelations_AtomicOnAttendeeFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	orig, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Title:      "Original Title",
+		StartTime:  time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("seed create: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE event_attendees`); err != nil {
+		t.Fatalf("drop event_attendees: %v", err)
+	}
+
+	_, err = svc.UpdateWithRelations(ctx, orig.ID, UpdateParams{
+		CalendarID: 1,
+		Title:      "Changed Title",
+		StartTime:  time.Date(2026, 4, 2, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 2, 15, 0, 0, 0, time.UTC),
+	},
+		[]model.Attendee{{Email: "a@example.com", Role: "REQ-PARTICIPANT", RSVPStatus: "NEEDS-ACTION"}},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("UpdateWithRelations succeeded, want error from failing attendee write")
+	}
+
+	got, err := svc.Get(ctx, orig.ID)
+	if err != nil {
+		t.Fatalf("get after failed update: %v", err)
+	}
+	if got.Title != "Original Title" {
+		t.Fatalf("title after failed UpdateWithRelations = %q, want %q", got.Title, "Original Title")
+	}
+	if !got.StartTime.Equal(orig.StartTime) {
+		t.Fatalf("start time after failed UpdateWithRelations = %v, want %v", got.StartTime, orig.StartTime)
 	}
 }

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -319,6 +319,51 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, 
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
 
+	e, err := updateEventTx(ctx, qtx, id, p)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit update event: %w", err)
+	}
+	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
+	return e, nil
+}
+
+// UpdateWithRelations updates an event row together with its attendees and
+// alarms in a single transaction, so a failure in any child write rolls the
+// whole edit back (issue #87). The TUI edit path uses this instead of calling
+// Update and then ReplaceAttendees/ReplaceAlarms in separate transactions,
+// which could leave a half-updated row when a later child write failed.
+func (s *Service) UpdateWithRelations(ctx context.Context, id int64, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
+	p.applyDefaults()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Event{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	e, err := updateEventTx(ctx, qtx, id, p)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
+		return Event{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit update event: %w", err)
+	}
+	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
+	return e, nil
+}
+
+// updateEventTx writes the event row and its categories using a tx-bound
+// Queries. It opens no transaction and does not commit or mark the resource
+// dirty, so callers can compose it with attendee/alarm writes inside one
+// transaction.
+func updateEventTx(ctx context.Context, qtx *storage.Queries, id int64, p UpdateParams) (Event, error) {
 	r, err := qtx.UpdateEvent(ctx, storage.UpdateEventParams{
 		ID:             id,
 		Title:          p.Title,
@@ -349,17 +394,21 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, 
 	if err := replaceCategoriesTx(ctx, qtx, e.ID, ParseCategoryList(p.Categories)); err != nil {
 		return Event{}, fmt.Errorf("replace categories: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return Event{}, fmt.Errorf("commit update event: %w", err)
-	}
 	e.Categories = p.Categories
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 
 func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Event, error) {
 	p.applyDefaults()
-	r, err := s.q.UpsertEventByUID(ctx, storage.UpsertEventByUIDParams{
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Event{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	r, err := qtx.UpsertEventByUID(ctx, storage.UpsertEventByUIDParams{
 		Uid:            p.UID,
 		CalendarID:     p.CalendarID,
 		Title:          p.Title,
@@ -388,8 +437,11 @@ func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Event, error
 		return Event{}, err
 	}
 	e := fromStorage(r)
-	if err := s.ReplaceCategories(ctx, e.ID, ParseCategoryList(p.Categories)); err != nil {
+	if err := replaceCategoriesTx(ctx, qtx, e.ID, ParseCategoryList(p.Categories)); err != nil {
 		return Event{}, fmt.Errorf("replace categories: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit upsert event: %w", err)
 	}
 	e.Categories = p.Categories
 	return e, nil
@@ -622,9 +674,52 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
 
+	e, calendarID, err := updateInstanceTx(ctx, qtx, uid, instanceTime, p)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit override: %w", err)
+	}
+	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
+	return e, nil
+}
+
+// UpdateInstanceWithRelations is UpdateInstance plus an attendee/alarm write in
+// the same transaction, so the override row and its children commit atomically
+// (issue #87).
+func (s *Service) UpdateInstanceWithRelations(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
+	p.applyDefaults()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Event{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	e, calendarID, err := updateInstanceTx(ctx, qtx, uid, instanceTime, p)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
+		return Event{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit override: %w", err)
+	}
+	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
+	return e, nil
+}
+
+// updateInstanceTx creates or updates a per-occurrence override row and its
+// categories using a tx-bound Queries, returning the resulting event and the
+// master's calendar ID (for marking the resource dirty after commit). It opens
+// no transaction so callers can compose it with attendee/alarm writes.
+func updateInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, instanceTime time.Time, p UpdateParams) (Event, int64, error) {
 	master, err := qtx.GetEventByUID(ctx, uid)
 	if err != nil {
-		return Event{}, fmt.Errorf("get master: %w", err)
+		return Event{}, 0, fmt.Errorf("get master: %w", err)
 	}
 	recID := instanceTime.UTC().Format(time.RFC3339)
 
@@ -639,7 +734,7 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 	}); gErr == nil {
 		r, err = qtx.UpdateEvent(ctx, overrideUpdateParams(existing.ID, p))
 		if err != nil {
-			return Event{}, fmt.Errorf("update override: %w", err)
+			return Event{}, 0, fmt.Errorf("update override: %w", err)
 		}
 	} else {
 		r, err = qtx.CreateEvent(ctx, overrideCreateParams(uid, recID, master.Sequence+1, p))
@@ -652,38 +747,25 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 					RecurrenceID: recID,
 				})
 				if eErr != nil {
-					return Event{}, fmt.Errorf("retry get override: %w", eErr)
+					return Event{}, 0, fmt.Errorf("retry get override: %w", eErr)
 				}
 				r, err = qtx.UpdateEvent(ctx, overrideUpdateParams(existing.ID, p))
 				if err != nil {
-					return Event{}, fmt.Errorf("retry update override: %w", err)
+					return Event{}, 0, fmt.Errorf("retry update override: %w", err)
 				}
 			} else {
-				return Event{}, fmt.Errorf("create override: %w", err)
+				return Event{}, 0, fmt.Errorf("create override: %w", err)
 			}
 		}
 	}
 
-	if err := qtx.DeleteCategoriesByEventID(ctx, r.ID); err != nil {
-		return Event{}, fmt.Errorf("clear override categories: %w", err)
-	}
-	for _, c := range carriedCats {
-		if _, err := qtx.CreateEventCategory(ctx, storage.CreateEventCategoryParams{
-			EventID:  r.ID,
-			Category: c,
-		}); err != nil {
-			return Event{}, fmt.Errorf("create override category: %w", err)
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return Event{}, fmt.Errorf("commit override: %w", err)
+	if err := replaceCategoriesTx(ctx, qtx, r.ID, carriedCats); err != nil {
+		return Event{}, 0, err
 	}
 
 	e := fromStorage(r)
 	e.Categories = timeutil.JoinCategoryList(carriedCats)
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
-	return e, nil
+	return e, master.CalendarID, nil
 }
 
 // overrideUpdateParams builds the storage params for updating an existing
@@ -774,14 +856,6 @@ func isUniqueViolationOnRecurrenceID(err error) bool {
 // so the trash view can offer an atomic restore later.
 func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams) (Event, error) {
 	p.applyDefaults()
-	master, err := s.q.GetEventByUID(ctx, uid)
-	if err != nil {
-		return Event{}, fmt.Errorf("get master: %w", err)
-	}
-
-	prevRRule := storage.NullableToString(master.RecurrenceRule)
-	until := instanceTime.UTC().Add(-time.Second)
-	truncatedRule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -790,11 +864,66 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
 
+	e, masterCalendarID, err := updateFromInstanceTx(ctx, qtx, uid, instanceTime, p)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit split: %w", err)
+	}
+	_ = storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event")
+	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
+	return e, nil
+}
+
+// UpdateFromInstanceWithRelations is UpdateFromInstance plus an attendee/alarm
+// write on the new split series in the same transaction, so the truncation, the
+// new master, and its children commit atomically (issue #87).
+func (s *Service) UpdateFromInstanceWithRelations(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
+	p.applyDefaults()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Event{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	e, masterCalendarID, err := updateFromInstanceTx(ctx, qtx, uid, instanceTime, p)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
+		return Event{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit split: %w", err)
+	}
+	_ = storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event")
+	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
+	return e, nil
+}
+
+// updateFromInstanceTx truncates the master series, soft-deletes future
+// overrides, records the pre-truncation state, and creates the new split-series
+// master with its categories, all using a tx-bound Queries. It returns the new
+// event and the master's calendar ID, opening no transaction so callers can
+// compose it with attendee/alarm writes.
+func updateFromInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, instanceTime time.Time, p UpdateParams) (Event, int64, error) {
+	master, err := qtx.GetEventByUID(ctx, uid)
+	if err != nil {
+		return Event{}, 0, fmt.Errorf("get master: %w", err)
+	}
+
+	prevRRule := storage.NullableToString(master.RecurrenceRule)
+	until := instanceTime.UTC().Add(-time.Second)
+	truncatedRule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
+
 	if err := qtx.UpdateEventRecurrenceRule(ctx, storage.UpdateEventRecurrenceRuleParams{
 		RecurrenceRule: storage.StringToNullable(truncatedRule),
 		ID:             master.ID,
 	}); err != nil {
-		return Event{}, fmt.Errorf("truncate master rrule: %w", err)
+		return Event{}, 0, fmt.Errorf("truncate master rrule: %w", err)
 	}
 
 	cutoff := instanceTime.UTC().Format(time.RFC3339)
@@ -802,7 +931,7 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 		Uid:          uid,
 		RecurrenceID: cutoff,
 	}); err != nil {
-		return Event{}, fmt.Errorf("soft-delete future overrides: %w", err)
+		return Event{}, 0, fmt.Errorf("soft-delete future overrides: %w", err)
 	}
 
 	if err := qtx.RecordEventTruncateDelete(ctx, storage.RecordEventTruncateDeleteParams{
@@ -811,7 +940,7 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 		CutoffTime:    cutoff,
 		PreviousRrule: prevRRule,
 	}); err != nil {
-		return Event{}, fmt.Errorf("record truncate: %w", err)
+		return Event{}, 0, fmt.Errorf("record truncate: %w", err)
 	}
 
 	// Caller is the source of truth for categories. An empty p.Categories
@@ -845,27 +974,16 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 		ConferenceUri:  p.ConferenceURI,
 	})
 	if err != nil {
-		return Event{}, fmt.Errorf("create split series: %w", err)
+		return Event{}, 0, fmt.Errorf("create split series: %w", err)
 	}
 
-	for _, c := range carriedCats {
-		if _, err := qtx.CreateEventCategory(ctx, storage.CreateEventCategoryParams{
-			EventID:  r.ID,
-			Category: c,
-		}); err != nil {
-			return Event{}, fmt.Errorf("create split category: %w", err)
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return Event{}, fmt.Errorf("commit split: %w", err)
+	if err := replaceCategoriesTx(ctx, qtx, r.ID, carriedCats); err != nil {
+		return Event{}, 0, err
 	}
 
 	e := fromStorage(r)
 	e.Categories = timeutil.JoinCategoryList(carriedCats)
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
-	_ = storage.MarkResourceDirty(ctx, s.db, p.CalendarID, newUID, "event")
-	return e, nil
+	return e, master.CalendarID, nil
 }
 
 // setRRuleUntil adds or replaces the UNTIL parameter in an RRULE string.
@@ -1197,8 +1315,20 @@ func (s *Service) ReplaceAlarms(ctx context.Context, eventID int64, alarms []mod
 	}
 	defer tx.Rollback()
 
-	qtx := s.q.WithTx(tx)
+	if err := replaceAlarmsTx(ctx, s.q.WithTx(tx), eventID, alarms); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.markDirtyByID(ctx, eventID)
+	return nil
+}
 
+// replaceAlarmsTx reconciles an event's alarms (content/UID matching, in-place
+// edits, creates, deletes) using a tx-bound Queries. It opens no transaction so
+// callers can compose it with the event row write inside one transaction.
+func replaceAlarmsTx(ctx context.Context, qtx *storage.Queries, eventID int64, alarms []model.Alarm) error {
 	// Load existing alarms with attendees for content matching.
 	existing, err := loadExistingAlarms(ctx, qtx, eventID)
 	if err != nil {
@@ -1240,15 +1370,17 @@ func (s *Service) ReplaceAlarms(ctx context.Context, eventID int64, alarms []mod
 	}
 
 	// Delete existing alarms that were not matched (they were removed).
-	if err := deleteUnmatchedAlarms(ctx, qtx, existing, matched); err != nil {
-		return err
-	}
+	return deleteUnmatchedAlarms(ctx, qtx, existing, matched)
+}
 
-	if err := tx.Commit(); err != nil {
+// replaceRelationsTx replaces an event's attendees and alarms using a tx-bound
+// Queries, so the *WithRelations methods can write both child collections
+// inside the same transaction as the event row.
+func replaceRelationsTx(ctx context.Context, qtx *storage.Queries, eventID int64, attendees []model.Attendee, alarms []model.Alarm) error {
+	if err := replaceAttendeesTx(ctx, qtx, eventID, attendees); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return replaceAlarmsTx(ctx, qtx, eventID, alarms)
 }
 
 // Attendee CRUD
@@ -1272,7 +1404,20 @@ func (s *Service) ReplaceAttendees(ctx context.Context, eventID int64, attendees
 	}
 	defer tx.Rollback()
 
-	qtx := s.q.WithTx(tx)
+	if err := replaceAttendeesTx(ctx, s.q.WithTx(tx), eventID, attendees); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.markDirtyByID(ctx, eventID)
+	return nil
+}
+
+// replaceAttendeesTx replaces an event's attendees using a tx-bound Queries. It
+// opens no transaction so callers can compose it with the event row write
+// inside one transaction.
+func replaceAttendeesTx(ctx context.Context, qtx *storage.Queries, eventID int64, attendees []model.Attendee) error {
 	if err := qtx.DeleteAttendeesByEventID(ctx, eventID); err != nil {
 		return fmt.Errorf("delete attendees: %w", err)
 	}
@@ -1301,10 +1446,6 @@ func (s *Service) ReplaceAttendees(ctx context.Context, eventID int64, attendees
 			return fmt.Errorf("create attendee: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	s.markDirtyByID(ctx, eventID)
 	return nil
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -578,20 +578,14 @@ func (m Model) dispatchEditScope(editID int64, choice int, save EventFormSaveMsg
 		Categories:     save.Categories,
 	}
 
-	var writtenID int64
+	// Each branch writes the event row together with its attendees and alarms
+	// in a single transaction, so a failed child write rolls the whole edit
+	// back instead of leaving a half-updated row (issue #87).
 	switch choice {
 	case 0: // This event only
-		written, err := m.app.Events.UpdateInstance(ctx, master.UID, save.InstanceTime, params)
-		if err != nil {
-			return eventUpdateAfterScopeMsg{calendarID: save.CalendarID, err: err}
-		}
-		writtenID = written.ID
+		_, err = m.app.Events.UpdateInstanceWithRelations(ctx, master.UID, save.InstanceTime, params, save.Attendees, save.Alarms)
 	case 1: // This and following
-		written, err := m.app.Events.UpdateFromInstance(ctx, master.UID, save.InstanceTime, params)
-		if err != nil {
-			return eventUpdateAfterScopeMsg{calendarID: save.CalendarID, err: err}
-		}
-		writtenID = written.ID
+		_, err = m.app.Events.UpdateFromInstanceWithRelations(ctx, master.UID, save.InstanceTime, params, save.Attendees, save.Alarms)
 	default: // All events
 		// The form opened showing the clicked instance's time, so save.StartTime
 		// is relative to that occurrence — not the master's DTSTART. Apply the
@@ -601,16 +595,9 @@ func (m Model) dispatchEditScope(editID int64, choice int, save EventFormSaveMsg
 		newDuration := save.EndTime.Sub(save.StartTime)
 		params.StartTime = master.StartTime.Add(delta)
 		params.EndTime = params.StartTime.Add(newDuration)
-		if _, err := m.app.Events.Update(ctx, master.ID, params); err != nil {
-			return eventUpdateAfterScopeMsg{calendarID: save.CalendarID, err: err}
-		}
-		writtenID = master.ID
+		_, err = m.app.Events.UpdateWithRelations(ctx, master.ID, params, save.Attendees, save.Alarms)
 	}
-
-	if err := m.app.Events.ReplaceAttendees(ctx, writtenID, save.Attendees); err != nil {
-		return eventUpdateAfterScopeMsg{calendarID: save.CalendarID, err: err}
-	}
-	if err := m.app.Events.ReplaceAlarms(ctx, writtenID, save.Alarms); err != nil {
+	if err != nil {
 		return eventUpdateAfterScopeMsg{calendarID: save.CalendarID, err: err}
 	}
 	return eventUpdateAfterScopeMsg{calendarID: save.CalendarID}
@@ -1896,7 +1883,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			calID := msg.CalendarID
 			return m, func() tea.Msg {
 				ctx := context.Background()
-				_, err := m.app.Events.Update(ctx, eventID, event.UpdateParams{
+				// Update the row and its attendees/alarms in one transaction so a
+				// failed child write rolls the whole edit back (issue #87).
+				_, err := m.app.Events.UpdateWithRelations(ctx, eventID, event.UpdateParams{
 					CalendarID:     calID,
 					Title:          msg.Title,
 					Description:    msg.Description,
@@ -1910,14 +1899,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					Transp:         msg.Transp,
 					Class:          msg.Class,
 					Categories:     msg.Categories,
-				})
-				if err != nil {
-					return eventUpdatedMsg{calendarID: calID, err: err}
-				}
-				if err = m.app.Events.ReplaceAttendees(ctx, eventID, attendees); err != nil {
-					return eventUpdatedMsg{calendarID: calID, err: err}
-				}
-				err = m.app.Events.ReplaceAlarms(ctx, eventID, alarms)
+				}, attendees, alarms)
 				return eventUpdatedMsg{calendarID: calID, err: err}
 			}
 		}


### PR DESCRIPTION
Fixes #87

## Root cause

Two sibling paths committed the event row and its child collections in **separate** transactions — the same shape #73 fixed for `Create`/`Update`:

1. **`event.UpsertByUID`** committed the row via the upsert query in autocommit, then ran `ReplaceCategories` in its own transaction. A category failure returned an error while the row stayed committed (orphan row / category-wipe contract violation).
2. **TUI event-edit path** (`internal/tui/app.go`) called `Update` (or `UpdateInstance` / `UpdateFromInstance`) and then `ReplaceAttendees` / `ReplaceAlarms` separately, so a failing child write left a half-updated row.

## Fix

- `UpsertByUID` now wraps the upsert and category replacement in one `q.WithTx(tx)` transaction, mirroring the #73 fix via the existing `replaceCategoriesTx` helper.
- Added `UpdateWithRelations` / `UpdateInstanceWithRelations` / `UpdateFromInstanceWithRelations`, which write the event row plus attendees and alarms in a single transaction, and routed the two TUI edit call sites through them.
- Factored the existing methods into tx-bound cores (`updateEventTx` / `updateInstanceTx` / `updateFromInstanceTx`) and added tx-bound `replaceAttendeesTx` / `replaceAlarmsTx` (plus a small `replaceRelationsTx` combinator), so the plain and `*WithRelations` variants share one implementation. The single-purpose `Update*` / `Replace*` public methods keep their existing behavior and signatures.

The override-edit ("This event only") flow now marks only the master's sync resource `(master.CalendarID, uid)` dirty — the resource that actually carries the override — instead of also marking the override row's own calendar. That difference is observable only when moving a single recurring instance to a *different* synced calendar (a malformed CalDAV state), where the new behavior is the correct one.

## Tests (`internal/event/atomic_test.go`)

- `TestUpsertByUID_AtomicOnCategoryFailure` — passes duplicate categories (`event_categories` has `PRIMARY KEY (event_id, category)` and `ParseCategoryList` does not dedupe) so the **category** child-write fails while the upsert row write succeeds; asserts **no** event row persists. Fails before the fix (orphan row), passes after.
- `TestUpdateWithRelations_AtomicOnAttendeeFailure` — drops `event_attendees` (no `events` trigger references it, so the row UPDATE still runs) so the **attendee** child-write fails inside the transaction; asserts the original title/start are unchanged.

Note: dropping `event_categories` cannot probe the upsert path — SQLite compiles the upsert's `ON CONFLICT` UPDATE-branch FTS trigger (which reads `event_categories`) at prepare time, so a dropped table fails the parent write itself; the duplicate-category probe isolates the child write cleanly.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` are all green.
