### PR TITLE
fix(duration): reject per-component signs and round-trip days/weeks in FromGo

### DIFF
--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -16,8 +16,10 @@ type parsed struct {
 	seconds int
 }
 
-// consumeComponent extracts the integer preceding letter in s.
-// If letter is absent, returns (s, 0, nil).
+// consumeComponent extracts the unsigned integer preceding letter in s.
+// If letter is absent, returns (s, 0, nil). Per RFC 5545 a component
+// value is one or more DIGITs with no embedded sign; the whole-duration
+// sign is handled once in parse, so "PT-1H" and "PT+1H" are rejected.
 func consumeComponent(s string, letter byte, orig string) (string, int, error) {
 	i := strings.IndexByte(s, letter)
 	if i < 0 {
@@ -26,9 +28,16 @@ func consumeComponent(s string, letter byte, orig string) (string, int, error) {
 	if i == 0 {
 		return "", 0, fmt.Errorf("invalid duration %q: %c requires a number", orig, letter)
 	}
-	v, err := strconv.Atoi(s[:i])
+	num := s[:i]
+	// strconv.Atoi rejects every non-digit except a leading sign, so a
+	// first-byte sign check is all that's needed to forbid per-component
+	// signs (num is non-empty here because i > 0).
+	if num[0] == '+' || num[0] == '-' {
+		return "", 0, fmt.Errorf("invalid duration %q: bad %c value %q", orig, letter, num)
+	}
+	v, err := strconv.Atoi(num)
 	if err != nil {
-		return "", 0, fmt.Errorf("invalid duration %q: bad %c value %q", orig, letter, s[:i])
+		return "", 0, fmt.Errorf("invalid duration %q: bad %c value %q", orig, letter, num)
 	}
 	return s[i+1:], v, nil
 }
@@ -111,34 +120,60 @@ func parse(s string) (parsed, error) {
 }
 
 // FromGo converts a Go time.Duration to an RFC 5545 duration string.
-// e.g. 1h30m → "PT1H30M", 90s → "PT1M30S", -15m → "-PT15M".
+// e.g. 1h30m → "PT1H30M", 90s → "PT1M30S", -15m → "-PT15M",
+// 48h → "P2D", 168h → "P1W".
+//
+// Whole days are emitted as the date form (P#D) and exact whole weeks as
+// the mutually-exclusive week form (P#W) so that nominal multi-day spans
+// round-trip through Add, which uses calendar-aware AddDate for days and
+// weeks. An absolute "PT48H" would otherwise drift by an hour across a
+// DST boundary.
+//
+// Sub-second precision is truncated toward zero: a Go duration carries
+// nanoseconds but RFC 5545 durations have whole-second granularity, so
+// 1500ms becomes "PT1S" and 500ms becomes "PT0S".
 func FromGo(d time.Duration) string {
-	if d == 0 {
+	total := int64(d / time.Second)
+	if total == 0 {
 		return "PT0S"
 	}
 	var b strings.Builder
-	neg := d < 0
-	if neg {
+	if total < 0 {
 		b.WriteByte('-')
-		d = -d
+		total = -total
 	}
 	b.WriteByte('P')
-	total := int(d / time.Second)
-	h := total / 3600
-	m := (total % 3600) / 60
-	s := total % 60
+
+	const secsPerDay = 86400
+	// Exact whole weeks use the week form, which RFC 5545 makes
+	// mutually exclusive with all other components.
+	if total%(7*secsPerDay) == 0 {
+		b.WriteString(strconv.FormatInt(total/(7*secsPerDay), 10))
+		b.WriteByte('W')
+		return b.String()
+	}
+
+	days := total / secsPerDay
+	rem := total % secsPerDay
+	h := rem / 3600
+	m := (rem % 3600) / 60
+	s := rem % 60
+	if days > 0 {
+		b.WriteString(strconv.FormatInt(days, 10))
+		b.WriteByte('D')
+	}
 	if h > 0 || m > 0 || s > 0 {
 		b.WriteByte('T')
 		if h > 0 {
-			b.WriteString(strconv.Itoa(h))
+			b.WriteString(strconv.FormatInt(h, 10))
 			b.WriteByte('H')
 		}
 		if m > 0 {
-			b.WriteString(strconv.Itoa(m))
+			b.WriteString(strconv.FormatInt(m, 10))
 			b.WriteByte('M')
 		}
 		if s > 0 {
-			b.WriteString(strconv.Itoa(s))
+			b.WriteString(strconv.FormatInt(s, 10))
 			b.WriteByte('S')
 		}
 	}

--- a/internal/duration/duration_test.go
+++ b/internal/duration/duration_test.go
@@ -68,6 +68,16 @@ func TestValidate(t *testing.T) {
 		{"H without number", "-PTH", true},
 		{"M without number", "-PTM", true},
 		{"S without number", "-PTS", true},
+
+		// Per-component signs are forbidden by RFC 5545; only the
+		// whole-duration may carry a single leading sign.
+		{"signed hours", "PT-1H", true},
+		{"signed days", "P-1D", true},
+		{"signed weeks", "P-1W", true},
+		{"signed minutes after prefix", "-PT-15M", true},
+		{"signed seconds", "PT-30S", true},
+		{"plus signed minutes", "PT+15M", true},
+		{"signed trailing component", "PT1H-30M", true},
 	}
 
 	for _, tt := range tests {
@@ -75,6 +85,46 @@ func TestValidate(t *testing.T) {
 			err := Validate(tt.dur)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate(%q) error = %v, wantErr %v", tt.dur, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFromGo(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"zero", 0, "PT0S"},
+		{"15 minutes", 15 * time.Minute, "PT15M"},
+		{"negative 15 minutes", -15 * time.Minute, "-PT15M"},
+		{"hour and a half", 90 * time.Minute, "PT1H30M"},
+		{"90 seconds", 90 * time.Second, "PT1M30S"},
+		// Whole days factor into the date form so nominal multi-day
+		// spans round-trip through Add without DST drift.
+		{"two days", 48 * time.Hour, "P2D"},
+		{"day and two hours", 26 * time.Hour, "P1DT2H"},
+		{"negative two days", -48 * time.Hour, "-P2D"},
+		// Exact whole weeks use the mutually-exclusive week form.
+		{"one week", 7 * 24 * time.Hour, "P1W"},
+		{"two weeks", 14 * 24 * time.Hour, "P2W"},
+		// Eight days is not a whole week: date form, not week form.
+		{"eight days", 8 * 24 * time.Hour, "P8D"},
+		// Sub-second input truncates to whole seconds (documented).
+		{"sub-second truncates", 1500 * time.Millisecond, "PT1S"},
+		{"under one second", 500 * time.Millisecond, "PT0S"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromGo(tt.d)
+			if got != tt.want {
+				t.Errorf("FromGo(%v) = %q, want %q", tt.d, got, tt.want)
+			}
+			// Round-trip: the emitted string must validate.
+			if err := Validate(got); err != nil {
+				t.Errorf("Validate(FromGo(%v)=%q) = %v, want nil", tt.d, got, err)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #129

## Root cause

`internal/duration/duration.go` had two defects in its RFC 5545 handling:

1. **Lenient parser (`consumeComponent`)** used `strconv.Atoi`, which silently
   accepts a leading sign on a single component. RFC 5545 forbids per-component
   signs — only the whole duration may carry one leading `+`/`-`. So
   `Validate("-PT-1H")`, `P-1D`, `PT+15M`, etc. all passed, and the malformed
   string then fed `Add`, producing a surprising offset.

2. **`FromGo`** truncated sub-second input (`int(d / time.Second)`) and only
   ever emitted T-components, so a 2-day span became `PT48H`, never `P2D`/`P2W`.
   Because `Add` applies whole days via calendar-aware `AddDate` while `PT48H`
   is an absolute 48 hours, a nominal multi-day span that round-tripped through
   `FromGo` drifted by an hour across a DST boundary.

## Fix

- `consumeComponent`: reject a leading sign on the component value. `Atoi`
  already rejects every other non-digit, so a single first-byte check is
  sufficient and minimal.
- `FromGo`: factor whole days into the date form (`P#D`) and exact whole weeks
  into the mutually-exclusive week form (`P#W`) so nominal durations round-trip
  through `Add` without DST drift. Sub-second truncation toward zero is now
  documented (`1500ms` -> `PT1S`, `500ms` -> `PT0S`).

## Tests

- `TestValidate`: added cases asserting per-component signs are rejected
  (`PT-1H`, `P-1D`, `P-1W`, `-PT-15M`, `PT-30S`, `PT+15M`, `PT1H-30M`).
- `TestFromGo` (new): covers existing behavior (minutes, seconds, negatives),
  the new day/week emission (`P2D`, `P1DT2H`, `-P2D`, `P1W`, `P2W`, `P8D`), and
  sub-second truncation. Each case also round-trips through `Validate`.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
