### PR TITLE
fix(ical): emit yearly RRULE for VTIMEZONE DST transitions

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -783,7 +783,7 @@ func buildVTimezone(tzID string) (*ical.Component, error) {
 		return fmt.Sprintf("%s%02d%02d", sign, secs/3600, (secs%3600)/60)
 	}
 
-	addSubComp := func(compName, tzName string, offset, fromOffset int, dtstart time.Time) {
+	addSubComp := func(compName, tzName string, offset, fromOffset int, dtstart time.Time, rrule string) {
 		comp := ical.NewComponent(compName)
 
 		p := &ical.Prop{Name: ical.PropDateTimeStart}
@@ -802,13 +802,23 @@ func buildVTimezone(tzID string) (*ical.Component, error) {
 		p.Value = tzName
 		comp.Props.Set(p)
 
+		// A yearly RRULE makes the transition apply to every year rather than
+		// the single export year, so events far in the past/future still
+		// resolve the right offset from the embedded VTIMEZONE (RFC 5545
+		// Section 3.6.5).
+		if rrule != "" {
+			p = &ical.Prop{Name: ical.PropRecurrenceRule}
+			p.Value = rrule
+			comp.Props.Set(p)
+		}
+
 		vtz.Children = append(vtz.Children, comp)
 	}
 
 	if len(transitions) == 0 {
 		// No DST — single STANDARD component
 		addSubComp("STANDARD", janName, janOffset, janOffset,
-			time.Date(refYear, 1, 1, 0, 0, 0, 0, loc))
+			time.Date(refYear, 1, 1, 0, 0, 0, 0, loc), "")
 	} else {
 		for _, tr := range transitions {
 			// The transition was detected between month M-1 and M, but the
@@ -818,7 +828,8 @@ func buildVTimezone(tzID string) (*ical.Component, error) {
 			if tr.offset > tr.fromOffset {
 				compName = "DAYLIGHT"
 			}
-			addSubComp(compName, tr.name, tr.offset, tr.fromOffset, dtstart)
+			addSubComp(compName, tr.name, tr.offset, tr.fromOffset, dtstart,
+				transitionRRULE(dtstart))
 		}
 	}
 
@@ -842,6 +853,25 @@ func findTransitionDay(loc *time.Location, year int, detectedMonth time.Month, p
 		}
 	}
 	return searchEnd
+}
+
+// transitionRRULE builds a yearly RFC 5545 recurrence rule describing when a
+// DST transition repeats, derived from the weekday-of-month of dtstart. Most
+// IANA zones transition on a fixed ordinal weekday (e.g. "2nd Sunday of March"
+// -> FREQ=YEARLY;BYMONTH=3;BYDAY=2SU). When the weekday is the last such
+// weekday of the month, BYDAY uses -1 (e.g. last Sunday -> BYDAY=-1SU), which
+// also matches the common European rule.
+func transitionRRULE(dtstart time.Time) string {
+	weekdays := [...]string{"SU", "MO", "TU", "WE", "TH", "FR", "SA"}
+	wd := weekdays[dtstart.Weekday()]
+	month := int(dtstart.Month())
+	// Last occurrence of this weekday in the month? (One week later spills
+	// into the next month.)
+	if dtstart.AddDate(0, 0, 7).Month() != dtstart.Month() {
+		return fmt.Sprintf("FREQ=YEARLY;BYMONTH=%d;BYDAY=-1%s", month, wd)
+	}
+	nth := (dtstart.Day()-1)/7 + 1
+	return fmt.Sprintf("FREQ=YEARLY;BYMONTH=%d;BYDAY=%d%s", month, nth, wd)
 }
 
 // setAttendeeParams adds RFC 5545 ATTENDEE parameters beyond the base CN/PARTSTAT/ROLE.

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -319,6 +319,44 @@ func TestExport_VTimezonePresent(t *testing.T) {
 	}
 }
 
+func TestExport_VTimezoneRecurringTransitions(t *testing.T) {
+	t.Parallel()
+	// An event years away from "now" must still get a VTIMEZONE whose
+	// transitions cover its date. Emitting recurring RRULE transition rules
+	// (rather than one-shot DTSTARTs in the current year) satisfies this.
+	events := []event.Event{{
+		UID:       "vtz-recurring",
+		Title:     "Future TZ Event",
+		StartTime: time.Date(2035, 7, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2035, 7, 1, 15, 0, 0, 0, time.UTC),
+		Timezone:  "America/New_York",
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}}
+
+	data, _ := ExportEvents(events, "")
+	ics := string(data)
+
+	if !strings.Contains(ics, "BEGIN:VTIMEZONE") {
+		t.Fatalf("missing VTIMEZONE block:\n%s", ics)
+	}
+	// DST transitions must be expressed as yearly recurrence rules so the
+	// VTIMEZONE applies to every year, not just the export year.
+	if !strings.Contains(ics, "RRULE:FREQ=YEARLY") {
+		t.Errorf("VTIMEZONE missing recurring RRULE transition:\n%s", ics)
+	}
+	// America/New_York: DST begins the 2nd Sunday of March, ends the 1st
+	// Sunday of November.
+	if !strings.Contains(ics, "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU") {
+		t.Errorf("missing DAYLIGHT transition rule (2nd Sunday of March):\n%s", ics)
+	}
+	if !strings.Contains(ics, "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU") {
+		t.Errorf("missing STANDARD transition rule (1st Sunday of November):\n%s", ics)
+	}
+}
+
 func TestExport_VTimezoneNoDST(t *testing.T) {
 	t.Parallel()
 	// Asia/Kolkata does not observe DST


### PR DESCRIPTION
Fixes #130

## Root cause
`buildVTimezone` (`internal/ical/export.go`) probed only `time.Now().Year()`
and emitted STANDARD/DAYLIGHT sub-components with a single one-shot `DTSTART`
and no `RRULE`/`RDATE`. The resulting VTIMEZONE only described that one year's
transitions, so an event years in the past or future referencing the same TZID
got a VTIMEZONE that did not cover its date. Strict consumers that resolve
offsets from the embedded VTIMEZONE then compute the wrong offset.

## Fix
Derive a yearly RFC 5545 recurrence rule from the weekday-of-month of each
detected transition and attach it to the sub-component:
- 2nd Sunday of March -> `FREQ=YEARLY;BYMONTH=3;BYDAY=2SU`
- last such weekday of the month -> `BYDAY=-1SU` (also the common EU rule)

The no-DST case still emits a single STANDARD with no RRULE. This matches the
RFC 5545 Section 3.6.5 examples and makes the embedded VTIMEZONE valid for
every year.

## Test coverage
Added `TestExport_VTimezoneRecurringTransitions` in
`internal/ical/export_test.go`: exports an `America/New_York` event in 2035
(far from the current year) and asserts the VTIMEZONE contains
`RRULE:FREQ=YEARLY`, the DAYLIGHT rule `FREQ=YEARLY;BYMONTH=3;BYDAY=2SU`, and
the STANDARD rule `FREQ=YEARLY;BYMONTH=11;BYDAY=1SU`. The test fails before the
fix (no RRULE emitted) and passes after. Existing VTIMEZONE tests (DST and
no-DST) continue to pass.

Assisted-by: Claude Code:claude-opus-4-8
