### PR TITLE
fix(event): read recurring master inside tx for EXDATE/RRULE updates

### DIFF
--- a/internal/event/delete_instance_concurrency_test.go
+++ b/internal/event/delete_instance_concurrency_test.go
@@ -1,0 +1,94 @@
+package event
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// TestDeleteInstance_ConcurrentNoLostUpdate is a regression test for issue
+// #116: DeleteInstance read the master's EXDATE list outside the writing
+// transaction, so two concurrent instance-deletes both computed their new
+// list from the same pre-transaction snapshot and the second write silently
+// clobbered the first — an excluded occurrence reappeared on next expansion.
+//
+// The test fires N concurrent DeleteInstance calls, each excluding a distinct
+// occurrence of the same recurring master, and asserts that every EXDATE
+// survives. Under the buggy read-modify-write the final list is short.
+func TestDeleteInstance_ConcurrentNoLostUpdate(t *testing.T) {
+	// A file-backed DB is required: ":memory:" gives every pooled connection
+	// its own private database, which breaks once goroutines fan out across
+	// connections.
+	dbPath := filepath.Join(t.TempDir(), "issue116.db")
+	db, q, err := storage.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	start := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	master, err := svc.Create(ctx, CreateParams{
+		CalendarID:     1,
+		Title:          "Daily Standup",
+		StartTime:      start,
+		EndTime:        start.Add(15 * time.Minute),
+		RecurrenceRule: "FREQ=DAILY;COUNT=30",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	const n = 12
+	instances := make([]time.Time, n)
+	for i := range instances {
+		instances[i] = start.AddDate(0, 0, i)
+	}
+
+	var wg sync.WaitGroup
+	gate := make(chan struct{})
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-gate // release all goroutines together to maximize interleaving
+			errs[i] = svc.DeleteInstance(ctx, master.UID, instances[i])
+		}(i)
+	}
+	close(gate)
+	wg.Wait()
+
+	for i, e := range errs {
+		if e != nil {
+			t.Fatalf("DeleteInstance[%d]: %v", i, e)
+		}
+	}
+
+	got, err := q.GetEventByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("reload master: %v", err)
+	}
+	exdates := ParseTimeList(storage.NullableToString(got.Exdates))
+	have := make(map[time.Time]bool, len(exdates))
+	for _, d := range exdates {
+		have[d.UTC()] = true
+	}
+
+	missing := 0
+	for _, want := range instances {
+		if !have[want.UTC()] {
+			missing++
+		}
+	}
+	if missing != 0 {
+		t.Fatalf("lost %d of %d EXDATEs under concurrency (have %d): concurrent DeleteInstance clobbered the master EXDATE list",
+			missing, n, len(exdates))
+	}
+}

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -532,17 +532,20 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 // DeleteInstance excludes a single occurrence of a recurring event by adding
 // an EXDATE to the master. instanceTime is the StartTime of the occurrence.
 func (s *Service) DeleteInstance(ctx context.Context, uid string, instanceTime time.Time) error {
-	master, err := s.q.GetEventByUID(ctx, uid)
-	if err != nil {
-		return fmt.Errorf("get master: %w", err)
-	}
-
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
+
+	// Read the master inside the transaction so the EXDATE list we recompute
+	// reflects a concurrent writer's changes (issue #116). Reading outside the
+	// tx let a second instance-delete clobber the first one's EXDATE.
+	master, err := qtx.GetEventByUID(ctx, uid)
+	if err != nil {
+		return fmt.Errorf("get master: %w", err)
+	}
 
 	existing := ParseTimeList(storage.NullableToString(master.Exdates))
 	existing = append(existing, instanceTime.UTC())
@@ -598,7 +601,17 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 // commit but before a separate read would otherwise have its updated_at
 // captured as the undo baseline, letting RestoreUndo clobber that edit.
 func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTime time.Time) (string, error) {
-	master, err := s.q.GetEventByUID(ctx, uid)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	// Read the master inside the transaction so the RRULE we truncate reflects
+	// a concurrent writer's edits rather than a pre-transaction snapshot
+	// (issue #116).
+	master, err := qtx.GetEventByUID(ctx, uid)
 	if err != nil {
 		return "", fmt.Errorf("get master: %w", err)
 	}
@@ -606,13 +619,6 @@ func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTi
 	prevRRule := storage.NullableToString(master.RecurrenceRule)
 	until := instanceTime.UTC().Add(-time.Second)
 	rule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return "", fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
 
 	if err := qtx.UpdateEventRecurrenceRule(ctx, storage.UpdateEventRecurrenceRuleParams{
 		RecurrenceRule: storage.StringToNullable(rule),

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -249,17 +249,20 @@ func (s *Service) restoreInstanceByLogID(ctx context.Context, logID int64) error
 		}
 		return fmt.Errorf("get exdate log: %w", err)
 	}
-	master, err := s.q.GetEventByUID(ctx, log.Uid)
-	if err != nil {
-		return fmt.Errorf("get master: %w", err)
-	}
-
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
+
+	// Read the master inside the transaction so the EXDATE list we rewrite
+	// reflects a concurrent writer's changes rather than a pre-transaction
+	// snapshot (issue #116).
+	master, err := qtx.GetEventByUID(ctx, log.Uid)
+	if err != nil {
+		return fmt.Errorf("get master: %w", err)
+	}
 
 	existing := ParseTimeList(storage.NullableToString(master.Exdates))
 	target, err := time.Parse(time.RFC3339, log.RecurrenceID)

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -17,11 +17,19 @@ func Open(dbPath string) (*sql.DB, *Queries, error) {
 	// Encode pragmas in the DSN so every pooled connection gets them,
 	// not just the first one. PRAGMA foreign_keys is per-connection in
 	// SQLite; setting it via Exec on the pool only affects one conn.
+	// _txlock=immediate makes every read-write transaction acquire SQLite's
+	// write lock at BEGIN instead of lazily on first write. This serializes
+	// read-modify-write flows (e.g. appending an EXDATE to a master) so a
+	// concurrent writer cannot slip in between the read and the write and get
+	// its change silently clobbered, and it avoids the deferred-transaction
+	// upgrade deadlock that returns SQLITE_BUSY immediately. SQLite already
+	// allows only one writer at a time, so this costs no real concurrency.
 	dsn := dbPath +
 		"?_pragma=journal_mode(WAL)" +
 		"&_pragma=foreign_keys(ON)" +
 		"&_pragma=busy_timeout(5000)" +
-		"&_pragma=synchronous(NORMAL)"
+		"&_pragma=synchronous(NORMAL)" +
+		"&_txlock=immediate"
 
 	conn, err := sql.Open("sqlite", dsn)
 	if err != nil {


### PR DESCRIPTION
Fixes #116

## Root cause
`DeleteInstance`, `deleteFromInstance`, `UpdateFromInstance` (internal/event/service.go) and `restoreInstanceByLogID` (internal/event/trash.go) loaded the recurring master via `GetEventByUID` **before** `BeginTx`, then recomputed the EXDATE list (or truncated the RRULE) from that pre-transaction snapshot and wrote it back inside the tx. Because the read was not part of the writing transaction, SQLite's snapshot-conflict protection did not apply: a concurrent writer (background sync, a second instance-delete) that modified the same master's EXDATEs/RRULE between this function's read and write was silently clobbered. The excluded occurrence reappeared on next expansion (lost update). The override path in `Delete` and `UpdateInstance` already read via `qtx` inside the tx and were correct.

## Fix
- Move each master read inside the transaction (`qtx.GetEventByUID`), matching the already-correct override paths, so the recomputation uses the in-transaction snapshot.
- Set `_txlock=immediate` on the DSN (internal/storage/connect.go) so every read-modify-write transaction acquires SQLite's single write lock at `BEGIN`. This serializes these flows via `busy_timeout` instead of deadlocking with the deferred-transaction upgrade error (`SQLITE_BUSY`), and guarantees the in-tx read sees the latest committed state. SQLite already allows only one writer at a time, so this costs no real concurrency.

## Test
`TestDeleteInstance_ConcurrentNoLostUpdate` (internal/event/delete_instance_concurrency_test.go) fires N concurrent `DeleteInstance` calls on distinct occurrences of one master (released together via a gate channel) and asserts every EXDATE survives. It fails on the pre-fix code (concurrent read-modify-write loses EXDATEs / errors with SQLITE_BUSY) and passes after the fix. Uses a file-backed DB because `:memory:` gives each pooled connection its own database.

## Verification
`make fmt`, `go vet ./...`, `go test ./internal/... ./cmd/... -count=1` all green.