### PR TITLE
fix(alarm): preserve fired_at on todo alarm dismiss and snooze

### DIFF
--- a/db/queries/todo_alarm_state.sql
+++ b/db/queries/todo_alarm_state.sql
@@ -7,10 +7,11 @@ INSERT INTO todo_alarm_state (alarm_id, todo_id, trigger_at, fired_at, acked_at,
 VALUES (?, ?, ?, ?, ?, ?)
 RETURNING *;
 
--- name: UpdateTodoAlarmState :exec
-UPDATE todo_alarm_state 
-SET fired_at = ?, acked_at = ?, snoozed_to = ?
-WHERE id = ?;
+-- name: AcknowledgeTodoAlarmState :exec
+UPDATE todo_alarm_state SET acked_at = ? WHERE id = ?;
+
+-- name: SnoozeTodoAlarmState :exec
+UPDATE todo_alarm_state SET snoozed_to = ? WHERE id = ?;
 
 -- name: ListTodoAlarmStates :many
 SELECT * FROM todo_alarm_state 

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -226,18 +226,18 @@ func (s *TodoService) MarkTodoAlarmFired(ctx context.Context, alarmID, todoID in
 // DismissTodoAlarm acknowledges a fired todo alarm
 func (s *TodoService) DismissTodoAlarm(ctx context.Context, stateID int64) error {
 	now := time.Now().UTC().Format(time.RFC3339)
-	return s.q.UpdateTodoAlarmState(ctx, storage.UpdateTodoAlarmStateParams{
-		ID:      stateID,
+	return s.q.AcknowledgeTodoAlarmState(ctx, storage.AcknowledgeTodoAlarmStateParams{
 		AckedAt: &now,
+		ID:      stateID,
 	})
 }
 
 // SnoozeTodoAlarm reschedules a todo alarm
 func (s *TodoService) SnoozeTodoAlarm(ctx context.Context, stateID int64, snoozeUntil time.Time) error {
 	snoozeStr := snoozeUntil.UTC().Format(time.RFC3339)
-	return s.q.UpdateTodoAlarmState(ctx, storage.UpdateTodoAlarmStateParams{
-		ID:        stateID,
+	return s.q.SnoozeTodoAlarmState(ctx, storage.SnoozeTodoAlarmStateParams{
 		SnoozedTo: &snoozeStr,
+		ID:        stateID,
 	})
 }
 

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -287,6 +287,93 @@ func TestSnoozeTodoAlarm(t *testing.T) {
 	}
 }
 
+func TestDismissTodoAlarm_PreservesFiredAt(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+
+	todoSvc := todo.NewService(db, q)
+	base := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	newTodo, _ := todoSvc.Create(context.Background(), todo.CreateParams{
+		CalendarID: 1,
+		Summary:    "Test Todo",
+		DueDate:    base.Format(time.RFC3339),
+	})
+	alarm, _ := q.CreateTodoAlarm(context.Background(), storage.CreateTodoAlarmParams{
+		TodoID:       newTodo.ID,
+		Uid:          storage.StringToNullable("test-alarm-uid"),
+		Action:       "DISPLAY",
+		TriggerValue: "-PT1H",
+		Related:      "START",
+	})
+
+	todoAlarmSvc := NewTodoService(db, q, &mockTodoAlarmLister{})
+
+	triggerAt := time.Date(2026, 4, 1, 16, 0, 0, 0, time.UTC)
+	stateID, _ := todoAlarmSvc.MarkTodoAlarmFired(context.Background(), alarm.ID, newTodo.ID, triggerAt)
+
+	if err := todoAlarmSvc.DismissTodoAlarm(context.Background(), stateID); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+
+	state, err := q.GetTodoAlarmState(context.Background(), storage.GetTodoAlarmStateParams{
+		AlarmID:   alarm.ID,
+		TriggerAt: triggerAt.UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("get state: %v", err)
+	}
+
+	if state.AckedAt == nil {
+		t.Error("expected alarm to be dismissed (acked_at set)")
+	}
+	if state.FiredAt == nil {
+		t.Error("dismiss must preserve fired_at, but it was cleared")
+	}
+}
+
+func TestSnoozeTodoAlarm_PreservesFiredAt(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+
+	todoSvc := todo.NewService(db, q)
+	base := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	newTodo, _ := todoSvc.Create(context.Background(), todo.CreateParams{
+		CalendarID: 1,
+		Summary:    "Test Todo",
+		DueDate:    base.Format(time.RFC3339),
+	})
+	alarm, _ := q.CreateTodoAlarm(context.Background(), storage.CreateTodoAlarmParams{
+		TodoID:       newTodo.ID,
+		Uid:          storage.StringToNullable("test-alarm-uid"),
+		Action:       "DISPLAY",
+		TriggerValue: "-PT1H",
+		Related:      "START",
+	})
+
+	todoAlarmSvc := NewTodoService(db, q, &mockTodoAlarmLister{})
+
+	triggerAt := time.Date(2026, 4, 1, 16, 0, 0, 0, time.UTC)
+	stateID, _ := todoAlarmSvc.MarkTodoAlarmFired(context.Background(), alarm.ID, newTodo.ID, triggerAt)
+
+	snoozeUntil := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	if err := todoAlarmSvc.SnoozeTodoAlarm(context.Background(), stateID, snoozeUntil); err != nil {
+		t.Fatalf("snooze: %v", err)
+	}
+
+	state, err := q.GetTodoAlarmState(context.Background(), storage.GetTodoAlarmStateParams{
+		AlarmID:   alarm.ID,
+		TriggerAt: triggerAt.UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("get state: %v", err)
+	}
+
+	if state.SnoozedTo == nil {
+		t.Error("expected snooze time to be set")
+	}
+	if state.FiredAt == nil {
+		t.Error("snooze must preserve fired_at, but it was cleared")
+	}
+}
+
 func TestListExpiredTodoSnoozed(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 

--- a/internal/storage/todo_alarm_state.sql.go
+++ b/internal/storage/todo_alarm_state.sql.go
@@ -9,6 +9,20 @@ import (
 	"context"
 )
 
+const acknowledgeTodoAlarmState = `-- name: AcknowledgeTodoAlarmState :exec
+UPDATE todo_alarm_state SET acked_at = ? WHERE id = ?
+`
+
+type AcknowledgeTodoAlarmStateParams struct {
+	AckedAt *string
+	ID      int64
+}
+
+func (q *Queries) AcknowledgeTodoAlarmState(ctx context.Context, arg AcknowledgeTodoAlarmStateParams) error {
+	_, err := q.db.ExecContext(ctx, acknowledgeTodoAlarmState, arg.AckedAt, arg.ID)
+	return err
+}
+
 const countTodoAlarmStates = `-- name: CountTodoAlarmStates :one
 SELECT COUNT(*) FROM todo_alarm_state WHERE todo_id = ?
 `
@@ -303,25 +317,16 @@ func (q *Queries) RefireTodoAlarmState(ctx context.Context, arg RefireTodoAlarmS
 	return result.RowsAffected()
 }
 
-const updateTodoAlarmState = `-- name: UpdateTodoAlarmState :exec
-UPDATE todo_alarm_state 
-SET fired_at = ?, acked_at = ?, snoozed_to = ?
-WHERE id = ?
+const snoozeTodoAlarmState = `-- name: SnoozeTodoAlarmState :exec
+UPDATE todo_alarm_state SET snoozed_to = ? WHERE id = ?
 `
 
-type UpdateTodoAlarmStateParams struct {
-	FiredAt   *string
-	AckedAt   *string
+type SnoozeTodoAlarmStateParams struct {
 	SnoozedTo *string
 	ID        int64
 }
 
-func (q *Queries) UpdateTodoAlarmState(ctx context.Context, arg UpdateTodoAlarmStateParams) error {
-	_, err := q.db.ExecContext(ctx, updateTodoAlarmState,
-		arg.FiredAt,
-		arg.AckedAt,
-		arg.SnoozedTo,
-		arg.ID,
-	)
+func (q *Queries) SnoozeTodoAlarmState(ctx context.Context, arg SnoozeTodoAlarmStateParams) error {
+	_, err := q.db.ExecContext(ctx, snoozeTodoAlarmState, arg.SnoozedTo, arg.ID)
 	return err
 }


### PR DESCRIPTION
Fixes #135

## Root cause
`UpdateTodoAlarmState` wrote all three columns (`fired_at`, `acked_at`,
`snoozed_to`) on every call. `DismissTodoAlarm` passed only `AckedAt`, so it
nulled `fired_at`; `SnoozeTodoAlarm` passed only `SnoozedTo`, so it nulled both
`fired_at` and `acked_at`. This diverged from the event side, where
acknowledge/snooze touch a single column and preserve `fired_at`. The bug was
masked only because `ListPendingTodoAlarmStates` ORs in `snoozed_to IS NOT NULL`;
any future query that gates on `fired_at IS NOT NULL` (as the event queries do)
would silently drop these rows.

## What the tests cover
- `TestDismissTodoAlarm_PreservesFiredAt`: after marking a todo alarm fired then
  dismissing it, `acked_at` is set AND `fired_at` is still present.
- `TestSnoozeTodoAlarm_PreservesFiredAt`: after marking a todo alarm fired then
  snoozing it, `snoozed_to` is set AND `fired_at` is still present.

Both fail on `master` (fired_at cleared) and pass with the fix.

## Fix
Replace the three-column `UpdateTodoAlarmState` query with two dedicated
single-column updates, `AcknowledgeTodoAlarmState` and `SnoozeTodoAlarmState`,
mirroring `AcknowledgeAlarmState` / `SnoozeAlarmState` on the event side. Queries
added to `db/queries/todo_alarm_state.sql` and regenerated via `make generate`;
`DismissTodoAlarm` / `SnoozeTodoAlarm` updated to call them.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
