### PR TITLE
fix(sync): treat tombstone DELETE 404/410 as success

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -225,9 +225,34 @@ func (c *Client) PutResource(ctx context.Context, path string, data *ical.Calend
 	return normalizeETag(resp.Header.Get("ETag")), nil
 }
 
-// DeleteResource removes a resource by path.
+// ErrResourceGone reports that a DELETE targeted a resource the server no
+// longer has (404 Not Found or 410 Gone). For tombstone processing this is the
+// desired end state, not a failure: the resource is already absent server-side,
+// so callers can clear their local sync bookkeeping instead of retrying.
+var ErrResourceGone = errors.New("caldav: resource already gone")
+
+// DeleteResource removes a resource by path. A 404/410 response is reported as
+// ErrResourceGone so callers can treat an already-absent resource as success.
 func (c *Client) DeleteResource(ctx context.Context, path string) error {
-	return c.inner.RemoveAll(ctx, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.ResolveURL(path), nil)
+	if err != nil {
+		return fmt.Errorf("new DELETE request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete resource: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone:
+		return ErrResourceGone
+	case resp.StatusCode/100 == 2:
+		return nil
+	default:
+		return fmt.Errorf("delete resource: %w", httpError(resp))
+	}
 }
 
 // GetResource fetches a single calendar object by path.

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -2,6 +2,7 @@ package caldav
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -84,6 +85,55 @@ func TestClientPutResourceSendsIfMatch(t *testing.T) {
 	}
 	if etag != "etag-after" {
 		t.Fatalf("etag = %q, want %q", etag, "etag-after")
+	}
+}
+
+func TestClientDeleteResourceReportsGone(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		statusCode int
+		wantGone   bool
+		wantErr    bool
+	}{
+		{"not found", http.StatusNotFound, true, true},
+		{"gone", http.StatusGone, true, true},
+		{"no content", http.StatusNoContent, false, false},
+		{"ok", http.StatusOK, false, false},
+		{"server error", http.StatusInternalServerError, false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := NewClient(putTestHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodDelete {
+					t.Fatalf("method = %s, want DELETE", req.Method)
+				}
+				if req.URL.String() != "https://example.com/cal/test.ics" {
+					t.Fatalf("url = %s, want https://example.com/cal/test.ics", req.URL.String())
+				}
+				return &http.Response{
+					StatusCode: tc.statusCode,
+					Status:     http.StatusText(tc.statusCode),
+					Body:       io.NopCloser(http.NoBody),
+					Request:    req,
+				}, nil
+			}}, "https://example.com")
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+
+			err = client.DeleteResource(context.Background(), "/cal/test.ics")
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("DeleteResource err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if got := errors.Is(err, ErrResourceGone); got != tc.wantGone {
+				t.Fatalf("errors.Is(err, ErrResourceGone) = %v, want %v (err = %v)", got, tc.wantGone, err)
+			}
+		})
 	}
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1110,7 +1110,10 @@ func (e *Engine) processTombstones(ctx context.Context, client *caldav.Client, c
 		e.logger.Debug("deleting tombstone", "uid", ts.Uid, "remote_url", deletePath)
 		if _, err := caldav.Retry(ctx, syncRetryOptions, func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, client.DeleteResource(ctx, deletePath)
-		}); err != nil {
+		}); err != nil && !errors.Is(err, caldav.ErrResourceGone) {
+			// A 404/410 means the resource is already absent server-side —
+			// the desired end state — so fall through and clear the local
+			// rows instead of re-issuing the DELETE on every sync.
 			e.logger.Warn("delete remote resource failed", "uid", ts.Uid, "error", err)
 			result.errors = append(result.errors, fmt.Errorf("delete tombstone %s: %w", ts.Uid, err))
 			continue

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1141,6 +1141,90 @@ func TestEngineProcessTombstonesContinuesAfterDeleteFailure(t *testing.T) {
 	}
 }
 
+func TestEngineProcessTombstonesTreatsGoneAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	engine, _, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	deletes := 0
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+		deletes++
+		switch r.URL.Path {
+		case "/calendar/already-gone-404.ics":
+			return newResponse(http.StatusNotFound, nil), nil
+		case "/calendar/already-gone-410.ics":
+			return newResponse(http.StatusGone, nil), nil
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+
+	for _, tc := range []struct{ uid, path string }{
+		{"already-gone-404", "/calendar/already-gone-404.ics"},
+		{"already-gone-410", "/calendar/already-gone-410.ics"},
+	} {
+		if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+			CalendarID:   calendarID,
+			Uid:          tc.uid,
+			OwnerType:    "event",
+			RemoteUrl:    tc.path,
+			Etag:         "etag",
+			SyncStrategy: "sync-token",
+		}); err != nil {
+			t.Fatalf("UpsertSyncResource %q: %v", tc.uid, err)
+		}
+		if err := q.CreateTombstone(ctx, storage.CreateTombstoneParams{
+			CalendarID: calendarID,
+			Uid:        tc.uid,
+			RemoteUrl:  tc.path,
+		}); err != nil {
+			t.Fatalf("CreateTombstone %q: %v", tc.uid, err)
+		}
+	}
+
+	result, err := engine.processTombstones(ctx, client, calendarID, "/calendar/")
+	if err != nil {
+		t.Fatalf("processTombstones: %v", err)
+	}
+	// A resource already absent server-side (404/410) is the desired end
+	// state, so the tombstone is cleared rather than retried forever.
+	if result.deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", result.deleted)
+	}
+	if len(result.errors) != 0 {
+		t.Fatalf("errors = %v, want none", result.errors)
+	}
+	if deletes != 2 {
+		t.Fatalf("delete requests = %d, want 2 (no retry of an already-gone resource)", deletes)
+	}
+
+	tombstones, err := q.ListTombstonesByCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("ListTombstonesByCalendar: %v", err)
+	}
+	if len(tombstones) != 0 {
+		t.Fatalf("remaining tombstones = %d, want 0", len(tombstones))
+	}
+	resources, err := q.ListSyncResourcesByCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("ListSyncResourcesByCalendar: %v", err)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("remaining sync resources = %d, want 0", len(resources))
+	}
+}
+
 func TestEnginePullSkipsTombstonedRemoteResource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #133

## Root cause
`processTombstones` (`internal/sync/engine.go`) treated *any* error from
`DeleteResource` as a failure: it logged a warning, recorded an error, and
`continue`d without clearing the `sync_resource` or tombstone rows. When a
resource was already gone server-side — because the user deleted it on the
server too, or a prior DELETE succeeded but its response was lost — the server
answers the DELETE with 404 Not Found or 410 Gone. That *is* the desired end
state, but the old code treated it as an error, so every subsequent sync
re-issued the DELETE and the tombstone lingered for up to 30 days.

## Fix
- `caldav.DeleteResource` now issues the DELETE via the authenticated HTTP
  client and reports a 404/410 as a typed sentinel, `caldav.ErrResourceGone`.
  Other non-2xx responses still surface as wrapped errors (so transient 5xx
  responses are still retried by `caldav.Retry`).
- `processTombstones` treats `ErrResourceGone` as success via
  `errors.Is`, falling through to clear the `sync_resource` and tombstone
  rows instead of retrying.

## Tests
- `internal/caldav`: `TestClientDeleteResourceReportsGone` — table-driven check
  that 404/410 return `ErrResourceGone`, 2xx returns nil, and 5xx returns a
  non-gone error.
- `internal/sync`: `TestEngineProcessTombstonesTreatsGoneAsSuccess` — two
  tombstones whose DELETEs return 404 and 410 are both cleared (tombstone and
  sync_resource rows removed), with no retry. This test fails on the old code
  (`deleted = 0, want 2`).

All `internal/...` tests, `go vet ./...`, and `gofmt` are green.
