### PR TITLE
fix(retry): classify HTTP status from a typed error, not a regex scrape

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -457,6 +457,13 @@ func EncodeCalendar(cal *ical.Calendar) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// statusErrorf wraps a formatted message in a typed retry.HTTPError so
+// transient/conflict classification reads the real status regardless of
+// any numeric tokens the message (or a future wrapping layer) carries.
+func statusErrorf(status int, format string, args ...any) error {
+	return retry.NewHTTPError(status, fmt.Errorf(format, args...))
+}
+
 func httpError(resp *http.Response) error {
 	if resp == nil {
 		return fmt.Errorf("HTTP 0")
@@ -479,9 +486,9 @@ func httpError(resp *http.Response) error {
 
 	var err error
 	if bodyText == "" {
-		err = fmt.Errorf("HTTP %s", status)
+		err = retry.NewHTTPError(resp.StatusCode, fmt.Errorf("HTTP %s", status))
 	} else {
-		err = fmt.Errorf("HTTP %s: %s", status, bodyText)
+		err = retry.NewHTTPError(resp.StatusCode, fmt.Errorf("HTTP %s: %s", status, bodyText))
 	}
 
 	// Servers ask clients to back off via Retry-After (typically on 429 or

--- a/internal/caldav/freebusy.go
+++ b/internal/caldav/freebusy.go
@@ -39,7 +39,7 @@ func QueryFreeBusy(ctx context.Context, httpClient webdav.HTTPClient, calendarUR
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusMultiStatus {
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return freebusy.Result{}, fmt.Errorf("free-busy query: HTTP %d", resp.StatusCode)
+		return freebusy.Result{}, statusErrorf(resp.StatusCode, "free-busy query: HTTP %d", resp.StatusCode)
 	}
 
 	results, err := freebusy.ParseCalendar(resp.Body)

--- a/internal/caldav/properties.go
+++ b/internal/caldav/properties.go
@@ -50,7 +50,7 @@ func GetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusMultiStatus {
-		return "", fmt.Errorf("PROPFIND calendar-color: HTTP %d", resp.StatusCode)
+		return "", statusErrorf(resp.StatusCode, "PROPFIND calendar-color: HTTP %d", resp.StatusCode)
 	}
 
 	var ms calendarColorMultiStatus
@@ -67,7 +67,7 @@ func GetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 			case code == http.StatusNotFound:
 				return "", nil
 			case code != 0:
-				return "", fmt.Errorf("PROPFIND calendar-color: HTTP %d", code)
+				return "", statusErrorf(code, "PROPFIND calendar-color: HTTP %d", code)
 			}
 		}
 	}
@@ -149,14 +149,14 @@ func SetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 			for _, propstat := range response.PropStats {
 				code := parseStatusCode(propstat.Status)
 				if code < 200 || code >= 300 {
-					return fmt.Errorf("PROPPATCH calendar-color: HTTP %d", code)
+					return statusErrorf(code, "PROPPATCH calendar-color: HTTP %d", code)
 				}
 			}
 		}
 		return nil
 	default:
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("PROPPATCH calendar-color: HTTP %d", resp.StatusCode)
+		return statusErrorf(resp.StatusCode, "PROPPATCH calendar-color: HTTP %d", resp.StatusCode)
 	}
 }
 

--- a/internal/caldav/sync_collection.go
+++ b/internal/caldav/sync_collection.go
@@ -85,7 +85,7 @@ func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncTo
 		if bytes.Contains(raw, []byte("valid-sync-token")) {
 			return nil, ErrSyncTokenInvalid
 		}
-		return nil, fmt.Errorf("REPORT sync-collection: HTTP %d", resp.StatusCode)
+		return nil, statusErrorf(resp.StatusCode, "REPORT sync-collection: HTTP %d", resp.StatusCode)
 	case http.StatusBadRequest, http.StatusMethodNotAllowed,
 		http.StatusUnsupportedMediaType, http.StatusUnprocessableEntity,
 		http.StatusNotImplemented:

--- a/internal/retry/transient.go
+++ b/internal/retry/transient.go
@@ -3,6 +3,7 @@ package retry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"regexp"
 	"strings"
@@ -42,6 +43,34 @@ func retryAfter(err error) time.Duration {
 	}
 	return 0
 }
+
+// HTTPError carries an HTTP status code as a typed field so that
+// transient/conflict classification can rely on the real status instead
+// of scraping the error string. String scraping is fragile: any wrapping
+// that prepends a numeric token (a batch index, a host:port segment)
+// would shadow the status and mis-route retries.
+type HTTPError struct {
+	Status int
+	// Err holds the underlying error (typically a formatted message with
+	// the status text and a body excerpt). It is preserved for Error and
+	// Unwrap so existing message-based diagnostics keep working.
+	Err error
+}
+
+// NewHTTPError builds an HTTPError for the given status. The message is
+// supplied by the caller so the rich, human-readable form is preserved.
+func NewHTTPError(status int, err error) *HTTPError {
+	return &HTTPError{Status: status, Err: err}
+}
+
+func (e *HTTPError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("HTTP %d", e.Status)
+}
+
+func (e *HTTPError) Unwrap() error { return e.Err }
 
 // IsTransient reports whether err is worth retrying.
 func IsTransient(err error) bool {
@@ -101,6 +130,14 @@ func statusCode(err error) int {
 		return 0
 	}
 
+	// Prefer the typed status when present: it is authoritative and
+	// immune to numeric tokens injected by wrapping layers.
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.Status
+	}
+
+	// Fall back to scraping the message for legacy string-only errors.
 	match := httpStatusPattern.FindStringSubmatch(err.Error())
 	if len(match) != 2 {
 		return 0

--- a/internal/retry/transient_test.go
+++ b/internal/retry/transient_test.go
@@ -3,9 +3,35 @@ package retry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 )
+
+// TestTypedStatusNotShadowedByNumericPrefix guards against regressions of
+// issue #134: when a wrapping layer prepends a numeric token (a batch
+// index, a host:port segment), classification must still read the real
+// HTTP status from the typed HTTPError rather than scraping the first
+// 3-digit token out of the message.
+func TestTypedStatusNotShadowedByNumericPrefix(t *testing.T) {
+	t.Parallel()
+
+	serverErr := fmt.Errorf("multiget batch 100: %w", NewHTTPError(503, errors.New("HTTP 503 Service Unavailable")))
+	if !IsTransient(serverErr) {
+		t.Fatalf("IsTransient(%v) = false, want true (wrapped 503 must be retried)", serverErr)
+	}
+	if IsConflict(serverErr) {
+		t.Fatalf("IsConflict(%v) = true, want false (503 is not a conflict)", serverErr)
+	}
+
+	conflictErr := fmt.Errorf("PUT https://dav.example.com:100/cal: %w", NewHTTPError(412, errors.New("HTTP 412 Precondition Failed")))
+	if !IsConflict(conflictErr) {
+		t.Fatalf("IsConflict(%v) = false, want true (wrapped 412 must be detected)", conflictErr)
+	}
+	if IsTransient(conflictErr) {
+		t.Fatalf("IsTransient(%v) = true, want false (412 must not be retried)", conflictErr)
+	}
+}
 
 func TestIsTransient(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #134

## Root cause
`retry.statusCode()` extracted the HTTP status by scraping the error
string for the first `\b[1-5][0-9][0-9]\b` token, assuming the status was
always the first 3-digit number in the message. Any wrapping that prepends
a numeric token — a multiget batch index (`multiget batch 100: ...`) or a
host:port segment (`...example.com:100/...`) — shadows the real status, so
`IsTransient` and `IsConflict` mis-route: a wrapped 5xx is classified
non-transient (not retried) and a wrapped 412 is missed (not detected as a
conflict).

## Fix
- Add a typed `retry.HTTPError{Status int, Err error}` (with `Error()` /
  `Unwrap()` preserving the rich message) plus a `NewHTTPError` constructor.
- `statusCode()` now reads the status via `errors.As` when a typed
  `HTTPError` is present, falling back to the legacy regex scrape only for
  string-only errors (keeps backward compatibility).
- Route the CalDAV client's HTTP error constructions through the typed
  form: `httpError` plus the `free-busy`, `REPORT calendar-multiget`,
  `REPORT sync-collection`, and `PROPFIND`/`PROPPATCH calendar-color`
  status errors (via a small `statusErrorf` helper). Classification is now
  immune to message contents.

## Test coverage
`TestTypedStatusNotShadowedByNumericPrefix` wraps a typed 503 behind a
`multiget batch 100:` prefix and a typed 412 behind a `host:100` prefix,
asserting `IsTransient`/`IsConflict` read the real status. It fails on the
old regex (`100` shadows the status) and passes with the typed lookup.
Existing string-based `TestIsTransient`/`TestIsConflict` cases still pass
via the fallback.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.

Assisted-by: Claude Code:claude-opus-4-8
