### PR TITLE
fix(cmd): show rrule and collection fields in event detail text output

### DIFF
--- a/cmd/chroncal/output.go
+++ b/cmd/chroncal/output.go
@@ -338,11 +338,17 @@ func printEventDetail(w io.Writer, e event.Event, showDate bool) {
 	printDetailField(w, labelWidth, "url", e.URL)
 	printDetailField(w, labelWidth, "tags", e.Categories)
 	printDetailField(w, labelWidth, "timezone", e.Timezone)
+	printDetailField(w, labelWidth, "rrule", e.RecurrenceRule)
 	printDetailInt(w, labelWidth, "calendar", e.CalendarID)
 	printDetailInt(w, labelWidth, "id", e.ID)
 	printDetailField(w, labelWidth, "uid", e.UID)
 	printDetailCount(w, "reminders", len(e.Alarms))
 	printDetailCount(w, "participants", len(e.Attendees))
+	printDetailCount(w, "attachments", len(e.Attachments))
+	printDetailField(w, labelWidth, "comments", fmtStrings(e.Comments))
+	printDetailField(w, labelWidth, "contacts", fmtStrings(e.Contacts))
+	printDetailField(w, labelWidth, "resources", fmtStrings(e.Resources))
+	printDetailField(w, labelWidth, "relations", fmtModelRelations(e.Relations))
 }
 
 func printCalendar(w io.Writer, c calendar.Calendar) {

--- a/cmd/chroncal/output_test.go
+++ b/cmd/chroncal/output_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/calendar"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/journal"
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 	"github.com/douglasdemoura/chroncal/internal/tui"
 )
@@ -130,6 +131,46 @@ func TestPrintEvent_UsesASCIIDetailLayout(t *testing.T) {
 		"    uid:       team-standup-uid\n"
 	if got != want {
 		t.Fatalf("printEvent output mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+	assertASCII(t, got)
+}
+
+func TestPrintEvent_RendersRecurrenceAndCollectionFields(t *testing.T) {
+	withLocalUTC(t)
+
+	var buf bytes.Buffer
+	printEvent(&buf, event.Event{
+		ID:             42,
+		UID:            "team-standup-uid",
+		Title:          "Team Standup",
+		StartTime:      time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 21, 9, 30, 0, 0, time.UTC),
+		CalendarID:     1,
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=MO",
+		Attachments:    []model.Attachment{{URI: "https://example.com/agenda.pdf"}},
+		Comments:       []string{"bring laptop"},
+		Contacts:       []string{"Alex Doe"},
+		Resources:      []string{"Projector"},
+		Relations:      []model.Relation{{RelType: "PARENT", RelUID: "parent-uid"}},
+	})
+
+	got := buf.String()
+	for _, want := range []string{
+		"rrule:",
+		"FREQ=WEEKLY;BYDAY=MO",
+		"attachments: 1",
+		"comments:",
+		"bring laptop",
+		"contacts:",
+		"Alex Doe",
+		"resources:",
+		"Projector",
+		"relations:",
+		"PARENT:parent-uid",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("printEvent output missing %q\ngot:\n%s", want, got)
+		}
 	}
 	assertASCII(t, got)
 }


### PR DESCRIPTION
Fixes #138

## Root cause
`printEventDetail` (cmd/chroncal/output.go) rendered only when/location/notes/
status/url/tags/timezone/ids plus reminder and participant counts. `printTodo`
and `printJournal` additionally render rrule, attachments, comments, contacts,
resources, and relations. Since the event JSON payload already includes these
fields, text and JSON output disagreed, and `chroncal event get <recurring-uid>`
in text mode never showed the recurrence rule or attachments — a user couldn't
tell an event recurs without switching to `-o json`.

## Fix
Added the missing fields (`rrule`, `attachments`, `comments`, `contacts`,
`resources`, `relations`) to `printEventDetail`, mirroring the field ordering
and helpers (`fmtStrings`, `fmtModelRelations`) already used by
`printTodo`/`printJournal`. No new helpers introduced.

## Test coverage
`TestPrintEvent_RendersRecurrenceAndCollectionFields` builds an event with a
recurrence rule, an attachment, and comments/contacts/resources/relations, then
asserts the text detail output contains each. It fails before the fix (output
omits `rrule:` etc.) and passes after.

Verification: new test passes; `make fmt`, `go vet ./...`, and
`go test ./internal/... ./cmd/...` all green.
