### PR TITLE
fix(cmd): make freebusy date-only --to inclusive of end day

### DIFF
--- a/cmd/chroncal/freebusy.go
+++ b/cmd/chroncal/freebusy.go
@@ -36,11 +36,11 @@ queries the connected remote CalDAV calendar instead.`,
   chroncal freebusy --calendar Work --from 2026-04-01T09:00:00-03:00 --to 2026-04-01T18:00:00-03:00
   chroncal freebusy --calendar Work --remote --from 2026-04-01 --to 2026-04-07 --format ical`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			from, err := parseFreeBusyTime("from", fromStr)
+			from, err := parseFreeBusyTime("from", fromStr, false)
 			if err != nil {
 				return err
 			}
-			to, err := parseFreeBusyTime("to", toStr)
+			to, err := parseFreeBusyTime("to", toStr, true)
 			if err != nil {
 				return err
 			}
@@ -151,8 +151,16 @@ queries the connected remote CalDAV calendar instead.`,
 	return cmd
 }
 
-func parseFreeBusyTime(flag, input string) (time.Time, error) {
+// parseFreeBusyTime parses a free/busy range bound that may be a date-only
+// (YYYY-MM-DD) value or a full RFC3339 timestamp. When inclusiveEnd is true and
+// the input is date-only, the result is advanced by one day so the named day is
+// fully covered by the half-open [from, to) range — matching the inclusive
+// end-of-day semantics of parseDateRange used by `list`/`export` (issue #137).
+func parseFreeBusyTime(flag, input string, inclusiveEnd bool) (time.Time, error) {
 	if t, err := time.ParseInLocation("2006-01-02", input, time.Local); err == nil {
+		if inclusiveEnd {
+			t = t.AddDate(0, 0, 1)
+		}
 		return t, nil
 	}
 	if t, err := time.Parse(time.RFC3339, input); err == nil {

--- a/cmd/chroncal/freebusy_test.go
+++ b/cmd/chroncal/freebusy_test.go
@@ -7,17 +7,37 @@ import (
 
 func TestParseFreeBusyTime(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
-		want  time.Time
+		name         string
+		flag         string
+		input        string
+		inclusiveEnd bool
+		want         time.Time
 	}{
 		{
-			name:  "date only",
+			name:  "date only from",
+			flag:  "from",
 			input: "2026-04-10",
 			want:  time.Date(2026, 4, 10, 0, 0, 0, 0, time.Local),
 		},
 		{
-			name:  "rfc3339",
+			name:         "date only to is inclusive end-of-day",
+			flag:         "to",
+			input:        "2026-04-07",
+			inclusiveEnd: true,
+			// Half-open range must cover all of Apr 7, so the bound is Apr 8
+			// 00:00 — matching parseDateRange used by list/export (issue #137).
+			want: time.Date(2026, 4, 8, 0, 0, 0, 0, time.Local),
+		},
+		{
+			name:         "rfc3339 to is unchanged",
+			flag:         "to",
+			input:        "2026-04-10T09:30:00Z",
+			inclusiveEnd: true,
+			want:         time.Date(2026, 4, 10, 9, 30, 0, 0, time.UTC),
+		},
+		{
+			name:  "rfc3339 from",
+			flag:  "from",
 			input: "2026-04-10T09:30:00Z",
 			want:  time.Date(2026, 4, 10, 9, 30, 0, 0, time.UTC),
 		},
@@ -25,7 +45,7 @@ func TestParseFreeBusyTime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseFreeBusyTime("from", tt.input)
+			got, err := parseFreeBusyTime(tt.flag, tt.input, tt.inclusiveEnd)
 			if err != nil {
 				t.Fatalf("parseFreeBusyTime: %v", err)
 			}


### PR DESCRIPTION
Fixes #137

## Root cause
`parseFreeBusyTime` (cmd/chroncal/freebusy.go) returned the bare parsed date for a
date-only `--to`, so `freebusy --from 2026-04-01 --to 2026-04-07` produced the
half-open range `[..., Apr 7 00:00)` and silently omitted all of Apr 7's busy
periods. Meanwhile `parseDateRange` (used by `event list` / `export`) adds a day
to make `--to` inclusive of the end day. The same flag spelling meant different
windows across commands.

## Fix
Add an `inclusiveEnd` parameter to `parseFreeBusyTime`. When set (the `--to`
bound) and the input is date-only, advance the bound by one day so the named end
day is fully covered by the half-open range — matching list/export semantics.
RFC3339 bounds and the `--from` bound are unchanged. As a side benefit, a
single-day query like `--from D --to D` now works instead of failing the
`--to must be after --from` check.

## Test coverage
`TestParseFreeBusyTime` now asserts:
- date-only `--to 2026-04-07` (inclusiveEnd) resolves to Apr 8 00:00 (covers all of Apr 7)
- RFC3339 `--to` is returned unchanged
- date-only and RFC3339 `--from` are unchanged

Verified the new assertion fails against the pre-fix code and passes after.
`make fmt`, `go vet ./...`, `go test ./internal/... ./cmd/...` all green.
