### PR TITLE
fix(cmd): correct todo/journal list --to help to 30-day default

### DIFF
--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -119,7 +119,7 @@ CANCELLED entries.`,
 	cmd.Flags().StringVar(&status, "status", "", "filter by status (DRAFT, FINAL, CANCELLED)")
 	cmd.Flags().BoolVar(&all, "all", false, "include draft, final, and cancelled entries together")
 	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD, default: today)")
-	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 14 days from now)")
+	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days from now)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "one line per entry (DATE  SUMMARY)")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted journals (see `journal restore`)")
 	return cmd

--- a/cmd/chroncal/list_window_help_test.go
+++ b/cmd/chroncal/list_window_help_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// defaultWindowDays derives the number of days parseDateRange spans when no
+// --from/--to are supplied, so the help text can be asserted against the real
+// default rather than a hard-coded literal.
+func defaultWindowDays(t *testing.T) int {
+	t.Helper()
+	from, to, err := parseDateRange("", "")
+	if err != nil {
+		t.Fatalf("parseDateRange: %v", err)
+	}
+	// Round rather than truncate: a 30-day local window that spans a DST
+	// transition is 719 or 721 hours, not an exact multiple of 24.
+	return int(math.Round(to.Sub(from).Hours() / 24))
+}
+
+// TestListToFlagHelpMatchesDefaultWindow guards against the --to flag help text
+// drifting from the actual default window in parseDateRange. The todo and
+// journal list commands previously advertised "14 days" while the code
+// defaulted to 30 (issue #139).
+func TestListToFlagHelpMatchesDefaultWindow(t *testing.T) {
+	want := fmt.Sprintf("%d days from now", defaultWindowDays(t))
+
+	cases := map[string]*cobra.Command{
+		"todo":    todoListCmd(),
+		"journal": journalListCmd(),
+		"event":   eventListCmd(),
+	}
+
+	for name, cmd := range cases {
+		t.Run(name, func(t *testing.T) {
+			flag := cmd.Flags().Lookup("to")
+			if flag == nil {
+				t.Fatalf("%s list has no --to flag", name)
+			}
+			if !strings.Contains(flag.Usage, want) {
+				t.Errorf("%s list --to help = %q, want it to mention %q", name, flag.Usage, want)
+			}
+		})
+	}
+}

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -115,7 +115,7 @@ By default completed and cancelled todos are hidden unless you pass
 	cmd.Flags().StringVar(&status, "status", "", "filter by status (NEEDS-ACTION, IN-PROCESS, COMPLETED, CANCELLED)")
 	cmd.Flags().BoolVar(&all, "all", false, "include completed and cancelled")
 	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD, default: today)")
-	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 14 days from now)")
+	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days from now)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "one line per todo ([STATUS] DUE  TITLE)")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted todos (see `todo restore`)")
 	return cmd


### PR DESCRIPTION
Fixes #139

## Root cause
The `--to` flag help for `todo list` and `journal list` read
"default: 14 days from now", but `parseDateRange` (cmd/chroncal/main.go:360)
defaults the window end to `from.AddDate(0, 0, 30)` — 30 days. `event list`
already documented 30 correctly; todo and journal drifted. A user trusting the
documented 14-day window silently got 30 days of results.

## Fix
Correct both help strings to "30 days from now" so they match the actual
default behavior.

## Test coverage
Adds `TestListToFlagHelpMatchesDefaultWindow`
(cmd/chroncal/list_window_help_test.go). It derives the real default window in
days from `parseDateRange("", "")` and asserts that the `--to` flag help of the
todo, journal, and event list commands mentions that day count. This fails on
the old "14 days" strings and guards against future drift. The day computation
rounds the local-time duration so it stays correct across DST boundaries.

## Verification
`make fmt`, `go vet ./...`, and `go test ./internal/... ./cmd/...` all pass.
