### PR TITLE
fix(cmd): reject non-positive --days in alarm missed

### DIFF
--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -880,6 +880,10 @@ system was not running when they became due.`,
   chroncal alarm missed --days 3
   chroncal alarm missed --days 14 --output json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if days <= 0 {
+				return errInvalidInputf("--days must be a positive number of days, got %d", days)
+			}
+
 			a, err := initApp()
 			if err != nil {
 				return err

--- a/cmd/chroncal/alarm_missed_test.go
+++ b/cmd/chroncal/alarm_missed_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestAlarmMissed_RejectsNonPositiveDays guards against issue #140: a
+// zero or negative --days value produced an empty/undefined lookback
+// window instead of an invalid_input error. Validation runs before
+// initApp, so the command must fail without ever touching the database.
+func TestAlarmMissed_RejectsNonPositiveDays(t *testing.T) {
+	for _, days := range []string{"0", "-1", "-5"} {
+		t.Run("days="+days, func(t *testing.T) {
+			cmd := alarmMissedCmd()
+			if err := cmd.ParseFlags([]string{"--days", days}); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+
+			err := cmd.RunE(cmd, nil)
+			if err == nil {
+				t.Fatalf("--days %s: want error, got nil", days)
+			}
+			var ce *cliError
+			if !errors.As(err, &ce) {
+				t.Fatalf("--days %s: want *cliError, got %T: %v", days, err, err)
+			}
+			if ce.Code != "invalid_input" {
+				t.Fatalf("--days %s: code = %q, want invalid_input", days, ce.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #140

## Root cause
`chroncal alarm missed` computed `lookback := time.Duration(days) * 24 * time.Hour` from an unvalidated int. `--days 0` yields a zero-width window and `--days -N` a negative one, both passed straight to `CheckMissed`, which silently returns an empty/undefined result instead of signaling bad input.

## Fix
Validate `days <= 0` at the top of the `missed` command's `RunE` — before `initApp` — and return an `invalid_input` `cliError` via the existing `errInvalidInputf` helper. This matches the validation pattern used across the other CLI commands and lets JSON/YAML consumers dispatch on the bad flag. The downstream retention warning (`days > retentionDays`) is now guaranteed a positive value.

## Test coverage
`TestAlarmMissed_RejectsNonPositiveDays` (table-driven over `0`, `-1`, `-5`) asserts the command returns a `*cliError` with code `invalid_input` without touching the database. Confirmed failing before the fix (returned nil) and passing after.