### PR TITLE
fix(ical): preserve custom VTIMEZONE zone identity on import

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -80,8 +80,13 @@ func ImportFile(r io.Reader) (ImportResult, error) {
 			}
 			var buf bytes.Buffer
 			enc := ical.NewEncoder(&buf)
-			// Wrap in a minimal calendar for encoding.
+			// Wrap in a minimal calendar for encoding. go-ical's encoder
+			// rejects a VCALENDAR that is missing the mandatory PRODID and
+			// VERSION properties, so set them; otherwise Encode fails and the
+			// VTIMEZONE block is silently dropped from result.Timezones.
 			tmpCal := ical.NewCalendar()
+			tmpCal.Props.SetText(ical.PropVersion, "2.0")
+			tmpCal.Props.SetText(ical.PropProductID, ProductID)
 			tmpCal.Children = append(tmpCal.Children, child)
 			if err := enc.Encode(tmpCal); err == nil {
 				// Extract just the VTIMEZONE block from the encoded output.

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -986,3 +986,61 @@ func TestImport_VJournal_OptionalDTSTART(t *testing.T) {
 		t.Errorf("StartDate = %q, want empty", result.Journals[0].StartDate)
 	}
 }
+
+// TestImport_CustomVTimezone_PreservesZoneLabel covers issue #131: a TZID that
+// is neither IANA nor a Windows alias (a private VTIMEZONE) must keep its zone
+// identity on import. Previously resolveComponentTZIDs converted the value to
+// UTC and dropped the TZID param, so the event was stored with an empty
+// Timezone (silently becoming a plain UTC event). The instant must stay
+// correct AND the original TZID label must be preserved.
+func TestImport_CustomVTimezone_PreservesZoneLabel(t *testing.T) {
+	t.Parallel()
+	ics := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//test//test//EN\r\n" +
+		"BEGIN:VTIMEZONE\r\n" +
+		"TZID:Custom/Office\r\n" +
+		"BEGIN:STANDARD\r\n" +
+		"DTSTART:19700101T000000\r\n" +
+		"TZOFFSETFROM:+0100\r\n" +
+		"TZOFFSETTO:+0100\r\n" +
+		"TZNAME:OFC\r\n" +
+		"END:STANDARD\r\n" +
+		"END:VTIMEZONE\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:custom-tz-1\r\n" +
+		"DTSTAMP:20240115T100000Z\r\n" +
+		"DTSTART;TZID=Custom/Office:20240115T120000\r\n" +
+		"DTEND;TZID=Custom/Office:20240115T130000\r\n" +
+		"SUMMARY:Custom Zone Event\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile error: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	e := result.Events[0]
+	if e.Timezone != "Custom/Office" {
+		t.Errorf("Timezone = %q, want %q", e.Timezone, "Custom/Office")
+	}
+	// +0100 local 12:00 == 11:00 UTC; the instant must be preserved.
+	wantStart := time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC)
+	if !e.StartTime.UTC().Equal(wantStart) {
+		t.Errorf("StartTime = %v, want %v", e.StartTime.UTC(), wantStart)
+	}
+	wantEnd := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	if !e.EndTime.UTC().Equal(wantEnd) {
+		t.Errorf("EndTime = %v, want %v", e.EndTime.UTC(), wantEnd)
+	}
+	// The VTIMEZONE block must be retained for storage/export.
+	var found bool
+	for _, tz := range result.Timezones {
+		if tz.TZID == "Custom/Office" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("VTIMEZONE Custom/Office not captured in result.Timezones")
+	}
+}

--- a/internal/ical/vtimezone.go
+++ b/internal/ical/vtimezone.go
@@ -148,10 +148,16 @@ func resolveComponentTZIDs(comp *goical.Component, tzMap map[string]*time.Locati
 			p.Params.Set(goical.ParamTimezoneID, iana)
 			return
 		}
-		// VTIMEZONE-derived fixed zone — parse using the offset and rewrite as UTC.
-		// EXDATE/RDATE may carry a comma-separated list of datetimes in a single
-		// value, so convert each element. Only rewrite if every element parses,
-		// otherwise leave the value untouched.
+		// VTIMEZONE-derived fixed zone — parse using the offset and rewrite the
+		// instant as UTC (go-ical's DateTime() can't LoadLocation a private
+		// TZID, so we resolve the offset here). The TZID parameter is kept so
+		// the original zone identity survives import: go-ical parses a value
+		// with a trailing "Z" as UTC and ignores the TZID, while the per-domain
+		// builders still read the TZID label into the stored Timezone. Dropping
+		// the param here would silently collapse the event to a plain UTC event
+		// (issue #131). EXDATE/RDATE may carry a comma-separated list of
+		// datetimes in a single value, so convert each element. Only rewrite if
+		// every element parses, otherwise leave the value untouched.
 		if loc, ok := tzMap[tzid]; ok {
 			parts := strings.Split(p.Value, ",")
 			converted := make([]string, len(parts))
@@ -166,7 +172,6 @@ func resolveComponentTZIDs(comp *goical.Component, tzMap map[string]*time.Locati
 			}
 			if allOK {
 				p.Value = strings.Join(converted, ",")
-				p.Params.Del(goical.ParamTimezoneID)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #131

## Root cause
For a TZID that is neither IANA nor a Windows alias (a private
VTIMEZONE such as `TZID:Custom/Office`), `resolveComponentTZIDs`
resolved the offset, rewrote the datetime to UTC, and then **deleted**
the TZID parameter. `eventFromVEvent` then saw a bare `Z` value with no
TZID and stored an empty `Timezone`, so the event silently degraded into
a plain UTC event. Re-export emitted `...Z` instead of the original local
time + TZID, changing how the event displays and edits.

Separately, the VTIMEZONE storage extraction wrapped each block in a
temporary VCALENDAR that lacked the mandatory `PRODID`/`VERSION`
properties. go-ical's encoder rejected it, so the block was silently
dropped from `ImportResult.Timezones` and the original VTIMEZONE was
never preserved.

## Fix
- Keep the TZID parameter after rewriting the value to UTC in
  `resolveComponentTZIDs`. go-ical parses a trailing-`Z` value as UTC and
  ignores the TZID, so the instant stays correct while the per-domain
  builders read the TZID label into the stored `Timezone`.
- Set `VERSION` and `PRODID` on the temporary VCALENDAR used for
  VTIMEZONE re-encoding so the block is captured into
  `ImportResult.Timezones`.

## Test coverage
`TestImport_CustomVTimezone_PreservesZoneLabel` imports a VEVENT bound to
a private `Custom/Office` VTIMEZONE (+0100) and asserts:
- `Event.Timezone == "Custom/Office"` (was `""` before the fix),
- the UTC instant is preserved (12:00 +0100 == 11:00Z for start/end),
- the VTIMEZONE block is captured in `result.Timezones`.

Verified: new test passes, `make fmt`, `go vet ./...`, and
`go test ./internal/... -count=1` all green.
