### PR TITLE
fix(cmd): make journal list --all hide CANCELLED entries by default

### DIFF
--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -54,7 +54,8 @@ func journalListCmd() *cobra.Command {
 		Short: "List journal entries",
 		Long: `List journal entries in a date window.
 
-Use --status when you want to narrow the list to DRAFT, FINAL, or
+CANCELLED entries are hidden by default. Pass --all to include them, or
+filter explicitly with --status to narrow the list to DRAFT, FINAL, or
 CANCELLED entries.`,
 		Example: `  chroncal journal list
   chroncal journal list --calendar Work --from 2026-04-01 --to 2026-04-30
@@ -81,14 +82,10 @@ CANCELLED entries.`,
 				}
 			}
 
-			filterStatus := status
-			if !all && status == "" {
-				filterStatus = ""
-			}
-
 			journals, err := a.Recurrences.ListFilteredJournals(ctx, recurrence.JournalListParams{
 				CalendarID:     calID,
-				Status:         filterStatus,
+				Status:         status,
+				HideCancelled:  !all && status == "",
 				From:           from,
 				To:             to,
 				IncludeDeleted: includeDeleted,
@@ -117,7 +114,7 @@ CANCELLED entries.`,
 	}
 	cmd.Flags().StringVar(&calendarName, "calendar", "", "filter by calendar name")
 	cmd.Flags().StringVar(&status, "status", "", "filter by status (DRAFT, FINAL, CANCELLED)")
-	cmd.Flags().BoolVar(&all, "all", false, "include draft, final, and cancelled entries together")
+	cmd.Flags().BoolVar(&all, "all", false, "include cancelled entries (hidden by default)")
 	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD, default: today)")
 	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days from now)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "one line per entry (DATE  SUMMARY)")

--- a/cmd/chroncal/journal_cli_test.go
+++ b/cmd/chroncal/journal_cli_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestJournalListHidesCancelledByDefault verifies that `journal list` hides
+// CANCELLED entries by default and that `--all` brings them back, mirroring
+// how `todo list` hides COMPLETED/CANCELLED. Regression test for issue #136,
+// where `--all` was a dead flag and CANCELLED journals were always shown.
+func TestJournalListHidesCancelledByDefault(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	if _, _, err := runChroncalCommand(t,
+		"journal", "add", "Active note",
+		"--calendar", "Work",
+		"--date", "2026-04-10",
+		"--status", "FINAL",
+	); err != nil {
+		t.Fatalf("journal add final: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"journal", "add", "Scrapped note",
+		"--calendar", "Work",
+		"--date", "2026-04-10",
+		"--status", "CANCELLED",
+	); err != nil {
+		t.Fatalf("journal add cancelled: %v", err)
+	}
+
+	listArgs := []string{
+		"journal", "list",
+		"--calendar", "Work",
+		"--from", "2026-04-01",
+		"--to", "2026-04-30",
+		"--compact",
+	}
+
+	// Default: CANCELLED entry must be hidden.
+	stdout, _, err := runChroncalCommand(t, listArgs...)
+	if err != nil {
+		t.Fatalf("journal list: %v", err)
+	}
+	if !strings.Contains(stdout, "Active note") {
+		t.Fatalf("default list = %q, want it to contain %q", stdout, "Active note")
+	}
+	if strings.Contains(stdout, "Scrapped note") {
+		t.Fatalf("default list = %q, should hide CANCELLED entry %q", stdout, "Scrapped note")
+	}
+
+	// --all: CANCELLED entry must reappear.
+	stdoutAll, _, err := runChroncalCommand(t, append(listArgs, "--all")...)
+	if err != nil {
+		t.Fatalf("journal list --all: %v", err)
+	}
+	if !strings.Contains(stdoutAll, "Active note") {
+		t.Fatalf("--all list = %q, want it to contain %q", stdoutAll, "Active note")
+	}
+	if !strings.Contains(stdoutAll, "Scrapped note") {
+		t.Fatalf("--all list = %q, want it to contain CANCELLED entry %q", stdoutAll, "Scrapped note")
+	}
+
+	// --status CANCELLED: explicit status filter shows only cancelled.
+	stdoutStatus, _, err := runChroncalCommand(t, append(listArgs, "--status", "CANCELLED")...)
+	if err != nil {
+		t.Fatalf("journal list --status CANCELLED: %v", err)
+	}
+	if !strings.Contains(stdoutStatus, "Scrapped note") {
+		t.Fatalf("--status CANCELLED list = %q, want it to contain %q", stdoutStatus, "Scrapped note")
+	}
+	if strings.Contains(stdoutStatus, "Active note") {
+		t.Fatalf("--status CANCELLED list = %q, should not contain FINAL entry %q", stdoutStatus, "Active note")
+	}
+}

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -1086,8 +1086,12 @@ type ExpandedJournal struct {
 type JournalListParams struct {
 	CalendarID int64
 	Status     string
-	From       time.Time
-	To         time.Time
+	// HideCancelled, when true, omits CANCELLED journals. Default (false)
+	// returns every status, matching the iCal model where a cancelled
+	// journal is still a real row the caller may want to see.
+	HideCancelled bool
+	From          time.Time
+	To            time.Time
 	// IncludeDeleted, when true, returns soft-deleted journals alongside
 	// live rows. Default (false) hides them.
 	IncludeDeleted bool
@@ -1270,6 +1274,11 @@ func (s *Service) expandRecurringJournalRows(ctx context.Context, rows []storage
 // date range is provided, recurring journals are expanded; otherwise master
 // entries are returned as-is.
 func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams) ([]journal.Journal, error) {
+	hideCancelled := int64(0)
+	if p.HideCancelled {
+		hideCancelled = 1
+	}
+
 	fromStr := ""
 	toStr := ""
 	hasRange := !p.From.IsZero() || !p.To.IsZero()
@@ -1283,6 +1292,7 @@ func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams)
 	rows, err := s.q.ListJournalsFiltered(ctx, storage.ListJournalsFilteredParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
+		HideCancelled:  hideCancelled,
 		FromDate:       fromStr,
 		ToDate:         toStr,
 		IncludeDeleted: p.IncludeDeleted,
@@ -1299,6 +1309,7 @@ func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams)
 	recurringRows, err := s.q.ListRecurringJournalsFiltered(ctx, storage.ListRecurringJournalsFilteredParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
+		HideCancelled:  hideCancelled,
 		IncludeDeleted: p.IncludeDeleted,
 	})
 	if err != nil {

--- a/internal/storage/journals_dynamic.go
+++ b/internal/storage/journals_dynamic.go
@@ -4,10 +4,25 @@ import "context"
 
 const journalCategoryExists = "EXISTS (SELECT 1 FROM journal_categories jc WHERE jc.journal_id = journals.id AND jc.category = ?)"
 
+// addJournalListFilters appends the calendar / status / hide-cancelled clauses
+// shared verbatim by ListJournalsFiltered and ListRecurringJournalsFiltered, in
+// the same order so positional args line up.
+func (w *whereBuilder) addJournalListFilters(calendarID int64, filterStatus string, hideCancelled int64) {
+	if calendarID != 0 {
+		w.add("calendar_id = ?", calendarID)
+	}
+	if filterStatus != "" {
+		w.add("status = ?", filterStatus)
+	}
+	if hideCancelled != 0 {
+		w.add("status != 'CANCELLED'")
+	}
+}
+
 type ListJournalsFilteredParams struct {
 	CalendarID     int64
 	FilterStatus   string
-	HideDrafts     int64
+	HideCancelled  int64
 	FromDate       string
 	ToDate         string
 	IncludeDeleted bool
@@ -18,15 +33,7 @@ func (q *Queries) ListJournalsFiltered(ctx context.Context, arg ListJournalsFilt
 	var w whereBuilder
 	w.add("recurrence_rule IS NULL AND recurrence_id = ''")
 	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	if arg.CalendarID != 0 {
-		w.add("calendar_id = ?", arg.CalendarID)
-	}
-	if arg.FilterStatus != "" {
-		w.add("status = ?", arg.FilterStatus)
-	}
-	if arg.HideDrafts != 0 {
-		w.add("status != 'CANCELLED'")
-	}
+	w.addJournalListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCancelled)
 	if arg.FromDate != "" {
 		w.add("(start_date IS NULL OR start_date >= ?)", arg.FromDate)
 	}
@@ -40,6 +47,7 @@ func (q *Queries) ListJournalsFiltered(ctx context.Context, arg ListJournalsFilt
 type ListRecurringJournalsFilteredParams struct {
 	CalendarID     int64
 	FilterStatus   string
+	HideCancelled  int64
 	IncludeDeleted bool
 	DeletedOnly    bool
 }
@@ -48,12 +56,7 @@ func (q *Queries) ListRecurringJournalsFiltered(ctx context.Context, arg ListRec
 	var w whereBuilder
 	w.add("recurrence_rule IS NOT NULL AND recurrence_id = ''")
 	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	if arg.CalendarID != 0 {
-		w.add("calendar_id = ?", arg.CalendarID)
-	}
-	if arg.FilterStatus != "" {
-		w.add("status = ?", arg.FilterStatus)
-	}
+	w.addJournalListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCancelled)
 	where, args := w.build()
 	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
 }


### PR DESCRIPTION
Fixes #136

## Root cause
`journal list --all` was a dead flag. The command body contained
`filterStatus := status; if !all && status == "" { filterStatus = "" }`,
which is a no-op — `filterStatus` always equals `status`. `JournalListParams`
had no hide field, so journals of every status (including CANCELLED) were
always listed and `--all` changed nothing, contradicting its help text.

The storage layer already carried a `HideDrafts` clause
(`status != 'CANCELLED'`) that was never wired to anything, strongly
suggesting the original intent was to hide CANCELLED journals by default —
mirroring how `todo list` hides COMPLETED/CANCELLED.

## Fix
Wire a real default filter through the whole stack, parallel to `todo list`:
- `internal/storage/journals_dynamic.go`: rename the dead `HideDrafts` field
  to `HideCancelled`, extract a shared `addJournalListFilters` helper (calendar
  / status / hide-cancelled), and apply it to both the recurring and
  non-recurring filtered queries.
- `internal/recurrence/service.go`: add `HideCancelled` to `JournalListParams`
  and pass it down to both storage calls.
- `cmd/chroncal/journal.go`: replace the dead block with
  `HideCancelled: !all && status == ""`, and update the `--all` help and the
  command's Long description to match the real behavior.

Resulting behavior:
- `journal list` hides CANCELLED entries by default.
- `journal list --all` shows them again.
- `journal list --status CANCELLED` still selects exactly that status.

## Test coverage
New `cmd/chroncal/journal_cli_test.go` (`TestJournalListHidesCancelledByDefault`)
creates a FINAL and a CANCELLED journal, then asserts:
- default list contains the FINAL entry and hides the CANCELLED one,
- `--all` brings the CANCELLED entry back,
- `--status CANCELLED` shows only the cancelled entry.

The test fails on the pre-fix code (CANCELLED shown by default) and passes
after. `make fmt`, `go vet ./...`, and `go test ./internal/... ./cmd/...` are
all green.
