### PR TITLE
fix(sync): make persistImported atomic per resource

### DIFF
--- a/.claude/skills/thermo-nuclear-code-quality-review
+++ b/.claude/skills/thermo-nuclear-code-quality-review
@@ -1,0 +1,1 @@
+../../.agents/skills/thermo-nuclear-code-quality-review

--- a/.claude/skills/thermo-nuclear-review
+++ b/.claude/skills/thermo-nuclear-review
@@ -1,0 +1,1 @@
+../../.agents/skills/thermo-nuclear-review

--- a/.claude/skills/thermos
+++ b/.claude/skills/thermos
@@ -1,0 +1,1 @@
+../../.agents/skills/thermos

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -34,10 +34,48 @@ type ExportParams struct {
 type Service struct {
 	db *sql.DB
 	q  *storage.Queries
+	// tx is non-nil when the service runs inside a caller-managed
+	// transaction (see WithTx). When set, q is already bound to tx and the
+	// per-method write helpers join the outer transaction instead of opening
+	// their own, so a multi-step sequence commits or rolls back atomically.
+	tx *sql.Tx
 }
 
 func NewService(db *sql.DB, q *storage.Queries) *Service {
 	return &Service{db: db, q: q}
+}
+
+// WithTx returns a copy of the service whose writes run inside tx. The caller
+// owns tx (commit/rollback); the returned service's mutating methods neither
+// begin nor commit their own transaction, letting several calls compose into a
+// single atomic unit.
+func (s *Service) WithTx(tx *sql.Tx) *Service {
+	return &Service{db: s.db, q: s.q.WithTx(tx), tx: tx}
+}
+
+// txscope returns a transaction-scoped Queries plus commit and rollback
+// helpers. When the service already runs inside a caller-managed transaction
+// (see WithTx), the work joins that transaction: commit is a no-op and rollback
+// is left to the outer owner. Otherwise it opens and owns a fresh transaction.
+func (s *Service) txscope(ctx context.Context) (qtx *storage.Queries, commit func() error, rollback func(), err error) {
+	if s.tx != nil {
+		return s.q, func() error { return nil }, func() {}, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("begin tx: %w", err)
+	}
+	return s.q.WithTx(tx), tx.Commit, func() { _ = tx.Rollback() }, nil
+}
+
+// dirtyExec returns the DBTX the dirty-marking side effect must use: the outer
+// transaction when one is active (so the write joins it and cannot deadlock
+// against the held write lock), otherwise the pooled *sql.DB.
+func (s *Service) dirtyExec() storage.DBTX {
+	if s.tx != nil {
+		return s.tx
+	}
+	return s.db
 }
 
 type CreateParams struct {
@@ -254,7 +292,7 @@ func (s *Service) markDirtyByID(ctx context.Context, eventID int64) {
 	if err != nil {
 		return
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, r.CalendarID, r.Uid, "event")
+	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "event")
 }
 
 func (s *Service) Create(ctx context.Context, p CreateParams) (Event, error) {
@@ -401,12 +439,11 @@ func updateEventTx(ctx context.Context, qtx *storage.Queries, id int64, p Update
 func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Event, error) {
 	p.applyDefaults()
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return Event{}, fmt.Errorf("begin tx: %w", err)
+		return Event{}, err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 
 	r, err := qtx.UpsertEventByUID(ctx, storage.UpsertEventByUIDParams{
 		Uid:            p.UID,
@@ -440,7 +477,7 @@ func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Event, error
 	if err := replaceCategoriesTx(ctx, qtx, e.ID, ParseCategoryList(p.Categories)); err != nil {
 		return Event{}, fmt.Errorf("replace categories: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return Event{}, fmt.Errorf("commit upsert event: %w", err)
 	}
 	e.Categories = p.Categories
@@ -1315,16 +1352,16 @@ func deleteUnmatchedAlarms(ctx context.Context, qtx *storage.Queries, existing [
 }
 
 func (s *Service) ReplaceAlarms(ctx context.Context, eventID int64, alarms []model.Alarm) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
-	if err := replaceAlarmsTx(ctx, s.q.WithTx(tx), eventID, alarms); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	defer rollback()
+
+	if err := replaceAlarmsTx(ctx, qtx, eventID, alarms); err != nil {
+		return err
+	}
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, eventID)
@@ -1404,16 +1441,16 @@ func (s *Service) ListAttendees(ctx context.Context, eventID int64) ([]model.Att
 }
 
 func (s *Service) ReplaceAttendees(ctx context.Context, eventID int64, attendees []model.Attendee) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
-	if err := replaceAttendeesTx(ctx, s.q.WithTx(tx), eventID, attendees); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	defer rollback()
+
+	if err := replaceAttendeesTx(ctx, qtx, eventID, attendees); err != nil {
+		return err
+	}
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, eventID)
@@ -1474,16 +1511,16 @@ func (s *Service) ListAllCategories(ctx context.Context) ([]string, error) {
 }
 
 func (s *Service) ReplaceCategories(ctx context.Context, eventID int64, categories []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
-	if err := replaceCategoriesTx(ctx, s.q.WithTx(tx), eventID, categories); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	defer rollback()
+
+	if err := replaceCategoriesTx(ctx, qtx, eventID, categories); err != nil {
+		return err
+	}
+	if err := commit(); err != nil {
 		return fmt.Errorf("commit replace categories: %w", err)
 	}
 	return nil
@@ -1523,12 +1560,11 @@ func (s *Service) ListAttachments(ctx context.Context, eventID int64) ([]model.A
 }
 
 func (s *Service) ReplaceAttachments(ctx context.Context, eventID int64, attachments []model.Attachment) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteEventAttachmentsByEventID(ctx, eventID); err != nil {
 		return fmt.Errorf("delete attachments: %w", err)
 	}
@@ -1540,7 +1576,7 @@ func (s *Service) ReplaceAttachments(ctx context.Context, eventID int64, attachm
 			return fmt.Errorf("create attachment: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, eventID)
@@ -1562,12 +1598,11 @@ func (s *Service) ListComments(ctx context.Context, eventID int64) ([]string, er
 }
 
 func (s *Service) ReplaceComments(ctx context.Context, eventID int64, comments []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteEventCommentsByEventID(ctx, eventID); err != nil {
 		return fmt.Errorf("delete comments: %w", err)
 	}
@@ -1579,7 +1614,7 @@ func (s *Service) ReplaceComments(ctx context.Context, eventID int64, comments [
 			return fmt.Errorf("create comment: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, eventID)
@@ -1601,12 +1636,11 @@ func (s *Service) ListContacts(ctx context.Context, eventID int64) ([]string, er
 }
 
 func (s *Service) ReplaceContacts(ctx context.Context, eventID int64, contacts []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteEventContactsByEventID(ctx, eventID); err != nil {
 		return fmt.Errorf("delete contacts: %w", err)
 	}
@@ -1618,7 +1652,7 @@ func (s *Service) ReplaceContacts(ctx context.Context, eventID int64, contacts [
 			return fmt.Errorf("create contact: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, eventID)
@@ -1640,12 +1674,11 @@ func (s *Service) ListResources(ctx context.Context, eventID int64) ([]string, e
 }
 
 func (s *Service) ReplaceResources(ctx context.Context, eventID int64, resources []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteEventResourcesByEventID(ctx, eventID); err != nil {
 		return fmt.Errorf("delete resources: %w", err)
 	}
@@ -1657,7 +1690,7 @@ func (s *Service) ReplaceResources(ctx context.Context, eventID int64, resources
 			return fmt.Errorf("create resource: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, eventID)
@@ -1679,12 +1712,11 @@ func (s *Service) ListRelations(ctx context.Context, eventID int64) ([]model.Rel
 }
 
 func (s *Service) ReplaceRelations(ctx context.Context, eventID int64, relations []model.Relation) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteEventRelationsByEventID(ctx, eventID); err != nil {
 		return fmt.Errorf("delete relations: %w", err)
 	}
@@ -1696,7 +1728,7 @@ func (s *Service) ReplaceRelations(ctx context.Context, eventID int64, relations
 			return fmt.Errorf("create relation: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, eventID)
@@ -1821,12 +1853,11 @@ func (s *Service) ListXProperties(ctx context.Context, eventID int64) ([]model.X
 }
 
 func (s *Service) ReplaceXProperties(ctx context.Context, eventID int64, xprops []model.XProperty) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteXPropertiesByOwner(ctx, storage.DeleteXPropertiesByOwnerParams{
 		OwnerType: "event", OwnerID: eventID,
 	}); err != nil {
@@ -1840,7 +1871,7 @@ func (s *Service) ReplaceXProperties(ctx context.Context, eventID int64, xprops 
 			return fmt.Errorf("insert x-property: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, eventID)

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -29,10 +29,48 @@ type ExportParams struct {
 type Service struct {
 	db *sql.DB
 	q  *storage.Queries
+	// tx is non-nil when the service runs inside a caller-managed
+	// transaction (see WithTx). When set, q is already bound to tx and the
+	// per-method write helpers join the outer transaction instead of opening
+	// their own, so a multi-step sequence commits or rolls back atomically.
+	tx *sql.Tx
 }
 
 func NewService(db *sql.DB, q *storage.Queries) *Service {
 	return &Service{db: db, q: q}
+}
+
+// WithTx returns a copy of the service whose writes run inside tx. The caller
+// owns tx (commit/rollback); the returned service's mutating methods neither
+// begin nor commit their own transaction, letting several calls compose into a
+// single atomic unit.
+func (s *Service) WithTx(tx *sql.Tx) *Service {
+	return &Service{db: s.db, q: s.q.WithTx(tx), tx: tx}
+}
+
+// txscope returns a transaction-scoped Queries plus commit and rollback
+// helpers. When the service already runs inside a caller-managed transaction
+// (see WithTx), the work joins that transaction: commit is a no-op and rollback
+// is left to the outer owner. Otherwise it opens and owns a fresh transaction.
+func (s *Service) txscope(ctx context.Context) (qtx *storage.Queries, commit func() error, rollback func(), err error) {
+	if s.tx != nil {
+		return s.q, func() error { return nil }, func() {}, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("begin tx: %w", err)
+	}
+	return s.q.WithTx(tx), tx.Commit, func() { _ = tx.Rollback() }, nil
+}
+
+// dirtyExec returns the DBTX the dirty-marking side effect must use: the outer
+// transaction when one is active (so the write joins it and cannot deadlock
+// against the held write lock), otherwise the pooled *sql.DB.
+func (s *Service) dirtyExec() storage.DBTX {
+	if s.tx != nil {
+		return s.tx
+	}
+	return s.db
 }
 
 type CreateParams struct {
@@ -233,7 +271,7 @@ func (s *Service) markDirtyByID(ctx context.Context, journalID int64) {
 	if err != nil {
 		return
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, r.CalendarID, r.Uid, "journal")
+	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "journal")
 }
 
 func (s *Service) Create(ctx context.Context, p CreateParams) (Journal, error) {
@@ -475,13 +513,12 @@ func (s *Service) ListAttendees(ctx context.Context, journalID int64) ([]model.A
 }
 
 func (s *Service) ReplaceAttendees(ctx context.Context, journalID int64, attendees []model.Attendee) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
+	defer rollback()
 
-	qtx := s.q.WithTx(tx)
 	if err := qtx.DeleteJournalAttendeesByJournalID(ctx, journalID); err != nil {
 		return fmt.Errorf("delete attendees: %w", err)
 	}
@@ -511,7 +548,7 @@ func (s *Service) ReplaceAttendees(ctx context.Context, journalID int64, attende
 			return fmt.Errorf("create attendee: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, journalID)
@@ -537,13 +574,12 @@ func (s *Service) ListAllCategories(ctx context.Context) ([]string, error) {
 }
 
 func (s *Service) ReplaceCategories(ctx context.Context, journalID int64, categories []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
+	defer rollback()
 
-	qtx := s.q.WithTx(tx)
 	if err := qtx.DeleteCategoriesByJournalID(ctx, journalID); err != nil {
 		return fmt.Errorf("delete categories: %w", err)
 	}
@@ -556,7 +592,7 @@ func (s *Service) ReplaceCategories(ctx context.Context, journalID int64, catego
 			return fmt.Errorf("create category: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return fmt.Errorf("commit replace categories: %w", err)
 	}
 	return nil
@@ -577,12 +613,11 @@ func (s *Service) ListAttachments(ctx context.Context, journalID int64) ([]model
 }
 
 func (s *Service) ReplaceAttachments(ctx context.Context, journalID int64, attachments []model.Attachment) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteJournalAttachmentsByJournalID(ctx, journalID); err != nil {
 		return fmt.Errorf("delete attachments: %w", err)
 	}
@@ -594,7 +629,7 @@ func (s *Service) ReplaceAttachments(ctx context.Context, journalID int64, attac
 			return fmt.Errorf("create attachment: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, journalID)
@@ -616,12 +651,11 @@ func (s *Service) ListComments(ctx context.Context, journalID int64) ([]string, 
 }
 
 func (s *Service) ReplaceComments(ctx context.Context, journalID int64, comments []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteJournalCommentsByJournalID(ctx, journalID); err != nil {
 		return fmt.Errorf("delete comments: %w", err)
 	}
@@ -633,7 +667,7 @@ func (s *Service) ReplaceComments(ctx context.Context, journalID int64, comments
 			return fmt.Errorf("create comment: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, journalID)
@@ -655,12 +689,11 @@ func (s *Service) ListContacts(ctx context.Context, journalID int64) ([]string, 
 }
 
 func (s *Service) ReplaceContacts(ctx context.Context, journalID int64, contacts []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteJournalContactsByJournalID(ctx, journalID); err != nil {
 		return fmt.Errorf("delete contacts: %w", err)
 	}
@@ -672,7 +705,7 @@ func (s *Service) ReplaceContacts(ctx context.Context, journalID int64, contacts
 			return fmt.Errorf("create contact: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, journalID)
@@ -694,12 +727,11 @@ func (s *Service) ListRelations(ctx context.Context, journalID int64) ([]model.R
 }
 
 func (s *Service) ReplaceRelations(ctx context.Context, journalID int64, relations []model.Relation) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteJournalRelationsByJournalID(ctx, journalID); err != nil {
 		return fmt.Errorf("delete relations: %w", err)
 	}
@@ -711,7 +743,7 @@ func (s *Service) ReplaceRelations(ctx context.Context, journalID int64, relatio
 			return fmt.Errorf("create relation: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, journalID)
@@ -804,12 +836,11 @@ func (s *Service) ListXProperties(ctx context.Context, journalID int64) ([]model
 }
 
 func (s *Service) ReplaceXProperties(ctx context.Context, journalID int64, xprops []model.XProperty) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteXPropertiesByOwner(ctx, storage.DeleteXPropertiesByOwnerParams{
 		OwnerType: "journal", OwnerID: journalID,
 	}); err != nil {
@@ -823,7 +854,7 @@ func (s *Service) ReplaceXProperties(ctx context.Context, journalID int64, xprop
 			return fmt.Errorf("insert x-property: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, journalID)

--- a/internal/storage/sync_helpers.go
+++ b/internal/storage/sync_helpers.go
@@ -10,7 +10,7 @@ import (
 // linked to an account (synced), this upserts a sync_resources row with
 // dirty=1. For local-only calendars this is a no-op.
 // Called by service-layer mutations (Create, Update, ReplaceAlarms, etc.).
-func MarkResourceDirty(ctx context.Context, db *sql.DB, calendarID int64, uid, ownerType string) error {
+func MarkResourceDirty(ctx context.Context, db DBTX, calendarID int64, uid, ownerType string) error {
 	if calendarID == 0 || uid == "" {
 		return nil
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1273,137 +1273,174 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		}
 	}
 
-	// Import events
+	// Import events. Each resource's upsert plus its child-collection replaces
+	// run in one transaction (inTx) so a mid-sequence failure rolls back to the
+	// prior consistent state rather than leaving a half-updated row (e.g. new
+	// alarms but stale attendees). The resource stays dirty and is retried.
 	for _, ev := range result.Events {
-		saved, err := e.events.UpsertByUID(ctx, event.UpsertParams{
-			UID: ev.UID, CalendarID: calendarID,
-			Title: ev.Title, Description: ev.Description, Location: ev.Location,
-			StartTime: ev.StartTime, EndTime: ev.EndTime, AllDay: ev.AllDay,
-			RecurrenceRule: ev.RecurrenceRule, Timezone: ev.Timezone,
-			Status: ev.Status, Transp: ev.Transp, Sequence: ev.Sequence,
-			Priority: ev.Priority, Class: ev.Class, URL: ev.URL,
-			ConferenceURI: ev.ConferenceURI,
-			Categories:    ev.Categories, ExDates: ev.ExDates, RDates: ev.RDates,
-			RecurrenceID: ev.RecurrenceID, Geo: ev.Geo,
-			DurationValue: ev.DurationValue, DtStamp: ev.DtStamp,
-		})
-		if err != nil {
-			return fmt.Errorf("upsert event %q: %w", ev.UID, err)
-		}
-		// Replace child collections unconditionally so server-side removals
-		// (an empty list) are propagated, mirroring how Categories are handled
-		// via UpsertByUID. A full CalDAV pull sends the complete component, so
-		// the absence of a property means "cleared", not "unknown". Propagate
-		// any replace error so the caller keeps the resource dirty and retries.
-		if err := e.events.ReplaceAlarms(ctx, saved.ID, ev.Alarms); err != nil {
-			return fmt.Errorf("replace alarms for event %q: %w", ev.UID, err)
-		}
-		if err := e.events.ReplaceAttendees(ctx, saved.ID, ev.Attendees); err != nil {
-			return fmt.Errorf("replace attendees for event %q: %w", ev.UID, err)
-		}
-		if err := e.events.ReplaceAttachments(ctx, saved.ID, ev.Attachments); err != nil {
-			return fmt.Errorf("replace attachments for event %q: %w", ev.UID, err)
-		}
-		if err := e.events.ReplaceComments(ctx, saved.ID, ev.Comments); err != nil {
-			return fmt.Errorf("replace comments for event %q: %w", ev.UID, err)
-		}
-		if err := e.events.ReplaceContacts(ctx, saved.ID, ev.Contacts); err != nil {
-			return fmt.Errorf("replace contacts for event %q: %w", ev.UID, err)
-		}
-		if err := e.events.ReplaceResources(ctx, saved.ID, ev.Resources); err != nil {
-			return fmt.Errorf("replace resources for event %q: %w", ev.UID, err)
-		}
-		if err := e.events.ReplaceRelations(ctx, saved.ID, ev.Relations); err != nil {
-			return fmt.Errorf("replace relations for event %q: %w", ev.UID, err)
-		}
-		if err := e.events.ReplaceXProperties(ctx, saved.ID, ev.XProperties); err != nil {
-			return fmt.Errorf("replace xproperties for event %q: %w", ev.UID, err)
+		if err := e.inTx(ctx, func(tx *sql.Tx) error {
+			events := e.events.WithTx(tx)
+			saved, err := events.UpsertByUID(ctx, event.UpsertParams{
+				UID: ev.UID, CalendarID: calendarID,
+				Title: ev.Title, Description: ev.Description, Location: ev.Location,
+				StartTime: ev.StartTime, EndTime: ev.EndTime, AllDay: ev.AllDay,
+				RecurrenceRule: ev.RecurrenceRule, Timezone: ev.Timezone,
+				Status: ev.Status, Transp: ev.Transp, Sequence: ev.Sequence,
+				Priority: ev.Priority, Class: ev.Class, URL: ev.URL,
+				ConferenceURI: ev.ConferenceURI,
+				Categories:    ev.Categories, ExDates: ev.ExDates, RDates: ev.RDates,
+				RecurrenceID: ev.RecurrenceID, Geo: ev.Geo,
+				DurationValue: ev.DurationValue, DtStamp: ev.DtStamp,
+			})
+			if err != nil {
+				return fmt.Errorf("upsert event %q: %w", ev.UID, err)
+			}
+			// Replace child collections unconditionally so server-side removals
+			// (an empty list) are propagated, mirroring how Categories are handled
+			// via UpsertByUID. A full CalDAV pull sends the complete component, so
+			// the absence of a property means "cleared", not "unknown". Propagate
+			// any replace error so the caller keeps the resource dirty and retries.
+			if err := events.ReplaceAlarms(ctx, saved.ID, ev.Alarms); err != nil {
+				return fmt.Errorf("replace alarms for event %q: %w", ev.UID, err)
+			}
+			if err := events.ReplaceAttendees(ctx, saved.ID, ev.Attendees); err != nil {
+				return fmt.Errorf("replace attendees for event %q: %w", ev.UID, err)
+			}
+			if err := events.ReplaceAttachments(ctx, saved.ID, ev.Attachments); err != nil {
+				return fmt.Errorf("replace attachments for event %q: %w", ev.UID, err)
+			}
+			if err := events.ReplaceComments(ctx, saved.ID, ev.Comments); err != nil {
+				return fmt.Errorf("replace comments for event %q: %w", ev.UID, err)
+			}
+			if err := events.ReplaceContacts(ctx, saved.ID, ev.Contacts); err != nil {
+				return fmt.Errorf("replace contacts for event %q: %w", ev.UID, err)
+			}
+			if err := events.ReplaceResources(ctx, saved.ID, ev.Resources); err != nil {
+				return fmt.Errorf("replace resources for event %q: %w", ev.UID, err)
+			}
+			if err := events.ReplaceRelations(ctx, saved.ID, ev.Relations); err != nil {
+				return fmt.Errorf("replace relations for event %q: %w", ev.UID, err)
+			}
+			if err := events.ReplaceXProperties(ctx, saved.ID, ev.XProperties); err != nil {
+				return fmt.Errorf("replace xproperties for event %q: %w", ev.UID, err)
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 
-	// Import todos
+	// Import todos. One transaction per resource; see the event loop above.
 	for _, t := range result.Todos {
-		saved, err := e.todos.UpsertByUID(ctx, todo.UpsertParams{
-			UID: t.UID, CalendarID: calendarID,
-			Summary: t.Summary, Description: t.Description, Location: t.Location,
-			DueDate: t.DueDate, StartDate: t.StartDate, Duration: t.Duration,
-			CompletedAt: t.CompletedAt, PercentComplete: t.PercentComplete,
-			Status: t.Status, Priority: t.Priority, Class: t.Class,
-			URL: t.URL, Categories: t.Categories,
-			RecurrenceRule: t.RecurrenceRule, Timezone: t.Timezone,
-			Sequence: t.Sequence, ExDates: t.ExDates, RDates: t.RDates,
-			RecurrenceID: t.RecurrenceID, Geo: t.Geo,
-			DtStamp: t.DtStamp,
-		})
-		if err != nil {
-			return fmt.Errorf("upsert todo %q: %w", t.UID, err)
-		}
-		// Replace child collections unconditionally so server-side removals
-		// (an empty list) are propagated. See the event loop above.
-		if err := e.todos.ReplaceAlarms(ctx, saved.ID, t.Alarms); err != nil {
-			return fmt.Errorf("replace alarms for todo %q: %w", t.UID, err)
-		}
-		if err := e.todos.ReplaceAttendees(ctx, saved.ID, t.Attendees); err != nil {
-			return fmt.Errorf("replace attendees for todo %q: %w", t.UID, err)
-		}
-		if err := e.todos.ReplaceAttachments(ctx, saved.ID, t.Attachments); err != nil {
-			return fmt.Errorf("replace attachments for todo %q: %w", t.UID, err)
-		}
-		if err := e.todos.ReplaceComments(ctx, saved.ID, t.Comments); err != nil {
-			return fmt.Errorf("replace comments for todo %q: %w", t.UID, err)
-		}
-		if err := e.todos.ReplaceContacts(ctx, saved.ID, t.Contacts); err != nil {
-			return fmt.Errorf("replace contacts for todo %q: %w", t.UID, err)
-		}
-		if err := e.todos.ReplaceResources(ctx, saved.ID, t.Resources); err != nil {
-			return fmt.Errorf("replace resources for todo %q: %w", t.UID, err)
-		}
-		if err := e.todos.ReplaceRelations(ctx, saved.ID, t.Relations); err != nil {
-			return fmt.Errorf("replace relations for todo %q: %w", t.UID, err)
-		}
-		if err := e.todos.ReplaceXProperties(ctx, saved.ID, t.XProperties); err != nil {
-			return fmt.Errorf("replace xproperties for todo %q: %w", t.UID, err)
+		if err := e.inTx(ctx, func(tx *sql.Tx) error {
+			todos := e.todos.WithTx(tx)
+			saved, err := todos.UpsertByUID(ctx, todo.UpsertParams{
+				UID: t.UID, CalendarID: calendarID,
+				Summary: t.Summary, Description: t.Description, Location: t.Location,
+				DueDate: t.DueDate, StartDate: t.StartDate, Duration: t.Duration,
+				CompletedAt: t.CompletedAt, PercentComplete: t.PercentComplete,
+				Status: t.Status, Priority: t.Priority, Class: t.Class,
+				URL: t.URL, Categories: t.Categories,
+				RecurrenceRule: t.RecurrenceRule, Timezone: t.Timezone,
+				Sequence: t.Sequence, ExDates: t.ExDates, RDates: t.RDates,
+				RecurrenceID: t.RecurrenceID, Geo: t.Geo,
+				DtStamp: t.DtStamp,
+			})
+			if err != nil {
+				return fmt.Errorf("upsert todo %q: %w", t.UID, err)
+			}
+			// Replace child collections unconditionally so server-side removals
+			// (an empty list) are propagated. See the event loop above.
+			if err := todos.ReplaceAlarms(ctx, saved.ID, t.Alarms); err != nil {
+				return fmt.Errorf("replace alarms for todo %q: %w", t.UID, err)
+			}
+			if err := todos.ReplaceAttendees(ctx, saved.ID, t.Attendees); err != nil {
+				return fmt.Errorf("replace attendees for todo %q: %w", t.UID, err)
+			}
+			if err := todos.ReplaceAttachments(ctx, saved.ID, t.Attachments); err != nil {
+				return fmt.Errorf("replace attachments for todo %q: %w", t.UID, err)
+			}
+			if err := todos.ReplaceComments(ctx, saved.ID, t.Comments); err != nil {
+				return fmt.Errorf("replace comments for todo %q: %w", t.UID, err)
+			}
+			if err := todos.ReplaceContacts(ctx, saved.ID, t.Contacts); err != nil {
+				return fmt.Errorf("replace contacts for todo %q: %w", t.UID, err)
+			}
+			if err := todos.ReplaceResources(ctx, saved.ID, t.Resources); err != nil {
+				return fmt.Errorf("replace resources for todo %q: %w", t.UID, err)
+			}
+			if err := todos.ReplaceRelations(ctx, saved.ID, t.Relations); err != nil {
+				return fmt.Errorf("replace relations for todo %q: %w", t.UID, err)
+			}
+			if err := todos.ReplaceXProperties(ctx, saved.ID, t.XProperties); err != nil {
+				return fmt.Errorf("replace xproperties for todo %q: %w", t.UID, err)
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 
-	// Import journals
+	// Import journals. One transaction per resource; see the event loop above.
 	for _, j := range result.Journals {
-		saved, err := e.journals.UpsertByUID(ctx, journal.UpsertParams{
-			UID: j.UID, CalendarID: calendarID,
-			Summary: j.Summary, Description: j.Description,
-			StartDate: j.StartDate, Status: j.Status, Class: j.Class,
-			URL: j.URL, Categories: j.Categories,
-			RecurrenceRule: j.RecurrenceRule, Timezone: j.Timezone,
-			Sequence: j.Sequence, ExDates: j.ExDates, RDates: j.RDates,
-			RecurrenceID: j.RecurrenceID,
-			DtStamp:      j.DtStamp,
-		})
-		if err != nil {
-			return fmt.Errorf("upsert journal %q: %w", j.UID, err)
-		}
-		// Replace child collections unconditionally so server-side removals
-		// (an empty list) are propagated. See the event loop above.
-		if err := e.journals.ReplaceAttendees(ctx, saved.ID, j.Attendees); err != nil {
-			return fmt.Errorf("replace attendees for journal %q: %w", j.UID, err)
-		}
-		if err := e.journals.ReplaceAttachments(ctx, saved.ID, j.Attachments); err != nil {
-			return fmt.Errorf("replace attachments for journal %q: %w", j.UID, err)
-		}
-		if err := e.journals.ReplaceComments(ctx, saved.ID, j.Comments); err != nil {
-			return fmt.Errorf("replace comments for journal %q: %w", j.UID, err)
-		}
-		if err := e.journals.ReplaceContacts(ctx, saved.ID, j.Contacts); err != nil {
-			return fmt.Errorf("replace contacts for journal %q: %w", j.UID, err)
-		}
-		if err := e.journals.ReplaceRelations(ctx, saved.ID, j.Relations); err != nil {
-			return fmt.Errorf("replace relations for journal %q: %w", j.UID, err)
-		}
-		if err := e.journals.ReplaceXProperties(ctx, saved.ID, j.XProperties); err != nil {
-			return fmt.Errorf("replace xproperties for journal %q: %w", j.UID, err)
+		if err := e.inTx(ctx, func(tx *sql.Tx) error {
+			journals := e.journals.WithTx(tx)
+			saved, err := journals.UpsertByUID(ctx, journal.UpsertParams{
+				UID: j.UID, CalendarID: calendarID,
+				Summary: j.Summary, Description: j.Description,
+				StartDate: j.StartDate, Status: j.Status, Class: j.Class,
+				URL: j.URL, Categories: j.Categories,
+				RecurrenceRule: j.RecurrenceRule, Timezone: j.Timezone,
+				Sequence: j.Sequence, ExDates: j.ExDates, RDates: j.RDates,
+				RecurrenceID: j.RecurrenceID,
+				DtStamp:      j.DtStamp,
+			})
+			if err != nil {
+				return fmt.Errorf("upsert journal %q: %w", j.UID, err)
+			}
+			// Replace child collections unconditionally so server-side removals
+			// (an empty list) are propagated. See the event loop above.
+			if err := journals.ReplaceAttendees(ctx, saved.ID, j.Attendees); err != nil {
+				return fmt.Errorf("replace attendees for journal %q: %w", j.UID, err)
+			}
+			if err := journals.ReplaceAttachments(ctx, saved.ID, j.Attachments); err != nil {
+				return fmt.Errorf("replace attachments for journal %q: %w", j.UID, err)
+			}
+			if err := journals.ReplaceComments(ctx, saved.ID, j.Comments); err != nil {
+				return fmt.Errorf("replace comments for journal %q: %w", j.UID, err)
+			}
+			if err := journals.ReplaceContacts(ctx, saved.ID, j.Contacts); err != nil {
+				return fmt.Errorf("replace contacts for journal %q: %w", j.UID, err)
+			}
+			if err := journals.ReplaceRelations(ctx, saved.ID, j.Relations); err != nil {
+				return fmt.Errorf("replace relations for journal %q: %w", j.UID, err)
+			}
+			if err := journals.ReplaceXProperties(ctx, saved.ID, j.XProperties); err != nil {
+				return fmt.Errorf("replace xproperties for journal %q: %w", j.UID, err)
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+// inTx runs fn inside a single transaction, committing on success and rolling
+// back on any error. It is the atomicity boundary for persistImported: a failed
+// Replace* part-way through a resource unwinds the whole resource so the local
+// row never reflects a partial server component.
+func (e *Engine) inTx(ctx context.Context, fn func(*sql.Tx) error) error {
+	tx, err := e.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // importICal parses raw iCal data and persists it to the local database via

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2574,3 +2574,57 @@ END:VCALENDAR
 		t.Fatalf("victim etag = %q, want old preserved (persist failed)", res.Etag)
 	}
 }
+
+// TestPersistImportedRollsBackOnReplaceFailure verifies that persistImported is
+// atomic per resource: if any Replace* step fails after the event row and some
+// of its child collections have already been written, the entire resource is
+// rolled back rather than left in a partial state.
+func TestPersistImportedRollsBackOnReplaceFailure(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	const uid = "atomic-import"
+	result := icalPkg.ImportResult{
+		Events: []event.Event{{
+			UID:       uid,
+			Title:     "Meeting",
+			StartTime: time.Date(2026, 4, 3, 10, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2026, 4, 3, 11, 0, 0, 0, time.UTC),
+			Status:    "CONFIRMED",
+			Transp:    "OPAQUE",
+			Class:     "PUBLIC",
+			Alarms: []model.Alarm{{
+				Action:       "DISPLAY",
+				TriggerValue: "-PT15M",
+				Description:  "Reminder",
+				Related:      "START",
+			}},
+			Attendees: []model.Attendee{{Email: "a@example.com"}},
+			Comments:  []string{"note"},
+		}},
+	}
+
+	// Force the ReplaceComments step (which runs after the event upsert and
+	// after ReplaceAlarms/ReplaceAttendees succeed) to fail mid-sequence,
+	// mirroring a transient DB error.
+	if _, err := db.ExecContext(ctx, "DROP TABLE event_comments"); err != nil {
+		t.Fatalf("drop event_comments: %v", err)
+	}
+
+	if err := engine.persistImported(ctx, calendarID, result); err == nil {
+		t.Fatal("expected persistImported to fail when a Replace step errors")
+	}
+
+	// The whole resource must roll back: no partial event row left behind.
+	if _, err := engine.events.GetByUID(ctx, uid); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected event %q to be absent after rollback, got err=%v", uid, err)
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -32,10 +32,48 @@ type ExportParams struct {
 type Service struct {
 	db *sql.DB
 	q  *storage.Queries
+	// tx is non-nil when the service runs inside a caller-managed
+	// transaction (see WithTx). When set, q is already bound to tx and the
+	// per-method write helpers join the outer transaction instead of opening
+	// their own, so a multi-step sequence commits or rolls back atomically.
+	tx *sql.Tx
 }
 
 func NewService(db *sql.DB, q *storage.Queries) *Service {
 	return &Service{db: db, q: q}
+}
+
+// WithTx returns a copy of the service whose writes run inside tx. The caller
+// owns tx (commit/rollback); the returned service's mutating methods neither
+// begin nor commit their own transaction, letting several calls compose into a
+// single atomic unit.
+func (s *Service) WithTx(tx *sql.Tx) *Service {
+	return &Service{db: s.db, q: s.q.WithTx(tx), tx: tx}
+}
+
+// txscope returns a transaction-scoped Queries plus commit and rollback
+// helpers. When the service already runs inside a caller-managed transaction
+// (see WithTx), the work joins that transaction: commit is a no-op and rollback
+// is left to the outer owner. Otherwise it opens and owns a fresh transaction.
+func (s *Service) txscope(ctx context.Context) (qtx *storage.Queries, commit func() error, rollback func(), err error) {
+	if s.tx != nil {
+		return s.q, func() error { return nil }, func() {}, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("begin tx: %w", err)
+	}
+	return s.q.WithTx(tx), tx.Commit, func() { _ = tx.Rollback() }, nil
+}
+
+// dirtyExec returns the DBTX the dirty-marking side effect must use: the outer
+// transaction when one is active (so the write joins it and cannot deadlock
+// against the held write lock), otherwise the pooled *sql.DB.
+func (s *Service) dirtyExec() storage.DBTX {
+	if s.tx != nil {
+		return s.tx
+	}
+	return s.db
 }
 
 type CreateParams struct {
@@ -290,7 +328,7 @@ func (s *Service) markDirtyByID(ctx context.Context, todoID int64) {
 	if err != nil {
 		return
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, r.CalendarID, r.Uid, "todo")
+	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "todo")
 }
 
 func (s *Service) Create(ctx context.Context, p CreateParams) (Todo, error) {
@@ -624,13 +662,11 @@ func fromStorageTodoAlarm(r storage.TodoAlarm) model.Alarm {
 }
 
 func (s *Service) ReplaceAlarms(ctx context.Context, todoID int64, alarms []model.Alarm) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 
 	// Merge instead of wipe-and-recreate: deleting a todo alarm row cascades
 	// away its todo_alarm_state, which would resurrect dismissed firings on
@@ -687,7 +723,7 @@ func (s *Service) ReplaceAlarms(ctx context.Context, todoID int64, alarms []mode
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, todoID)
@@ -923,13 +959,12 @@ func (s *Service) ListAttendees(ctx context.Context, todoID int64) ([]model.Atte
 }
 
 func (s *Service) ReplaceAttendees(ctx context.Context, todoID int64, attendees []model.Attendee) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
+	defer rollback()
 
-	qtx := s.q.WithTx(tx)
 	if err := qtx.DeleteTodoAttendeesByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete attendees: %w", err)
 	}
@@ -959,7 +994,7 @@ func (s *Service) ReplaceAttendees(ctx context.Context, todoID int64, attendees 
 			return fmt.Errorf("create attendee: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, todoID)
@@ -985,13 +1020,12 @@ func (s *Service) ListAllCategories(ctx context.Context) ([]string, error) {
 }
 
 func (s *Service) ReplaceCategories(ctx context.Context, todoID int64, categories []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
+	defer rollback()
 
-	qtx := s.q.WithTx(tx)
 	if err := qtx.DeleteCategoriesByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete categories: %w", err)
 	}
@@ -1004,7 +1038,7 @@ func (s *Service) ReplaceCategories(ctx context.Context, todoID int64, categorie
 			return fmt.Errorf("create category: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return fmt.Errorf("commit replace categories: %w", err)
 	}
 	return nil
@@ -1025,12 +1059,11 @@ func (s *Service) ListAttachments(ctx context.Context, todoID int64) ([]model.At
 }
 
 func (s *Service) ReplaceAttachments(ctx context.Context, todoID int64, attachments []model.Attachment) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteTodoAttachmentsByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete attachments: %w", err)
 	}
@@ -1042,7 +1075,7 @@ func (s *Service) ReplaceAttachments(ctx context.Context, todoID int64, attachme
 			return fmt.Errorf("create attachment: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, todoID)
@@ -1064,12 +1097,11 @@ func (s *Service) ListComments(ctx context.Context, todoID int64) ([]string, err
 }
 
 func (s *Service) ReplaceComments(ctx context.Context, todoID int64, comments []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteTodoCommentsByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete comments: %w", err)
 	}
@@ -1081,7 +1113,7 @@ func (s *Service) ReplaceComments(ctx context.Context, todoID int64, comments []
 			return fmt.Errorf("create comment: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, todoID)
@@ -1103,12 +1135,11 @@ func (s *Service) ListContacts(ctx context.Context, todoID int64) ([]string, err
 }
 
 func (s *Service) ReplaceContacts(ctx context.Context, todoID int64, contacts []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteTodoContactsByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete contacts: %w", err)
 	}
@@ -1120,7 +1151,7 @@ func (s *Service) ReplaceContacts(ctx context.Context, todoID int64, contacts []
 			return fmt.Errorf("create contact: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, todoID)
@@ -1142,12 +1173,11 @@ func (s *Service) ListResources(ctx context.Context, todoID int64) ([]string, er
 }
 
 func (s *Service) ReplaceResources(ctx context.Context, todoID int64, resources []string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteTodoResourcesByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete resources: %w", err)
 	}
@@ -1159,7 +1189,7 @@ func (s *Service) ReplaceResources(ctx context.Context, todoID int64, resources 
 			return fmt.Errorf("create resource: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, todoID)
@@ -1181,12 +1211,11 @@ func (s *Service) ListRelations(ctx context.Context, todoID int64) ([]model.Rela
 }
 
 func (s *Service) ReplaceRelations(ctx context.Context, todoID int64, relations []model.Relation) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteTodoRelationsByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete relations: %w", err)
 	}
@@ -1198,7 +1227,7 @@ func (s *Service) ReplaceRelations(ctx context.Context, todoID int64, relations 
 			return fmt.Errorf("create relation: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, todoID)
@@ -1298,12 +1327,11 @@ func (s *Service) ListXProperties(ctx context.Context, todoID int64) ([]model.XP
 }
 
 func (s *Service) ReplaceXProperties(ctx context.Context, todoID int64, xprops []model.XProperty) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return err
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
+	defer rollback()
 	if err := qtx.DeleteXPropertiesByOwner(ctx, storage.DeleteXPropertiesByOwnerParams{
 		OwnerType: "todo", OwnerID: todoID,
 	}); err != nil {
@@ -1317,7 +1345,7 @@ func (s *Service) ReplaceXProperties(ctx context.Context, todoID int64, xprops [
 			return fmt.Errorf("insert x-property: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 	s.markDirtyByID(ctx, todoID)

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "thermo-nuclear-code-quality-review": {
+      "source": "cursor/plugins",
+      "sourceType": "github",
+      "skillPath": "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+      "computedHash": "9052b01b46b1d8dbf94c45f9313ec1983443f9a460e83d49cdc7fe0f640ca476"
+    },
+    "thermo-nuclear-review": {
+      "source": "cursor/plugins",
+      "sourceType": "github",
+      "skillPath": "thermos/skills/thermo-nuclear-review/SKILL.md",
+      "computedHash": "c13babcfb10d8f33325af0b00c3eff7b5efb034147f93993c4d9ed569faa5570"
+    },
+    "thermos": {
+      "source": "cursor/plugins",
+      "sourceType": "github",
+      "skillPath": "thermos/skills/thermos/SKILL.md",
+      "computedHash": "f7f174564eddf63e60ac2b5d6831230942e57ecc5142ac276afe402d3ff99174"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #106

## Root cause
`internal/sync/engine.go:persistImported` ran `UpsertByUID` followed by ~8
sequential `Replace*` calls per resource with **no enclosing transaction**.
If one Replace failed mid-sequence (e.g. a transient DB error on
`ReplaceAttendees` after `ReplaceAlarms` already committed), the local row was
left with new alarms but stale attendees. On the sync-collection path the
token then advanced past the now-inconsistent resource, so it was never
retried.

## Fix
The event, todo, and journal services gain a composable transaction:

- `WithTx(tx)` returns a service copy whose writes run inside the
  caller-owned transaction.
- `txscope(ctx)` joins that transaction (no-op commit/rollback) when one is
  active, and otherwise opens and owns its own — so all existing standalone
  callers behave exactly as before.
- `markDirtyByID` now routes its dirty-marking write through the active
  transaction via `dirtyExec()`, so it can't deadlock against the held write
  lock. This required widening `storage.MarkResourceDirty` to take a
  `storage.DBTX` (satisfied by both `*sql.DB` and `*sql.Tx`).

`persistImported` now wraps each resource's `upsert + Replace*` sequence in a
single engine-level transaction (`inTx`). Any mid-sequence failure rolls back
to the prior consistent state, and the resource stays dirty so the next sync
cycle retries it cleanly.

## Test
`TestPersistImportedRollsBackOnReplaceFailure` (internal/sync/engine_test.go)
imports an event carrying alarms, attendees, and comments, then forces the
`ReplaceComments` step to fail mid-sequence (by dropping `event_comments`).
It asserts the whole resource rolls back — the event row is absent afterward.
The test fails on the old non-transactional code (the event row persists in a
partial state) and passes with the fix.

## Verification
`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
