### PR TITLE
fix(tui): make ctrl+c quit while a non-quit confirm is open

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1302,6 +1302,21 @@ func (m Model) innerDims() (int, int) {
 	return mw - padding*2, mh - padding*2
 }
 
+// clearConfirmPending drops the pending state owned by a destructive confirm
+// (event delete, trash purge, calendar delete). Used when ctrl+c abandons such
+// a confirm in favor of the quit confirm, so the destructive action can never
+// fire afterward.
+func (m Model) clearConfirmPending() Model {
+	m.pendingDelete = event.Event{}
+	m.pendingPurgeEntries = nil
+	m.pendingPurgeTitle = ""
+	m.pendingCalendarDelete = 0
+	m.pendingCalendarDeleteName = ""
+	m.pendingCalendarPromote = 0
+	m.pendingCalendarPromoteName = ""
+	return m
+}
+
 // openQuitConfirm builds and opens the quit-confirm dialog. Shared by the
 // q and ctrl+c entry points so the two keystrokes can't drift in styling.
 func (m Model) openQuitConfirm() Model {
@@ -1326,9 +1341,14 @@ func (m Model) interceptGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 			m.oauthFlow.Abort() // release any in-flight OAuth listener
 			return m, tea.Quit, true
 		}
-		if !m.confirmOpen {
-			return m.openQuitConfirm(), nil, true
-		}
+		// ctrl+c is truly global: even when a destructive (non-quit)
+		// confirm — event delete, trash purge, calendar delete — owns
+		// input, replace it with the quit confirm rather than letting the
+		// keystroke fall through to confirmDialog.Update (which ignores
+		// it). Clearing the abandoned confirm's pending state keeps the
+		// destructive action from firing later.
+		m = m.clearConfirmPending()
+		return m.openQuitConfirm(), nil, true
 	}
 	textEntryActive := m.paletteOpen || m.formOpen || m.calendarDialogOpen || m.oauthFlowOpen
 	if key.Matches(msg, m.keys.Quit) && !m.confirmOpen && !textEntryActive {

--- a/internal/tui/quit_confirm_test.go
+++ b/internal/tui/quit_confirm_test.go
@@ -1,0 +1,67 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/trash"
+)
+
+// TestCtrlCConvertsNonQuitConfirmToQuit reproduces issue #143: ctrl+c is
+// documented as "truly global", but when a destructive (non-quit) confirm is
+// open it used to fall through and be swallowed. ctrl+c must instead replace
+// the open confirm with the quit confirm, and clear the abandoned destructive
+// pending state so it can't fire later.
+func TestCtrlCConvertsNonQuitConfirmToQuit(t *testing.T) {
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+
+	m := Model{}
+	// Simulate an open event-delete confirm: confirm dialog is up but it is
+	// NOT the quit confirm.
+	m.confirmOpen = true
+	m.pendingQuit = false
+	m.pendingDelete = event.Event{ID: 7, Title: "Standup"}
+
+	next, _, handled := m.interceptGlobalKeys(ctrlC)
+	if !handled {
+		t.Fatalf("ctrl+c not handled while a non-quit confirm is open (issue #143)")
+	}
+	if !next.confirmOpen || !next.pendingQuit {
+		t.Fatalf("ctrl+c should replace the open confirm with the quit confirm: confirmOpen=%v pendingQuit=%v", next.confirmOpen, next.pendingQuit)
+	}
+	if next.pendingDelete.ID != 0 {
+		t.Fatalf("abandoned destructive pending state not cleared: pendingDelete.ID=%d", next.pendingDelete.ID)
+	}
+
+	// A second ctrl+c now force-quits.
+	_, cmd, handled := next.interceptGlobalKeys(ctrlC)
+	if !handled || cmd == nil {
+		t.Fatalf("second ctrl+c should force quit: handled=%v cmd=%v", handled, cmd)
+	}
+}
+
+// TestCtrlCClearsPurgePendingState guards the trash-purge variant of the same
+// bug: the bulk-purge confirm must also be convertible to a quit without
+// leaving its pending entries armed.
+func TestCtrlCClearsPurgePendingState(t *testing.T) {
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+
+	m := Model{}
+	m.confirmOpen = true
+	m.pendingQuit = false
+	m.pendingPurgeEntries = []trash.Entry{{Kind: trash.KindEvent}}
+	m.pendingPurgeTitle = "1 item"
+
+	next, _, handled := m.interceptGlobalKeys(ctrlC)
+	if !handled {
+		t.Fatalf("ctrl+c not handled while a purge confirm is open (issue #143)")
+	}
+	if !next.pendingQuit {
+		t.Fatalf("ctrl+c should open the quit confirm")
+	}
+	if len(next.pendingPurgeEntries) != 0 || next.pendingPurgeTitle != "" {
+		t.Fatalf("abandoned purge pending state not cleared: entries=%d title=%q", len(next.pendingPurgeEntries), next.pendingPurgeTitle)
+	}
+}


### PR DESCRIPTION
Fixes #143

## Root cause
`interceptGlobalKeys` (`internal/tui/app.go`) treated ctrl+c as global only in
two narrow cases: force-quit while already in the quit confirm, and open the
quit confirm when no confirm was open (`!m.confirmOpen`). When a destructive
*non-quit* confirm was open (`confirmOpen == true && pendingQuit == false` —
event delete, trash purge, calendar delete), neither branch fired, so ctrl+c
fell through to `confirmDialog.Update`, which ignores it. The user was stuck
until they answered the confirm — contradicting the comment that "ctrl+c is
truly global."

## Fix
In the ctrl+c branch, when a non-quit confirm is open, replace it with the quit
confirm instead of letting the keystroke fall through. A new
`clearConfirmPending` helper zeroes the abandoned confirm's pending state
(`pendingDelete`, `pendingPurge*`, `pendingCalendar*`) so the destructive
action can never fire afterward.

## Test coverage
`internal/tui/quit_confirm_test.go`:
- `TestCtrlCConvertsNonQuitConfirmToQuit` — ctrl+c on an open event-delete
  confirm is handled, swaps in the quit confirm (`pendingQuit == true`), clears
  `pendingDelete`, and a second ctrl+c force-quits.
- `TestCtrlCClearsPurgePendingState` — same for the bulk trash-purge confirm,
  asserting `pendingPurgeEntries`/`pendingPurgeTitle` are cleared.

Both fail before the fix (ctrl+c not handled) and pass after. `make fmt`,
`go vet ./...`, and `go test ./internal/... -count=1` are all green.
