### PR TITLE
fix(tui): guard SelectField against empty option set

### DIFF
--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -286,10 +286,15 @@ func NewSelectField(options []SelectOption) *SelectField {
 	return f
 }
 
-func (f *SelectField) Selected() int                { return f.selected }
-func (f *SelectField) SetSelected(i int)            { f.selected = i }
-func (f *SelectField) SelectedOption() SelectOption { return f.options[f.selected] }
-func (f *SelectField) Value() string                { return f.options[f.selected].Value }
+func (f *SelectField) Selected() int     { return f.selected }
+func (f *SelectField) SetSelected(i int) { f.selected = i }
+func (f *SelectField) SelectedOption() SelectOption {
+	if f.selected < 0 || f.selected >= len(f.options) {
+		return SelectOption{}
+	}
+	return f.options[f.selected]
+}
+func (f *SelectField) Value() string { return f.SelectedOption().Value }
 func (f *SelectField) SetOptions(options []SelectOption) {
 	f.options = options
 	if len(f.options) == 0 {
@@ -336,6 +341,9 @@ func (f *SelectField) Update(msg tea.Msg) tea.Cmd {
 		return nil
 	case tea.KeyPressMsg:
 		n := len(f.options)
+		if n == 0 {
+			return nil
+		}
 		switch msg.String() {
 		case "left", "h":
 			f.selected = (f.selected - 1 + n) % n
@@ -391,8 +399,11 @@ func (f *SelectField) Blur() {
 	f.highlight = selectNone
 }
 
-func (f *SelectField) SetWidth(int)      {}
-func (f *SelectField) IsFocusable() bool { return true }
+func (f *SelectField) SetWidth(int) {}
+
+// IsFocusable reports false for an empty option set: a select with nothing
+// to choose has no useful interaction and must not capture focus or input.
+func (f *SelectField) IsFocusable() bool { return len(f.options) > 0 }
 
 // ---------------------------------------------------------------------------
 // QuantitySelectField

--- a/internal/tui/form_test.go
+++ b/internal/tui/form_test.go
@@ -199,6 +199,30 @@ func TestSelectField_ImplementsFormField(t *testing.T) {
 	var _ FormField = NewSelectField(testSelectOptions())
 }
 
+func TestSelectField_EmptyOptionsNoPanic(t *testing.T) {
+	f := NewSelectField(nil)
+
+	// Arrow/vim input on an empty option set must not panic
+	// (would divide by zero via (selected +/- 1 + n) % n).
+	assert.NotPanics(t, func() {
+		f.Update(keyPressMsg("right"))
+		f.Update(keyPressMsg("left"))
+		f.Update(keyPressMsg("l"))
+		f.Update(keyPressMsg("h"))
+	})
+	assert.Equal(t, 0, f.Selected())
+
+	// Value()/SelectedOption() must not panic on an empty option set
+	// (would index f.options[f.selected] out of range).
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "", f.Value())
+		assert.Equal(t, SelectOption{}, f.SelectedOption())
+	})
+
+	// An empty select must not capture focus or input.
+	assert.False(t, f.IsFocusable())
+}
+
 // ---------------------------------------------------------------------------
 // CheckboxField tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #145

## Root cause
`SelectField` (internal/tui/form.go) assumed a non-empty option set:

- `Update` computed `(selected +/- 1 + n) % n` with `n = len(options)`,
  which divides by zero — a panic — when the option set is empty.
- `Value()` / `SelectedOption()` indexed `options[selected]` with no
  bounds check, panicking on an out-of-range read.
- `IsFocusable()` returned `true` even when empty, so a field built via
  `NewSelectField(nil)` could take focus and receive arrow/vim input
  before `SetOptions` was ever called.

## Fix
- `Update`: early-return when there are no options (guards the modulo).
- `SelectedOption()`/`Value()`: return a zero `SelectOption` / empty
  string when `selected` is out of range.
- `IsFocusable()`: return `len(options) > 0` so an empty select cannot
  capture focus or input until it has options.

## Test coverage
New `TestSelectField_EmptyOptionsNoPanic` constructs `NewSelectField(nil)`
and asserts that left/right/h/l input, `Value()`, and `SelectedOption()`
do not panic, that `Selected()` stays 0, and that `IsFocusable()` is
false. It panics (divide-by-zero / index-out-of-range) before the fix and
passes after.

## Verification
`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.
