### PR TITLE
fix(tui): pop undo entry by identity to survive in-flight restore race

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -187,8 +187,12 @@ type eventDeletedMsg struct {
 }
 
 // eventRestoredMsg is emitted after an Undo attempt. On success err is nil.
-// On failure err carries the reason.
+// On failure err carries the reason. meta identifies which undo entry the
+// restore acted on, so the success handler can remove that specific entry
+// rather than blindly popping the top (a concurrent delete may have pushed a
+// new entry while the restore was in flight).
 type eventRestoredMsg struct {
+	meta  event.UndoMeta
 	title string
 	err   error
 }
@@ -1379,7 +1383,7 @@ func (m Model) interceptGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 			title := meta.Label
 			cmd := func() tea.Msg {
 				err := m.app.Events.RestoreUndo(context.Background(), meta)
-				return eventRestoredMsg{title: title, err: err}
+				return eventRestoredMsg{meta: meta, title: title, err: err}
 			}
 			return m, cmd, true
 		}
@@ -3006,7 +3010,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// different context (e.g. restoring the calendar first).
 			return m, cmd
 		}
-		m.undoStack.Pop()
+		// Remove the entry that was actually restored by identity, not the
+		// current top: a delete landing while the restore was in flight may
+		// have pushed a newer entry whose undo affordance must survive.
+		m.undoStack.Remove(msg.meta)
 		toastCmd := m.toast.Restored(msg.title)
 		return m, tea.Batch(m.loadEvents(), toastCmd)
 

--- a/internal/tui/undo.go
+++ b/internal/tui/undo.go
@@ -63,5 +63,29 @@ func (s *UndoStack) Pop() (UndoEntry, bool) {
 	return last, true
 }
 
+// Remove deletes the most recent entry whose metadata identifies the same
+// soft-delete as meta, returning whether a match was found. It exists because
+// a restore runs asynchronously: a delete landing between the Peek (when the
+// undo key is pressed) and the restore's success message can push a new entry
+// onto the stack, so the success handler must remove the entry it actually
+// restored by identity rather than blindly popping the top.
+func (s *UndoStack) Remove(meta event.UndoMeta) bool {
+	for i := len(s.entries) - 1; i >= 0; i-- {
+		if sameUndoTarget(s.entries[i].Meta, meta) {
+			s.entries = append(s.entries[:i], s.entries[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// sameUndoTarget reports whether two UndoMeta values describe the same
+// soft-delete operation. Kind + UID + RecurrenceID uniquely identifies a
+// reversible delete: a series and a single-instance delete of the same UID
+// differ by Kind, and distinct overrides differ by RecurrenceID.
+func sameUndoTarget(a, b event.UndoMeta) bool {
+	return a.Kind == b.Kind && a.UID == b.UID && a.RecurrenceID == b.RecurrenceID
+}
+
 // Len returns the current depth.
 func (s *UndoStack) Len() int { return len(s.entries) }

--- a/internal/tui/undo_test.go
+++ b/internal/tui/undo_test.go
@@ -75,3 +75,35 @@ func TestUndoStack_DepthEviction(t *testing.T) {
 func labelFor(i int) string {
 	return string([]byte{byte('A' + i)})
 }
+
+// TestEventRestoredMsg_RemovesRestoredEntryNotTop reproduces issue #144: the
+// undo restore runs in an async tea.Cmd, so a delete that lands between the
+// Peek (when 'u' is pressed) and the eventRestoredMsg success can push a new
+// entry onto the stack. The success handler must remove the entry that was
+// actually restored (matched by identity), not blindly pop the new top.
+func TestEventRestoredMsg_RemovesRestoredEntryNotTop(t *testing.T) {
+	m := Model{undoStack: NewUndoStack()}
+
+	// Delete A, then press 'u' — restore for A is now in flight. Before the
+	// success message lands, delete B pushes a second entry.
+	entryA := entry("A")
+	entryB := entry("B")
+	m.undoStack.Push(entryA)
+	m.undoStack.Push(entryB)
+
+	// The async restore for A completes and reports back.
+	updated, _ := m.Update(eventRestoredMsg{meta: entryA.Meta, title: entryA.Meta.Label})
+	m = updated.(Model)
+
+	if m.undoStack.Len() != 1 {
+		t.Fatalf("Len after restore = %d, want 1", m.undoStack.Len())
+	}
+	top, ok := m.undoStack.Peek()
+	if !ok {
+		t.Fatal("stack unexpectedly empty after restore")
+	}
+	if top.Meta.UID != entryB.Meta.UID {
+		t.Fatalf("restore removed the wrong entry: top UID = %q, want %q (B's undo affordance must survive)",
+			top.Meta.UID, entryB.Meta.UID)
+	}
+}


### PR DESCRIPTION
Fixes #144

## Root cause
The undo restore runs in an async `tea.Cmd`. The keydown handler reads the
top entry via `Peek()` when `u` is pressed, kicks off the restore, and the
`eventRestoredMsg` success handler then `Pop()`ed the top of `undoStack` —
assuming the top was still the entry that was restored. If a new delete lands
between the Peek and the restore completion, its `Push` makes the success
handler pop the *newly deleted* entry instead of the restored one. Result:
the already-restored entry stays on the stack and the new delete loses its
undo affordance.

Scenario: delete A, press `u` (restore A in flight), delete B before the
restore message arrives → the success handler pops B instead of A.

## Fix
- `eventRestoredMsg` now carries the restored `event.UndoMeta`.
- New `UndoStack.Remove(meta)` deletes the most recent entry matching the
  restore by identity (`Kind` + `UID` + `RecurrenceID`) rather than blindly
  popping the top.
- The success handler calls `Remove(msg.meta)` instead of `Pop()`.

## Test
`TestEventRestoredMsg_RemovesRestoredEntryNotTop` reproduces the interleave:
pushes A then B onto the stack, drives `Update(eventRestoredMsg{meta: A})`,
and asserts that B's entry survives (top UID == B). The test fails on the old
`Pop()` behavior (removes B) and passes with the identity-based `Remove`.

## Verification
`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.
