### PR TITLE
fix(tui): refresh "today" highlight across midnight in all views

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -513,7 +513,7 @@ func NewModel(a *app.App, themeName string) Model {
 		undoStack:          NewUndoStack(),
 		toast:              NewToastModel(theme),
 		footer:             NewFooterModel(theme),
-		clockTickScheduled: clockTickEnabledFor(vm),
+		clockTickScheduled: true,
 		oauthFlow:          NewOAuthFlowModel(theme),
 	}
 }
@@ -1190,16 +1190,11 @@ func nextClockTick(token int) tea.Cmd {
 	})
 }
 
-func clockTickEnabledFor(mode viewMode) bool {
-	return mode == viewDay || mode == viewWeek
-}
-
-func (m Model) clockTickEnabled() bool {
-	return clockTickEnabledFor(m.viewMode)
-}
-
+// scheduleClockTick arms the once-a-minute tick if one isn't already pending.
+// Every view runs it: day/week need it to advance the now-line, and all views
+// need it so the "today" cell highlight follows the midnight day rollover.
 func (m Model) scheduleClockTick() (Model, tea.Cmd) {
-	if !m.clockTickEnabled() || m.clockTickScheduled {
+	if m.clockTickScheduled {
 		return m, nil
 	}
 	m.clockTickToken++
@@ -1207,11 +1202,19 @@ func (m Model) scheduleClockTick() (Model, tea.Cmd) {
 	return m, nextClockTick(m.clockTickToken)
 }
 
-func (m Model) disableClockTick() Model {
-	if m.clockTickScheduled {
-		m.clockTickToken++
-		m.clockTickScheduled = false
-	}
+// refreshToday recomputes the local "today" date and propagates it into every
+// view model. The views render their "today" highlight from these stored
+// fields, so without this they freeze on the date captured at startup once the
+// app is left open across midnight. Day view's grid and the sidebar mini-month
+// recompute today at render time and are already immune; refreshing the stored
+// fields keeps week, month, and agenda current and ensures a later view switch
+// carries the right date.
+func (m Model) refreshToday(now time.Time) Model {
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	m.day.today = today
+	m.week.today = today
+	m.agenda.today = today
+	m.calendar.today = today
 	return m
 }
 
@@ -1477,9 +1480,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.clockTickScheduled = false
-		if !m.clockTickEnabled() {
-			return m, nil
-		}
+		m = m.refreshToday(time.Now())
 		return m.scheduleClockTick()
 	}
 
@@ -3660,14 +3661,10 @@ func (m Model) switchToView(mode viewMode) (tea.Model, tea.Cmd) {
 		}
 	}
 	cmds := []tea.Cmd{m.switchView()}
-	if m.clockTickEnabled() {
-		var cmd tea.Cmd
-		m, cmd = m.scheduleClockTick()
-		if cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-	} else {
-		m = m.disableClockTick()
+	var cmd tea.Cmd
+	m, cmd = m.scheduleClockTick()
+	if cmd != nil {
+		cmds = append(cmds, cmd)
 	}
 	return m, tea.Batch(cmds...)
 }

--- a/internal/tui/clock_tick_test.go
+++ b/internal/tui/clock_tick_test.go
@@ -30,15 +30,44 @@ func TestModelClockTickReschedules(t *testing.T) {
 	}
 }
 
-func TestModelClockTickIgnoredOutsideClockViews(t *testing.T) {
-	_, cmd := Model{viewMode: viewMonth}.Update(clockTickMsg{})
-	if cmd != nil {
-		t.Fatal("clockTickMsg scheduled another tick outside day/week views")
+// Every view (not just day/week) needs the clock tick so the "today" cell
+// highlight follows the day rollover; otherwise month/agenda freeze on the
+// startup date until the user navigates.
+func TestModelClockTickReschedulesInEveryView(t *testing.T) {
+	for _, mode := range []viewMode{viewMonth, viewWeek, viewDay, viewAgenda} {
+		_, cmd := Model{viewMode: mode}.Update(clockTickMsg{})
+		if cmd == nil {
+			t.Fatalf("clockTickMsg did not reschedule in view mode %v", mode)
+		}
 	}
+}
 
-	_, cmd = Model{viewMode: viewAgenda}.Update(clockTickMsg{})
-	if cmd != nil {
-		t.Fatal("clockTickMsg scheduled another tick outside day/week views")
+// Leaving the app open across midnight must roll the stored "today" forward in
+// every view model, not just the active one, so a later view switch carries the
+// current date.
+func TestModelClockTickRefreshesTodayAcrossMidnight(t *testing.T) {
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	stale := today.AddDate(0, 0, -2)
+
+	m := Model{viewMode: viewMonth}
+	m.day.today = stale
+	m.week.today = stale
+	m.agenda.today = stale
+	m.calendar.today = stale
+
+	next, _ := m.Update(clockTickMsg{})
+	got := next.(Model)
+
+	for name, field := range map[string]time.Time{
+		"day":      got.day.today,
+		"week":     got.week.today,
+		"agenda":   got.agenda.today,
+		"calendar": got.calendar.today,
+	} {
+		if !sameDay(field, today) {
+			t.Errorf("%s.today = %v after clock tick, want %v", name, field, today)
+		}
 	}
 }
 
@@ -51,7 +80,9 @@ func TestSwitchToClockViewSchedulesClockTick(t *testing.T) {
 	}
 }
 
-func TestSwitchAwayFromClockViewDisablesClockTick(t *testing.T) {
+// The clock tick now runs in every view, so switching between views must keep
+// the existing tick alive rather than tearing it down.
+func TestSwitchBetweenViewsKeepsClockTick(t *testing.T) {
 	next, _ := Model{
 		viewMode:           viewDay,
 		clockTickToken:     3,
@@ -59,10 +90,10 @@ func TestSwitchAwayFromClockViewDisablesClockTick(t *testing.T) {
 	}.switchToView(viewAgenda)
 	m := next.(Model)
 
-	if m.clockTickScheduled {
-		t.Fatal("switching away from day/week left the clock tick scheduled")
+	if !m.clockTickScheduled {
+		t.Fatal("switching between views tore down the clock tick")
 	}
-	if m.clockTickToken != 4 {
-		t.Fatalf("clockTickToken = %d, want 4", m.clockTickToken)
+	if m.clockTickToken != 3 {
+		t.Fatalf("clockTickToken = %d, want 3 (existing tick reused)", m.clockTickToken)
 	}
 }


### PR DESCRIPTION
Fixes #142

## Root cause
The minute clock tick was gated to day/week views (`clockTickEnabledFor`) and
its handler only rescheduled itself — it never recomputed the `today` date
captured at startup. WeekGrid and the month Calendar render their "today" cell
highlight from that stale per-view `today` field while the now-line reads
`time.Now()` directly, and month/agenda views received no tick at all. Leaving
the app open across midnight left the highlight stuck on the previous day until
the user navigated or switched views. (Day view's grid and the sidebar
mini-month recompute today at render time, so they were already immune.)

## Fix
- Run the once-a-minute tick in every view instead of only day/week.
- On each tick, recompute `today` and propagate it into the day, week, agenda,
  and calendar models (`refreshToday`), so the highlight rolls over and a later
  view switch carries the current date.
- Remove the now-redundant per-view enable/disable gating
  (`clockTickEnabledFor`, `clockTickEnabled`, `disableClockTick`).

## Test coverage
- `TestModelClockTickRefreshesTodayAcrossMidnight`: seeds every view model with
  a stale `today`, fires a clock tick, asserts all four roll forward to the real
  current date.
- `TestModelClockTickReschedulesInEveryView`: the tick now reschedules in month,
  week, day, and agenda.
- `TestSwitchBetweenViewsKeepsClockTick`: switching views keeps the existing
  tick alive rather than tearing it down.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.

Assisted-by: Claude Code:claude-opus-4-8
