### PR TITLE
fix(tui): anchor recurrence UNTIL to end of local day

### DIFF
--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -532,20 +532,34 @@ func parseRecurrenceRule(rule string, fallbackDate time.Time) (int, string, ends
 
 // parseRRuleUntil parses an RRULE UNTIL value as either a UTC datetime
 // (20060102T150405Z) or a date-only value (20060102), returning ok=false when
-// neither layout matches.
+// neither layout matches. The result is expressed in the local zone so the
+// end-of-day anchor written by formatRRuleUntil maps back to the calendar day
+// the user picked (see issue #146).
 func parseRRuleUntil(val string) (time.Time, bool) {
 	if t, err := time.Parse("20060102T150405Z", val); err == nil {
-		return t, true
+		return t.Local(), true
 	}
 	if t, err := time.Parse("20060102", val); err == nil {
-		return t, true
+		// A date-only UNTIL is a floating calendar date, not an absolute
+		// instant; reinterpret the wall-clock date in the local zone so it is
+		// not shifted a day by the parser's UTC default.
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local), true
 	}
 	return time.Time{}, false
 }
 
 // formatRRuleUntil renders a time as an RRULE UNTIL value in iCal UTC form.
+//
+// The ends-date arrives from the date picker as local midnight, i.e. the start
+// of the chosen end day. UNTIL is inclusive, so anchoring there would exclude
+// every same-day occurrence (they fire at the event's start time, later than
+// midnight) and, for a positive UTC offset, would even roll the UTC value back
+// to the previous calendar day. Anchor to the final second of that local day
+// before converting to UTC so the chosen end day is always covered.
 func formatRRuleUntil(t time.Time) string {
-	return t.UTC().Format("20060102T150405Z")
+	y, mo, d := t.Date()
+	endOfDay := time.Date(y, mo, d, 23, 59, 59, 0, t.Location())
+	return endOfDay.UTC().Format("20060102T150405Z")
 }
 
 func rruleParam(rule, name string) string {

--- a/internal/tui/recurrence_reopen_test.go
+++ b/internal/tui/recurrence_reopen_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -81,7 +82,20 @@ func TestRecurrenceEditor_LoadRuleRestoresIntervalCountUntilMonthly(t *testing.T
 		m.LoadRule("FREQ=DAILY;UNTIL=20260620T000000Z")
 		require.Equal(t, "DAILY", m.currentFreq())
 		require.Equal(t, endsOnDate, m.currentEnds())
-		require.Equal(t, "FREQ=DAILY;UNTIL=20260620T000000Z", m.BuildRule())
+
+		// UNTIL is rebuilt anchored to end-of-day (issue #146), so the exact
+		// clock value differs from the loaded one; what must be preserved is
+		// the chosen calendar day in the user's zone.
+		rule := m.BuildRule()
+		until, ok := strings.CutPrefix(rule, "FREQ=DAILY;UNTIL=")
+		require.True(t, ok, "rebuilt rule should keep FREQ=DAILY;UNTIL=, got %q", rule)
+		parsed, ok := parseRRuleUntil(until)
+		require.True(t, ok, "rebuilt UNTIL %q should parse", until)
+		loaded, ok := parseRRuleUntil("20260620T000000Z")
+		require.True(t, ok)
+		require.Equal(t, loaded.Year(), parsed.Year())
+		require.Equal(t, loaded.YearDay(), parsed.YearDay(),
+			"rebuilt UNTIL should fall on the same calendar day as loaded")
 	})
 
 	t.Run("monthly nth weekday", func(t *testing.T) {

--- a/internal/tui/recurrence_until_test.go
+++ b/internal/tui/recurrence_until_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFormatRRuleUntil_KeepsEndDayAcrossTimezones guards against issue #146:
+// the ends-date arrives from the date picker as local midnight, which is the
+// *start* of the chosen end day. UNTIL is inclusive, so a local-midnight UNTIL
+// excludes every same-day occurrence (which fire at the event's start time,
+// later than midnight). For a positive UTC offset the value even rolls back to
+// the previous calendar day in UTC. The emitted UNTIL must instead cover the
+// whole chosen end day in the user's zone, for every offset.
+func TestFormatRRuleUntil_KeepsEndDayAcrossTimezones(t *testing.T) {
+	cases := []struct {
+		name      string
+		offsetSec int
+	}{
+		{"positive offset (UTC+2)", 2 * 3600},
+		{"large positive offset (UTC+14)", 14 * 3600},
+		{"negative offset (UTC-10)", -10 * 3600},
+		{"utc", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loc := time.FixedZone(tc.name, tc.offsetSec)
+			endsDate := time.Date(2026, 4, 30, 0, 0, 0, 0, loc) // local midnight
+
+			got := formatRRuleUntil(endsDate)
+
+			parsed, ok := parseRRuleUntil(strings.TrimPrefix(got, "UNTIL="))
+			require.True(t, ok, "parseRRuleUntil(%q) failed", got)
+
+			// Viewed in the user's zone, UNTIL must land at the end of the
+			// chosen day so any same-day occurrence is included.
+			local := parsed.In(loc)
+			require.Equal(t, 2026, local.Year())
+			require.Equal(t, time.April, local.Month())
+			require.Equal(t, 30, local.Day(),
+				"UNTIL should map back to Apr 30 in the user's zone, got %s", local)
+			require.Equal(t, 23, local.Hour(),
+				"UNTIL should anchor to end-of-day, not start-of-day, got %s", local)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #146

## Root cause
`formatRRuleUntil` (`internal/tui/event_form.go`) rendered the recurrence
end-date — which the date picker supplies as **local midnight**, i.e. the
*start* of the chosen end day — directly as `t.UTC().Format(...)`. Because
RRULE `UNTIL` is inclusive, anchoring at local midnight excludes every
same-day occurrence (they fire at the event's start time, later than
midnight). For a positive UTC offset the value even rolls back to the
previous calendar day (`2026-04-30T00:00 +02:00` -> `20260429T220000Z`),
dropping the occurrence on the chosen end day entirely.

## Fix
- `formatRRuleUntil` now anchors `UNTIL` to the final second of the chosen
  local day (`23:59:59` in the value's own zone) before converting to UTC,
  so the end day is always covered for every offset.
- `parseRRuleUntil` now returns the parsed value in the local zone: a
  datetime `...Z` value as an absolute instant via `.Local()`, and a
  date-only value as a floating calendar date reinterpreted at local
  midnight (so a negative-offset zone doesn't shift it back a day). This
  keeps the editor redisplaying the same calendar day it stored.

Both functions are the shared helpers used by `event_form.go` and
`recurrence_editor.go`, so the fix applies to every UNTIL call site.

## Tests
- New `TestFormatRRuleUntil_KeepsEndDayAcrossTimezones`
  (`internal/tui/recurrence_until_test.go`) drives local-midnight ends-dates
  across UTC+2, UTC+14, UTC-10, and UTC, and asserts the emitted `UNTIL`
  round-trips back to end-of-day on the chosen calendar day in the user's
  zone. It fails on the pre-fix code (rolls back to Apr 29 / anchors at
  start-of-day) and passes after the fix.
- Updated the existing `until` round-trip subtest in
  `recurrence_reopen_test.go` to assert calendar-day preservation rather
  than the old (buggy) exact-midnight string, in a timezone-robust way.

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all pass.
