### PR TITLE
fix(storage): make sync-tracking writes transactional and propagate errors

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -339,11 +339,16 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Event, error) {
 			return Event{}, fmt.Errorf("replace categories: %w", err)
 		}
 	}
+	// Mark dirty inside the transaction so a failed sync-tracking write rolls
+	// the new event back rather than committing a row that can never be pushed
+	// (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit create event: %w", err)
 	}
 	e.Categories = p.Categories
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 
@@ -507,9 +512,24 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 	}
 
 	// If this is a standalone event (no recurrence or a solo master), create
-	// a tombstone so the sync engine can send a DELETE to the server.
+	// a tombstone so the sync engine can send a DELETE to the server. The
+	// tombstone and the soft-delete commit together: if the tombstone write
+	// fails the soft-delete rolls back, so the next sync can never DELETE a
+	// still-live event from the server (issue #107).
 	if evt.RecurrenceID == "" {
-		_, _ = storage.CreateTombstoneIfSynced(ctx, s.db, evt.CalendarID, evt.UID)
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer tx.Rollback()
+		qtx := s.q.WithTx(tx)
+		if _, err := storage.CreateTombstoneIfSynced(ctx, tx, evt.CalendarID, evt.UID); err != nil {
+			return fmt.Errorf("create tombstone: %w", err)
+		}
+		if err := qtx.SoftDeleteEvent(ctx, id); err != nil {
+			return fmt.Errorf("soft-delete event: %w", err)
+		}
+		return tx.Commit()
 	}
 
 	// If this is an override, add EXDATE to the master so the instance
@@ -563,6 +583,7 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		return nil
 	}
 
+	// Unreachable: RecurrenceID is either "" (handled above) or non-empty.
 	return s.q.SoftDeleteEvent(ctx, id)
 }
 

--- a/internal/event/sync_atomic_test.go
+++ b/internal/event/sync_atomic_test.go
@@ -1,0 +1,115 @@
+package event
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// makeSyncedCalendar links calendar 1 to an account so the sync-tracking
+// writes (MarkResourceDirty / CreateTombstoneIfSynced) actually fire.
+func makeSyncedCalendar(t *testing.T, s *Service) {
+	t.Helper()
+	ctx := context.Background()
+	acct, err := s.q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      "test",
+		ServerUrl: "https://example.com",
+		AuthType:  "basic",
+		Username:  "u",
+	})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	remote := "https://example.com/cal/"
+	if err := s.q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		AccountID: &acct.ID,
+		RemoteUrl: &remote,
+		ID:        1,
+	}); err != nil {
+		t.Fatalf("link calendar: %v", err)
+	}
+}
+
+// TestCreate_SyncMarkIsAtomic exercises issue #107: the sync-tracking write
+// must participate in the mutation's transaction and its error must not be
+// discarded. We force the sync_resources INSERT to fail (by dropping the
+// table) and assert that Create reports the failure and rolls the event back
+// rather than silently committing a row that will never be pushed.
+func TestCreate_SyncMarkIsAtomic(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	// Force the dirty-mark INSERT to fail.
+	if _, err := svc.db.ExecContext(ctx, `DROP TABLE sync_resources`); err != nil {
+		t.Fatalf("drop sync_resources: %v", err)
+	}
+
+	_, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Title:      "Synced Event",
+		StartTime:  time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("Create succeeded but the sync-tracking write failed; the error was discarded")
+	}
+
+	// The mutation must have rolled back: no event should be persisted.
+	var n int
+	if err := svc.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&n); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("event was committed (%d rows) despite the sync-tracking write failing; "+
+			"the dirty-mark is not atomic with the mutation", n)
+	}
+}
+
+// TestDelete_TombstoneIsAtomic exercises the most dangerous half of issue #107:
+// for a synced standalone event the tombstone is written together with the
+// soft-delete. If the tombstone write fails, the soft-delete must roll back so
+// the next sync cannot DELETE a still-live event from the server.
+func TestDelete_TombstoneIsAtomic(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	evt := createEvent(t, svc)
+
+	// Mark the resource as already synced (non-empty remote_url) so Delete
+	// takes the tombstone-creating path.
+	if err := svc.q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   evt.CalendarID,
+		Uid:          evt.UID,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/evt.ics",
+		Etag:         "etag-1",
+		Dirty:        0,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("upsert sync resource: %v", err)
+	}
+
+	// Force the tombstone INSERT to fail.
+	if _, err := svc.db.ExecContext(ctx, `DROP TABLE tombstones`); err != nil {
+		t.Fatalf("drop tombstones: %v", err)
+	}
+
+	if err := svc.Delete(ctx, evt.ID); err == nil {
+		t.Fatal("Delete succeeded but the tombstone write failed; the error was discarded")
+	}
+
+	// The soft-delete must have rolled back: the event is still live.
+	var deletedAt *string
+	if err := svc.db.QueryRowContext(ctx,
+		`SELECT deleted_at FROM events WHERE id = ?`, evt.ID).Scan(&deletedAt); err != nil {
+		t.Fatalf("read event: %v", err)
+	}
+	if deletedAt != nil && *deletedAt != "" {
+		t.Fatalf("event was soft-deleted (deleted_at=%q) despite the tombstone write failing; "+
+			"the tombstone is not atomic with the soft-delete", *deletedAt)
+	}
+}

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -279,11 +279,10 @@ func (s *Service) restoreInstanceByLogID(ctx context.Context, logID int64) error
 	if err := qtx.DeleteEventExdateDelete(ctx, logID); err != nil {
 		return fmt.Errorf("delete log row: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return err
+	if err := storage.MarkResourceDirty(ctx, tx, master.CalendarID, log.Uid, "event"); err != nil {
+		return fmt.Errorf("mark resource dirty: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, log.Uid, "event")
-	return nil
+	return tx.Commit()
 }
 
 // restoreTruncationByLogID rewrites the master's RRULE back to the
@@ -325,11 +324,10 @@ func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) err
 	if err := qtx.DeleteEventTruncateDelete(ctx, logID); err != nil {
 		return fmt.Errorf("delete log row: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return err
+	if err := storage.MarkResourceDirty(ctx, tx, master.CalendarID, log.Uid, "event"); err != nil {
+		return fmt.Errorf("mark resource dirty: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, log.Uid, "event")
-	return nil
+	return tx.Commit()
 }
 
 // removeTimeFromList returns list with the first element equal to target

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -389,7 +389,25 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 	}
 
 	if j.RecurrenceID == "" {
-		_, _ = storage.CreateTombstoneIfSynced(ctx, s.db, j.CalendarID, j.UID)
+		// Tombstone + soft-delete commit together so a failed tombstone write
+		// can't leave a soft-deleted row whose next sync DELETEs a still-live
+		// server resource (issue #107).
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer tx.Rollback()
+		qtx := s.q.WithTx(tx)
+		if _, err := storage.CreateTombstoneIfSynced(ctx, tx, j.CalendarID, j.UID); err != nil {
+			return fmt.Errorf("create tombstone: %w", err)
+		}
+		if err := qtx.SoftDeleteJournal(ctx, id); err != nil {
+			return fmt.Errorf("soft-delete journal: %w", err)
+		}
+		if err := storage.MarkResourceDirty(ctx, tx, j.CalendarID, j.UID, "journal"); err != nil {
+			return fmt.Errorf("mark resource dirty: %w", err)
+		}
+		return tx.Commit()
 	}
 
 	if j.RecurrenceID != "" {
@@ -439,6 +457,7 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		return nil
 	}
 
+	// Unreachable: RecurrenceID is either "" (handled above) or non-empty.
 	if err := s.q.SoftDeleteJournal(ctx, id); err != nil {
 		return err
 	}

--- a/internal/storage/sync_helpers.go
+++ b/internal/storage/sync_helpers.go
@@ -43,7 +43,11 @@ func MarkResourceDirty(ctx context.Context, db DBTX, calendarID int64, uid, owne
 // CreateTombstoneIfSynced inserts a tombstone row if the resource was
 // previously synced (has a sync_resources row with a non-empty remote_url).
 // Returns true if a tombstone was created.
-func CreateTombstoneIfSynced(ctx context.Context, db *sql.DB, calendarID int64, uid string) (bool, error) {
+//
+// db is a DBTX so callers can pass their own *sql.Tx, letting the tombstone
+// write commit (or roll back) atomically with the soft-delete it accompanies.
+// Pass *sql.DB only when there is no surrounding transaction.
+func CreateTombstoneIfSynced(ctx context.Context, db DBTX, calendarID int64, uid string) (bool, error) {
 	if calendarID == 0 || uid == "" {
 		return false, nil
 	}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -495,7 +495,25 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 	}
 
 	if td.RecurrenceID == "" {
-		_, _ = storage.CreateTombstoneIfSynced(ctx, s.db, td.CalendarID, td.UID)
+		// Tombstone + soft-delete commit together so a failed tombstone write
+		// can't leave a soft-deleted row whose next sync DELETEs a still-live
+		// server resource (issue #107).
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer tx.Rollback()
+		qtx := s.q.WithTx(tx)
+		if _, err := storage.CreateTombstoneIfSynced(ctx, tx, td.CalendarID, td.UID); err != nil {
+			return fmt.Errorf("create tombstone: %w", err)
+		}
+		if err := qtx.SoftDeleteTodo(ctx, id); err != nil {
+			return fmt.Errorf("soft-delete todo: %w", err)
+		}
+		if err := storage.MarkResourceDirty(ctx, tx, td.CalendarID, td.UID, "todo"); err != nil {
+			return fmt.Errorf("mark resource dirty: %w", err)
+		}
+		return tx.Commit()
 	}
 
 	if td.RecurrenceID != "" {
@@ -545,6 +563,7 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		return nil
 	}
 
+	// Unreachable: RecurrenceID is either "" (handled above) or non-empty.
 	if err := s.q.SoftDeleteTodo(ctx, id); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #107

## Root cause

`storage.MarkResourceDirty` and `storage.CreateTombstoneIfSynced` took a
`*sql.DB`, so they always ran on a different connection than the service
mutation's transaction — the dirty flag / tombstone could never commit
atomically with the data change. Every caller also discarded the returned
error (`_ = MarkResourceDirty(...)`). In `Delete`/`DeleteSeries` the tombstone
was created *before* the soft-delete committed.

Consequences:
- Mutation commits but the dirty-mark/tombstone write fails (SQLITE_BUSY,
  mid-crash) → a locally modified resource is never marked dirty (won't push),
  or a deleted synced resource gets no tombstone (server copy never deleted).
- Tombstone is created but the soft-delete then fails → the next sync DELETEs a
  still-live resource from the server.

## Fix

- `MarkResourceDirty` / `CreateTombstoneIfSynced` now accept `storage.DBTX`
  (satisfied by both `*sql.DB` and `*sql.Tx`), so callers can pass their own
  transaction.
- Every sync-tracking write was moved **inside** the surrounding transaction
  (before commit) and now **propagates its error**, so a failed dirty-mark /
  tombstone rolls the whole mutation back.
- `Delete`/`DeleteSeries` create the tombstone in the same transaction as the
  soft-delete, eliminating the orphan-tombstone / orphan-delete windows.
- The error-swallowing `markDirtyByID` becomes `markDirtyByIDTx` (lookup +
  dirty-mark on the caller's tx).
- Todo and journal `Create`/`Update`, which were not transactional at all, are
  now wrapped in a single transaction (matching the event package) via new
  `replace{Todo,Journal}CategoriesTx` helpers.
- The triplicated `reconcileSyncAfterRestore` is consolidated into a shared
  `storage.ReconcileSyncAfterRestore` helper.

Covers event, todo, and journal services plus their soft-delete / trash paths.

## What the tests cover

`internal/event/sync_atomic_test.go`:
- `TestCreate_SyncMarkIsAtomic` — drops `sync_resources` to force the dirty-mark
  INSERT to fail, then asserts `Create` returns an error and **no event row is
  committed** (previously the error was swallowed and the row persisted).
- `TestDelete_TombstoneIsAtomic` — for a synced standalone event, drops
  `tombstones` to force the tombstone INSERT to fail, then asserts `Delete`
  errors and the event stays **live** (not soft-deleted), so the next sync can't
  DELETE a live event from the server.

Both fail on the pre-fix code and pass after.

## Verification

`make fmt`, `go vet ./...`, and `go test ./internal/... -count=1` all green.
Reviewed with `/code-review` (no correctness findings) and `/simplify`
(applied: hoisted the duplicated soft-delete tail in the three `Delete`
methods; extracted the shared `ReconcileSyncAfterRestore`).
