### PR TITLE
fix(ical): keep importing past a failed component and surface child-field drops

### DIFF
--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/douglasdemoura/chroncal/internal/app"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/ical"
 	"github.com/douglasdemoura/chroncal/internal/journal"
@@ -76,103 +77,10 @@ again updates existing items instead of blindly duplicating them.`,
 				return err
 			}
 
-			// Store imported VTIMEZONE components.
-			for _, tz := range result.Timezones {
-				if _, err := a.Queries.UpsertTimezone(ctx, storage.UpsertTimezoneParams{
-					Tzid:          tz.TZID,
-					VtimezoneData: tz.Data,
-				}); err != nil {
-					result.Warnings = append(result.Warnings, fmt.Sprintf("store VTIMEZONE %s: %v", tz.TZID, err))
-				}
-			}
-
-			// Import events
-			var importedEvents []event.Event
-			var newEvents, updatedEvents int
-			for _, e := range result.Events {
-				_, lookupErr := a.Events.GetByUID(ctx, e.UID)
-				saved, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
-					UID: e.UID, CalendarID: calID,
-					Title: e.Title, Description: e.Description, Location: e.Location,
-					StartTime: e.StartTime, EndTime: e.EndTime, AllDay: e.AllDay,
-					RecurrenceRule: e.RecurrenceRule, Timezone: e.Timezone,
-					Status: e.Status, Transp: e.Transp, Sequence: e.Sequence,
-					Priority: e.Priority, Class: e.Class, URL: e.URL,
-					ConferenceURI: e.ConferenceURI,
-					Categories:    e.Categories, ExDates: e.ExDates, RDates: e.RDates,
-					RecurrenceID: e.RecurrenceID, Geo: e.Geo,
-					DurationValue: e.DurationValue, DtStamp: e.DtStamp,
-				})
-				if err != nil {
-					return fmt.Errorf("upsert event %q: %w", safeText(e.Title), err)
-				}
-				importEventFields(ctx, a.Events, saved.ID, e)
-				importedEvents = append(importedEvents, saved)
-				if lookupErr != nil {
-					newEvents++
-				} else {
-					updatedEvents++
-				}
-			}
-
-			// Import todos
-			var importedTodos []todo.Todo
-			var newTodos, updatedTodos int
-			for _, t := range result.Todos {
-				_, lookupErr := a.Todos.GetByUID(ctx, t.UID)
-				saved, err := a.Todos.UpsertByUID(ctx, todo.UpsertParams{
-					UID: t.UID, CalendarID: calID,
-					Summary: t.Summary, Description: t.Description, Location: t.Location,
-					DueDate: t.DueDate, StartDate: t.StartDate, Duration: t.Duration,
-					CompletedAt: t.CompletedAt, PercentComplete: t.PercentComplete,
-					Status: t.Status, Priority: t.Priority, Class: t.Class,
-					URL: t.URL, Categories: t.Categories,
-					RecurrenceRule: t.RecurrenceRule, Timezone: t.Timezone,
-					Sequence: t.Sequence, ExDates: t.ExDates, RDates: t.RDates,
-					RecurrenceID: t.RecurrenceID, Geo: t.Geo,
-					DtStamp: t.DtStamp,
-				})
-				if err != nil {
-					return fmt.Errorf("upsert todo %q: %w", safeText(t.Summary), err)
-				}
-				importTodoFields(ctx, a.Todos, saved.ID, t)
-				importedTodos = append(importedTodos, saved)
-				if lookupErr != nil {
-					newTodos++
-				} else {
-					updatedTodos++
-				}
-			}
-
-			// Import journals
-			var importedJournals []journal.Journal
-			var newJournals, updatedJournals int
-			for _, j := range result.Journals {
-				_, lookupErr := a.Journals.GetByUID(ctx, j.UID)
-				saved, err := a.Journals.UpsertByUID(ctx, journal.UpsertParams{
-					UID: j.UID, CalendarID: calID,
-					Summary: j.Summary, Description: j.Description,
-					StartDate: j.StartDate, Status: j.Status, Class: j.Class,
-					URL: j.URL, Categories: j.Categories,
-					RecurrenceRule: j.RecurrenceRule, Timezone: j.Timezone,
-					Sequence: j.Sequence, ExDates: j.ExDates, RDates: j.RDates,
-					RecurrenceID: j.RecurrenceID,
-					DtStamp:      j.DtStamp,
-				})
-				if err != nil {
-					return fmt.Errorf("upsert journal %q: %w", safeText(j.Summary), err)
-				}
-				importJournalFields(ctx, a.Journals, saved.ID, j)
-				importedJournals = append(importedJournals, saved)
-				if lookupErr != nil {
-					newJournals++
-				} else {
-					updatedJournals++
-				}
-			}
+			summary := importComponents(ctx, a, calID, &result)
 
 			if len(result.Warnings) > 0 {
-				fmt.Fprintf(os.Stderr, "chroncal: %d component(s) skipped during import:\n", len(result.Warnings))
+				fmt.Fprintf(os.Stderr, "chroncal: %d warning(s) during import:\n", len(result.Warnings))
 				limit := 5
 				if len(result.Warnings) < limit {
 					limit = len(result.Warnings)
@@ -188,31 +96,167 @@ again updates existing items instead of blindly duplicating them.`,
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
 				out := map[string]any{
-					"events":           toJSONEvents(importedEvents),
-					"todos":            toJSONTodos(importedTodos),
-					"journals":         toJSONJournals(importedJournals),
+					"events":           toJSONEvents(summary.events),
+					"todos":            toJSONTodos(summary.todos),
+					"journals":         toJSONJournals(summary.journals),
 					"freebusy":         result.FreeBusy,
-					"new_events":       newEvents,
-					"updated_events":   updatedEvents,
-					"new_todos":        newTodos,
-					"updated_todos":    updatedTodos,
-					"new_journals":     newJournals,
-					"updated_journals": updatedJournals,
+					"new_events":       summary.newEvents,
+					"updated_events":   summary.updatedEvents,
+					"new_todos":        summary.newTodos,
+					"updated_todos":    summary.updatedTodos,
+					"new_journals":     summary.newJournals,
+					"updated_journals": summary.updatedJournals,
+					"failed":           summary.failed,
 					"warnings":         result.Warnings,
 				}
-				return printOutput(w, out)
+				if err := printOutput(w, out); err != nil {
+					return err
+				}
+			} else {
+				fmt.Fprintf(w, "Imported %d new, updated %d existing (%d events, %d todos, %d journals).\n",
+					summary.newEvents+summary.newTodos+summary.newJournals,
+					summary.updatedEvents+summary.updatedTodos+summary.updatedJournals,
+					len(summary.events), len(summary.todos), len(summary.journals))
+				if len(result.FreeBusy) > 0 {
+					fmt.Fprintf(w, "Parsed %d VFREEBUSY component(s); they were not imported into local storage.\n", len(result.FreeBusy))
+				}
 			}
-			fmt.Fprintf(w, "Imported %d new, updated %d existing (%d events, %d todos, %d journals).\n",
-				newEvents+newTodos+newJournals, updatedEvents+updatedTodos+updatedJournals,
-				len(importedEvents), len(importedTodos), len(importedJournals))
-			if len(result.FreeBusy) > 0 {
-				fmt.Fprintf(w, "Parsed %d VFREEBUSY component(s); they were not imported into local storage.\n", len(result.FreeBusy))
+
+			// A non-zero exit signals that the import was partial, but the
+			// summary above still reports exactly what landed so the caller
+			// can retry only the failed components.
+			if summary.failed > 0 {
+				return fmt.Errorf("%d component(s) failed to import; see warnings", summary.failed)
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&calendarName, "calendar", "", "calendar to import into (default: first available)")
 	return cmd
+}
+
+// icalImportSummary records what an import landed and what it dropped.
+type icalImportSummary struct {
+	events   []event.Event
+	todos    []todo.Todo
+	journals []journal.Journal
+
+	newEvents, updatedEvents     int
+	newTodos, updatedTodos       int
+	newJournals, updatedJournals int
+
+	// failed counts components whose own upsert failed (and were therefore
+	// skipped entirely). Child-field failures are recorded as warnings
+	// instead, since the parent component itself did land.
+	failed int
+}
+
+// importComponents upserts the parsed timezones, events, todos, and journals
+// into calID. A failure on any single component is recorded in
+// result.Warnings (and summary.failed) and the loop moves on, so one bad item
+// no longer aborts the run and discards the components that follow it. Child
+// collections (alarms, attendees, ...) that fail to attach are likewise
+// surfaced as warnings rather than silently dropped, so the import never
+// reports a clean success while quietly losing data.
+func importComponents(ctx context.Context, a *app.App, calID int64, result *ical.ImportResult) icalImportSummary {
+	var summary icalImportSummary
+
+	// Store imported VTIMEZONE components.
+	for _, tz := range result.Timezones {
+		if _, err := a.Queries.UpsertTimezone(ctx, storage.UpsertTimezoneParams{
+			Tzid:          tz.TZID,
+			VtimezoneData: tz.Data,
+		}); err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("store VTIMEZONE %s: %v", tz.TZID, err))
+		}
+	}
+
+	// Import events.
+	for _, e := range result.Events {
+		_, lookupErr := a.Events.GetByUID(ctx, e.UID)
+		saved, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
+			UID: e.UID, CalendarID: calID,
+			Title: e.Title, Description: e.Description, Location: e.Location,
+			StartTime: e.StartTime, EndTime: e.EndTime, AllDay: e.AllDay,
+			RecurrenceRule: e.RecurrenceRule, Timezone: e.Timezone,
+			Status: e.Status, Transp: e.Transp, Sequence: e.Sequence,
+			Priority: e.Priority, Class: e.Class, URL: e.URL,
+			ConferenceURI: e.ConferenceURI,
+			Categories:    e.Categories, ExDates: e.ExDates, RDates: e.RDates,
+			RecurrenceID: e.RecurrenceID, Geo: e.Geo,
+			DurationValue: e.DurationValue, DtStamp: e.DtStamp,
+		})
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("import event %q: %v", safeText(e.Title), err))
+			summary.failed++
+			continue
+		}
+		result.Warnings = append(result.Warnings, importEventFields(ctx, a.Events, saved.ID, e)...)
+		summary.events = append(summary.events, saved)
+		if lookupErr != nil {
+			summary.newEvents++
+		} else {
+			summary.updatedEvents++
+		}
+	}
+
+	// Import todos.
+	for _, t := range result.Todos {
+		_, lookupErr := a.Todos.GetByUID(ctx, t.UID)
+		saved, err := a.Todos.UpsertByUID(ctx, todo.UpsertParams{
+			UID: t.UID, CalendarID: calID,
+			Summary: t.Summary, Description: t.Description, Location: t.Location,
+			DueDate: t.DueDate, StartDate: t.StartDate, Duration: t.Duration,
+			CompletedAt: t.CompletedAt, PercentComplete: t.PercentComplete,
+			Status: t.Status, Priority: t.Priority, Class: t.Class,
+			URL: t.URL, Categories: t.Categories,
+			RecurrenceRule: t.RecurrenceRule, Timezone: t.Timezone,
+			Sequence: t.Sequence, ExDates: t.ExDates, RDates: t.RDates,
+			RecurrenceID: t.RecurrenceID, Geo: t.Geo,
+			DtStamp: t.DtStamp,
+		})
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("import todo %q: %v", safeText(t.Summary), err))
+			summary.failed++
+			continue
+		}
+		result.Warnings = append(result.Warnings, importTodoFields(ctx, a.Todos, saved.ID, t)...)
+		summary.todos = append(summary.todos, saved)
+		if lookupErr != nil {
+			summary.newTodos++
+		} else {
+			summary.updatedTodos++
+		}
+	}
+
+	// Import journals.
+	for _, j := range result.Journals {
+		_, lookupErr := a.Journals.GetByUID(ctx, j.UID)
+		saved, err := a.Journals.UpsertByUID(ctx, journal.UpsertParams{
+			UID: j.UID, CalendarID: calID,
+			Summary: j.Summary, Description: j.Description,
+			StartDate: j.StartDate, Status: j.Status, Class: j.Class,
+			URL: j.URL, Categories: j.Categories,
+			RecurrenceRule: j.RecurrenceRule, Timezone: j.Timezone,
+			Sequence: j.Sequence, ExDates: j.ExDates, RDates: j.RDates,
+			RecurrenceID: j.RecurrenceID,
+			DtStamp:      j.DtStamp,
+		})
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("import journal %q: %v", safeText(j.Summary), err))
+			summary.failed++
+			continue
+		}
+		result.Warnings = append(result.Warnings, importJournalFields(ctx, a.Journals, saved.ID, j)...)
+		summary.journals = append(summary.journals, saved)
+		if lookupErr != nil {
+			summary.newJournals++
+		} else {
+			summary.updatedJournals++
+		}
+	}
+
+	return summary
 }
 
 func icalExportCmd() *cobra.Command {

--- a/cmd/chroncal/ical_import_test.go
+++ b/cmd/chroncal/ical_import_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/ical"
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+func newImportTestApp(t *testing.T) *app.App {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "chroncal.db")
+	t.Setenv("CHRONCAL_DB", dbPath)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg-config"))
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	t.Cleanup(func() { a.Close() })
+	return a
+}
+
+// TestImportComponentsContinuesPastItemFailure is the regression test for
+// issue #141: a mid-file upsert failure used to `return` out of the import
+// loop, so components after the bad one were silently dropped while the rows
+// before it stayed committed. Importing must now skip only the failing
+// component, persist the rest, and report the failure instead of aborting.
+func TestImportComponentsContinuesPastItemFailure(t *testing.T) {
+	ctx := context.Background()
+	a := newImportTestApp(t)
+
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC)
+	mkEvent := func(uid, title string, priority int64) event.Event {
+		return event.Event{
+			UID:       uid,
+			Title:     title,
+			StartTime: start,
+			EndTime:   start.Add(time.Hour),
+			Priority:  priority,
+		}
+	}
+
+	// The middle event carries an out-of-range priority (CHECK constraint is
+	// 0..9), so its upsert fails. The events on either side are valid.
+	result := ical.ImportResult{
+		Events: []event.Event{
+			mkEvent("evt-before", "Before", 0),
+			mkEvent("evt-bad", "Bad", 99),
+			mkEvent("evt-after", "After", 0),
+		},
+	}
+
+	summary := importComponents(ctx, a, cal.ID, &result)
+
+	if summary.failed != 1 {
+		t.Fatalf("summary.failed = %d, want 1", summary.failed)
+	}
+	if summary.newEvents != 2 {
+		t.Fatalf("summary.newEvents = %d, want 2", summary.newEvents)
+	}
+
+	// The event after the failing one must still be persisted: this is the
+	// core of the bug, where the early return discarded it.
+	if _, err := a.Events.GetByUID(ctx, "evt-after"); err != nil {
+		t.Fatalf("evt-after not persisted (import aborted early): %v", err)
+	}
+	if _, err := a.Events.GetByUID(ctx, "evt-before"); err != nil {
+		t.Fatalf("evt-before not persisted: %v", err)
+	}
+	if _, err := a.Events.GetByUID(ctx, "evt-bad"); err == nil {
+		t.Fatalf("evt-bad should not have been persisted")
+	}
+
+	// The failure must be surfaced, not silently swallowed.
+	if !containsSubstring(result.Warnings, "Bad") {
+		t.Fatalf("warnings = %v, want a warning mentioning the failed event", result.Warnings)
+	}
+}
+
+// TestImportComponentsSurfacesChildFieldFailure covers the second half of
+// issue #141: child-field imports (alarms, attendees, ...) only logged on
+// failure, so partial child data was dropped while the command reported a
+// clean success. A failing child import must now appear in the warnings.
+func TestImportComponentsSurfacesChildFieldFailure(t *testing.T) {
+	ctx := context.Background()
+	a := newImportTestApp(t)
+
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC)
+	evt := event.Event{
+		UID:       "evt-bad-alarm",
+		Title:     "Has bad alarm",
+		StartTime: start,
+		EndTime:   start.Add(time.Hour),
+		// ACTION is constrained to AUDIO/DISPLAY/EMAIL, so this alarm fails
+		// to attach even though the event itself is valid.
+		Alarms: []model.Alarm{{
+			Action:       "BOGUS",
+			TriggerValue: "-PT15M",
+			Related:      "START",
+		}},
+	}
+
+	result := ical.ImportResult{Events: []event.Event{evt}}
+
+	summary := importComponents(ctx, a, cal.ID, &result)
+
+	// The event itself lands (failed counts only whole-component failures).
+	if summary.failed != 0 {
+		t.Fatalf("summary.failed = %d, want 0", summary.failed)
+	}
+	if _, err := a.Events.GetByUID(ctx, "evt-bad-alarm"); err != nil {
+		t.Fatalf("event with bad alarm should still be imported: %v", err)
+	}
+
+	// But the dropped alarm must be reported instead of only logged.
+	if !containsSubstring(result.Warnings, "alarms") {
+		t.Fatalf("warnings = %v, want a warning about the dropped alarm", result.Warnings)
+	}
+}
+
+func containsSubstring(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/chroncal/populate.go
+++ b/cmd/chroncal/populate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/douglasdemoura/chroncal/internal/event"
@@ -65,123 +66,106 @@ func populateTodoFields(ctx context.Context, svc *todo.Service, t *todo.Todo) {
 	}
 }
 
-func importEventFields(ctx context.Context, svc *event.Service, id int64, e event.Event) {
-	if len(e.Alarms) > 0 {
-		if err := svc.ReplaceAlarms(ctx, id, e.Alarms); err != nil {
-			log.Printf("warning: import event %d: replace alarms: %v", id, err)
+// importEventFields attaches the transient child collections (alarms,
+// attendees, ...) to a freshly imported event. Each failure is returned as a
+// warning rather than only logged, so callers can surface partially-dropped
+// child data in the import summary instead of silently reporting success.
+func importEventFields(ctx context.Context, svc *event.Service, id int64, e event.Event) []string {
+	var warns []string
+	add := func(field string, err error) {
+		if err != nil {
+			warns = append(warns, fmt.Sprintf("import event %d: replace %s: %v", id, field, err))
 		}
+	}
+	if len(e.Alarms) > 0 {
+		add("alarms", svc.ReplaceAlarms(ctx, id, e.Alarms))
 	}
 	if len(e.Attendees) > 0 {
-		if err := svc.ReplaceAttendees(ctx, id, e.Attendees); err != nil {
-			log.Printf("warning: import event %d: replace attendees: %v", id, err)
-		}
+		add("attendees", svc.ReplaceAttendees(ctx, id, e.Attendees))
 	}
 	if len(e.Attachments) > 0 {
-		if err := svc.ReplaceAttachments(ctx, id, e.Attachments); err != nil {
-			log.Printf("warning: import event %d: replace attachments: %v", id, err)
-		}
+		add("attachments", svc.ReplaceAttachments(ctx, id, e.Attachments))
 	}
 	if len(e.Comments) > 0 {
-		if err := svc.ReplaceComments(ctx, id, e.Comments); err != nil {
-			log.Printf("warning: import event %d: replace comments: %v", id, err)
-		}
+		add("comments", svc.ReplaceComments(ctx, id, e.Comments))
 	}
 	if len(e.Contacts) > 0 {
-		if err := svc.ReplaceContacts(ctx, id, e.Contacts); err != nil {
-			log.Printf("warning: import event %d: replace contacts: %v", id, err)
-		}
+		add("contacts", svc.ReplaceContacts(ctx, id, e.Contacts))
 	}
 	if len(e.Resources) > 0 {
-		if err := svc.ReplaceResources(ctx, id, e.Resources); err != nil {
-			log.Printf("warning: import event %d: replace resources: %v", id, err)
-		}
+		add("resources", svc.ReplaceResources(ctx, id, e.Resources))
 	}
 	if len(e.Relations) > 0 {
-		if err := svc.ReplaceRelations(ctx, id, e.Relations); err != nil {
-			log.Printf("warning: import event %d: replace relations: %v", id, err)
-		}
+		add("relations", svc.ReplaceRelations(ctx, id, e.Relations))
 	}
 	if len(e.XProperties) > 0 {
-		if err := svc.ReplaceXProperties(ctx, id, e.XProperties); err != nil {
-			log.Printf("warning: import event %d: replace x-properties: %v", id, err)
-		}
+		add("x-properties", svc.ReplaceXProperties(ctx, id, e.XProperties))
 	}
+	return warns
 }
 
-func importTodoFields(ctx context.Context, svc *todo.Service, id int64, t todo.Todo) {
-	if len(t.Alarms) > 0 {
-		if err := svc.ReplaceAlarms(ctx, id, t.Alarms); err != nil {
-			log.Printf("warning: import todo %d: replace alarms: %v", id, err)
+// importTodoFields mirrors importEventFields for todos.
+func importTodoFields(ctx context.Context, svc *todo.Service, id int64, t todo.Todo) []string {
+	var warns []string
+	add := func(field string, err error) {
+		if err != nil {
+			warns = append(warns, fmt.Sprintf("import todo %d: replace %s: %v", id, field, err))
 		}
+	}
+	if len(t.Alarms) > 0 {
+		add("alarms", svc.ReplaceAlarms(ctx, id, t.Alarms))
 	}
 	if len(t.Attendees) > 0 {
-		if err := svc.ReplaceAttendees(ctx, id, t.Attendees); err != nil {
-			log.Printf("warning: import todo %d: replace attendees: %v", id, err)
-		}
+		add("attendees", svc.ReplaceAttendees(ctx, id, t.Attendees))
 	}
 	if len(t.Attachments) > 0 {
-		if err := svc.ReplaceAttachments(ctx, id, t.Attachments); err != nil {
-			log.Printf("warning: import todo %d: replace attachments: %v", id, err)
-		}
+		add("attachments", svc.ReplaceAttachments(ctx, id, t.Attachments))
 	}
 	if len(t.Comments) > 0 {
-		if err := svc.ReplaceComments(ctx, id, t.Comments); err != nil {
-			log.Printf("warning: import todo %d: replace comments: %v", id, err)
-		}
+		add("comments", svc.ReplaceComments(ctx, id, t.Comments))
 	}
 	if len(t.Contacts) > 0 {
-		if err := svc.ReplaceContacts(ctx, id, t.Contacts); err != nil {
-			log.Printf("warning: import todo %d: replace contacts: %v", id, err)
-		}
+		add("contacts", svc.ReplaceContacts(ctx, id, t.Contacts))
 	}
 	if len(t.Resources) > 0 {
-		if err := svc.ReplaceResources(ctx, id, t.Resources); err != nil {
-			log.Printf("warning: import todo %d: replace resources: %v", id, err)
-		}
+		add("resources", svc.ReplaceResources(ctx, id, t.Resources))
 	}
 	if len(t.Relations) > 0 {
-		if err := svc.ReplaceRelations(ctx, id, t.Relations); err != nil {
-			log.Printf("warning: import todo %d: replace relations: %v", id, err)
-		}
+		add("relations", svc.ReplaceRelations(ctx, id, t.Relations))
 	}
 	if len(t.XProperties) > 0 {
-		if err := svc.ReplaceXProperties(ctx, id, t.XProperties); err != nil {
-			log.Printf("warning: import todo %d: replace x-properties: %v", id, err)
-		}
+		add("x-properties", svc.ReplaceXProperties(ctx, id, t.XProperties))
 	}
+	return warns
 }
 
-func importJournalFields(ctx context.Context, svc *journal.Service, id int64, j journal.Journal) {
-	if len(j.Attendees) > 0 {
-		if err := svc.ReplaceAttendees(ctx, id, j.Attendees); err != nil {
-			log.Printf("warning: import journal %d: replace attendees: %v", id, err)
+// importJournalFields mirrors importEventFields for journals.
+func importJournalFields(ctx context.Context, svc *journal.Service, id int64, j journal.Journal) []string {
+	var warns []string
+	add := func(field string, err error) {
+		if err != nil {
+			warns = append(warns, fmt.Sprintf("import journal %d: replace %s: %v", id, field, err))
 		}
+	}
+	if len(j.Attendees) > 0 {
+		add("attendees", svc.ReplaceAttendees(ctx, id, j.Attendees))
 	}
 	if len(j.Attachments) > 0 {
-		if err := svc.ReplaceAttachments(ctx, id, j.Attachments); err != nil {
-			log.Printf("warning: import journal %d: replace attachments: %v", id, err)
-		}
+		add("attachments", svc.ReplaceAttachments(ctx, id, j.Attachments))
 	}
 	if len(j.Comments) > 0 {
-		if err := svc.ReplaceComments(ctx, id, j.Comments); err != nil {
-			log.Printf("warning: import journal %d: replace comments: %v", id, err)
-		}
+		add("comments", svc.ReplaceComments(ctx, id, j.Comments))
 	}
 	if len(j.Contacts) > 0 {
-		if err := svc.ReplaceContacts(ctx, id, j.Contacts); err != nil {
-			log.Printf("warning: import journal %d: replace contacts: %v", id, err)
-		}
+		add("contacts", svc.ReplaceContacts(ctx, id, j.Contacts))
 	}
 	if len(j.Relations) > 0 {
-		if err := svc.ReplaceRelations(ctx, id, j.Relations); err != nil {
-			log.Printf("warning: import journal %d: replace relations: %v", id, err)
-		}
+		add("relations", svc.ReplaceRelations(ctx, id, j.Relations))
 	}
 	if len(j.XProperties) > 0 {
-		if err := svc.ReplaceXProperties(ctx, id, j.XProperties); err != nil {
-			log.Printf("warning: import journal %d: replace x-properties: %v", id, err)
-		}
+		add("x-properties", svc.ReplaceXProperties(ctx, id, j.XProperties))
 	}
+	return warns
 }
 
 func populateJournalFields(ctx context.Context, svc *journal.Service, j *journal.Journal) {


### PR DESCRIPTION
Fixes #141

## Root cause
`cmd/chroncal/ical.go`'s import loop upserted each event/todo/journal in its
own call and `return`ed on the first upsert error. Earlier rows (and
timezones) were already committed, so a large `.ics` that failed on item N
exited non-zero with items 1..N-1 persisted and the rest silently dropped.
Separately, the child-field imports (`importEventFields` etc.) only
`log.Printf`'d on failure, so partial child data (alarms, attendees, ...)
was lost while the command still reported a clean success.

A single transaction wrapping the whole import is not achievable here: every
service upsert opens its own transaction on the connection pool, so there is
no shared tx to enroll the calls into without a service-layer rewrite. The
fix therefore follows the issue's suggested alternative — a per-item failure
summary.

## Fix
- Extract the import into `importComponents`, which continues past a failing
  component instead of aborting: the failure is recorded in
  `result.Warnings` and a new `failed` counter, and the remaining
  components are still imported.
- Surface child-field failures: `importEventFields` / `importTodoFields` /
  `importJournalFields` now return their warnings (via a small `add`
  closure) instead of only logging, and the caller folds them into
  `result.Warnings`.
- The command still prints the full summary (text or JSON, now including a
  `failed` count) of exactly what landed, then returns a non-zero exit when
  `failed > 0` so a partial import is signalled without discarding the
  report. Callers can retry only the failed components.
- Reword the stderr header from "component(s) skipped" to "warning(s)" since
  the list now mixes skipped components with child-field drops.

## Tests
`cmd/chroncal/ical_import_test.go`:
- `TestImportComponentsContinuesPastItemFailure` — three events where the
  middle one has an out-of-range priority (fails the CHECK constraint).
  Asserts the failing item is skipped, both surrounding events are
  persisted (the event *after* the failure is the regression signal),
  `failed == 1`, and the failure is reported in warnings.
- `TestImportComponentsSurfacesChildFieldFailure` — an event with an alarm
  whose `ACTION` is invalid. Asserts the event still imports, `failed == 0`,
  and the dropped alarm appears in warnings.

Both tests fail against the pre-fix behavior (verified by reintroducing the
early `return`) and pass after the fix. `make fmt`, `go vet ./...`, and
`go test ./internal/... ./cmd/...` are all green.
