### PR TITLE
fix(recurrence): return recurring event masters when no range given

### DIFF
--- a/internal/recurrence/integration_test.go
+++ b/internal/recurrence/integration_test.go
@@ -522,6 +522,61 @@ func TestListExpandedByDateRange_CancelledOverride(t *testing.T) {
 	}
 }
 
+func TestListFilteredEvents_DefaultIncludesRecurring(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	eventsSvc := event.NewService(db, q)
+	recurSvc := NewService(db, q)
+	ctx := context.Background()
+
+	// Recurring weekly event.
+	_, err := eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID:     1,
+		Title:          "Weekly Sync",
+		StartTime:      time.Date(2020, 1, 6, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2020, 1, 6, 10, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=MO",
+	})
+	if err != nil {
+		t.Fatalf("create recurring: %v", err)
+	}
+
+	// Non-recurring event.
+	_, err = eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "One-off Meeting",
+		StartTime:  time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("create one-off: %v", err)
+	}
+
+	// Default list with no date range must include recurring masters,
+	// mirroring the todo/journal contract.
+	events, err := recurSvc.ListFilteredEvents(ctx, EventListParams{})
+	if err != nil {
+		t.Fatalf("ListFilteredEvents: %v", err)
+	}
+
+	if len(events) != 2 {
+		for i, e := range events {
+			t.Logf("  events[%d]: %s start=%s rrule=%s", i, e.Title, e.StartTime, e.RecurrenceRule)
+		}
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+
+	found := map[string]bool{}
+	for _, e := range events {
+		found[e.Title] = true
+	}
+	if !found["Weekly Sync"] {
+		t.Error("missing recurring event 'Weekly Sync'")
+	}
+	if !found["One-off Meeting"] {
+		t.Error("missing one-off event 'One-off Meeting'")
+	}
+}
+
 func TestListFilteredTodos_DefaultIncludesRecurring(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 	todoSvc := todo.NewService(db, q)

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -849,11 +849,14 @@ type EventListParams struct {
 }
 
 // ListFilteredEvents returns events matching all supplied filters. Calendar,
-// status, and date-range filters compose freely. Recurring events are always
-// expanded within the date range, with overrides applied.
+// status, and date-range filters compose freely. When a date range is
+// provided, recurring events are expanded within it, with overrides applied;
+// otherwise recurring masters are returned as-is, matching the
+// todo/journal contract.
 func (s *Service) ListFilteredEvents(ctx context.Context, p EventListParams) ([]event.Event, error) {
 	fromStr := ""
 	toStr := ""
+	hasRange := !p.From.IsZero() || !p.To.IsZero()
 	if !p.From.IsZero() {
 		fromStr = p.From.Format(time.RFC3339)
 	}
@@ -887,7 +890,13 @@ func (s *Service) ListFilteredEvents(ctx context.Context, p EventListParams) ([]
 	if err != nil {
 		return nil, err
 	}
-	result = append(result, s.expandRecurringRows(ctx, recurringRows, p.From, p.To)...)
+	if hasRange {
+		result = append(result, s.expandRecurringRows(ctx, recurringRows, p.From, p.To)...)
+	} else {
+		for _, row := range recurringRows {
+			result = append(result, eventFromRow(row))
+		}
+	}
 
 	s.populateEventCategories(ctx, result)
 	sort.Slice(result, func(i, j int) bool {


### PR DESCRIPTION
Fixes #125

## Root cause
`ListFilteredEvents` (`internal/recurrence/service.go`) unconditionally called
`expandRecurringRows(ctx, recurringRows, p.From, p.To)`. When `From`/`To` are
left zero (an unbounded list), `ExpandEvent` runs `Between(zeroTime, zeroTime)`
and returns nothing, so every recurring event silently disappears. This is
inconsistent with `ListFilteredTodos` and `ListFilteredJournals`, which guard
expansion behind a `hasRange` check and otherwise return masters as-is.

## Fix
Add the same `hasRange := !p.From.IsZero() || !p.To.IsZero()` guard: expand
recurring rows only when a date range is provided; otherwise append the
recurring masters unexpanded via `eventFromRow`. Restores the consistent
contract across event/todo/journal. Doc comment updated to match.

## Test coverage
`TestListFilteredEvents_DefaultIncludesRecurring` creates a recurring weekly
event and a one-off event, then calls `ListFilteredEvents` with an empty
`EventListParams` (no range) and asserts both appear. Fails before the fix
(recurring master dropped, got 1 want 2), passes after.

## Verification
- `make fmt`, `go vet ./...` clean
- `go test ./internal/... -count=1` all green