### PR TITLE
fix(tui): clamp day when navigating months in calendar grid

### DIFF
--- a/internal/tui/calendar_model.go
+++ b/internal/tui/calendar_model.go
@@ -247,9 +247,9 @@ func (m CalendarModel) Update(msg tea.Msg) (CalendarModel, tea.Cmd) {
 	case key.Matches(keyMsg, m.keys.Right):
 		target = m.cursor.AddDate(0, 0, 1)
 	case key.Matches(keyMsg, m.keys.PrevMonth):
-		target = m.cursor.AddDate(0, -1, 0)
+		target = addMonthClamped(m.cursor, -1)
 	case key.Matches(keyMsg, m.keys.NextMonth):
-		target = m.cursor.AddDate(0, 1, 0)
+		target = addMonthClamped(m.cursor, 1)
 	case key.Matches(keyMsg, m.keys.Today):
 		target = m.today
 	case key.Matches(keyMsg, m.keys.Select):

--- a/internal/tui/calendar_model_test.go
+++ b/internal/tui/calendar_model_test.go
@@ -1,0 +1,54 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCalendarMonthNavClampsDay verifies that prev/next-month navigation from a
+// day that does not exist in the target month clamps to the last valid day
+// rather than rolling forward (Go's AddDate normalizes 2026-02-31 -> 2026-03-03).
+func TestCalendarMonthNavClampsDay(t *testing.T) {
+	tests := []struct {
+		name      string
+		cursor    time.Time
+		key       string
+		wantYear  int
+		wantMonth time.Month
+		wantDay   int
+	}{
+		{
+			name:      "next month from Jan 31 lands in February",
+			cursor:    time.Date(2026, 1, 31, 12, 0, 0, 0, time.Local),
+			key:       "]",
+			wantYear:  2026,
+			wantMonth: time.February,
+			wantDay:   28,
+		},
+		{
+			name:      "prev month from Mar 31 lands in February",
+			cursor:    time.Date(2026, 3, 31, 12, 0, 0, 0, time.Local),
+			key:       "[",
+			wantYear:  2026,
+			wantMonth: time.February,
+			wantDay:   28,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewCalendarModel(tc.cursor)
+			m, _ = m.Update(keyPressMsg(tc.key))
+
+			cur := m.Cursor()
+			if cur.Year() != tc.wantYear || cur.Month() != tc.wantMonth || cur.Day() != tc.wantDay {
+				t.Errorf("cursor = %04d-%02d-%02d, want %04d-%02d-%02d",
+					cur.Year(), cur.Month(), cur.Day(), tc.wantYear, tc.wantMonth, tc.wantDay)
+			}
+			if mo := m.Month(); mo.Year() != tc.wantYear || mo.Month() != tc.wantMonth {
+				t.Errorf("displayed month = %04d-%02d, want %04d-%02d",
+					mo.Year(), mo.Month(), tc.wantYear, tc.wantMonth)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #212

## Problem
Month-view prev/next navigation applied raw `cursor.AddDate(0, ±1, 0)` with no day clamping. Go normalizes overflowing dates (e.g. `2026-02-31 → 2026-03-03`), so shifting a month from the 29th–31st rolled into the wrong month, and `moveCursor` then derived the displayed month from that wrong date.

## Fix
Reuse the existing `addMonthClamped()` helper (already used by the recurrence editor) in the PrevMonth/NextMonth cases, so the day is clamped to the target month.

## Test
`TestCalendarMonthNavClampsDay` (table-driven): next-month from Jan 31 and prev-month from Mar 31 now both land on Feb 28 (cursor + displayed month). Confirmed failing before the fix, passing after.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8