### PR TITLE
fix(cmd): validate sync run --conflict instead of silently falling back to server-wins

### DIFF
--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -70,6 +70,15 @@ run to a single local calendar.`,
   chroncal sync run --calendar Work
   chroncal sync run --conflict prompt`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Validate the flag up front so a typo (e.g. "Prompt", "ask")
+			// fails loudly instead of silently falling back to server-wins
+			// and discarding local edits. Mirrors the service.go check.
+			strategy := syncPkg.ConflictStrategy(conflict)
+			if strategy != syncPkg.ConflictServerWins && strategy != syncPkg.ConflictPrompt {
+				return errInvalidInputf("--conflict: invalid value %q (use %q or %q)",
+					conflict, syncPkg.ConflictServerWins, syncPkg.ConflictPrompt)
+			}
+
 			a, err := initApp()
 			if err != nil {
 				return err
@@ -85,11 +94,6 @@ run to a single local calendar.`,
 
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, logger)
-
-			strategy := syncPkg.ConflictServerWins
-			if conflict == "prompt" {
-				strategy = syncPkg.ConflictPrompt
-			}
 
 			// Look up names for every calendar up front so both the JSON and
 			// text views can label results without re-querying per result.

--- a/cmd/chroncal/sync_cli_test.go
+++ b/cmd/chroncal/sync_cli_test.go
@@ -23,6 +23,23 @@ func TestSyncResetMatchesCalendarCaseInsensitively(t *testing.T) {
 	}
 }
 
+// TestSyncRunRejectsInvalidConflictStrategy guards against issue #215:
+// `sync run --conflict <bad>` must be rejected up front rather than
+// silently falling back to server-wins (which would discard local edits
+// for a user who meant "prompt" but mistyped, e.g. "Prompt").
+func TestSyncRunRejectsInvalidConflictStrategy(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	createLinkedCalendarForTest(t, dbPath)
+
+	_, stderr, err := runChroncalCommand(t, "sync", "run", "--conflict", "Prompt")
+	if err == nil {
+		t.Fatalf("sync run --conflict Prompt was accepted; expected an invalid-input error")
+	}
+	if !strings.Contains(stderr, "conflict") || !strings.Contains(stderr, "Prompt") {
+		t.Fatalf("sync run --conflict Prompt: error did not mention the bad value; stderr = %q", stderr)
+	}
+}
+
 // TestSyncRunMatchesCalendarCaseInsensitively guards against issue #112:
 // `sync run --calendar work` must resolve a calendar named "Work"
 // case-insensitively. Before the fix the run loop compared names with ==,


### PR DESCRIPTION
Closes #215

## Problem
`sync run --conflict` was a plain `StringVar` whose handler only special-cased the literal `"prompt"`. Every other value (typos, wrong case like `Prompt`, `ask`) silently fell through to `ConflictServerWins`, auto-resolving conflicts in the server's favor and discarding local edits with no warning. The `service install` path validated this value, but the CLI flag path did not.

## Fix
Validate `--conflict` against `{server-wins, prompt}` at the top of `RunE` and return `errInvalidInputf` on anything else, mirroring the precedent in `service.go:164-167`. The strategy is now computed once and reused (removing the duplicate assignment), and validation runs before `initApp()` so a bad flag fails fast without DB/credential setup.

## Test
`TestSyncRunRejectsInvalidConflictStrategy` — confirmed failing before ("`--conflict Prompt` was accepted"), passing after.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8