### PR TITLE
fix(ical): fall back sanely on malformed VEVENT DURATION instead of year-0001 EndTime

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -380,10 +380,13 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		endTime, _ = ve.Props.DateTime(ical.PropDateTimeEnd, nil)
 	}
 	if endTime.IsZero() {
-		if prop := ve.Props.Get(ical.PropDuration); prop != nil {
+		if prop := ve.Props.Get(ical.PropDuration); prop != nil && duration.Validate(prop.Value) == nil {
 			durationValue = prop.Value
 			endTime = addDuration(startTime, prop.Value)
 		} else {
+			// No DURATION, or a malformed one (go-ical stores the raw value
+			// without validating). Fall back to a 1h span and drop the bad
+			// value so it is neither persisted nor re-exported.
 			endTime = startTime.Add(time.Hour)
 		}
 	}

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -569,6 +569,35 @@ END:VCALENDAR`
 	}
 }
 
+func TestImport_MalformedDuration(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:bad-dur-test
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T140000Z
+DURATION:garbage
+SUMMARY:Bad Duration Event
+END:VEVENT
+END:VCALENDAR`
+	result, _ := ImportFile(strings.NewReader(ics))
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d", len(result.Events))
+	}
+	e := result.Events[0]
+	if !e.EndTime.After(e.StartTime) {
+		t.Errorf("EndTime = %s is not after StartTime = %s; want sane fallback",
+			e.EndTime.Format(time.RFC3339), e.StartTime.Format(time.RFC3339))
+	}
+	if want := e.StartTime.Add(time.Hour); !e.EndTime.Equal(want) {
+		t.Errorf("EndTime = %s, want fallback %s", e.EndTime.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+	if e.DurationValue != "" {
+		t.Errorf("DurationValue = %q, want empty (malformed value should be cleared)", e.DurationValue)
+	}
+}
+
 func TestImport_Attach(t *testing.T) {
 	t.Parallel()
 	ics := `BEGIN:VCALENDAR


### PR DESCRIPTION
Closes #220

## Problem
When a VEVENT had no DTEND, EndTime was derived from DURATION via `duration.Add`, which returns the zero time on a parse error. go-ical stores the raw DURATION value unvalidated, so an invalid string (e.g. `DURATION:garbage`) yielded a year-0001 EndTime (negative span) that broke duration display and `overlapsWindow` range checks — and the bad string was re-emitted on export.

## Fix
Guard the DURATION branch with `duration.Validate(prop.Value) == nil`. On invalid input it falls through to the existing `startTime + 1h` fallback and leaves `durationValue` empty, so the garbage is neither persisted nor re-exported.

Scope kept strictly to #220 — the all-day no-DTEND default is handled separately in #219, and these two fixes remain independent and non-conflicting.

## Test
`TestImport_MalformedDuration` — confirmed failing before (EndTime `0001-01-01`, DurationValue retained `"garbage"`), passing after.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8