### PR TITLE
fix(storage): pin :memory: pool to one connection so schema is shared

### DIFF
--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -36,6 +36,15 @@ func Open(dbPath string) (*sql.DB, *Queries, error) {
 		return nil, nil, fmt.Errorf("open database: %w", err)
 	}
 
+	// A plain ":memory:" database is private to each connection with
+	// modernc.org/sqlite, so migrations applied on one pooled connection are
+	// invisible to the next. Pin the pool to a single connection so every
+	// query — including concurrent ones — sees the same schema and data.
+	// File-backed databases keep the default unbounded pool.
+	if dbPath == ":memory:" {
+		conn.SetMaxOpenConns(1)
+	}
+
 	if err := runMigrations(conn); err != nil {
 		conn.Close()
 		return nil, nil, fmt.Errorf("run migrations: %w", err)

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestOpen_InMemory(t *testing.T) {
@@ -96,6 +97,59 @@ func TestBackfillAlarmUIDs_TodoOnly(t *testing.T) {
 	if len(remaining) != 0 {
 		t.Fatalf("expected 0 todo alarms with empty uid after backfill, got %d", len(remaining))
 	}
+}
+
+// TestOpen_InMemorySchemaVisibleAcrossConnections guards issue #214: a plain
+// ":memory:" DSN is a private per-connection database with modernc.org/sqlite.
+// Migrations run on whichever connection the pool hands out first; without
+// pinning the pool to a single connection, a second concurrent connection sees
+// a brand-new, schema-less database and reads fail with "no such table".
+func TestOpen_InMemorySchemaVisibleAcrossConnections(t *testing.T) {
+	db, _, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open(:memory:) error: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Hold one pooled connection open inside a live transaction so the read
+	// below is forced onto a different connection.
+	txReady := make(chan struct{})
+	txErr := make(chan error, 1)
+	txDone := make(chan struct{})
+	go func() {
+		defer close(txDone)
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			txErr <- err
+			close(txReady)
+			return
+		}
+		close(txReady)
+		// Keep the connection busy long enough that the pool must use a
+		// second connection for any concurrent query.
+		time.Sleep(200 * time.Millisecond)
+		_ = tx.Rollback()
+	}()
+
+	<-txReady
+	select {
+	case err := <-txErr:
+		t.Fatalf("BeginTx: %v", err)
+	default:
+	}
+
+	// Before the fix, an unpinned in-memory pool hands this query a brand-new,
+	// schema-less connection and the read fails with "no such table". After
+	// the fix the pool is pinned to a single connection for ":memory:", so the
+	// read blocks until the transaction releases the connection and then
+	// succeeds against the same schema.
+	var n int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM calendars").Scan(&n); err != nil {
+		t.Fatalf("read calendars on second connection: %v", err)
+	}
+	<-txDone
 }
 
 func TestOpen_ForeignKeys(t *testing.T) {


### PR DESCRIPTION
Closes #214

## Problem
With modernc.org/sqlite a plain `:memory:` DSN is a *private per-connection* database. `Open()` ran migrations on the pool's first connection but never pinned the pool, so any second concurrent connection got a brand-new, schema-less DB (`no such table: ...`). Production is safe (always a file path), but the package's own tests and any ephemeral/preview mode using `:memory:` only pass today because sequential single-goroutine access reuses one idle connection.

## Fix
When `dbPath == ":memory:"`, call `conn.SetMaxOpenConns(1)` before migrations run, so every query shares the one connection (and its schema). File-backed (production) pooling is unchanged.

## Test
`TestOpen_InMemorySchemaVisibleAcrossConnections` holds one pooled connection open inside a live transaction, then forces a read onto a second connection. Confirmed failing pre-fix (`no such table: calendars`), passing post-fix.

`go build ./...` and full `go test ./...` are green.

## Note
Two existing test files (`alarm/service_test.go`, `event/delete_instance_concurrency_test.go`) already worked around this with file-backed DBs; those remain correct and untouched. Revisiting whether they can return to `:memory:` is a possible future cleanup, out of scope here.

Assisted-by: Claude:claude-opus-4-8