### PR TITLE
fix(ical): default all-day VEVENT with no DTEND/DURATION to a one-day span

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -376,6 +376,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 
 	var endTime time.Time
 	var durationValue string
+	explicitEnd := false
 	if prop := ve.Props.Get(ical.PropDateTimeEnd); prop != nil {
 		endTime, _ = ve.Props.DateTime(ical.PropDateTimeEnd, nil)
 	}
@@ -383,9 +384,12 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		if prop := ve.Props.Get(ical.PropDuration); prop != nil {
 			durationValue = prop.Value
 			endTime = addDuration(startTime, prop.Value)
+			explicitEnd = true
 		} else {
 			endTime = startTime.Add(time.Hour)
 		}
+	} else {
+		explicitEnd = true
 	}
 
 	allDay := false
@@ -400,7 +404,15 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 			// instant — e.g. under TZ=UTC+12 midnight local is 12:00Z the day
 			// before, corrupting the calendar date and recurrence occurrences.
 			startTime = time.Date(startTime.Year(), startTime.Month(), startTime.Day(), 0, 0, 0, 0, time.UTC)
-			endTime = time.Date(endTime.Year(), endTime.Month(), endTime.Day(), 0, 0, 0, 0, time.UTC)
+			if explicitEnd {
+				endTime = time.Date(endTime.Year(), endTime.Month(), endTime.Day(), 0, 0, 0, 0, time.UTC)
+			} else {
+				// RFC 5545 §3.6.1: an all-day VEVENT with no DTEND/DURATION has
+				// an implicit duration of one day. The timed +1h default above
+				// would otherwise be truncated back to startTime, storing a
+				// zero-length event.
+				endTime = startTime.AddDate(0, 0, 1)
+			}
 		}
 	}
 

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -250,6 +250,44 @@ func TestImport_AllDayEvent(t *testing.T) {
 	}
 }
 
+// Regression test for issue #219: an all-day VEVENT carrying only
+// DTSTART;VALUE=DATE (no DTEND, no DURATION) has an implicit duration of one
+// day per RFC 5545 §3.6.1. Before the fix the timed +1h default leaked in and
+// the all-day truncation collapsed EndTime back to StartTime, storing a
+// zero-length event.
+func TestImport_AllDayEvent_NoEndDefaultsToOneDay(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:no-end-allday@example.com\r\n" +
+		"DTSTART;VALUE=DATE:20260415\r\n" +
+		"SUMMARY:All day, no end\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	evt := result.Events[0]
+	if !evt.AllDay {
+		t.Error("AllDay = false, want true")
+	}
+	wantStart := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	if !evt.StartTime.Equal(wantStart) {
+		t.Errorf("StartTime = %v, want %v", evt.StartTime, wantStart)
+	}
+	if !evt.EndTime.Equal(wantEnd) {
+		t.Errorf("EndTime = %v, want %v (one full day)", evt.EndTime, wantEnd)
+	}
+}
+
 // Regression test for issue #64: all-day (VALUE=DATE) events must be stored
 // at midnight UTC, independent of the importing host's timezone. Before the
 // fix the importer built the date in time.Local and then called .UTC(), so the


### PR DESCRIPTION
Closes #219

## Problem
In `eventFromVEvent`, the missing-end fallback set `endTime = startTime + 1h` *before* the all-day block ran; the all-day block then truncated that to midnight, collapsing EndTime back to StartTime. So an all-day VEVENT carrying only `DTSTART;VALUE=DATE` (common from minimal producers) was stored zero-length — rendering as an instant, droppable by range queries, and exporting an invalid `DTEND == DTSTART`.

## Fix
Track whether an explicit DTEND/DURATION was present (`explicitEnd`); when absent for an all-day event, default `endTime = startTime.AddDate(0, 0, 1)` (one full day) per RFC 5545 §3.6.1.

Independent of #220 (malformed DURATION) — different branch of the end-time logic, no conflict.

## Test
`TestImport_AllDayEvent_NoEndDefaultsToOneDay` — fails before (EndTime `2026-04-15`), passes after (`2026-04-16`). Existing all-day-with-explicit-end and all-day-with-DURATION paths verified unaffected.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8