### PR TITLE
fix(cmd): alarm check -o json emits [] not null when all due alarms lose the claim race

### DIFF
--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -278,7 +278,10 @@ func runAlarmCheck(ctx context.Context, a *app.App, w io.Writer, now time.Time, 
 		return nil
 	}
 
-	var results []map[string]any
+	// Non-nil so the JSON branch emits [] (not null) when every due alarm is
+	// suppressed (lost-claim race or mark failure), matching the zero-due-set
+	// branch above and keeping the wire shape stable for consumers (issue #217).
+	results := []map[string]any{}
 	for _, da := range due {
 		res := markAndFireEventAlarm(ctx, a, da, policy)
 		if !res.Fired {

--- a/cmd/chroncal/alarm_fire_test.go
+++ b/cmd/chroncal/alarm_fire_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -210,6 +211,15 @@ func TestRunAlarmCheckEmitsNoFiredRecordOnLostClaim(t *testing.T) {
 	}
 	if len(records) != 0 {
 		t.Fatalf("checker B emitted %d record(s) on a lost claim, want 0: %s", len(records), bOut.String())
+	}
+
+	// The wire shape must be an empty JSON array, not null (issue #217). A
+	// non-empty due set whose alarms all lose the claim race left results as a
+	// nil slice, which json.Encode renders as `null` and breaks consumers
+	// doing `jq '.[]'`. This must match the zero-due-set branch, which emits
+	// `[]`. json.Unmarshal accepts both null and [], so assert the raw shape.
+	if got := strings.TrimSpace(bOut.String()); got != "[]" {
+		t.Fatalf("checker B JSON shape on all-claims-lost = %q, want %q", got, "[]")
 	}
 }
 


### PR DESCRIPTION
Closes #217

## Problem
In `runAlarmCheck`, `results` was a nil slice appended to only for alarms that actually fired. When the due set is non-empty but every alarm is suppressed (lost-claim race with an overlapping checker, or MarkFired failure), the `if !res.Fired { continue }` path drops all of them, leaving `results` nil — which `json.Encode` renders as `null`. The zero-due-set branch deliberately emits `[]`, so the output shape was inconsistent and a consumer doing `jq '.[]'` errors on `null`.

## Fix
Initialize `results := []map[string]any{}` (non-nil empty slice), matching the empty-due-set branch.

## Test
Extended `TestRunAlarmCheckEmitsNoFiredRecordOnLostClaim` to assert the raw wire shape (`== "[]"`) rather than just `json.Unmarshal` (which silently accepts both `null` and `[]`). Fails pre-fix (`got "null", want "[]"`), passes post-fix.

Verified the sibling `alarm list` command has no equivalent bug (early empty-set guard + unconditional append).

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8