### PR TITLE
fix(cmd): validate freebusy --format instead of silently rendering non-ical as text

### DIFF
--- a/cmd/chroncal/freebusy.go
+++ b/cmd/chroncal/freebusy.go
@@ -36,6 +36,12 @@ queries the connected remote CalDAV calendar instead.`,
   chroncal freebusy --calendar Work --from 2026-04-01T09:00:00-03:00 --to 2026-04-01T18:00:00-03:00
   chroncal freebusy --calendar Work --remote --from 2026-04-01 --to 2026-04-07 --format ical`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			switch format {
+			case "text", "ical":
+			default:
+				return errInvalidInputf("invalid --format %q (must be text or ical)", format)
+			}
+
 			from, err := parseFreeBusyTime("from", fromStr, false)
 			if err != nil {
 				return err

--- a/cmd/chroncal/freebusy_test.go
+++ b/cmd/chroncal/freebusy_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -53,6 +54,23 @@ func TestParseFreeBusyTime(t *testing.T) {
 				t.Fatalf("parseFreeBusyTime(%q) = %s, want %s", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFreeBusyRejectsInvalidFormat(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	_, stderr, err := runChroncalCommand(t,
+		"freebusy",
+		"--from", "2026-04-01",
+		"--to", "2026-04-07",
+		"--format", "json",
+	)
+	if err == nil {
+		t.Fatalf("expected error for invalid --format value, got none (stderr=%q)", stderr)
+	}
+	if !strings.Contains(stderr, "format") {
+		t.Fatalf("expected error mentioning format, got: %s", stderr)
 	}
 }
 


### PR DESCRIPTION
Closes #218

## Problem
`freebusy`'s `RunE` only special-cased `format == "ical"` and otherwise fell through to the text/`-o` path, so any other `--format` value (`json`, `xml`, typos like `ica`) was silently rendered as text with no error — despite the flag being documented as "text or ical".

## Fix
Validate `format` against `{text, ical}` at the top of `RunE` and return `errInvalidInputf`, mirroring the `--output` validation in `PersistentPreRunE`. Validation runs before `initApp()`, so invalid input fails fast without opening the DB.

## Test
`TestFreeBusyRejectsInvalidFormat` runs `freebusy … --format json` via the subprocess harness and asserts a non-zero exit with an error mentioning "format". Fails pre-fix (`got none`), passes post-fix.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8