### PR TITLE
fix(tui): place all-day events on correct day in agenda for negative-UTC-offset zones

### DIFF
--- a/internal/tui/agenda_allday_tz_test.go
+++ b/internal/tui/agenda_allday_tz_test.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+)
+
+// TestBuildAgendaRows_AllDayNegativeOffset guards against the agenda view
+// placing all-day events on the wrong day for negative-UTC-offset timezones.
+// All-day events are stored as midnight-UTC datestamps; converting them with
+// .Local() in a UTC-7 zone rolls them back to the previous day. The agenda
+// must use the UTC date, matching the month/week/day grids.
+func TestBuildAgendaRows_AllDayNegativeOffset(t *testing.T) {
+	orig := time.Local
+	time.Local = time.FixedZone("US/Pacific", -7*60*60)
+	defer func() { time.Local = orig }()
+
+	// All-day event on 2026-04-17 (stored at midnight UTC).
+	ev := event.Event{
+		ID:        1,
+		Title:     "Conference",
+		AllDay:    true,
+		StartTime: time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC),
+	}
+
+	start := time.Date(2026, 4, 15, 0, 0, 0, 0, time.Local)
+	rows := buildAgendaRows([]event.Event{ev}, start, 7, false)
+
+	var gotDays []string
+	for _, r := range rows {
+		if r.event.ID == ev.ID {
+			gotDays = append(gotDays, r.day.Format("2006-01-02"))
+		}
+	}
+	if len(gotDays) != 1 || gotDays[0] != "2026-04-17" {
+		t.Fatalf("all-day event placed on %v, want exactly [2026-04-17]", gotDays)
+	}
+}

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -66,8 +66,25 @@ func effectiveStartOnDay(ev event.Event, day time.Time, dayIndex int) time.Time 
 
 // spanDays returns the local calendar days an event touches. The end time
 // is treated as exclusive, so an event ending exactly at midnight does not
-// count the following day.
+// count the following day. All-day events are stored as midnight-UTC
+// datestamps, so their span is derived from the UTC date — anchored at local
+// midnight to match the timed-event convention used by callers' window and
+// boundary comparisons — so they land on the correct day regardless of the
+// local timezone offset (mirrors eventCalendarDays).
 func spanDays(ev event.Event) []time.Time {
+	if ev.AllDay {
+		s := ev.StartTime.UTC()
+		e := ev.EndTime.UTC()
+		startDay := time.Date(s.Year(), s.Month(), s.Day(), 0, 0, 0, 0, time.Local)
+		var days []time.Time
+		for d := s; d.Before(e); d = d.AddDate(0, 0, 1) {
+			days = append(days, time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, time.Local))
+		}
+		if len(days) == 0 {
+			days = []time.Time{startDay}
+		}
+		return days
+	}
 	s := ev.StartTime.Local()
 	startDay := time.Date(s.Year(), s.Month(), s.Day(), 0, 0, 0, 0, s.Location())
 	e := ev.EndTime.Local()


### PR DESCRIPTION
Closes #211

## Problem
`spanDays` converted `StartTime`/`EndTime` with `.Local()` unconditionally. All-day events are midnight-UTC datestamps, so in a negative-UTC-offset zone (e.g. US/Pacific, UTC-7) the start rolled back to the previous day — the agenda (and CLI `FormatEventList`, which shares `spanDays`) listed the event on the wrong day, and the 24h local window even spanned two days. The month/week/day grids avoid this via the UTC-aware `eventDay`/`eventCalendarDays` helpers; the agenda path had no all-day branch.

## Fix
Add an all-day branch to `spanDays` that derives the day span from the UTC date (mirroring `eventCalendarDays`) but anchors each returned day at local midnight — intentional, so it stays compatible with `buildAgendaRows`' boundary checks against the local-midnight `windowStart` (a pure UTC anchor would clip the near edge).

## Test
`TestBuildAgendaRows_AllDayNegativeOffset` pins `time.Local` to US/Pacific and asserts an all-day event at `2026-04-17T00:00:00Z` lands on exactly `[2026-04-17]`. Fails pre-fix (`[2026-04-16 2026-04-17]`), passes post-fix.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8