### PR TITLE
fix(caldav): preserve weak ETag marker so If-Match isn't sent as a strong validator

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -208,8 +208,8 @@ func (c *Client) PutResource(ctx context.Context, path string, data *ical.Calend
 		return "", fmt.Errorf("new PUT request: %w", err)
 	}
 	req.Header.Set("Content-Type", ical.MIMEType)
-	if etag != "" {
-		req.Header.Set("If-Match", formatIfMatch(etag))
+	if ifMatch := formatIfMatch(etag); ifMatch != "" {
+		req.Header.Set("If-Match", ifMatch)
 	}
 
 	resp, err := c.httpClient.Do(req)
@@ -524,16 +524,34 @@ func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
 	return 0, false
 }
 
+// normalizeETag strips surrounding whitespace and the quotes from an ETag,
+// preserving the weak "W/" marker (RFC 7232 §2.3) so callers can tell a weak
+// validator apart from a strong one. Weak tags are kept as "W/<opaque>", strong
+// tags as "<opaque>". Comparisons elsewhere are opaque equality, which stays
+// consistent because both sides flow through this function.
 func normalizeETag(etag string) string {
 	etag = strings.TrimSpace(etag)
-	etag = strings.TrimPrefix(etag, "W/")
-	etag = strings.TrimSpace(etag)
-	return strings.Trim(etag, `"`)
+	weak := false
+	if rest, ok := strings.CutPrefix(etag, "W/"); ok {
+		weak = true
+		etag = strings.TrimSpace(rest)
+	}
+	etag = strings.Trim(etag, `"`)
+	if weak && etag != "" {
+		return "W/" + etag
+	}
+	return etag
 }
 
+// formatIfMatch renders an ETag for the If-Match request header, or returns ""
+// when no precondition should be sent. RFC 7232 §3.1 mandates the strong
+// comparison function for If-Match, under which a weak validator never matches
+// (not even itself). Asserting a weak tag as strong would 412 on every push, so
+// weak validators yield no precondition and conflict detection falls back to
+// the sync-token/ctag pull comparison instead.
 func formatIfMatch(etag string) string {
 	etag = normalizeETag(etag)
-	if etag == "" {
+	if etag == "" || strings.HasPrefix(etag, "W/") {
 		return ""
 	}
 	return `"` + etag + `"`

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -88,6 +88,68 @@ func TestClientPutResourceSendsIfMatch(t *testing.T) {
 	}
 }
 
+func TestNormalizeAndFormatIfMatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		raw           string
+		wantNorm, ifM string
+	}{
+		{"strong", `"abc"`, "abc", `"abc"`},
+		{"strong_unquoted", "abc", "abc", `"abc"`},
+		{"strong_spaced", ` "abc" `, "abc", `"abc"`},
+		// Weak validators must keep their W/ marker through normalization and
+		// must NOT be asserted as strong validators in If-Match (RFC 7232 §3.1).
+		{"weak", `W/"abc"`, `W/abc`, ""},
+		{"weak_spaced", `W/ "abc"`, `W/abc`, ""},
+		{"empty", "", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeETag(tc.raw); got != tc.wantNorm {
+				t.Fatalf("normalizeETag(%q) = %q, want %q", tc.raw, got, tc.wantNorm)
+			}
+			if got := formatIfMatch(tc.raw); got != tc.ifM {
+				t.Fatalf("formatIfMatch(%q) = %q, want %q", tc.raw, got, tc.ifM)
+			}
+		})
+	}
+}
+
+// TestClientPutResourceWeakETagOmitsIfMatch verifies that a weak validator is
+// not echoed into If-Match as a strong tag. Doing so makes the strong
+// comparison fail server-side and produces perpetual 412s.
+func TestClientPutResourceWeakETagOmitsIfMatch(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(putTestHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("If-Match"); got != "" {
+			t.Fatalf("If-Match = %q, want empty for weak validator", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Status:     "204 No Content",
+			Header:     http.Header{"Etag": []string{`W/"etag-after"`}},
+			Body:       io.NopCloser(http.NoBody),
+			Request:    req,
+		}, nil
+	}}, "https://example.com")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	etag, err := client.PutResource(context.Background(), "/cal/test.ics", testCalendar(t), `W/"etag-before"`)
+	if err != nil {
+		t.Fatalf("PutResource: %v", err)
+	}
+	if etag != `W/etag-after` {
+		t.Fatalf("etag = %q, want %q", etag, `W/etag-after`)
+	}
+}
+
 func TestClientDeleteResourceReportsGone(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #226

## Problem
`normalizeETag` unconditionally stripped the `W/` weak marker before storage, so `formatIfMatch` re-emitted the opaque value as a *strong* `If-Match` validator. RFC 7232 §3.1 mandates strong comparison for `If-Match`, under which a server-side weak ETag never matches — producing perpetual 412 loops and (with the default `ConflictServerWins`) silent local-edit loss.

## Fix
Preserve the `W/` marker through normalization (stored as `W/<opaque>`, quotes still stripped). `formatIfMatch` now omits the precondition for weak validators, and `PutResource` only sets `If-Match` when a strong validator is present — conflict detection falls back to the existing sync-token/ctag pull comparison.

## Test
`TestNormalizeAndFormatIfMatch` and `TestClientPutResourceWeakETagOmitsIfMatch` — both confirmed failing before (strong `"etag-before"` sent for a weak validator; `W/` stripped) and passing after.

`go build ./...` and full `go test ./...` are green.

## Notes
- Post-upgrade, weak-ETag servers may trigger one harmless re-sync per resource (old stored `x` vs new `W/x`); self-heals on next pull.
- Minor inherent limitation (out of scope): a strong opaque ETag whose value literally starts with `W/` would be misclassified as weak and skip If-Match, degrading only to an unconditional push (no data loss; pull-side conflict detection still active). Eliminating it would require storing weakness as a separate field.

Assisted-by: Claude:claude-opus-4-8