### PR TITLE
fix(auth): persist server-rotated Google refresh token

### DIFF
--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -336,16 +336,24 @@ func RefreshGoogleToken(ctx context.Context, clientID, clientSecret, refreshToke
 		}
 
 		var result struct {
-			AccessToken string `json:"access_token"`
-			ExpiresIn   int    `json:"expires_in"`
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+			ExpiresIn    int    `json:"expires_in"`
 		}
 		if err := json.Unmarshal(body, &result); err != nil {
 			return nil, fmt.Errorf("parse refresh response: %w", err)
 		}
 
+		// RFC 6749 §6: the server MAY rotate the refresh token. Persist the
+		// new one when present; otherwise keep reusing the existing token.
+		newRefreshToken := result.RefreshToken
+		if newRefreshToken == "" {
+			newRefreshToken = refreshToken
+		}
+
 		return &GoogleOAuthResult{
 			AccessToken:  result.AccessToken,
-			RefreshToken: refreshToken, // refresh token stays the same
+			RefreshToken: newRefreshToken,
 			Expiry:       time.Now().Add(time.Duration(result.ExpiresIn) * time.Second),
 		}, nil
 	})

--- a/internal/auth/google_test.go
+++ b/internal/auth/google_test.go
@@ -108,6 +108,54 @@ func TestRefreshGoogleToken_SendsClientSecret(t *testing.T) {
 	}
 }
 
+func TestRefreshGoogleToken_PersistsRotatedRefreshToken(t *testing.T) {
+	prevClient := googleHTTPClient
+	googleHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"fresh","expires_in":3600,"refresh_token":"rotated-token"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	t.Cleanup(func() {
+		googleHTTPClient = prevClient
+	})
+
+	result, err := RefreshGoogleToken(context.Background(), "client-id", "secret-xyz", "old-token")
+	if err != nil {
+		t.Fatalf("RefreshGoogleToken: %v", err)
+	}
+	if result.RefreshToken != "rotated-token" {
+		t.Fatalf("RefreshToken = %q, want rotated-token (server-rotated token discarded)", result.RefreshToken)
+	}
+}
+
+func TestRefreshGoogleToken_KeepsOldRefreshTokenWhenOmitted(t *testing.T) {
+	prevClient := googleHTTPClient
+	googleHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"access_token":"fresh","expires_in":3600}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	t.Cleanup(func() {
+		googleHTTPClient = prevClient
+	})
+
+	result, err := RefreshGoogleToken(context.Background(), "client-id", "secret-xyz", "old-token")
+	if err != nil {
+		t.Fatalf("RefreshGoogleToken: %v", err)
+	}
+	if result.RefreshToken != "old-token" {
+		t.Fatalf("RefreshToken = %q, want old-token (existing token should be retained)", result.RefreshToken)
+	}
+}
+
 func TestExchangeGoogleCode_RetriesTransientError(t *testing.T) {
 	var calls atomic.Int32
 	prevClient := googleHTTPClient

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1023,9 +1023,10 @@ func (m Model) startOAuthFlow(clientID, clientSecret string) (Model, tea.Cmd) {
 }
 
 // finishOAuthReauth persists the fresh tokens for a re-authenticated
-// account. A full re-consent returns a new refresh token (unlike
-// RefreshGoogleToken, which preserves the old one); the stored credential's
-// username and client config are kept, the token triple is replaced.
+// account. A full re-consent always returns a new refresh token (unlike
+// RefreshGoogleToken, which only returns a new one if the server rotates it);
+// the stored credential's username and client config are kept, the token
+// triple is replaced.
 func (m Model) finishOAuthReauth(result *auth.GoogleOAuthResult) tea.Cmd {
 	p := m.oauthPurpose
 	return func() tea.Msg {


### PR DESCRIPTION
Closes #228

## Problem
`RefreshGoogleToken`'s response struct only decoded `access_token`/`expires_in` and hard-coded the inbound refresh token into the result, so a server-rotated `refresh_token` (allowed by RFC 6749 §6) was thrown away. Google could later invalidate the stale token, failing the next refresh with `invalid_grant` and silently stopping CalDAV sync (permanent silent re-auth).

## Fix
Parse `refresh_token` from the refresh response; return the rotated token when present, fall back to the existing one when omitted. The caller chain already persists the returned token (`caldav/auth.go:38`), so the fix takes effect end-to-end with no caller changes. Also corrected a now-stale doc comment in `tui/app.go`.

## Test
- `TestRefreshGoogleToken_PersistsRotatedRefreshToken` — fails before (`RefreshToken = "old-token"`), passes after.
- `TestRefreshGoogleToken_KeepsOldRefreshTokenWhenOmitted` — guards the fallback path.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8