### PR TITLE
fix(tui): make alarm before/after timing an interactive toggle

### DIFF
--- a/internal/tui/alarm_editor.go
+++ b/internal/tui/alarm_editor.go
@@ -46,6 +46,14 @@ var alarmActionOpts = []SelectOption{
 	{Label: "Audio", Value: "AUDIO"},
 }
 
+// alarmTimingOpts is the before/after toggle controlling the sign of a
+// relative trigger. Index 0 ("before") maps to a negative offset, index 1
+// ("after") to a positive one.
+var alarmTimingOpts = []SelectOption{
+	{Label: "before", Value: "before"},
+	{Label: "after", Value: "after"},
+}
+
 // parseOffsetTrigger parses a relative-trigger string like "-PT15M" into
 // (qty, unitIdx, before). Only single-unit offsets are supported so the
 // editor stays lossless; absolute triggers and mixed forms return ok=false.
@@ -148,7 +156,7 @@ type AlarmListEditorModel struct {
 
 	actionField *SelectField
 	offsetField *QuantitySelectField
-	editBefore  bool // sign of the trigger being edited (true = before anchor)
+	timingField *SelectField // before/after toggle for the trigger sign
 
 	form      Form
 	fieldKeys []string
@@ -245,14 +253,15 @@ func (m *AlarmListEditorModel) buildEditForm(a model.Alarm) {
 	if !ok {
 		qty, unitIdx, before = 15, 0, true
 	}
-	m.editBefore = before
 	m.offsetField = NewQuantitySelectField(unitOpts, unitIdx)
 	m.offsetField.SetAmount(strconv.Itoa(qty))
-	suffix := "before"
-	if !before {
-		suffix = "after"
+
+	m.timingField = NewSelectField(alarmTimingOpts)
+	timingIdx := 1 // "after"
+	if before {
+		timingIdx = 0 // "before"
 	}
-	m.offsetField.SetSuffix(suffix)
+	m.timingField.SetSelected(timingIdx)
 
 	styles := DefaultFormStyles()
 	styles.LabelLayout = LabelInline
@@ -262,9 +271,10 @@ func (m *AlarmListEditorModel) buildEditForm(a model.Alarm) {
 
 	items := []FormItem{
 		{Label: "Remind me", Field: m.offsetField},
+		{Label: "Timing", Field: m.timingField},
 		{Label: actionLabelFor(m.actionField.Value()), Field: m.actionField},
 	}
-	m.fieldKeys = []string{"offset", "action"}
+	m.fieldKeys = []string{"offset", "timing", "action"}
 
 	m.form = NewForm("Save", styles, items...)
 	m.form.OnSubmit(func(f *Form) tea.Cmd {
@@ -282,7 +292,8 @@ func (m *AlarmListEditorModel) applyEditForm() {
 		qty = 1
 	}
 	unitIdx := m.offsetField.Selected()
-	trigger := buildOffsetTrigger(qty, unitIdx, m.editBefore)
+	before := m.timingField.Selected() == 0
+	trigger := buildOffsetTrigger(qty, unitIdx, before)
 
 	action := strings.ToUpper(m.actionField.Value())
 
@@ -374,7 +385,7 @@ func (m *AlarmListEditorModel) syncActionLabel() {
 	if m.actionField == nil {
 		return
 	}
-	m.form.SetItemLabel(1, actionLabelFor(m.actionField.Value()))
+	m.form.SetItemLabel(2, actionLabelFor(m.actionField.Value()))
 }
 
 // actionLabelFor returns the grammatically correct article for the action.

--- a/internal/tui/alarm_editor_test.go
+++ b/internal/tui/alarm_editor_test.go
@@ -248,3 +248,25 @@ func TestAlarmEditor_EditPreservesAfterSignRelatedAndXProps(t *testing.T) {
 	require.Len(t, got.XProperties, 1, "X-properties must survive an edit")
 	assert.Equal(t, "X-APPLE-DEFAULT-ALARM", got.XProperties[0].Name)
 }
+
+func TestAlarmEditor_AuthorsAfterTrigger(t *testing.T) {
+	// A brand-new alarm defaults to "before"; the user must be able to flip
+	// the timing toggle to author an RFC 5545 positive ("after") trigger.
+	m := NewAlarmListEditorModel(nil, 80, 24, Theme{})
+	m, _ = m.Update(keyMsg("n"))
+	require.Equal(t, alarmModeEdit, m.mode)
+
+	// Tab off the offset field (amount -> unit -> next field) to land on the
+	// before/after timing toggle, then switch it from "before" to "after".
+	m, _ = m.Update(keyMsg("tab"))
+	m, _ = m.Update(keyMsg("tab"))
+	m, _ = m.Update(keyMsg("right"))
+
+	m, cmd := m.Update(keyMsg("ctrl+s"))
+	require.NotNil(t, cmd)
+	m, _ = m.Update(cmd())
+
+	require.Len(t, m.Alarms(), 1)
+	assert.Equal(t, "PT15M", m.Alarms()[0].TriggerValue,
+		"toggling the timing field must produce a positive (after-anchor) trigger")
+}


### PR DESCRIPTION
Closes #209

## Problem
The alarm editor only rendered "before"/"after" as a non-interactive `QuantitySelectField` suffix; `m.editBefore` was set once in `buildEditForm` and never flipped by any handler, so `buildOffsetTrigger` always baked in the sign chosen at build time. New alarms defaulted to "before", making positive (after-anchor) RFC 5545 triggers unauthorable through the TUI.

## Fix
Added an `alarmTimingOpts` before/after `SelectField` (`timingField`) as a real, focusable form item between the offset and action fields; removed the dead suffix and `editBefore` field; derive the sign from `timingField.Selected() == 0` at save. Adjusted `syncActionLabel`'s item index and the `fieldKeys` order for the inserted item.

## Test
`TestAlarmEditor_AuthorsAfterTrigger` drives the editor via key presses (`n`, `tab`, `tab`, `right`, `ctrl+s`); trigger stayed `-PT15M` before the fix, is `PT15M` after. Existing `TestAlarmEditor_EditPreservesAfterSignRelatedAndXProps` still passes (existing "after" alarms load with the toggle pre-set).

`go build ./...`, full `go test ./...`, and `go vet ./internal/tui/` are clean.

Assisted-by: Claude:claude-opus-4-8