### PR TITLE
fix(todo): clear completion fields when reopening a completed todo

### DIFF
--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -687,11 +687,9 @@ a --progress value other than 100.`,
 				default:
 					return errInvalidInputf("invalid --status %q: must be NEEDS-ACTION, IN-PROCESS, COMPLETED, or CANCELLED", status)
 				}
+				// The service reconciles completed_at and percent_complete
+				// with the status (set on completion, cleared on reopen).
 				p.Status = strings.ToUpper(status)
-				if strings.ToUpper(status) == "COMPLETED" {
-					p.CompletedAt = time.Now().UTC().Format(time.RFC3339)
-					p.PercentComplete = 100
-				}
 			}
 			if cmd.Flags().Changed("progress") {
 				if progress < 0 || progress > 100 {

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -168,8 +168,14 @@ func defaults(status, class string) (string, string) {
 	return status, class
 }
 
-func completedAtIfMissing(status, completedAt string) string {
-	if status == "COMPLETED" && completedAt == "" {
+// completedAtFor reconciles the completed_at timestamp with the status: a
+// COMPLETED todo gets a timestamp (preserving any existing one, else now),
+// and any other status clears it so reopened todos don't keep a stale value.
+func completedAtFor(status, completedAt string) string {
+	if status != "COMPLETED" {
+		return ""
+	}
+	if completedAt == "" {
 		return time.Now().UTC().Format(time.RFC3339)
 	}
 	return completedAt
@@ -197,10 +203,21 @@ func (p *CreateParams) applyDefaults() {
 
 func (p *UpsertParams) applyDefaults() {
 	p.Status, p.Class = defaults(p.Status, p.Class)
-	p.CompletedAt = completedAtIfMissing(p.Status, p.CompletedAt)
-	if p.Status == "COMPLETED" {
-		p.PercentComplete = 100
+	p.CompletedAt = completedAtFor(p.Status, p.CompletedAt)
+	p.PercentComplete = percentCompleteFor(p.Status, p.PercentComplete)
+}
+
+// percentCompleteFor reconciles percent-complete with the status: a COMPLETED
+// todo is forced to 100, and a stale 100 left over from completion is reset to
+// 0 when the todo is reopened to a non-completed status.
+func percentCompleteFor(status string, percent int64) int64 {
+	if status == "COMPLETED" {
+		return 100
 	}
+	if percent == 100 {
+		return 0
+	}
+	return percent
 }
 
 func (s *Service) Search(ctx context.Context, p SearchParams) ([]Todo, error) {
@@ -378,10 +395,8 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Todo, error) {
 
 func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Todo, error) {
 	p.Status, p.Class = defaults(p.Status, p.Class)
-	p.CompletedAt = completedAtIfMissing(p.Status, p.CompletedAt)
-	if p.Status == "COMPLETED" {
-		p.PercentComplete = 100
-	}
+	p.CompletedAt = completedAtFor(p.Status, p.CompletedAt)
+	p.PercentComplete = percentCompleteFor(p.Status, p.PercentComplete)
 	if err := validateTiming(p.DueDate, p.StartDate, p.Duration); err != nil {
 		return Todo{}, err
 	}

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -292,6 +292,44 @@ func TestTodoService_UpdateToCompleted(t *testing.T) {
 	}
 }
 
+func TestTodoService_ReopenCompletedClearsCompletion(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	created := createTodo(t, svc)
+
+	completed, err := svc.Update(ctx, created.ID, UpdateParams{
+		Summary:    created.Summary,
+		DueDate:    created.DueDate,
+		CalendarID: 1,
+		Status:     "COMPLETED",
+	})
+	if err != nil {
+		t.Fatalf("Update to COMPLETED: %v", err)
+	}
+	if completed.CompletedAt == "" || completed.PercentComplete != 100 {
+		t.Fatalf("precondition: want completed_at set and 100%%, got %q / %d",
+			completed.CompletedAt, completed.PercentComplete)
+	}
+
+	reopened, err := svc.Update(ctx, created.ID, UpdateParams{
+		Summary:         created.Summary,
+		DueDate:         created.DueDate,
+		CalendarID:      1,
+		Status:          "IN-PROCESS",
+		CompletedAt:     completed.CompletedAt,
+		PercentComplete: completed.PercentComplete,
+	})
+	if err != nil {
+		t.Fatalf("Update to IN-PROCESS: %v", err)
+	}
+	if reopened.CompletedAt != "" {
+		t.Errorf("CompletedAt = %q, want cleared when reopening", reopened.CompletedAt)
+	}
+	if reopened.PercentComplete == 100 {
+		t.Errorf("PercentComplete = 100, want reset when reopening")
+	}
+}
+
 func TestTodoService_UpsertByUID(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()


### PR DESCRIPTION
Closes #216

## Problem
On `todo update --status` to a non-completed value, the handler set completion fields only when transitioning TO completed and never cleared them on the reverse transition. The service didn't compensate either, so reopening a completed todo persisted `completed_at=<old ts>` and `percent_complete=100` with status IN-PROCESS/NEEDS-ACTION — and `todoCheckbox()` still rendered it as `[x]` (it checks `CompletedAt != ""`).

## Fix
Normalize in the service (covers the cmd path *and* the `UpsertByUID` sync-ingestion path): clear `completed_at` whenever status != COMPLETED, and reset a `percent_complete == 100` to 0 for non-completed status. Percent 100 with a non-completed status is contradictory per RFC 5545, so normalizing is correct; no-op updates preserve existing values.

## Test
`TestUpdate_*` reconciliation tests in `internal/todo/service_test.go` — fail before the fix (stale `completed_at` / 100%), pass after.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8