### PR TITLE
fix(journal): make Create/Update/UpsertByUID category writes atomic

### DIFF
--- a/internal/journal/atomic_test.go
+++ b/internal/journal/atomic_test.go
@@ -1,0 +1,128 @@
+package journal
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/testutil"
+)
+
+// countRows returns the number of rows matching the given query.
+func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&n); err != nil {
+		t.Fatalf("count query %q: %v", query, err)
+	}
+	return n
+}
+
+// The category child-write is forced to fail by passing duplicate categories:
+// journal_categories has PRIMARY KEY (journal_id, category) and
+// ParseCategoryList does not dedupe, so inserting "dup,dup" fails on the second
+// row. That isolates the failure to the category child-write while the parent
+// journal row write succeeds — exactly the partial-failure window the fix must
+// close. (Dropping journal_categories would instead break the UpdateJournal
+// statement itself: SQLite compiles the journals_fts_au trigger, which reads
+// journal_categories, at prepare time.)
+
+// TestCreate_AtomicOnCategoryFailure asserts that when the category child-write
+// fails, Create returns an error AND leaves no journal row behind. Before the
+// fix the journal row was committed in autocommit before categories ran, so a
+// failure left an orphan row (the mirror of issue #73).
+func TestCreate_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Summary:    "Atomic Create",
+		StartDate:  "2026-04-01",
+		Categories: "dup,dup",
+	})
+	if err == nil {
+		t.Fatal("Create succeeded, want error from duplicate category write")
+	}
+
+	if n := countRows(t, db, `SELECT COUNT(*) FROM journals`); n != 0 {
+		t.Fatalf("journal rows persisted after failed Create = %d, want 0", n)
+	}
+}
+
+// TestUpdate_AtomicOnCategoryFailure asserts that when the category child-write
+// fails during Update, the original journal row and its categories are left
+// unchanged. Before the fix the journal row was updated in autocommit before
+// categories ran, so a failure produced a half-updated, category-wiped row.
+func TestUpdate_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	orig, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Summary:    "Original Summary",
+		StartDate:  "2026-04-01",
+		Categories: "work,urgent",
+	})
+	if err != nil {
+		t.Fatalf("seed create: %v", err)
+	}
+
+	catsBefore := countRows(t, db,
+		`SELECT COUNT(*) FROM journal_categories WHERE journal_id = ?`, orig.ID)
+	if catsBefore != 2 {
+		t.Fatalf("seed categories = %d, want 2", catsBefore)
+	}
+
+	_, err = svc.Update(ctx, orig.ID, UpdateParams{
+		CalendarID: 1,
+		Summary:    "Changed Summary",
+		StartDate:  "2026-04-02",
+		Categories: "dup,dup",
+	})
+	if err == nil {
+		t.Fatal("Update succeeded, want error from duplicate category write")
+	}
+
+	// The row write must have rolled back: summary is unchanged.
+	got, err := svc.Get(ctx, orig.ID)
+	if err != nil {
+		t.Fatalf("get after failed update: %v", err)
+	}
+	if got.Summary != "Original Summary" {
+		t.Fatalf("summary after failed Update = %q, want %q", got.Summary, "Original Summary")
+	}
+	// Categories must be intact too: the replace rolled back.
+	if n := countRows(t, db,
+		`SELECT COUNT(*) FROM journal_categories WHERE journal_id = ?`, orig.ID); n != 2 {
+		t.Fatalf("categories after failed Update = %d, want 2", n)
+	}
+}
+
+// TestUpsertByUID_AtomicOnCategoryFailure asserts that when the category
+// child-write fails, UpsertByUID returns an error AND leaves no journal row
+// behind. Before the fix the upsert committed the row in autocommit and only
+// then ran ReplaceCategories in a separate transaction, so a failure left an
+// orphan row.
+func TestUpsertByUID_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	_, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:        "upsert-atomic-uid",
+		CalendarID: 1,
+		Summary:    "Atomic Upsert",
+		StartDate:  "2026-04-01",
+		Categories: "dup,dup",
+	})
+	if err == nil {
+		t.Fatal("UpsertByUID succeeded, want error from duplicate category write")
+	}
+
+	if n := countRows(t, db, `SELECT COUNT(*) FROM journals`); n != 0 {
+		t.Fatalf("journal rows persisted after failed UpsertByUID = %d, want 0", n)
+	}
+}

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -276,7 +276,14 @@ func (s *Service) markDirtyByID(ctx context.Context, journalID int64) {
 
 func (s *Service) Create(ctx context.Context, p CreateParams) (Journal, error) {
 	p.applyDefaults()
-	r, err := s.q.CreateJournal(ctx, storage.CreateJournalParams{
+
+	qtx, commit, rollback, err := s.txscope(ctx)
+	if err != nil {
+		return Journal{}, err
+	}
+	defer rollback()
+
+	r, err := qtx.CreateJournal(ctx, storage.CreateJournalParams{
 		Uid:            uuid.New().String(),
 		CalendarID:     p.CalendarID,
 		Summary:        p.Summary,
@@ -297,17 +304,27 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Journal, error) {
 		return Journal{}, err
 	}
 	j := fromStorage(r)
-	if err := s.ReplaceCategories(ctx, j.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
+	if err := replaceCategoriesTx(ctx, qtx, j.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
 		return Journal{}, fmt.Errorf("replace categories: %w", err)
 	}
+	if err := commit(); err != nil {
+		return Journal{}, fmt.Errorf("commit create journal: %w", err)
+	}
 	j.Categories = p.Categories
-	_ = storage.MarkResourceDirty(ctx, s.db, j.CalendarID, j.UID, "journal")
+	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), j.CalendarID, j.UID, "journal")
 	return j, nil
 }
 
 func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Journal, error) {
 	p.Status, p.Class = defaults(p.Status, p.Class)
-	r, err := s.q.UpdateJournal(ctx, storage.UpdateJournalParams{
+
+	qtx, commit, rollback, err := s.txscope(ctx)
+	if err != nil {
+		return Journal{}, err
+	}
+	defer rollback()
+
+	r, err := qtx.UpdateJournal(ctx, storage.UpdateJournalParams{
 		ID:             id,
 		Summary:        p.Summary,
 		Description:    storage.StringToNullable(p.Description),
@@ -326,17 +343,27 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Journal
 		return Journal{}, err
 	}
 	j := fromStorage(r)
-	if err := s.ReplaceCategories(ctx, j.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
+	if err := replaceCategoriesTx(ctx, qtx, j.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
 		return Journal{}, fmt.Errorf("replace categories: %w", err)
 	}
+	if err := commit(); err != nil {
+		return Journal{}, fmt.Errorf("commit update journal: %w", err)
+	}
 	j.Categories = p.Categories
-	_ = storage.MarkResourceDirty(ctx, s.db, j.CalendarID, j.UID, "journal")
+	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), j.CalendarID, j.UID, "journal")
 	return j, nil
 }
 
 func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Journal, error) {
 	p.applyDefaults()
-	r, err := s.q.UpsertJournalByUID(ctx, storage.UpsertJournalByUIDParams{
+
+	qtx, commit, rollback, err := s.txscope(ctx)
+	if err != nil {
+		return Journal{}, err
+	}
+	defer rollback()
+
+	r, err := qtx.UpsertJournalByUID(ctx, storage.UpsertJournalByUIDParams{
 		Uid:            p.UID,
 		CalendarID:     p.CalendarID,
 		Summary:        p.Summary,
@@ -357,8 +384,11 @@ func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Journal, err
 		return Journal{}, err
 	}
 	j := fromStorage(r)
-	if err := s.ReplaceCategories(ctx, j.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
+	if err := replaceCategoriesTx(ctx, qtx, j.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
 		return Journal{}, fmt.Errorf("replace categories: %w", err)
+	}
+	if err := commit(); err != nil {
+		return Journal{}, fmt.Errorf("commit upsert journal: %w", err)
 	}
 	j.Categories = p.Categories
 	return j, nil
@@ -606,6 +636,19 @@ func (s *Service) ReplaceCategories(ctx context.Context, journalID int64, catego
 	}
 	defer rollback()
 
+	if err := replaceCategoriesTx(ctx, qtx, journalID, categories); err != nil {
+		return err
+	}
+	if err := commit(); err != nil {
+		return fmt.Errorf("commit replace categories: %w", err)
+	}
+	return nil
+}
+
+// replaceCategoriesTx replaces a journal's categories using a tx-bound Queries.
+// It does not open or commit a transaction, so callers can compose it with the
+// journal row write inside a single transaction.
+func replaceCategoriesTx(ctx context.Context, qtx *storage.Queries, journalID int64, categories []string) error {
 	if err := qtx.DeleteCategoriesByJournalID(ctx, journalID); err != nil {
 		return fmt.Errorf("delete categories: %w", err)
 	}
@@ -617,9 +660,6 @@ func (s *Service) ReplaceCategories(ctx context.Context, journalID int64, catego
 		if err != nil {
 			return fmt.Errorf("create category: %w", err)
 		}
-	}
-	if err := commit(); err != nil {
-		return fmt.Errorf("commit replace categories: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #223

## Problem
`journal.Create/Update/UpsertByUID` committed the journal row in autocommit, then ran `ReplaceCategories` in a *separate* transaction with `MarkResourceDirty` only afterward. A category-write failure (or crash between commits) left the row committed, categories inconsistent, and the resource never marked dirty — even though the caller received an error. Same defect the event fix #73 already corrected; journal still used the pre-fix split-commit pattern.

## Fix
Mirror the event package: wrap the journal row write + a tx-scoped `replaceCategoriesTx` in one transaction via `txscope`, commit once, then `MarkResourceDirty` via `s.dirtyExec()` (which joins an outer tx under `WithTx`, avoiding write-lock contention). `ReplaceCategories` now delegates to the extracted helper. `UpsertByUID` intentionally skips `MarkResourceDirty` (matching `event.UpsertByUID`).

## Test
`TestCreate_AtomicOnCategoryFailure`, `TestUpdate_AtomicOnCategoryFailure`, `TestUpsertByUID_AtomicOnCategoryFailure` inject a duplicate-category PK violation after the row write. All three fail before (orphaned/changed rows), pass after.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8