### PR TITLE
fix(tui): preserve timed multi-day event end when it falls exactly on midnight

### DIFF
--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -1732,6 +1732,16 @@ func (m EventFormModel) save(f *Form) tea.Cmd {
 	endDay := day
 	if m.rangeHasEnd {
 		endDay = m.rangeEndDate
+		// rangeEndDate holds the last *included* day (multiDayEndDate
+		// subtracts the exclusive midnight day for display). A midnight
+		// end time means the event runs through the end of that day, i.e.
+		// to exclusive midnight of the following day, so re-add the day
+		// here to keep the save path symmetric with the display path and
+		// avoid silently shifting the end back 24h (issue #208). Mirrors
+		// the all-day branch's endDay.AddDate(0, 0, 1).
+		if et.Hour() == 0 && et.Minute() == 0 {
+			endDay = endDay.AddDate(0, 0, 1)
+		}
 	}
 	end := time.Date(endDay.Year(), endDay.Month(), endDay.Day(),
 		et.Hour(), et.Minute(), 0, 0, loc).UTC()

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -463,3 +463,36 @@ func TestEventForm_EditPreservesAttendeeMetadata(t *testing.T) {
 	assert.Equal(t, "ROOM", room.CUType)
 	assert.Equal(t, "Big Room", room.Name)
 }
+
+// TestEventForm_EditTimedMultiDayMidnightEndPreservesEnd guards against issue
+// #208: editing a timed multi-day event whose end instant is exactly midnight
+// (e.g. Apr 1 09:00 -> Apr 3 00:00, occupying Apr 1 and Apr 2) and saving with
+// no changes must not shift the end back a full day. multiDayEndDate stores the
+// last *included* day (Apr 2); the save path must re-add the exclusive midnight
+// day so the saved end is still Apr 3 00:00, not Apr 2 00:00.
+func TestEventForm_EditTimedMultiDayMidnightEndPreservesEnd(t *testing.T) {
+	origLocal := time.Local
+	time.Local = time.UTC
+	defer func() { time.Local = origLocal }()
+
+	start := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 3, 0, 0, 0, 0, time.UTC)
+
+	m, _ := NewEventFormModelForEdit(event.Event{
+		ID:         11,
+		CalendarID: 1,
+		Title:      "Conference",
+		StartTime:  start,
+		EndTime:    end,
+		Timezone:   "UTC",
+	}, testEventFormCalendars(), Theme{})
+
+	cmd := m.save(&m.form)
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(EventFormSaveMsg)
+	require.True(t, ok)
+
+	assert.Equal(t, start, msg.StartTime)
+	assert.Truef(t, end.Equal(msg.EndTime),
+		"no-op edit shifted end: want %s, got %s", end, msg.EndTime)
+}


### PR DESCRIPTION
Closes #208

## Problem
`multiDayEndDate()` subtracts the exclusive-midnight day to *display* the last included day of a timed multi-day range, but `save()` rebuilt the end from that inclusive day plus the entered end time (00:00) without re-adding the day — and the cross-midnight `+1` fallback was skipped because `rangeHasEnd` was true. Result: opening a timed event ending exactly at midnight (e.g. Apr 1 09:00 → Apr 3 00:00) and saving with no changes silently shifted its end back 24h.

## Fix
In `save()`, inside the `rangeHasEnd` branch, add one day to `endDay` when the entered end time is exactly 00:00 before constructing the localized end instant — mirroring the all-day branch and making the save path symmetric with `multiDayEndDate`. Done in local-date space before `time.Date(...loc).UTC()`, so it's DST-safe.

## Test
`TestEventForm_EditTimedMultiDayMidnightEndPreservesEnd` — fails before (saved end Apr 2 00:00), passes after (Apr 3 00:00). Verified no regression on non-midnight multi-day ends, single-day cross-midnight events, and the all-day branch.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8