### PR TITLE
fix(config): surface malformed config errors instead of silently reverting to defaults

### DIFF
--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -197,7 +197,11 @@ Helpful conventions:
   # Get machine-readable output for scripts or LLMs
   chroncal todo list --output json`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		cfg = config.Load()
+		var err error
+		cfg, err = config.Load()
+		if err != nil {
+			return err
+		}
 		if cfg.ProductID != "" {
 			ical.ProductID = cfg.ProductID
 		}

--- a/cmd/chroncal/push_writepaths_test.go
+++ b/cmd/chroncal/push_writepaths_test.go
@@ -37,8 +37,9 @@ func runWriteCommand(t *testing.T, sub *cobra.Command, args ...string) error {
 	root := &cobra.Command{
 		Use: "chroncal-test",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			cfg = config.Load()
-			return nil
+			var err error
+			cfg, err = config.Load()
+			return err
 		},
 	}
 	root.AddCommand(sub)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -65,17 +67,29 @@ const DefaultSMTPPort = 587
 
 // Load reads configuration with precedence: env > config file > defaults.
 // The caller is responsible for applying flag overrides on top.
-func Load() Config {
+func Load() (Config, error) {
 	v := newViper()
 
 	if dir, err := configDir(); err == nil {
 		v.AddConfigPath(filepath.Join(dir, "chroncal"))
 	}
 
-	v.ReadInConfig() //nolint:errcheck // file is optional
+	// The config file is optional: a missing file is fine and falls back to
+	// env/defaults. A *malformed* file, however, must surface an error rather
+	// than be silently treated like an absent one — otherwise a typo anywhere
+	// in config.toml would revert db/security/SMTP/etc. to defaults and could
+	// open the wrong (default) database without warning.
+	if err := v.ReadInConfig(); err != nil {
+		var notFound viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFound) {
+			return Config{}, fmt.Errorf("read config file: %w", err)
+		}
+	}
 
 	var cfg Config
-	v.Unmarshal(&cfg) //nolint:errcheck // best-effort; zero-value Config is safe
+	if err := v.Unmarshal(&cfg); err != nil {
+		return Config{}, fmt.Errorf("parse config file: %w", err)
+	}
 	if cfg.SMTP.Port == 0 {
 		cfg.SMTP.Port = DefaultSMTPPort
 	}
@@ -86,7 +100,7 @@ func Load() Config {
 	if !v.IsSet("soft_delete.purge_days") {
 		cfg.SoftDelete.PurgeDays = DefaultSoftDeletePurgeDays
 	}
-	return cfg
+	return cfg, nil
 }
 
 // newViper creates a pre-configured Viper instance with CHRONCAL_ env prefix

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,8 +6,20 @@ import (
 	"testing"
 )
 
+// mustLoad calls Load and fails the test on error. Use it in tests that
+// exercise valid/absent config; tests asserting a parse error call Load
+// directly.
+func mustLoad(t *testing.T) Config {
+	t.Helper()
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	return cfg
+}
+
 func TestConfig_Default(t *testing.T) {
-	cfg := Load()
+	cfg := mustLoad(t)
 	if cfg.DB != "" {
 		t.Errorf("default DB = %q, want empty", cfg.DB)
 	}
@@ -15,7 +27,7 @@ func TestConfig_Default(t *testing.T) {
 
 func TestConfig_EnvVar(t *testing.T) {
 	t.Setenv("CHRONCAL_DB", "/tmp/test-env.db")
-	cfg := Load()
+	cfg := mustLoad(t)
 	if cfg.DB != "/tmp/test-env.db" {
 		t.Errorf("DB = %q, want %q", cfg.DB, "/tmp/test-env.db")
 	}
@@ -30,7 +42,7 @@ func TestConfig_File(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("CHRONCAL_DB", "")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 	if cfg.DB != "/tmp/test-file.db" {
 		t.Errorf("DB = %q, want %q", cfg.DB, "/tmp/test-file.db")
 	}
@@ -45,7 +57,7 @@ func TestConfig_EnvOverridesFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("CHRONCAL_DB", "/tmp/from-env.db")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 	if cfg.DB != "/tmp/from-env.db" {
 		t.Errorf("DB = %q, want %q (env should override file)", cfg.DB, "/tmp/from-env.db")
 	}
@@ -75,7 +87,7 @@ from = "noreply@example.com"
 	t.Setenv("CHRONCAL_SMTP_PASSWORD", "")
 	t.Setenv("CHRONCAL_SMTP_FROM", "")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 
 	if cfg.SMTP.Host != "smtp.example.com" {
 		t.Errorf("SMTP.Host = %q, want %q", cfg.SMTP.Host, "smtp.example.com")
@@ -110,7 +122,7 @@ port = 25
 	t.Setenv("CHRONCAL_SMTP_HOST", "env-host.example.com")
 	t.Setenv("CHRONCAL_SMTP_PORT", "465")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 
 	if cfg.SMTP.Host != "env-host.example.com" {
 		t.Errorf("SMTP.Host = %q, want %q (env should override file)", cfg.SMTP.Host, "env-host.example.com")
@@ -124,7 +136,7 @@ func TestLoad_SyncFromEnv(t *testing.T) {
 	t.Setenv("CHRONCAL_SYNC_INTERVAL", "15m")
 	t.Setenv("CHRONCAL_SYNC_CONFLICT_STRATEGY", "prompt")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 
 	if cfg.Sync.Interval != "15m" {
 		t.Fatalf("Sync.Interval = %q, want 15m", cfg.Sync.Interval)
@@ -138,7 +150,7 @@ func TestLoad_SecurityFromEnv(t *testing.T) {
 	t.Setenv("CHRONCAL_SECURITY_ALLOW_UNSAFE_ALARM_AUDIO_ATTACH", "true")
 	t.Setenv("CHRONCAL_SECURITY_ALLOW_UNSAFE_ALARM_EMAIL_ATTENDEES", "true")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 
 	if !cfg.Security.AllowUnsafeAlarmAudioAttach {
 		t.Fatal("Security.AllowUnsafeAlarmAudioAttach = false, want true")
@@ -162,7 +174,7 @@ allow_unsafe_alarm_email_attendees = true
 	t.Setenv("CHRONCAL_SECURITY_ALLOW_UNSAFE_ALARM_AUDIO_ATTACH", "")
 	t.Setenv("CHRONCAL_SECURITY_ALLOW_UNSAFE_ALARM_EMAIL_ATTENDEES", "")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 	if !cfg.Security.AllowUnsafeAlarmAudioAttach {
 		t.Fatal("Security.AllowUnsafeAlarmAudioAttach = false, want true")
 	}
@@ -174,7 +186,7 @@ allow_unsafe_alarm_email_attendees = true
 func TestLoad_PurgeDaysDefaultsWhenUnset(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no config file
 	t.Setenv("CHRONCAL_SOFT_DELETE_PURGE_DAYS", "")
-	cfg := Load()
+	cfg := mustLoad(t)
 	if cfg.SoftDelete.PurgeDays != DefaultSoftDeletePurgeDays {
 		t.Errorf("PurgeDays = %d, want %d when unset", cfg.SoftDelete.PurgeDays, DefaultSoftDeletePurgeDays)
 	}
@@ -189,7 +201,7 @@ func TestLoad_PurgeDaysZeroDisables(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("CHRONCAL_SOFT_DELETE_PURGE_DAYS", "")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 	if cfg.SoftDelete.PurgeDays != 0 {
 		t.Errorf("PurgeDays = %d, want 0 (explicit 0 must stay disabled, not default to %d)",
 			cfg.SoftDelete.PurgeDays, DefaultSoftDeletePurgeDays)
@@ -205,7 +217,7 @@ func TestLoad_PurgeDaysExplicitValue(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("CHRONCAL_SOFT_DELETE_PURGE_DAYS", "")
 
-	cfg := Load()
+	cfg := mustLoad(t)
 	if cfg.SoftDelete.PurgeDays != 7 {
 		t.Errorf("PurgeDays = %d, want 7", cfg.SoftDelete.PurgeDays)
 	}
@@ -214,8 +226,37 @@ func TestLoad_PurgeDaysExplicitValue(t *testing.T) {
 func TestLoad_SMTPPortDefaultsWhenUnset(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no config file
 	t.Setenv("CHRONCAL_SMTP_PORT", "")
-	cfg := Load()
+	cfg := mustLoad(t)
 	if cfg.SMTP.Port != DefaultSMTPPort {
 		t.Errorf("SMTP.Port = %d, want %d when unset", cfg.SMTP.Port, DefaultSMTPPort)
+	}
+}
+
+// TestLoad_MalformedFileReturnsError guards against silently swallowing a
+// syntax error in config.toml. A broken file must surface an error rather than
+// be treated like an absent file, which would revert db/security/etc. to
+// defaults and risk opening the wrong (default) database.
+func TestLoad_MalformedFileReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "chroncal")
+	os.MkdirAll(configDir, 0o755)
+	// Valid db key but a syntax error elsewhere (unterminated string).
+	content := "db = \"/home/me/work.db\"\nproduct_id = \"oops\n"
+	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(content), 0o644)
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_DB", "")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want a parse error for malformed config.toml")
+	}
+}
+
+// TestLoad_NoFileNoError confirms an absent config file is still treated as
+// optional (no error), distinguishing "no file" from "broken file".
+func TestLoad_NoFileNoError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no config file present
+	if _, err := Load(); err != nil {
+		t.Fatalf("Load() error = %v, want nil when config file is absent", err)
 	}
 }


### PR DESCRIPTION
Closes #227

## Problem
`Load()` discarded both the `ReadInConfig` and `Unmarshal` errors, so a TOML syntax error was treated identically to a missing file — every key reverted to env/zero values, and an empty `cfg.DB` then mapped to `app.DefaultDBPath()`, silently opening a fresh/empty database (apparent data loss).

## Fix
`Load()` now returns `(Config, error)`: it ignores only `viper.ConfigFileNotFoundError`, surfaces any other read error, and checks the `Unmarshal` error. `PersistentPreRunE` propagates it, so a broken config aborts the command rather than running against defaults. Chose "return error" over warn-to-stderr because it actually prevents the data-loss scenario.

## Test
- `TestLoad_MalformedFileReturnsError` — valid `db` key + a syntax error; fails before (`error = nil`), passes after.
- `TestLoad_NoFileNoError` — guards the "absent file is still optional" path.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8