### PR TITLE
fix(tui): truncate by display width so CJK/emoji titles don't overflow

### DIFF
--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -11,6 +11,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/model"
@@ -1038,20 +1039,21 @@ func truncateTo(s string, w int) string {
 	if strings.ContainsRune(s, '\x1b') {
 		plain = stripANSI(s)
 	}
-	r := []rune(plain)
-	cut := min(w-1, len(r))
+
+	// Width-bounded prefix that reserves one cell for the ellipsis. ansi.Cut
+	// measures display width and respects grapheme clusters, so wide runes
+	// (CJK/emoji) no longer overflow the column the way a rune-index slice
+	// would (issue #213).
+	head := ansi.Cut(plain, 0, w-1)
 
 	// Prefer breaking at whitespace within a small look-back window so
 	// truncation doesn't slice mid-word. If no whitespace is within reach
 	// (e.g., a single long token), fall back to a hard cut.
-	lookback := cut / 3
-	for i := cut; i > cut-lookback && i > 1; i-- {
-		if r[i-1] == ' ' || r[i-1] == '\t' {
-			trimmed := strings.TrimRight(string(r[:i-1]), " \t")
-			return trimmed + " …"
-		}
+	if idx := strings.LastIndexAny(head, " \t"); idx >= 0 &&
+		lipgloss.Width(head[idx:]) <= lipgloss.Width(head)/3 {
+		return strings.TrimRight(head[:idx], " \t") + " …"
 	}
-	return string(r[:cut]) + "…"
+	return head + "…"
 }
 
 func stripANSI(s string) string {

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -1155,13 +1155,7 @@ func renderTimeCellContent(p placedEvent, row, width int) string {
 		}
 	}
 
-	if lipgloss.Width(text) > width {
-		r := []rune(text)
-		limit := max(width-1, 1)
-		if len(r) > limit {
-			text = string(r[:limit]) + "…"
-		}
-	}
+	text = truncateTo(text, width)
 
 	return lipgloss.NewStyle().Background(bg).Foreground(fg).Width(width).Render(text)
 }
@@ -1223,14 +1217,7 @@ func renderTimeLabel(row, lph int, isNowRow bool, nowTimeLabel string) string {
 }
 
 func renderEventPill(ev CalendarEvent, cellW int, faint bool) string {
-	text := " " + ev.Title
-	if lipgloss.Width(text) > cellW {
-		r := []rune(text)
-		limit := max(cellW-1, 1)
-		if len(r) > limit {
-			text = string(r[:limit]) + "…"
-		}
-	}
+	text := truncateTo(" "+ev.Title, cellW)
 
 	bg := ActiveTheme().Muted
 	if ev.Color != "" {

--- a/internal/tui/truncate_width_test.go
+++ b/internal/tui/truncate_width_test.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+// TestTruncateToWideRunesBounded reproduces issue #213: truncateTo gated on
+// display width but cut by rune index, so wide (CJK/emoji) runes overflowed
+// the requested column width. The result must never be wider than w cells.
+func TestTruncateToWideRunesBounded(t *testing.T) {
+	cases := []struct {
+		name string
+		s    string
+		w    int
+	}{
+		{"cjk", strings.Repeat("世", 20), 10},
+		{"emoji", strings.Repeat("😀", 20), 8},
+		{"mixed", "会議 " + strings.Repeat("界", 30), 12},
+		{"ascii", strings.Repeat("a", 50), 10},
+		{"narrow", strings.Repeat("世", 5), 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateTo(tc.s, tc.w)
+			if w := lipgloss.Width(got); w > tc.w {
+				t.Fatalf("truncateTo(%q, %d) = %q has display width %d > %d",
+					tc.s, tc.w, got, w, tc.w)
+			}
+		})
+	}
+}
+
+// TestRenderEventPillWideRunesBounded covers the same rune-vs-width mismatch in
+// renderEventPill (format.go), which shares the truncation logic.
+func TestRenderEventPillWideRunesBounded(t *testing.T) {
+	ev := CalendarEvent{Title: strings.Repeat("世", 20)}
+	got := renderEventPill(ev, 10, false)
+	if w := lipgloss.Width(got); w != 10 {
+		t.Fatalf("renderEventPill width = %d, want 10 (content %q)", w, got)
+	}
+	if n := strings.Count(got, "\n"); n != 0 {
+		t.Fatalf("renderEventPill wrapped to %d extra lines; pill must stay one row (content %q)", n, got)
+	}
+}
+
+// TestRenderTimeCellContentWideRunesBounded covers renderTimeCellContent.
+func TestRenderTimeCellContentWideRunesBounded(t *testing.T) {
+	p := placedEvent{event: CalendarEvent{Title: strings.Repeat("世", 20)}}
+	got := renderTimeCellContent(p, 0, 10)
+	if w := lipgloss.Width(got); w != 10 {
+		t.Fatalf("renderTimeCellContent width = %d, want 10 (content %q)", w, got)
+	}
+	if n := strings.Count(got, "\n"); n != 0 {
+		t.Fatalf("renderTimeCellContent wrapped to %d extra lines; cell must stay one row (content %q)", n, got)
+	}
+}


### PR DESCRIPTION
Closes #213

## Problem
`truncateTo` gated on `lipgloss.Width` but truncated by rune index (`cut := min(w-1, len(r))`), so each double-width CJK/emoji rune counted as one toward the cut yet rendered as two cells — the result was far wider than the column. Since `lipgloss.Width().Render()` only pads (never clamps), wide titles overran the agenda/detail layout or wrapped to extra rows in week/day pills. `renderTimeCellContent` and `renderEventPill` in `format.go` had the identical rune-vs-width mismatch.

## Fix
Rewrote `truncateTo` to cut a width-bounded prefix via `ansi.Cut` (display-width + grapheme-cluster aware, the same primitive lipgloss is built on), with whitespace look-back measured in cells. Replaced the two ad-hoc rune-slice truncations in `format.go` with calls to the now-correct shared helper.

## Test
`TestTruncateToWideRunesBounded`, `TestRenderEventPillWideRunesBounded`, `TestRenderTimeCellContentWideRunesBounded` (CJK/emoji/mixed/ascii/narrow). Fail before (width 19 for a w=10 column; pills wrapped to 3 lines), pass after. Exhaustive check across widths 1–20 confirms output is always ≤ w with no wrapping.

## Notes
- Grapheme-aware, so it handles multi-rune emoji/ZWJ sequences (beyond the issue's suggested per-rune accumulation).
- The two `format.go` renderers now inherit `truncateTo`'s whitespace look-back: a multi-word title may break at a space with " …" instead of a hard mid-word cut (still within width, still single-line).

`go build ./...`, full `go test ./...`, `gofmt`, and `go vet` are clean.

Assisted-by: Claude:claude-opus-4-8