### PR TITLE
fix(event): store date-only EXDATE when excluding an all-day recurring occurrence

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -554,6 +554,13 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 				// restore path treats the same parse failure as fatal.
 				return fmt.Errorf("parse recurrence_id %q: %w", evt.RecurrenceID, parseErr)
 			}
+			// All-day masters store recurrence_ids as full RFC 3339, so
+			// ParseRecurrenceID yields a UTC-located time. Re-tag it as
+			// date-only so the EXDATE serializes as VALUE=DATE matching
+			// DTSTART;VALUE=DATE on export (RFC 5545 §3.8.5.1, issue #221).
+			if master.AllDay == 1 {
+				recIDTime = timeutil.AsDateOnly(recIDTime)
+			}
 			existing = append(existing, recIDTime)
 			if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
 				Exdates: storage.StringToNullable(SerializeTimeList(existing)),
@@ -607,7 +614,15 @@ func (s *Service) DeleteInstance(ctx context.Context, uid string, instanceTime t
 	}
 
 	existing := ParseTimeList(storage.NullableToString(master.Exdates))
-	existing = append(existing, instanceTime.UTC())
+	exdate := instanceTime.UTC()
+	// For an all-day master, tag the EXDATE as date-only so it serializes as
+	// VALUE=DATE matching DTSTART;VALUE=DATE on export; otherwise a strict
+	// CalDAV server ignores the mismatched DATE-TIME EXDATE and the deleted
+	// occurrence reappears (RFC 5545 §3.8.5.1, issue #221).
+	if master.AllDay == 1 {
+		exdate = timeutil.AsDateOnly(exdate)
+	}
+	existing = append(existing, exdate)
 	if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
 		Exdates: storage.StringToNullable(SerializeTimeList(existing)),
 		ID:      master.ID,

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -643,6 +643,65 @@ func TestDelete_AllDayOverrideAddsDateOnlyEXDATE(t *testing.T) {
 	}
 }
 
+func TestDeleteInstance_AllDayStoresDateOnlyEXDATE(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "allday-inst", CalendarID: 1, Title: "Daily Standup",
+		StartTime:      time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+		AllDay:         true,
+		RecurrenceRule: "FREQ=DAILY",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	instance := time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC)
+	if err := svc.DeleteInstance(ctx, master.UID, instance); err != nil {
+		t.Fatalf("DeleteInstance: %v", err)
+	}
+
+	got, _ := svc.GetByUID(ctx, master.UID)
+	// All-day master must store the EXDATE as a date-only value so iCal export
+	// emits EXDATE;VALUE=DATE matching DTSTART;VALUE=DATE (RFC 5545 §3.8.5.1).
+	if got.ExDates != "2026-04-08" {
+		t.Errorf("stored exdates = %q, want \"2026-04-08\" (date-only)", got.ExDates)
+	}
+}
+
+func TestDelete_AllDayOverrideRFC3339RecIDStoresDateOnlyEXDATE(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "allday-ovr", CalendarID: 1, Title: "Daily Standup",
+		StartTime:      time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+		AllDay:         true,
+		RecurrenceRule: "FREQ=DAILY",
+	})
+	// Override stored with a full RFC 3339 recurrence_id, as sync/import produce.
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "allday-ovr", CalendarID: 1, Title: "Standup (cancelled)",
+		StartTime:    time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 9, 0, 0, 0, 0, time.UTC),
+		AllDay:       true,
+		RecurrenceID: "2026-04-08T00:00:00Z",
+	})
+
+	override, _ := svc.GetByUIDAndRecurrenceID(ctx, "allday-ovr", "2026-04-08T00:00:00Z")
+	if err := svc.Delete(ctx, override.ID); err != nil {
+		t.Fatalf("Delete all-day override: %v", err)
+	}
+
+	master, _ := svc.GetByUID(ctx, "allday-ovr")
+	if master.ExDates != "2026-04-08" {
+		t.Errorf("stored exdates = %q, want \"2026-04-08\" (date-only)", master.ExDates)
+	}
+}
+
 func TestDeleteSeries_CascadesAll(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -15,6 +15,16 @@ import (
 // UTC, which must round-trip as a full RFC 3339 DATE-TIME.
 var dateOnlyLoc = time.FixedZone("DATE", 0)
 
+// AsDateOnly returns t's calendar date re-tagged with the all-day marker
+// location (dateOnlyLoc), so SerializeTimeList emits it as a date-only
+// "YYYY-MM-DD" value — i.e. an iCal VALUE=DATE matching DTSTART;VALUE=DATE for
+// all-day events (RFC 5545 §3.8.5.1). It uses t's UTC calendar day, matching
+// how all-day occurrences are stored (midnight UTC).
+func AsDateOnly(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, dateOnlyLoc)
+}
+
 // StorageTimeFormat is the canonical layout for UTC timestamps written to the
 // database (e.g. deleted_at cutoffs). It is RFC 3339 without the explicit
 // numeric offset, since all stored times are UTC.


### PR DESCRIPTION
Closes #221

## Problem
When excluding an all-day recurring occurrence, the EXDATE was appended as a UTC-located `time.Time` (`instanceTime.UTC()` in `DeleteInstance`; `ParseRecurrenceID`'s RFC-3339 result in `Delete`'s override branch), which lacks the date-only marker location. `SerializeTimeList` therefore wrote a full DATE-TIME EXDATE, producing `EXDATE;VALUE=DATE-TIME` paired with `DTSTART;VALUE=DATE` on export — a value-type mismatch (RFC 5545 §3.8.5.1) that strict CalDAV servers (Google, etc.) drop, resurrecting the deleted occurrence after sync round-trip.

## Fix
`DeleteInstance` and `Delete`'s override branch now re-tag the EXDATE as date-only when the master is all-day, via a new `timeutil.AsDateOnly(t)` helper (re-tags a time's UTC calendar day with the date-only marker location). Override recurrence_ids stay RFC 3339 for lookup/provenance; only the master EXDATE serialization changed.

## Test
`TestDeleteInstance_AllDayStoresDateOnlyEXDATE` and `TestDelete_AllDayOverrideRFC3339RecIDStoresDateOnlyEXDATE` — fail before (stored `"2026-04-08T00:00:00Z"`, want `"2026-04-08"`), pass after. The pre-existing test only exercised a date-only RecurrenceID, which masked the real-world RFC-3339 path.

## Notes
The todo service has a structurally identical override-delete path, but `todos` has no `AllDay` column, so there's no parallel bug.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8