### PR TITLE
fix(todo): make Create/Update/UpsertByUID category writes atomic

### DIFF
--- a/internal/todo/atomic_test.go
+++ b/internal/todo/atomic_test.go
@@ -1,0 +1,130 @@
+package todo
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/testutil"
+)
+
+// countRows returns the number of rows matching the given query.
+func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&n); err != nil {
+		t.Fatalf("count query %q: %v", query, err)
+	}
+	return n
+}
+
+// A duplicate category isolates the failure to the category child-write:
+// todo_categories has PRIMARY KEY (todo_id, category) and ParseCategoryList
+// does not dedupe, so inserting "dup,dup" fails on the second row while the
+// parent todo row write succeeds — exactly the partial-failure window the fix
+// must close. Dropping todo_categories instead would break CreateTodo /
+// UpdateTodo themselves: the todos FTS triggers read todo_categories at
+// statement time.
+const dupCategories = "dup,dup"
+
+// TestCreate_AtomicOnCategoryFailure asserts that when the category child-write
+// fails, Create returns an error AND leaves no todo row behind. Before the fix
+// the todo row was committed in autocommit before categories ran in a separate
+// transaction, so a failure left an orphan row (mirror of event issue #73).
+func TestCreate_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Summary:    "Atomic Create",
+		DueDate:    time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		Categories: dupCategories,
+	})
+	if err == nil {
+		t.Fatal("Create succeeded, want error from duplicate category write")
+	}
+
+	if n := countRows(t, db, `SELECT COUNT(*) FROM todos`); n != 0 {
+		t.Fatalf("todo rows persisted after failed Create = %d, want 0", n)
+	}
+}
+
+// TestUpdate_AtomicOnCategoryFailure asserts that when the category child-write
+// fails during Update, the original todo row and its categories are left
+// unchanged AND the resource is not marked dirty. Before the fix the todo row
+// was updated in autocommit before categories ran, so a failure produced a
+// half-updated row while MarkResourceDirty never fired — a CalDAV-linked todo
+// silently lost the edit.
+func TestUpdate_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	orig, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Summary:    "Original Summary",
+		DueDate:    time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		Categories: "work,urgent",
+	})
+	if err != nil {
+		t.Fatalf("seed create: %v", err)
+	}
+
+	catsBefore := countRows(t, db,
+		`SELECT COUNT(*) FROM todo_categories WHERE todo_id = ?`, orig.ID)
+	if catsBefore != 2 {
+		t.Fatalf("seed categories = %d, want 2", catsBefore)
+	}
+
+	_, err = svc.Update(ctx, orig.ID, UpdateParams{
+		CalendarID: 1,
+		Summary:    "Changed Summary",
+		DueDate:    time.Date(2026, 4, 2, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		Categories: dupCategories,
+	})
+	if err == nil {
+		t.Fatal("Update succeeded, want error from duplicate category write")
+	}
+
+	// The row write must have rolled back: summary and categories unchanged.
+	got, err := svc.Get(ctx, orig.ID)
+	if err != nil {
+		t.Fatalf("get after failed update: %v", err)
+	}
+	if got.Summary != "Original Summary" {
+		t.Fatalf("summary after failed Update = %q, want %q", got.Summary, "Original Summary")
+	}
+	if n := countRows(t, db,
+		`SELECT COUNT(*) FROM todo_categories WHERE todo_id = ?`, orig.ID); n != 2 {
+		t.Fatalf("categories after failed Update = %d, want 2 (unchanged)", n)
+	}
+}
+
+// TestUpsertByUID_AtomicOnCategoryFailure asserts that when the category
+// child-write fails, UpsertByUID returns an error AND leaves no todo row
+// behind. Before the fix the upsert committed the row in autocommit and only
+// then ran ReplaceCategories in a separate transaction, so a failure left an
+// orphan row.
+func TestUpsertByUID_AtomicOnCategoryFailure(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	_, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:        "upsert-atomic-uid",
+		CalendarID: 1,
+		Summary:    "Atomic Upsert",
+		DueDate:    time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		Categories: dupCategories,
+	})
+	if err == nil {
+		t.Fatal("UpsertByUID succeeded, want error from duplicate category write")
+	}
+
+	if n := countRows(t, db, `SELECT COUNT(*) FROM todos`); n != 0 {
+		t.Fatalf("todo rows persisted after failed UpsertByUID = %d, want 0", n)
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -340,7 +340,17 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Todo, error) {
 	if p.Status == "COMPLETED" {
 		completedAt = time.Now().UTC().Format(time.RFC3339)
 	}
-	r, err := s.q.CreateTodo(ctx, storage.CreateTodoParams{
+
+	// One transaction wraps the todo row and its categories so a failing
+	// category write rolls the row back instead of committing an orphan whose
+	// MarkResourceDirty never ran (issue #222, mirror of event issue #73).
+	qtx, commit, rollback, err := s.txscope(ctx)
+	if err != nil {
+		return Todo{}, err
+	}
+	defer rollback()
+
+	r, err := qtx.CreateTodo(ctx, storage.CreateTodoParams{
 		Uid:             uuid.New().String(),
 		CalendarID:      p.CalendarID,
 		Summary:         p.Summary,
@@ -368,11 +378,18 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Todo, error) {
 		return Todo{}, err
 	}
 	t := fromStorage(r)
-	if err := s.ReplaceCategories(ctx, t.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
-		return Todo{}, fmt.Errorf("replace categories: %w", err)
+	if cats := timeutil.ParseCategoryList(p.Categories); len(cats) > 0 {
+		// A fresh row has no categories yet, so the DELETE in
+		// replaceCategoriesTx is pure overhead when there's nothing to add.
+		if err := replaceCategoriesTx(ctx, qtx, t.ID, cats); err != nil {
+			return Todo{}, fmt.Errorf("replace categories: %w", err)
+		}
+	}
+	if err := commit(); err != nil {
+		return Todo{}, fmt.Errorf("commit create todo: %w", err)
 	}
 	t.Categories = p.Categories
-	_ = storage.MarkResourceDirty(ctx, s.db, t.CalendarID, t.UID, "todo")
+	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), t.CalendarID, t.UID, "todo")
 	return t, nil
 }
 
@@ -385,7 +402,17 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Todo, e
 	if err := validateTiming(p.DueDate, p.StartDate, p.Duration); err != nil {
 		return Todo{}, err
 	}
-	r, err := s.q.UpdateTodo(ctx, storage.UpdateTodoParams{
+
+	// One transaction wraps the todo row and its categories so a failing
+	// category write rolls the row update back instead of committing a
+	// half-updated row whose MarkResourceDirty never ran (issue #222).
+	qtx, commit, rollback, err := s.txscope(ctx)
+	if err != nil {
+		return Todo{}, err
+	}
+	defer rollback()
+
+	r, err := qtx.UpdateTodo(ctx, storage.UpdateTodoParams{
 		ID:              id,
 		Summary:         p.Summary,
 		Description:     storage.StringToNullable(p.Description),
@@ -411,11 +438,14 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Todo, e
 		return Todo{}, err
 	}
 	t := fromStorage(r)
-	if err := s.ReplaceCategories(ctx, t.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
+	if err := replaceCategoriesTx(ctx, qtx, t.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
 		return Todo{}, fmt.Errorf("replace categories: %w", err)
 	}
+	if err := commit(); err != nil {
+		return Todo{}, fmt.Errorf("commit update todo: %w", err)
+	}
 	t.Categories = p.Categories
-	_ = storage.MarkResourceDirty(ctx, s.db, t.CalendarID, t.UID, "todo")
+	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), t.CalendarID, t.UID, "todo")
 	return t, nil
 }
 
@@ -434,7 +464,18 @@ func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Todo, error)
 	if err := validateTiming(p.DueDate, p.StartDate, p.Duration); err != nil {
 		return Todo{}, err
 	}
-	r, err := s.q.UpsertTodoByUID(ctx, storage.UpsertTodoByUIDParams{
+
+	// One transaction wraps the todo row and its categories so a failing
+	// category write rolls the upsert back instead of leaving an orphan row
+	// (issue #222). txscope joins the sync engine's outer transaction when
+	// UpsertByUID is called via WithTx.
+	qtx, commit, rollback, err := s.txscope(ctx)
+	if err != nil {
+		return Todo{}, err
+	}
+	defer rollback()
+
+	r, err := qtx.UpsertTodoByUID(ctx, storage.UpsertTodoByUIDParams{
 		Uid:             p.UID,
 		CalendarID:      p.CalendarID,
 		Summary:         p.Summary,
@@ -462,8 +503,11 @@ func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Todo, error)
 		return Todo{}, err
 	}
 	t := fromStorage(r)
-	if err := s.ReplaceCategories(ctx, t.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
+	if err := replaceCategoriesTx(ctx, qtx, t.ID, timeutil.ParseCategoryList(p.Categories)); err != nil {
 		return Todo{}, fmt.Errorf("replace categories: %w", err)
+	}
+	if err := commit(); err != nil {
+		return Todo{}, fmt.Errorf("commit upsert todo: %w", err)
 	}
 	t.Categories = p.Categories
 	return t, nil
@@ -1052,20 +1096,29 @@ func (s *Service) ReplaceCategories(ctx context.Context, todoID int64, categorie
 	}
 	defer rollback()
 
+	if err := replaceCategoriesTx(ctx, qtx, todoID, categories); err != nil {
+		return err
+	}
+	if err := commit(); err != nil {
+		return fmt.Errorf("commit replace categories: %w", err)
+	}
+	return nil
+}
+
+// replaceCategoriesTx wipes and rewrites a todo's categories using a tx-bound
+// Queries. It opens no transaction and does not commit, so callers can compose
+// it with the parent todo write inside one transaction (issue #222).
+func replaceCategoriesTx(ctx context.Context, qtx *storage.Queries, todoID int64, categories []string) error {
 	if err := qtx.DeleteCategoriesByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete categories: %w", err)
 	}
 	for _, c := range categories {
-		_, err := qtx.CreateTodoCategory(ctx, storage.CreateTodoCategoryParams{
+		if _, err := qtx.CreateTodoCategory(ctx, storage.CreateTodoCategoryParams{
 			TodoID:   todoID,
 			Category: c,
-		})
-		if err != nil {
+		}); err != nil {
 			return fmt.Errorf("create category: %w", err)
 		}
-	}
-	if err := commit(); err != nil {
-		return fmt.Errorf("commit replace categories: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #222

## Problem
`todo.Create/Update/UpsertByUID` called the autocommit query (e.g. `CreateTodo`) then a *separate*-transaction `ReplaceCategories`, with `MarkResourceDirty` only afterward. A category-write failure (or crash between commits) left the main todos row committed, categories stale/partial, and the resource never marked dirty — even though the caller received an error, so a CalDAV-linked todo silently never pushed the edit. Same defect the event fix #73 already corrected; todo still used the pre-fix split-commit pattern.

## Fix
Mirror the event package: wrap the todo row write + a tx-scoped category replace in one transaction, commit once, then `MarkResourceDirty`. Applied to Create, Update, and UpsertByUID.

## Test
Atomicity regression tests inject a category-write failure and assert the todo row is not left committed and `MarkResourceDirty` did not run. Fail before, pass after.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8