### PR TITLE
fix(trash): populate Entry.Categories so the trash detail Tags row renders

### DIFF
--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -80,9 +80,14 @@ func (s *Service) ListTrash(ctx context.Context, calendarID int64) ([]TrashEntry
 		return nil, fmt.Errorf("list truncate deletes: %w", err)
 	}
 
+	deletedEvents := make([]Event, len(evts))
+	for i, r := range evts {
+		deletedEvents[i] = fromStorage(r)
+	}
+	s.populateCategories(ctx, deletedEvents)
+
 	entries := make([]TrashEntry, 0, len(evts)+len(instLogs)+len(truncLogs))
-	for _, r := range evts {
-		ev := fromStorage(r)
+	for _, ev := range deletedEvents {
 		deletedAt := time.Time{}
 		if ev.DeletedAt != nil {
 			deletedAt = *ev.DeletedAt
@@ -107,19 +112,26 @@ func (s *Service) ListTrash(ctx context.Context, calendarID int64) ([]TrashEntry
 	// For log rows, look up the master (including soft-deleted) once per
 	// UID so the trash dialog can render full context — title, location,
 	// description, status — without the user having to open a second view.
+	// Fetch each distinct master once, then batch category population into a
+	// single query rather than one per master.
 	masters := make(map[string]*Event, len(instLogs)+len(truncLogs))
-	lookupMaster := func(uid string) *Event {
-		if m, ok := masters[uid]; ok {
-			return m
-		}
-		if r, err := s.q.GetEventByUIDIncludingDeleted(ctx, uid); err == nil {
-			ev := fromStorage(r)
-			masters[uid] = &ev
-			return &ev
-		}
-		masters[uid] = nil
-		return nil
+	for _, l := range instLogs {
+		masters[l.Uid] = nil
 	}
+	for _, l := range truncLogs {
+		masters[l.Uid] = nil
+	}
+	masterList := make([]Event, 0, len(masters))
+	for uid := range masters {
+		if r, err := s.q.GetEventByUIDIncludingDeleted(ctx, uid); err == nil {
+			masterList = append(masterList, fromStorage(r))
+		}
+	}
+	s.populateCategories(ctx, masterList)
+	for i := range masterList {
+		masters[masterList[i].UID] = &masterList[i]
+	}
+	lookupMaster := func(uid string) *Event { return masters[uid] }
 
 	for _, l := range instLogs {
 		inst, _ := time.Parse(time.RFC3339, l.RecurrenceID)

--- a/internal/journal/soft_delete.go
+++ b/internal/journal/soft_delete.go
@@ -184,7 +184,9 @@ func (s *Service) ListDeleted(ctx context.Context, calendarID int64) ([]Journal,
 	if err != nil {
 		return nil, err
 	}
-	return fromStorageSlice(rows), nil
+	journals := fromStorageSlice(rows)
+	s.populateCategories(ctx, journals)
+	return journals, nil
 }
 
 // GetIncludingDeleted returns a journal by ID even if it has been soft-

--- a/internal/todo/soft_delete.go
+++ b/internal/todo/soft_delete.go
@@ -190,7 +190,9 @@ func (s *Service) ListDeleted(ctx context.Context, calendarID int64) ([]Todo, er
 	if err != nil {
 		return nil, err
 	}
-	return fromStorageSlice(rows), nil
+	todos := fromStorageSlice(rows)
+	s.populateCategories(ctx, todos)
+	return todos, nil
 }
 
 // GetIncludingDeleted returns a todo by ID even if it has been soft-

--- a/internal/trash/trash.go
+++ b/internal/trash/trash.go
@@ -364,6 +364,7 @@ func fromJournal(j journal.Journal) Entry {
 		StartTime:   startDate,
 		Description: j.Description,
 		Status:      j.Status,
+		Categories:  j.Categories,
 	}
 }
 

--- a/internal/trash/trash_test.go
+++ b/internal/trash/trash_test.go
@@ -171,3 +171,71 @@ func TestService_PurgeDispatchesByKind(t *testing.T) {
 		t.Fatalf("entries after purge = %d, want 0", len(entries))
 	}
 }
+
+// TestService_ListPopulatesCategories soft-deletes an event, todo, and
+// journal that each carry categories, then verifies List surfaces those
+// categories on the unified Entry. Without category population the trash
+// detail "Tags" row renders blank (issue #224).
+func TestService_ListPopulatesCategories(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	events := event.NewService(db, q)
+	todos := todo.NewService(db, q)
+	journals := journal.NewService(db, q)
+	svc := NewService(events, todos, journals)
+	ctx := context.Background()
+
+	ev, err := events.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Cat Event",
+		StartTime:  time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 5, 1, 11, 0, 0, 0, time.UTC),
+		Categories: "work,urgent",
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	td, err := todos.Create(ctx, todo.CreateParams{CalendarID: 1, Summary: "Cat Todo"})
+	if err != nil {
+		t.Fatalf("create todo: %v", err)
+	}
+	if err := todos.ReplaceCategories(ctx, td.ID, []string{"home", "chores"}); err != nil {
+		t.Fatalf("todo categories: %v", err)
+	}
+	j, err := journals.Create(ctx, journal.CreateParams{CalendarID: 1, Summary: "Cat Journal", StartDate: "2026-05-03"})
+	if err != nil {
+		t.Fatalf("create journal: %v", err)
+	}
+	if err := journals.ReplaceCategories(ctx, j.ID, []string{"notes", "personal"}); err != nil {
+		t.Fatalf("journal categories: %v", err)
+	}
+
+	if err := events.Delete(ctx, ev.ID); err != nil {
+		t.Fatalf("delete event: %v", err)
+	}
+	if err := todos.Delete(ctx, td.ID); err != nil {
+		t.Fatalf("delete todo: %v", err)
+	}
+	if err := journals.Delete(ctx, j.ID); err != nil {
+		t.Fatalf("delete journal: %v", err)
+	}
+
+	entries, err := svc.List(ctx, 1)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Categories come back normalized (sorted) by JoinCategoryList.
+	want := map[Kind]string{
+		KindEvent:   "urgent,work",
+		KindTodo:    "chores,home",
+		KindJournal: "notes,personal",
+	}
+	got := make(map[Kind]string, len(entries))
+	for _, e := range entries {
+		got[e.Kind] = e.Categories
+	}
+	for kind, wantCats := range want {
+		if got[kind] != wantCats {
+			t.Errorf("%s Categories = %q, want %q", kind.Label(), got[kind], wantCats)
+		}
+	}
+}


### PR DESCRIPTION
Closes #224

## Problem
The trash list paths returned soft-deleted events/todos/journals without their categories, so the unified trash `Entry` always had an empty `Categories` field and the detail "Tags" row rendered blank.

## Fix
Wire `populateCategories` into the soft-deleted read paths (`event/trash.go`, `todo`/`journal` `soft_delete.go`) and carry the journal's categories through the trash mapping. For the recurrence log rows in `event/trash.go`, distinct masters are fetched once and their categories populated in a single batched query rather than one per master.

## Test
`TestService_ListPopulatesCategories` soft-deletes an event, todo, and journal each carrying categories, then asserts `List` surfaces the (normalized/sorted) categories on the unified `Entry`. Fails before, passes after.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8