### PR TITLE
fix(sync): serialize per-calendar push to avoid duplicate server objects

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	gosync "sync"
 	"time"
 
 	"github.com/emersion/go-ical"
@@ -53,6 +54,46 @@ type Engine struct {
 	todos     *todo.Service
 	journals  *journal.Service
 	logger    *slog.Logger
+}
+
+// pushLockKey identifies a per-calendar push lock. It is keyed by the shared
+// database handle (not the Engine) because each sync operation builds a fresh
+// Engine over the app's shared *sql.DB — the TUI's save-time PushCalendar and a
+// periodic SyncCalendar run on different Engine instances but the same DB (see
+// internal/tui/app.go newSyncService). An Engine-scoped lock would not
+// serialize them; a registry keyed by (db, calendar) does. The db pointer keeps
+// independent databases (e.g. parallel tests) from sharing a lock.
+type pushLockKey struct {
+	db         *sql.DB
+	calendarID int64
+}
+
+var (
+	pushLocksMu gosync.Mutex
+	pushLocks   = map[pushLockKey]*gosync.Mutex{}
+)
+
+// pushLock returns the per-calendar mutex that serializes the push phase for
+// calendarID, creating it on first use. Concurrent push runs for the same
+// calendar — e.g. an opportunistic save-time PushCalendar racing a periodic
+// SyncCalendar — must not both read the same dirty, never-pushed sync_resource
+// (RemoteUrl=""): each would mint a distinct random href and PUT it without an
+// If-Match precondition, so the server would end up with two objects for one
+// UID. CalDAV servers key dedup on href, not UID, so an If-None-Match:* guard
+// would not catch this (the two hrefs differ). Serializing the phase lets the
+// first run record the remote_url and clear the dirty flag before the second
+// reads it. This guards only same-process concurrency; two CLI processes
+// pushing the same calendar at once can still race. See issue #225.
+func (e *Engine) pushLock(calendarID int64) *gosync.Mutex {
+	key := pushLockKey{db: e.db, calendarID: calendarID}
+	pushLocksMu.Lock()
+	defer pushLocksMu.Unlock()
+	lock, ok := pushLocks[key]
+	if !ok {
+		lock = &gosync.Mutex{}
+		pushLocks[key] = lock
+	}
+	return lock
 }
 
 var syncRetryOptions = caldav.RetryOptions{
@@ -217,8 +258,10 @@ func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy Co
 // local mutations are flushed upstream without pulling or rewriting
 // calendar metadata. Dirty resources that fail to push stay dirty, so the
 // next full SyncCalendar will retry them. Safe to call concurrently with
-// a full sync — both funnel through the same dirty/tombstone rows, and
-// the server arbitrates via ETag preconditions.
+// a full sync: the push phase holds a per-calendar lock (see pushLock), so
+// two runs cannot both create a server object for the same never-pushed,
+// etag-less resource. Existing resources are still arbitrated by the server
+// via ETag preconditions.
 func (e *Engine) PushCalendar(ctx context.Context, calendarID int64, strategy ConflictStrategy) (*SyncResult, error) {
 	_, client, remoteURL, err := e.loadCalendarClient(ctx, calendarID)
 	if err != nil {
@@ -278,6 +321,13 @@ type pushResult struct {
 }
 
 func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int64, remoteURL string, strategy ConflictStrategy) (*pushResult, error) {
+	// Serialize the push phase per calendar so a concurrent run cannot read the
+	// same dirty row and create a duplicate server object. See pushLock and
+	// issue #225.
+	lock := e.pushLock(calendarID)
+	lock.Lock()
+	defer lock.Unlock()
+
 	dirty, err := e.q.ListDirtySyncResources(ctx, calendarID)
 	if err != nil {
 		return nil, fmt.Errorf("list dirty: %w", err)

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	gosync "sync"
 	"testing"
 	"time"
 
@@ -733,6 +734,92 @@ END:VCALENDAR
 	}
 	if tok := storage.NullableToString(calRow.SyncToken); tok != "" {
 		t.Fatalf("sync_token = %q, want empty (held back due to multiget miss)", tok)
+	}
+}
+
+// TestEnginePushSerializesConcurrentNewResourceCreate is the regression test
+// for issue #225: two concurrent push runs for the same calendar (e.g. an
+// opportunistic save-time PushCalendar racing a periodic SyncCalendar) must not
+// both create a server object for the same never-pushed, etag-less resource.
+// Before the per-calendar push lock, each run read the same dirty
+// sync_resource (RemoteUrl=""), minted a distinct random href, and PUT it with
+// no If-Match precondition, leaving the server with two objects for one UID.
+//
+// The two runs use distinct Engine instances over a shared DB, mirroring the
+// TUI, which builds a fresh sync.Service per operation (see newSyncService) —
+// an Engine-scoped lock would not catch this; the lock registry is keyed by DB.
+func TestEnginePushSerializesConcurrentNewResourceCreate(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	// A plain :memory: database hands each pooled connection its own private
+	// DB; pin the pool to one connection so both goroutines share state.
+	db.SetMaxOpenConns(1)
+	ctx := context.Background()
+
+	// A second Engine over the same DB, standing in for the separate
+	// sync.Service the TUI spins up for the racing operation.
+	engine2 := NewEngine(db, q, &mockCredStore{creds: make(map[int64]auth.Credential)},
+		calendar.NewService(db, q), event.NewService(db, q),
+		todo.NewService(db, q), journal.NewService(db, q), nil)
+	engines := [2]*Engine{engine, engine2}
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	insertTestEvent(t, db, calendarID, "new-resource")
+
+	// A brand-new dirty resource: never pushed (RemoteUrl="") and no ETag.
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "new-resource",
+		OwnerType:    "event",
+		RemoteUrl:    "",
+		Etag:         "",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource new-resource: %v", err)
+	}
+
+	var mu gosync.Mutex
+	creates := 0
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodPut {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			return newResponse(http.StatusInternalServerError, nil), nil
+		}
+		if got := r.Header.Get("If-Match"); got != "" {
+			t.Errorf("If-Match = %q, want empty for a first-time create", got)
+		}
+		mu.Lock()
+		creates++
+		mu.Unlock()
+		// Widen the race window so an unserialized second run reads the dirty
+		// row before this run clears it.
+		time.Sleep(50 * time.Millisecond)
+		return newResponse(http.StatusCreated, map[string]string{"ETag": `"etag-new"`}), nil
+	})
+
+	var wg gosync.WaitGroup
+	for i := range engines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := engines[i].push(ctx, client, calendarID, "/calendar/", ConflictServerWins); err != nil {
+				t.Errorf("push: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if creates != 1 {
+		t.Fatalf("server create PUTs = %d, want 1 (concurrent pushes created duplicate objects)", creates)
 	}
 }
 


### PR DESCRIPTION
Closes #225

## Problem
Two concurrent push runs for the same calendar (an opportunistic save-time `PushCalendar` racing a periodic `SyncCalendar`, on distinct `Engine` instances over the shared `*sql.DB`) could both read the same dirty, never-pushed `sync_resource` (`RemoteUrl=""`), each mint a distinct random href, and `PUT` it with no `If-Match` precondition — leaving the server with two objects for one UID. CalDAV dedup is keyed on href, not UID, so an `If-None-Match: *` guard would not catch it (the two hrefs differ).

## Fix
Add a process-wide per-`(db, calendarID)` push lock (a registry keyed by the shared DB handle, since each operation builds a fresh `Engine` — an Engine-scoped lock wouldn't serialize them). The push phase takes the lock so the first run records `remote_url` and clears the dirty flag before the second reads it. Existing resources remain arbitrated by ETag preconditions. This guards same-process concurrency; two separate CLI processes can still race (documented).

## Test
`TestEnginePushSerializesConcurrentNewResourceCreate` runs two `Engine` instances over a shared (pool-pinned `:memory:`) DB pushing the same never-pushed etag-less resource concurrently, widening the race window in the mock transport, and asserts exactly one create `PUT` occurs (and that `If-Match` is empty for the first-time create). Fails before, passes after.

`go build ./...` and full `go test ./...` are green.

Assisted-by: Claude:claude-opus-4-8