### PR TITLE
fix(recurrence): share event.FromStorage mapper so instances keep ConferenceURI

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -258,7 +258,7 @@ func (s *Service) Get(ctx context.Context, id int64) (Event, error) {
 	if err != nil {
 		return Event{}, err
 	}
-	e := fromStorage(r)
+	e := FromStorage(r)
 	s.populateSingleCategories(ctx, &e)
 	return e, nil
 }
@@ -268,7 +268,7 @@ func (s *Service) GetByUID(ctx context.Context, uid string) (Event, error) {
 	if err != nil {
 		return Event{}, err
 	}
-	e := fromStorage(r)
+	e := FromStorage(r)
 	s.populateSingleCategories(ctx, &e)
 	return e, nil
 }
@@ -281,7 +281,7 @@ func (s *Service) GetByUIDAndRecurrenceID(ctx context.Context, uid, recurrenceID
 	if err != nil {
 		return Event{}, err
 	}
-	e := fromStorage(r)
+	e := FromStorage(r)
 	s.populateSingleCategories(ctx, &e)
 	return e, nil
 }
@@ -333,7 +333,7 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Event, error) {
 	if err != nil {
 		return Event{}, err
 	}
-	e := fromStorage(r)
+	e := FromStorage(r)
 	if cats := ParseCategoryList(p.Categories); len(cats) > 0 {
 		if err := replaceCategoriesTx(ctx, qtx, e.ID, cats); err != nil {
 			return Event{}, fmt.Errorf("replace categories: %w", err)
@@ -433,7 +433,7 @@ func updateEventTx(ctx context.Context, qtx *storage.Queries, id int64, p Update
 	if err != nil {
 		return Event{}, err
 	}
-	e := fromStorage(r)
+	e := FromStorage(r)
 	if err := replaceCategoriesTx(ctx, qtx, e.ID, ParseCategoryList(p.Categories)); err != nil {
 		return Event{}, fmt.Errorf("replace categories: %w", err)
 	}
@@ -478,7 +478,7 @@ func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Event, error
 	if err != nil {
 		return Event{}, err
 	}
-	e := fromStorage(r)
+	e := FromStorage(r)
 	if err := replaceCategoriesTx(ctx, qtx, e.ID, ParseCategoryList(p.Categories)); err != nil {
 		return Event{}, fmt.Errorf("replace categories: %w", err)
 	}
@@ -498,7 +498,7 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 	if err != nil {
 		return err
 	}
-	evt := fromStorage(r)
+	evt := FromStorage(r)
 
 	// If this is a recurring master, check for overrides.
 	if evt.RecurrenceRule != "" && evt.RecurrenceID == "" {
@@ -828,7 +828,7 @@ func updateInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, ins
 		return Event{}, 0, err
 	}
 
-	e := fromStorage(r)
+	e := FromStorage(r)
 	e.Categories = timeutil.JoinCategoryList(carriedCats)
 	return e, master.CalendarID, nil
 }
@@ -1046,7 +1046,7 @@ func updateFromInstanceTx(ctx context.Context, qtx *storage.Queries, uid string,
 		return Event{}, 0, err
 	}
 
-	e := fromStorage(r)
+	e := FromStorage(r)
 	e.Categories = timeutil.JoinCategoryList(carriedCats)
 	return e, master.CalendarID, nil
 }
@@ -1760,7 +1760,10 @@ func (s *Service) ReplaceRelations(ctx context.Context, eventID int64, relations
 
 // Converters
 
-func fromStorage(r storage.Event) Event {
+// FromStorage maps a storage.Event row to a domain Event. It is exported so
+// recurrence expansion shares one mapper with the event service, preventing the
+// two from drifting (every new storage.Event column lands here once).
+func FromStorage(r storage.Event) Event {
 	var deletedAt *time.Time
 	if r.DeletedAt != nil && *r.DeletedAt != "" {
 		t := timeutil.ParseDateTime(*r.DeletedAt)
@@ -1800,7 +1803,7 @@ func fromStorage(r storage.Event) Event {
 func fromStorageSlice(rows []storage.Event) []Event {
 	events := make([]Event, len(rows))
 	for i, r := range rows {
-		events[i] = fromStorage(r)
+		events[i] = FromStorage(r)
 	}
 	return events
 }

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -60,7 +60,7 @@ func (s *Service) DeleteWithUndo(ctx context.Context, id int64) (UndoMeta, error
 	if err != nil {
 		return UndoMeta{}, err
 	}
-	evt := fromStorage(r)
+	evt := FromStorage(r)
 	if err := s.Delete(ctx, id); err != nil {
 		return UndoMeta{}, err
 	}
@@ -221,7 +221,7 @@ func (s *Service) GetIncludingDeleted(ctx context.Context, id int64) (Event, err
 	if err != nil {
 		return Event{}, err
 	}
-	return fromStorage(r), nil
+	return FromStorage(r), nil
 }
 
 // PurgeDeleted hard-deletes rows soft-deleted before olderThan. Returns the

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -82,7 +82,7 @@ func (s *Service) ListTrash(ctx context.Context, calendarID int64) ([]TrashEntry
 
 	entries := make([]TrashEntry, 0, len(evts)+len(instLogs)+len(truncLogs))
 	for _, r := range evts {
-		ev := fromStorage(r)
+		ev := FromStorage(r)
 		deletedAt := time.Time{}
 		if ev.DeletedAt != nil {
 			deletedAt = *ev.DeletedAt
@@ -113,7 +113,7 @@ func (s *Service) ListTrash(ctx context.Context, calendarID int64) ([]TrashEntry
 			return m
 		}
 		if r, err := s.q.GetEventByUIDIncludingDeleted(ctx, uid); err == nil {
-			ev := fromStorage(r)
+			ev := FromStorage(r)
 			masters[uid] = &ev
 			return &ev
 		}

--- a/internal/recurrence/integration_test.go
+++ b/internal/recurrence/integration_test.go
@@ -1357,3 +1357,41 @@ func TestListExpandedByDateRange_OverrideEmptyEndTime(t *testing.T) {
 		t.Errorf("Apr 13 title = %q, want %q", found.Title, "Weekly Sync (overridden)")
 	}
 }
+
+// TestExpandedInstancesCarryConferenceURI guards against the recurrence mapper
+// drifting from event.FromStorage: a recurring event with a ConferenceURI must
+// keep that URI on every expanded instance (regression test for #256).
+func TestExpandedInstancesCarryConferenceURI(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	eventsSvc := event.NewService(db, q)
+	recurSvc := NewService(db, q)
+	ctx := context.Background()
+
+	const confURI = "https://meet.example.com/weekly-room"
+	_, err := eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID:     1,
+		Title:          "Weekly Sync",
+		StartTime:      time.Date(2026, 4, 6, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=MO;COUNT=3",
+		ConferenceURI:  confURI,
+	})
+	if err != nil {
+		t.Fatalf("create recurring: %v", err)
+	}
+
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	events, err := recurSvc.ListExpandedByDateRange(ctx, from, to)
+	if err != nil {
+		t.Fatalf("ListExpandedByDateRange: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	for i := range events {
+		if events[i].ConferenceURI != confURI {
+			t.Errorf("events[%d].ConferenceURI = %q, want %q", i, events[i].ConferenceURI, confURI)
+		}
+	}
+}

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -325,7 +325,7 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 		if row.RecurrenceID != "" {
 			continue
 		}
-		evt := eventFromRow(row)
+		evt := event.FromStorage(row)
 		results = append(results, ExpandedEvent{
 			Event:        evt,
 			InstanceTime: evt.StartTime,
@@ -333,7 +333,7 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 	}
 
 	for _, row := range recurRows {
-		evt := eventFromRow(row)
+		evt := event.FromStorage(row)
 		expanded := ExpandEvent(evt, from, to)
 
 		// Fetch overrides for this master.
@@ -359,7 +359,7 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 			if strings.EqualFold(o.Status, "CANCELLED") {
 				continue
 			}
-			oe := eventFromRow(o)
+			oe := event.FromStorage(o)
 			if !overlapsWindow(oe.StartTime, oe.EndTime, from, to) {
 				continue
 			}
@@ -452,43 +452,13 @@ func attendeeFromStorage(r storage.EventAttendee) model.Attendee {
 	}
 }
 
-func eventFromRow(row storage.Event) event.Event {
-	return event.Event{
-		ID:             row.ID,
-		UID:            row.Uid,
-		CalendarID:     row.CalendarID,
-		Title:          row.Title,
-		Description:    storage.NullableToString(row.Description),
-		Location:       storage.NullableToString(row.Location),
-		StartTime:      timeutil.ParseDateTime(row.StartTime),
-		EndTime:        timeutil.ParseDateTime(row.EndTime),
-		AllDay:         row.AllDay != 0,
-		RecurrenceRule: storage.NullableToString(row.RecurrenceRule),
-		Timezone:       storage.NullableToString(row.Timezone),
-		Status:         row.Status,
-		Transp:         row.Transp,
-		Sequence:       row.Sequence,
-		Priority:       row.Priority,
-		Class:          row.Class,
-		URL:            storage.NullableToString(row.Url),
-		ExDates:        storage.NullableToString(row.Exdates),
-		RDates:         storage.NullableToString(row.Rdates),
-		RecurrenceID:   row.RecurrenceID,
-		Geo:            storage.NullableToString(row.Geo),
-		DurationValue:  storage.NullableToString(row.Duration),
-		DtStamp:        storage.NullableToString(row.Dtstamp),
-		CreatedAt:      timeutil.ParseDateTime(row.CreatedAt),
-		UpdatedAt:      timeutil.ParseDateTime(row.UpdatedAt),
-	}
-}
-
 // expandRecurringRows expands recurring event rows into Event instances with
 // StartTime/EndTime adjusted to each occurrence. For each master, overrides
 // (rows with a matching RECURRENCE-ID) replace the original RRULE instance.
 func (s *Service) expandRecurringRows(ctx context.Context, rows []storage.Event, from, to time.Time) []event.Event {
 	var result []event.Event
 	for _, row := range rows {
-		evt := eventFromRow(row)
+		evt := event.FromStorage(row)
 		expanded := ExpandEvent(evt, from, to)
 
 		// Fetch overrides for this master.
@@ -518,7 +488,7 @@ func (s *Service) expandRecurringRows(ctx context.Context, rows []storage.Event,
 			if strings.EqualFold(o.Status, "CANCELLED") {
 				continue // CANCELLED override suppresses the instance.
 			}
-			oe := eventFromRow(o)
+			oe := event.FromStorage(o)
 			if !overlapsWindow(oe.StartTime, oe.EndTime, from, to) {
 				continue
 			}
@@ -546,7 +516,7 @@ func (s *Service) ListExpandedByDateRange(ctx context.Context, from, to time.Tim
 	var result []event.Event
 	for _, row := range rangeRows {
 		if row.RecurrenceRule == nil && row.RecurrenceID == "" {
-			result = append(result, eventFromRow(row))
+			result = append(result, event.FromStorage(row))
 		}
 	}
 
@@ -602,7 +572,7 @@ func (s *Service) ExportExpandedByDateRange(ctx context.Context, p ExportFilterP
 	seen := make(map[int64]bool)
 	for _, row := range rangeRows {
 		if row.RecurrenceRule == nil {
-			result = append(result, eventFromRow(row))
+			result = append(result, event.FromStorage(row))
 			seen[row.ID] = true
 		}
 	}
@@ -619,7 +589,7 @@ func (s *Service) ExportExpandedByDateRange(ctx context.Context, p ExportFilterP
 		if seen[row.ID] {
 			continue
 		}
-		evt := eventFromRow(row)
+		evt := event.FromStorage(row)
 		// Export must emit a cancelled master (STATUS:CANCELLED is how a
 		// downstream client is told to drop the series), so the in-range probe
 		// ignores the cancelled-expansion guard — unlike display, which hides it.
@@ -878,7 +848,7 @@ func (s *Service) ListFilteredEvents(ctx context.Context, p EventListParams) ([]
 
 	var result []event.Event
 	for _, row := range rangeRows {
-		result = append(result, eventFromRow(row))
+		result = append(result, event.FromStorage(row))
 	}
 
 	recurringRows, err := s.q.ListRecurringEventsFiltered(ctx, storage.EventFilterParams{
@@ -894,7 +864,7 @@ func (s *Service) ListFilteredEvents(ctx context.Context, p EventListParams) ([]
 		result = append(result, s.expandRecurringRows(ctx, recurringRows, p.From, p.To)...)
 	} else {
 		for _, row := range recurringRows {
-			result = append(result, eventFromRow(row))
+			result = append(result, event.FromStorage(row))
 		}
 	}
 


### PR DESCRIPTION
## Problem

`recurrence.eventFromRow` (`internal/recurrence/service.go`) was a hand-maintained
copy of `event.fromStorage` that had **drifted**: it mapped fields only through
`UpdatedAt` and omitted `ConferenceURI` and `DeletedAt`.

Every expanded recurring instance flows through this mapper, so a recurring
event with a conference URL had it **silently blanked on every instance**,
while the same value survived on a single non-recurring event via
`event.fromStorage`. The root cause is structural: each new `storage.Event`
column had to be wired into two hand-maintained mappers or it vanished on
recurring instances.

## Fix

Unify the mapper rather than patch the missing fields. Export the event
package's single mapper as `event.FromStorage` and call it from the recurrence
expansion paths, deleting the duplicate `eventFromRow`. New `storage.Event`
columns now land in exactly one place, preventing future drift.

## Test

Added `TestExpandedInstancesCarryConferenceURI`: creates a weekly recurring
event with a `ConferenceURI`, expands it over a date range, and asserts every
instance carries the URI. Confirmed it fails before the fix and passes after.

`make test`, `go build ./...`, `go vet ./...`, and `gofmt -l` are all green.

Closes #256
