### PR TITLE
fix(auth): surface legacy credential delete failures on migration

### DIFF
--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -255,7 +255,13 @@ func (s *migratingCredentialStore) Delete(accountID int64) error {
 		return err
 	}
 	if s.legacy != nil {
-		_ = s.legacy.Delete(accountID)
+		// Surface a real legacy-delete failure: discarding it would
+		// report success while the credential survives in the legacy
+		// store. PlaintextFileStore.Delete already treats a missing
+		// file as success, so only genuine failures reach here.
+		if err := s.legacy.Delete(accountID); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -275,6 +275,52 @@ func TestNewCredentialStore_MigratesLegacyPlaintextCredentials(t *testing.T) {
 	}
 }
 
+func TestMigratingCredentialStore_DeleteSurfacesLegacyError(t *testing.T) {
+	dir := t.TempDir()
+	legacy := &PlaintextFileStore{dir: dir}
+
+	// Force the legacy delete to fail with a real (non not-found) error by
+	// planting a non-empty directory where Delete expects to remove a file.
+	// os.Remove on a non-empty directory returns ENOTEMPTY, which is not
+	// os.IsNotExist, so PlaintextFileStore.Delete surfaces a wrapped error.
+	credPath := legacy.path(42)
+	if err := os.MkdirAll(filepath.Join(credPath, "blocker"), 0o700); err != nil {
+		t.Fatalf("seed blocker dir: %v", err)
+	}
+
+	backing := map[string]string{}
+	overrideKeyringForTest(t, true, backing)
+
+	store := &migratingCredentialStore{
+		primary: &KeyringStore{},
+		legacy:  legacy,
+	}
+
+	// The primary (keyring) delete succeeds, but the legacy delete fails.
+	// Delete must surface that failure rather than reporting success while
+	// the credential survives in the legacy store.
+	if err := store.Delete(42); err == nil {
+		t.Fatal("Delete should surface the legacy store error, got nil")
+	}
+}
+
+func TestMigratingCredentialStore_DeleteIgnoresLegacyNotFound(t *testing.T) {
+	// A missing legacy credential is not a failure: Delete should report
+	// success when both stores have nothing left to remove.
+	legacy := &PlaintextFileStore{dir: t.TempDir()}
+	backing := map[string]string{}
+	overrideKeyringForTest(t, true, backing)
+
+	store := &migratingCredentialStore{
+		primary: &KeyringStore{},
+		legacy:  legacy,
+	}
+
+	if err := store.Delete(7); err != nil {
+		t.Fatalf("Delete should ignore a missing legacy credential, got %v", err)
+	}
+}
+
 func TestPlaintextFileStore_WarningsRouteToInjectedWriter(t *testing.T) {
 	var buf strings.Builder
 	store := &PlaintextFileStore{dir: t.TempDir(), warn: &buf}


### PR DESCRIPTION
## Summary

`migratingCredentialStore.Delete` discarded the legacy store's delete error
(`_ = s.legacy.Delete(accountID)`). When the legacy delete failed for a real
(non not-found) reason, `Delete` still returned `nil`, so removing a CalDAV
account reported success while the credential survived in the legacy store --
a credential left behind on what the user believes is a full removal.

(Note: the legacy store is the `PlaintextFileStore` and `primary` is the
`KeyringStore`; the issue body has the two conceptually swapped, but the
defect -- a swallowed legacy-delete error reported as success -- is exactly
as described.)

## Fix

Return the legacy delete error after the primary delete succeeds.
`PlaintextFileStore.Delete` already maps a missing file (`os.IsNotExist`) to a
nil result, so not-found stays a success and only genuine failures propagate.

## Tests

- `TestMigratingCredentialStore_DeleteSurfacesLegacyError`: forces a real
  (ENOTEMPTY) legacy delete failure and asserts `Delete` surfaces it. Fails
  before the fix, passes after.
- `TestMigratingCredentialStore_DeleteIgnoresLegacyNotFound`: asserts a
  missing legacy credential is still treated as success.

`make test`, `go build ./...`, `go vet ./...`, and `gofmt -l .` all pass.

Closes #253
