### PR TITLE
perf(sync): reuse exported iCal for prompt-mode push conflict record

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -417,11 +417,11 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 						}
 					}
 				} else {
-					// ConflictPrompt: record conflict for manual resolution
-					localIcal, exportErr := e.exportResource(ctx, res.OwnerType, res.Uid)
-					if exportErr != nil {
-						e.logger.Warn("export local resource for conflict record", "uid", res.Uid, "error", exportErr)
-					}
+					// ConflictPrompt: record conflict for manual resolution.
+					// Reuse icalData exported above — it is the exact body we
+					// just tried to PUT and is unchanged here, so re-exporting
+					// would needlessly repeat ~10 DB queries plus an iCal encode
+					// per conflicting resource. See issue #264.
 					serverRes, fetchErr := client.GetResource(ctx, putPath)
 					if fetchErr == nil {
 						serverIcal, encodeErr := caldav.EncodeCalendar(serverRes.Data)
@@ -434,7 +434,7 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 							OwnerType:  res.OwnerType,
 							OwnerID:    ownerID,
 							Uid:        res.Uid,
-							LocalIcal:  string(localIcal),
+							LocalIcal:  string(icalData),
 							ServerIcal: string(serverIcal),
 							ServerEtag: serverRes.ETag,
 						})

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -836,6 +836,20 @@ END:VCALENDAR
 	if conflicts[0].ServerEtag != "etag-server" {
 		t.Fatalf("ServerEtag = %q, want %q", conflicts[0].ServerEtag, "etag-server")
 	}
+	// The recorded local body must be the exact iCal we attempted to PUT.
+	// The push path exports the resource once before the PUT and reuses that
+	// result for the conflict record instead of re-exporting (issue #264), so
+	// it must still match a fresh export of the same local resource.
+	wantLocal, err := engine.exportResource(ctx, "event", "conflict-event")
+	if err != nil {
+		t.Fatalf("exportResource: %v", err)
+	}
+	if conflicts[0].LocalIcal != string(wantLocal) {
+		t.Fatalf("LocalIcal = %q, want %q", conflicts[0].LocalIcal, string(wantLocal))
+	}
+	if !strings.Contains(conflicts[0].LocalIcal, "SUMMARY:Test conflict-event") {
+		t.Fatalf("LocalIcal missing local summary, got %q", conflicts[0].LocalIcal)
+	}
 	var evtID int64
 	if err := db.QueryRowContext(ctx, `SELECT id FROM events WHERE uid = ? AND recurrence_id = ''`, "conflict-event").Scan(&evtID); err != nil {
 		t.Fatalf("lookup event id: %v", err)


### PR DESCRIPTION
## Problem

In `internal/sync/engine.go`, the prompt-mode (non-`ServerWins`) push conflict
path exported the local resource **twice**. The push already exports the
resource just before the PUT (`icalData, err := e.exportResource(...)`). On a
412 Precondition Failed, the conflict-recording branch called
`exportResource` again with identical arguments to populate `LocalIcal`.

`exportResource` runs `GetByUID` + `ListOverridesByUID` and, per row, hydrates
eight child collections (Alarms/Attendees/Attachments/Comments/Contacts/
Resources/Relations/XProperties) plus an iCal encode — so every conflicting
resource paid for ~10 redundant DB queries and an extra encode on every
prompt-mode push conflict.

## Fix

Reuse the `icalData` already computed before the PUT. It is the exact body we
attempted to PUT and is unchanged on the conflict path (the only intervening
operations are the failed PUT and a server-side GET, neither of which touches
local rows). The now-dead re-export error handling is dropped.

## Test

Extended `TestEnginePushRecordsConflictOnPreconditionFailure` to assert the
recorded `LocalIcal` still equals a fresh export of the local resource and
contains the local event's summary, locking in correct conflict-record content
after removing the second export.

Verified: `make test`, `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.

Closes #264
