### PR TITLE
fix(sync): propagate override-list error in exportResource

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1187,7 +1187,10 @@ func (e *Engine) exportResource(ctx context.Context, ownerType string, uid strin
 		if evt, err := e.events.GetByUID(ctx, uid); err == nil {
 			rows = append(rows, evt)
 		}
-		overrides, _ := e.events.ListOverridesByUID(ctx, uid)
+		overrides, err := e.events.ListOverridesByUID(ctx, uid)
+		if err != nil {
+			return nil, fmt.Errorf("list overrides for event uid %s: %w", uid, err)
+		}
 		rows = append(rows, overrides...)
 		if len(rows) == 0 {
 			return nil, fmt.Errorf("%w: event uid %s", errResourceMissing, uid)
@@ -1201,7 +1204,10 @@ func (e *Engine) exportResource(ctx context.Context, ownerType string, uid strin
 		if t, err := e.todos.GetByUID(ctx, uid); err == nil {
 			rows = append(rows, t)
 		}
-		overrides, _ := e.todos.ListOverridesByUID(ctx, uid)
+		overrides, err := e.todos.ListOverridesByUID(ctx, uid)
+		if err != nil {
+			return nil, fmt.Errorf("list overrides for todo uid %s: %w", uid, err)
+		}
 		rows = append(rows, overrides...)
 		if len(rows) == 0 {
 			return nil, fmt.Errorf("%w: todo uid %s", errResourceMissing, uid)
@@ -1215,7 +1221,10 @@ func (e *Engine) exportResource(ctx context.Context, ownerType string, uid strin
 		if j, err := e.journals.GetByUID(ctx, uid); err == nil {
 			rows = append(rows, j)
 		}
-		overrides, _ := e.journals.ListOverridesByUID(ctx, uid)
+		overrides, err := e.journals.ListOverridesByUID(ctx, uid)
+		if err != nil {
+			return nil, fmt.Errorf("list overrides for journal uid %s: %w", uid, err)
+		}
 		rows = append(rows, overrides...)
 		if len(rows) == 0 {
 			return nil, fmt.Errorf("%w: journal uid %s", errResourceMissing, uid)

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -415,6 +415,71 @@ func TestEngineExportResourceFallsBackToOrphanOverride(t *testing.T) {
 	}
 }
 
+// TestEngineExportResourcePropagatesOverrideListError guards a data-loss bug:
+// exportResource used to discard the ListOverridesByUID error. For a recurring
+// resource (master row + override rows sharing the UID) a transient read error
+// (e.g. SQLite busy/locked) on the override list would then be silently dropped
+// — GetByUID still supplied the master, the non-empty guard passed, and the
+// exporter produced a master-ONLY iCal. PUTting that payload to the server
+// overwrites and deletes every overridden occurrence. The export must fail
+// instead of emitting a partial body. We force the override read to fail by
+// seeding a corrupt override row (non-numeric value in the INTEGER sequence
+// column) that the master lookup never reads but the override scan does.
+func TestEngineExportResourcePropagatesOverrideListError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		ownerType string
+		insertOK  string
+		insertBad string
+	}{
+		{
+			ownerType: "event",
+			insertOK: "INSERT INTO events (uid, calendar_id, title, start_time, end_time) " +
+				"VALUES (?, 1, 'Master', '2025-06-09T19:00:00Z', '2025-06-09T20:00:00Z')",
+			insertBad: "INSERT INTO events (uid, calendar_id, title, start_time, end_time, recurrence_id, sequence) " +
+				"VALUES (?, 1, 'Override', '2025-06-09T19:00:00Z', '2025-06-09T20:00:00Z', '2025-06-09T19:00:00Z', 'not-an-int')",
+		},
+		{
+			ownerType: "todo",
+			insertOK:  "INSERT INTO todos (uid, calendar_id, summary) VALUES (?, 1, 'Master')",
+			insertBad: "INSERT INTO todos (uid, calendar_id, summary, recurrence_id, sequence) " +
+				"VALUES (?, 1, 'Override', '2025-06-09T19:00:00Z', 'not-an-int')",
+		},
+		{
+			ownerType: "journal",
+			insertOK:  "INSERT INTO journals (uid, calendar_id, summary) VALUES (?, 1, 'Master')",
+			insertBad: "INSERT INTO journals (uid, calendar_id, summary, recurrence_id, sequence) " +
+				"VALUES (?, 1, 'Override', '2025-06-09T19:00:00Z', 'not-an-int')",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ownerType, func(t *testing.T) {
+			t.Parallel()
+
+			engine, db, _ := newTestEngine(t)
+			ctx := context.Background()
+			const uid = "recurring-uid"
+
+			if _, err := db.ExecContext(ctx, tc.insertOK, uid); err != nil {
+				t.Fatalf("insert master: %v", err)
+			}
+			if _, err := db.ExecContext(ctx, tc.insertBad, uid); err != nil {
+				t.Fatalf("insert corrupt override: %v", err)
+			}
+
+			data, err := engine.exportResource(ctx, tc.ownerType, uid)
+			if err == nil {
+				t.Fatalf("exportResource returned nil error; master-only export would delete overrides on the server:\n%s", string(data))
+			}
+			if errors.Is(err, errResourceMissing) {
+				t.Fatalf("exportResource reported missing resource, want the override read error: %v", err)
+			}
+		})
+	}
+}
+
 // TestEnginePullClearsDirtyAfterImport prevents the regression where pull's
 // persistImported call flipped dirty=1 (via the event service's Replace*
 // methods which mark the sync_resource dirty as a side effect for user


### PR DESCRIPTION
Closes #249

## Bug

`exportResource` (internal/sync/engine.go) discarded the `ListOverridesByUID` error with `overrides, _ :=` in all three owner branches (event, todo, journal).

When pushing a recurring resource (a master row plus override rows sharing the UID), `GetByUID` supplies the master, so `rows` is non-empty. If the subsequent override read then fails transiently (e.g. SQLite busy/locked under the 5s busy timeout with concurrent writers), the error was dropped, `overrides` came back empty, and the `len(rows) == 0` guard still passed because the master was present. The exporter produced a **master-only** iCal, which `push` PUT to the server — overwriting the resource and silently deleting every overridden occurrence, then propagating that loss to all other synced clients.

## Fix

Propagate the `ListOverridesByUID` error in the event, todo, and journal branches so a partial read aborts the export instead of pushing a master-only body. Callers (`push`) already treat a non-`errResourceMissing` export error as a real failure: the resource stays dirty and is retried, rather than being clobbered.

## Test

Added `TestEngineExportResourcePropagatesOverrideListError`, a table-driven test over event/todo/journal. It seeds a clean master row plus a corrupt override row (a non-numeric value in the INTEGER `sequence` column, which only the override scan reads), forcing `ListOverridesByUID` to fail while `GetByUID` succeeds. It asserts `exportResource` returns an error rather than a master-only body, and that the error is not `errResourceMissing`.

Verified the test fails on the pre-fix code (emits a master-only iCal) and passes with the fix. `make test`, `go build ./...`, `go vet ./...`, and `gofmt -l .` are all clean.
