### PR TITLE
perf(sync): thread loaded calendar/account into push identity resolution

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -111,39 +111,40 @@ func NewEngine(db *sql.DB, q *storage.Queries, credStore authpkg.CredentialStore
 }
 
 // loadCalendarClient loads the calendar, its account, and a ready CalDAV client.
-// Returns the calendar row and the remote calendar URL alongside the client.
-func (e *Engine) loadCalendarClient(ctx context.Context, calendarID int64) (storage.Calendar, *caldav.Client, string, error) {
+// Returns the calendar row, its account, and the remote calendar URL alongside
+// the client so callers can reuse them without re-querying.
+func (e *Engine) loadCalendarClient(ctx context.Context, calendarID int64) (storage.Calendar, storage.Account, *caldav.Client, string, error) {
 	cal, err := e.q.GetCalendar(ctx, calendarID)
 	if err != nil {
-		return storage.Calendar{}, nil, "", fmt.Errorf("get calendar: %w", err)
+		return storage.Calendar{}, storage.Account{}, nil, "", fmt.Errorf("get calendar: %w", err)
 	}
 	if cal.AccountID == nil || *cal.AccountID == 0 {
-		return cal, nil, "", fmt.Errorf("calendar %d is not linked to an account", calendarID)
+		return cal, storage.Account{}, nil, "", fmt.Errorf("calendar %d is not linked to an account", calendarID)
 	}
 	account, err := e.q.GetAccount(ctx, *cal.AccountID)
 	if err != nil {
-		return cal, nil, "", fmt.Errorf("get account: %w", err)
+		return cal, storage.Account{}, nil, "", fmt.Errorf("get account: %w", err)
 	}
 	cred, err := e.credStore.Get(account.ID)
 	if err != nil {
-		return cal, nil, "", fmt.Errorf("get credentials: %w", err)
+		return cal, account, nil, "", fmt.Errorf("get credentials: %w", err)
 	}
 	client, err := caldav.NewClientFromCredential(account.ServerUrl, cred, func(updated authpkg.Credential) error {
 		return e.credStore.Set(updated)
 	})
 	if err != nil {
-		return cal, nil, "", fmt.Errorf("create client: %w", err)
+		return cal, account, nil, "", fmt.Errorf("create client: %w", err)
 	}
 	remoteURL := storage.NullableToString(cal.RemoteUrl)
 	if remoteURL == "" {
-		return cal, nil, "", fmt.Errorf("calendar %d has no remote URL", calendarID)
+		return cal, account, nil, "", fmt.Errorf("calendar %d has no remote URL", calendarID)
 	}
-	return cal, client, remoteURL, nil
+	return cal, account, client, remoteURL, nil
 }
 
 // SyncCalendar runs a full sync cycle for one calendar.
 func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy ConflictStrategy) (result *SyncResult, err error) {
-	cal, client, remoteURL, err := e.loadCalendarClient(ctx, calendarID)
+	cal, account, client, remoteURL, err := e.loadCalendarClient(ctx, calendarID)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +166,7 @@ func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy Co
 	}
 
 	// Phase 1: Push dirty resources
-	pushResult, err := e.push(ctx, client, calendarID, remoteURL, strategy)
+	pushResult, err := e.push(ctx, client, calendarID, remoteURL, resolvePushIdentity(cal, account), strategy)
 	if err != nil {
 		e.logger.Error("push failed", "calendar_id", calendarID, "error", err)
 		result.Errors = append(result.Errors, fmt.Errorf("push: %w", err))
@@ -220,13 +221,13 @@ func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy Co
 // a full sync — both funnel through the same dirty/tombstone rows, and
 // the server arbitrates via ETag preconditions.
 func (e *Engine) PushCalendar(ctx context.Context, calendarID int64, strategy ConflictStrategy) (*SyncResult, error) {
-	_, client, remoteURL, err := e.loadCalendarClient(ctx, calendarID)
+	cal, account, client, remoteURL, err := e.loadCalendarClient(ctx, calendarID)
 	if err != nil {
 		return nil, err
 	}
 	result := &SyncResult{CalendarID: calendarID}
 
-	pushResult, err := e.push(ctx, client, calendarID, remoteURL, strategy)
+	pushResult, err := e.push(ctx, client, calendarID, remoteURL, resolvePushIdentity(cal, account), strategy)
 	if err != nil {
 		return result, fmt.Errorf("push: %w", err)
 	}
@@ -277,13 +278,11 @@ type pushResult struct {
 	errors    []error
 }
 
-func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int64, remoteURL string, strategy ConflictStrategy) (*pushResult, error) {
+func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int64, remoteURL, pushIdentity string, strategy ConflictStrategy) (*pushResult, error) {
 	dirty, err := e.q.ListDirtySyncResources(ctx, calendarID)
 	if err != nil {
 		return nil, fmt.Errorf("list dirty: %w", err)
 	}
-
-	pushIdentity := e.resolvePushIdentity(ctx, calendarID)
 
 	result := &pushResult{}
 	for _, res := range dirty {
@@ -1574,20 +1573,14 @@ func (e *Engine) updateSyncHealth(ctx context.Context, calendarID int64, attempt
 // falls back to the linked account's username (which is the user's email
 // for both basic-auth and OAuth providers we support). Returns empty when
 // neither is known — the caller should then skip the organizer gate
-// rather than guess.
-func (e *Engine) resolvePushIdentity(ctx context.Context, calendarID int64) string {
-	cal, err := e.q.GetCalendar(ctx, calendarID)
-	if err != nil {
-		return ""
-	}
+// rather than guess. The cal and account rows are passed in by the caller
+// (already loaded by loadCalendarClient), so this performs no queries.
+func resolvePushIdentity(cal storage.Calendar, account storage.Account) string {
 	if email := strings.TrimSpace(cal.OwnerEmail); email != "" {
 		return email
 	}
 	if cal.AccountID != nil && *cal.AccountID != 0 {
-		acc, err := e.q.GetAccount(ctx, *cal.AccountID)
-		if err == nil {
-			return acc.Username
-		}
+		return account.Username
 	}
 	return ""
 }

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -145,7 +145,7 @@ func TestEnginePushContinuesAfterResourceFailure(t *testing.T) {
 		t.Fatalf("UpsertSyncResource push-success: %v", err)
 	}
 
-	result, err := engine.push(ctx, client, calendarID, "", ConflictServerWins)
+	result, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestEnginePushPreservesConcurrentEditDuringPut(t *testing.T) {
 		return newResponse(http.StatusCreated, map[string]string{"ETag": `"etag-new"`}), nil
 	})
 
-	if _, err := engine.push(ctx, client, calendarID, "/calendar/", ConflictServerWins); err != nil {
+	if _, err := engine.push(ctx, client, calendarID, "/calendar/", "", ConflictServerWins); err != nil {
 		t.Fatalf("push: %v", err)
 	}
 
@@ -243,6 +243,58 @@ func TestEnginePushPreservesConcurrentEditDuringPut(t *testing.T) {
 	}
 	if len(dirty) != 1 {
 		t.Fatalf("dirty after push = %d, want 1 (concurrent edit must not be dropped)", len(dirty))
+	}
+}
+
+// TestResolvePushIdentity locks in the precedence rules for the push
+// identity now that it is resolved from the already-loaded calendar and
+// account rows instead of re-querying the database: a non-empty (trimmed)
+// owner_email wins, otherwise the linked account's username is used, and
+// an unlinked calendar with no owner_email yields the empty string so the
+// caller skips the organizer gate.
+func TestResolvePushIdentity(t *testing.T) {
+	t.Parallel()
+
+	accountID := int64(7)
+	tests := []struct {
+		name    string
+		cal     storage.Calendar
+		account storage.Account
+		want    string
+	}{
+		{
+			name:    "owner email wins",
+			cal:     storage.Calendar{OwnerEmail: "owner@example.com", AccountID: &accountID},
+			account: storage.Account{Username: "login@example.com"},
+			want:    "owner@example.com",
+		},
+		{
+			name:    "owner email trimmed",
+			cal:     storage.Calendar{OwnerEmail: "  owner@example.com  ", AccountID: &accountID},
+			account: storage.Account{Username: "login@example.com"},
+			want:    "owner@example.com",
+		},
+		{
+			name:    "falls back to account username",
+			cal:     storage.Calendar{OwnerEmail: "   ", AccountID: &accountID},
+			account: storage.Account{Username: "login@example.com"},
+			want:    "login@example.com",
+		},
+		{
+			name:    "no owner email and no account is empty",
+			cal:     storage.Calendar{},
+			account: storage.Account{Username: "login@example.com"},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolvePushIdentity(tt.cal, tt.account); got != tt.want {
+				t.Fatalf("resolvePushIdentity() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -316,7 +368,7 @@ func TestEnginePushSkipsForeignOrganizedEvents(t *testing.T) {
 		return newResponse(http.StatusCreated, map[string]string{"ETag": `"new-etag"`}), nil
 	})
 
-	result, err := engine.push(ctx, client, calendarID, "/calendar/", ConflictServerWins)
+	result, err := engine.push(ctx, client, calendarID, "/calendar/", "me@example.com", ConflictServerWins)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -365,7 +417,7 @@ func TestEnginePushClearsDirtyWhenLocalRowMissing(t *testing.T) {
 		return nil, nil
 	})
 
-	result, err := engine.push(ctx, client, calendarID, "/calendar/", ConflictServerWins)
+	result, err := engine.push(ctx, client, calendarID, "/calendar/", "", ConflictServerWins)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -809,7 +861,7 @@ END:VCALENDAR
 		t.Fatalf("UpsertSyncResource conflict-event: %v", err)
 	}
 
-	result, err := engine.push(ctx, client, calendarID, "", ConflictPrompt)
+	result, err := engine.push(ctx, client, calendarID, "", "", ConflictPrompt)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -928,7 +980,7 @@ END:VCALENDAR
 	}
 
 	// First sync: detects the 412 and records the conflict.
-	if _, err := engine.push(ctx, client, calendarID, "", ConflictPrompt); err != nil {
+	if _, err := engine.push(ctx, client, calendarID, "", "", ConflictPrompt); err != nil {
 		t.Fatalf("first push: %v", err)
 	}
 	if puts != 1 {
@@ -937,7 +989,7 @@ END:VCALENDAR
 
 	// Second sync: the conflict is still unresolved, so the resource must be
 	// skipped entirely — no second PUT, no duplicate conflict row.
-	result, err := engine.push(ctx, client, calendarID, "", ConflictPrompt)
+	result, err := engine.push(ctx, client, calendarID, "", "", ConflictPrompt)
 	if err != nil {
 		t.Fatalf("second push: %v", err)
 	}
@@ -1028,7 +1080,7 @@ END:VCALENDAR
 		t.Fatalf("UpsertSyncResource: %v", err)
 	}
 
-	result, err := engine.push(ctx, client, calendarID, "", ConflictServerWins)
+	result, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -1427,7 +1479,7 @@ END:VCALENDAR
 		}
 	})
 
-	pushResult, err := engine.push(ctx, client, calendarID, "/calendar/", ConflictServerWins)
+	pushResult, err := engine.push(ctx, client, calendarID, "/calendar/", "", ConflictServerWins)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -1510,7 +1562,7 @@ func TestEnginePushIgnoresUIDWhenAssigningNewResourcePath(t *testing.T) {
 		}, nil
 	})
 
-	pushResult, err := engine.push(ctx, client, calendarID, "/calendar/", ConflictServerWins)
+	pushResult, err := engine.push(ctx, client, calendarID, "/calendar/", "", ConflictServerWins)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -1562,7 +1614,7 @@ func TestEnginePushRejectsOffOriginStoredRemoteURL(t *testing.T) {
 		return newResponse(http.StatusCreated, map[string]string{"ETag": `"etag-off-origin"`}), nil
 	})
 
-	result, err := engine.push(ctx, client, calendarID, "/calendar/", ConflictServerWins)
+	result, err := engine.push(ctx, client, calendarID, "/calendar/", "", ConflictServerWins)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}


### PR DESCRIPTION
## Problem

`resolvePushIdentity` (engine.go) re-fetched the calendar via `GetCalendar`
on every call, plus `GetAccount` when the calendar's `owner_email` was empty —
even though `loadCalendarClient` had **already** loaded both the calendar and
its account at the start of every sync cycle. Under `SyncAll`, which loops over
every connected calendar, this was one redundant `GetCalendar` plus up to one
redundant `GetAccount` per calendar, per cycle. No correctness impact, purely
wasted I/O.

## Fix

- `loadCalendarClient` now returns the loaded `storage.Account` alongside the
  calendar, so callers can reuse it.
- `resolvePushIdentity` becomes a pure function taking the already-loaded
  `cal`/`account` rows instead of querying the database. Same precedence:
  trimmed `owner_email` wins, else the linked account's username, else empty.
- `SyncCalendar` and `PushCalendar` resolve the identity from the rows they
  already hold and pass it into `push` as a parameter; `push` no longer touches
  the DB to compute it.

The change is behavior-equivalent in production: `push` is only reached after
`loadCalendarClient` succeeds, which guarantees the account is loaded and the
calendar is account-linked.

## Tests

- New table-driven `TestResolvePushIdentity` locks in the precedence rules
  (owner_email wins / trimmed, account-username fallback, empty when neither is
  known).
- Existing push tests updated for the new `push` signature; the
  foreign-organizer test now passes the identity explicitly.
- `make test`, `go build ./...`, `go vet ./...`, `gofmt -l .` all green.

Closes #265
