### PR TITLE
refactor(timeutil): consolidate removeTimeFromList into timeutil

### DIFF
--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -394,7 +394,7 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
 	}
 	existing := ParseTimeList(storage.NullableToString(master.Exdates))
-	filtered := removeTimeFromList(existing, target)
+	filtered := timeutil.RemoveTimeFromList(existing, target)
 	if len(filtered) != len(existing) {
 		if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
 			Exdates: storage.StringToNullable(SerializeTimeList(filtered)),

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/storage"
@@ -269,7 +268,7 @@ func (s *Service) restoreInstanceByLogID(ctx context.Context, logID int64) error
 	if err != nil {
 		return fmt.Errorf("parse recurrence_id %q: %w", log.RecurrenceID, err)
 	}
-	filtered := removeTimeFromList(existing, target)
+	filtered := timeutil.RemoveTimeFromList(existing, target)
 	if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
 		Exdates: storage.StringToNullable(SerializeTimeList(filtered)),
 		ID:      master.ID,
@@ -328,23 +327,4 @@ func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) err
 		return fmt.Errorf("mark resource dirty: %w", err)
 	}
 	return tx.Commit()
-}
-
-// removeTimeFromList returns list with the first element equal to target
-// (after UTC normalization) removed. Used to reverse a single EXDATE
-// insertion: DeleteInstance appends one EXDATE per delete, so undo must drop
-// exactly one — removing every match would discard a pre-existing exclusion
-// for the same slot (e.g. an imported EXDATE alongside a detached override).
-func removeTimeFromList(list []time.Time, target time.Time) []time.Time {
-	out := make([]time.Time, 0, len(list))
-	targetKey := target.UTC().Format(time.RFC3339)
-	removed := false
-	for _, t := range list {
-		if !removed && strings.EqualFold(t.UTC().Format(time.RFC3339), targetKey) {
-			removed = true
-			continue
-		}
-		out = append(out, t)
-	}
-	return out
 }

--- a/internal/journal/soft_delete.go
+++ b/internal/journal/soft_delete.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/storage"
@@ -95,7 +94,7 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
 	}
 	existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
-	filtered := removeTimeFromList(existing, target)
+	filtered := timeutil.RemoveTimeFromList(existing, target)
 	if len(filtered) != len(existing) {
 		if err := qtx.UpdateJournalExdates(ctx, storage.UpdateJournalExdatesParams{
 			Exdates: storage.StringToNullable(timeutil.SerializeTimeList(filtered)),
@@ -108,25 +107,6 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 		return fmt.Errorf("delete exdate log: %w", err)
 	}
 	return nil
-}
-
-// removeTimeFromList returns list with the first element equal to target
-// (after UTC normalization) removed. Used to reverse an EXDATE insertion
-// when restoring a recurring override: a delete added exactly one EXDATE, so
-// restore strips exactly one — any duplicate (e.g. a pre-existing imported
-// exclusion at the same slot) is preserved. Mirrors event.removeTimeFromList.
-func removeTimeFromList(list []time.Time, target time.Time) []time.Time {
-	out := make([]time.Time, 0, len(list))
-	targetKey := target.UTC().Format(time.RFC3339)
-	removed := false
-	for _, t := range list {
-		if !removed && strings.EqualFold(t.UTC().Format(time.RFC3339), targetKey) {
-			removed = true
-			continue
-		}
-		out = append(out, t)
-	}
-	return out
 }
 
 // RestoreByUID un-hides every soft-deleted row sharing uid — master plus

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -127,6 +127,26 @@ func SerializeTimeList(times []time.Time) string {
 	return strings.Join(parts, ",")
 }
 
+// RemoveTimeFromList returns list with the first element equal to target
+// (after UTC normalization) removed. Used to reverse a single EXDATE
+// insertion: soft-delete appends exactly one EXDATE per delete, so undo must
+// drop exactly one — removing every match would discard a pre-existing
+// exclusion for the same slot (e.g. an imported EXDATE alongside a detached
+// override). Shared by the event, todo, and journal restore paths.
+func RemoveTimeFromList(list []time.Time, target time.Time) []time.Time {
+	out := make([]time.Time, 0, len(list))
+	targetKey := target.UTC().Format(time.RFC3339)
+	removed := false
+	for _, t := range list {
+		if !removed && strings.EqualFold(t.UTC().Format(time.RFC3339), targetKey) {
+			removed = true
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
 // JoinCategoryList joins category values into a single comma-separated string,
 // backslash-escaping any backslash or comma inside an individual value so the
 // result is an exact inverse of ParseCategoryList. This keeps a category that

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -3,6 +3,7 @@ package timeutil
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestCategoryListRoundtrip(t *testing.T) {
@@ -70,5 +71,69 @@ func TestJoinCategoryList_EscapesAndDropsEmpty(t *testing.T) {
 	}
 	if got := JoinCategoryList([]string{"a", "  ", "", "b"}); got != "a,b" {
 		t.Errorf("JoinCategoryList dropped-empty = %q, want %q", got, "a,b")
+	}
+}
+
+func TestRemoveTimeFromList(t *testing.T) {
+	t.Parallel()
+	mustParse := func(s string) time.Time {
+		v, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatalf("parse %q: %v", s, err)
+		}
+		return v
+	}
+	keys := func(times []time.Time) []string {
+		out := make([]string, len(times))
+		for i, v := range times {
+			out[i] = v.UTC().Format(time.RFC3339)
+		}
+		return out
+	}
+	cases := []struct {
+		name   string
+		list   []time.Time
+		target time.Time
+		want   []string
+	}{
+		{
+			name:   "removes single match",
+			list:   []time.Time{mustParse("2026-04-01T10:00:00Z"), mustParse("2026-04-02T10:00:00Z")},
+			target: mustParse("2026-04-01T10:00:00Z"),
+			want:   []string{"2026-04-02T10:00:00Z"},
+		},
+		{
+			name:   "drops only the first of a duplicate pair",
+			list:   []time.Time{mustParse("2026-04-01T10:00:00Z"), mustParse("2026-04-01T10:00:00Z")},
+			target: mustParse("2026-04-01T10:00:00Z"),
+			want:   []string{"2026-04-01T10:00:00Z"},
+		},
+		{
+			name:   "matches across timezone offsets after UTC normalization",
+			list:   []time.Time{mustParse("2026-04-01T12:00:00+02:00")},
+			target: mustParse("2026-04-01T10:00:00Z"),
+			want:   []string{},
+		},
+		{
+			name:   "no match leaves list unchanged",
+			list:   []time.Time{mustParse("2026-04-01T10:00:00Z")},
+			target: mustParse("2026-04-02T10:00:00Z"),
+			want:   []string{"2026-04-01T10:00:00Z"},
+		},
+		{
+			name:   "empty list",
+			list:   nil,
+			target: mustParse("2026-04-01T10:00:00Z"),
+			want:   []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := keys(RemoveTimeFromList(tc.list, tc.target))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("RemoveTimeFromList = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/todo/soft_delete.go
+++ b/internal/todo/soft_delete.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/storage"
@@ -101,7 +100,7 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
 	}
 	existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
-	filtered := removeTimeFromList(existing, target)
+	filtered := timeutil.RemoveTimeFromList(existing, target)
 	if len(filtered) != len(existing) {
 		if err := qtx.UpdateTodoExdates(ctx, storage.UpdateTodoExdatesParams{
 			Exdates: storage.StringToNullable(timeutil.SerializeTimeList(filtered)),
@@ -114,25 +113,6 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 		return fmt.Errorf("delete exdate log: %w", err)
 	}
 	return nil
-}
-
-// removeTimeFromList returns list with the first element equal to target
-// (after UTC normalization) removed. Used to reverse an EXDATE insertion
-// when restoring a recurring override: a delete added exactly one EXDATE, so
-// restore strips exactly one — any duplicate (e.g. a pre-existing imported
-// exclusion at the same slot) is preserved. Mirrors event.removeTimeFromList.
-func removeTimeFromList(list []time.Time, target time.Time) []time.Time {
-	out := make([]time.Time, 0, len(list))
-	targetKey := target.UTC().Format(time.RFC3339)
-	removed := false
-	for _, t := range list {
-		if !removed && strings.EqualFold(t.UTC().Format(time.RFC3339), targetKey) {
-			removed = true
-			continue
-		}
-		out = append(out, t)
-	}
-	return out
 }
 
 // RestoreByUID un-hides every soft-deleted row with the given UID —


### PR DESCRIPTION
## Problem

`removeTimeFromList` was duplicated byte-for-byte across three packages — `internal/event/trash.go`, `internal/todo/soft_delete.go`, and `internal/journal/soft_delete.go` (the todo/journal copies even commented "Mirrors event.removeTimeFromList."). Its load-bearing UTC-normalize + first-match-only semantics (drop exactly one EXDATE on restore, preserving a pre-existing imported exclusion at the same slot) had to be edited in all three places; a one-sided fix would silently diverge restore behavior across domains.

## Refactor

- Extract the helper as the exported `timeutil.RemoveTimeFromList`, alongside the `ParseTimeList` / `SerializeTimeList` siblings the same call sites already use.
- Route all four call sites (event soft-delete + trash, todo, journal) through it.
- Remove the three local copies and their now-unused `strings` imports.

Pure move — function body is byte-identical to the originals, no external behavior change.

## Test

Adds `TestRemoveTimeFromList` in `internal/timeutil/timeutil_test.go` covering the load-bearing branches: single-match removal, drop-only-the-first on a duplicate pair, cross-timezone UTC normalization, no-match passthrough, and the empty list.

`make test`, `go build ./...`, `go vet ./...`, and `gofmt -l .` all clean.

Closes #260
