### PR TITLE
fix(tui): strip OSC escape sequences in stripANSI

### DIFF
--- a/internal/textsafe/textsafe.go
+++ b/internal/textsafe/textsafe.go
@@ -6,16 +6,24 @@ import (
 	"unicode/utf8"
 )
 
-// Display removes terminal escape sequences and collapses control characters
-// into safe plain text for human-facing terminal, notification, and email
-// rendering.
-func Display(s string) string {
+// StripEscapes removes terminal escape sequences (CSI `ESC [ … final` and OSC
+// `ESC ] … BEL|ST`) and lone ESC bytes, leaving every other byte untouched. It
+// preserves whitespace and other runes, so callers that measure or wrap text
+// can rely on byte/rune positions matching the visible output.
+func StripEscapes(s string) string {
+	if strings.IndexByte(s, 0x1b) < 0 {
+		// No ESC byte: nothing to strip, avoid allocating a copy.
+		return s
+	}
+
 	var b strings.Builder
+	b.Grow(len(s))
 
 	for i := 0; i < len(s); {
 		if s[i] == 0x1b {
 			switch {
 			case i+1 < len(s) && s[i+1] == '[':
+				// CSI: runs until a final byte in 0x40–0x7e.
 				i += 2
 				for i < len(s) {
 					c := s[i]
@@ -24,8 +32,8 @@ func Display(s string) string {
 						break
 					}
 				}
-				continue
 			case i+1 < len(s) && s[i+1] == ']':
+				// OSC: runs until BEL or ST (ESC \).
 				i += 2
 				for i < len(s) {
 					if s[i] == 0x07 {
@@ -38,13 +46,28 @@ func Display(s string) string {
 					}
 					i++
 				}
-				continue
 			default:
+				// Lone ESC: drop just the escape byte.
 				i++
-				continue
 			}
+			continue
 		}
 
+		b.WriteByte(s[i])
+		i++
+	}
+
+	return b.String()
+}
+
+// Display removes terminal escape sequences and collapses control characters
+// into safe plain text for human-facing terminal, notification, and email
+// rendering.
+func Display(s string) string {
+	s = StripEscapes(s)
+
+	var b strings.Builder
+	for i := 0; i < len(s); {
 		r, size := utf8.DecodeRuneInString(s[i:])
 		if r == utf8.RuneError && size == 1 {
 			i++

--- a/internal/textsafe/textsafe_test.go
+++ b/internal/textsafe/textsafe_test.go
@@ -1,0 +1,45 @@
+package textsafe
+
+import "testing"
+
+func TestStripEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "hello world", "hello world"},
+		{"csi color", "\x1b[31mred\x1b[0m", "red"},
+		{"osc 8 hyperlink bel", "\x1b]8;;https://example.com\x07link\x1b]8;;\x07", "link"},
+		{"osc terminated by st", "\x1b]0;title\x1b\\rest", "rest"},
+		{"lone esc dropped", "a\x1bb", "ab"},
+		{"whitespace preserved", "a\tb\n c", "a\tb\n c"},
+		{"multibyte preserved", "café — \x1b[1mok\x1b[0m", "café — ok"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StripEscapes(tc.in); got != tc.want {
+				t.Fatalf("StripEscapes(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDisplayStripsEscapesAndCollapsesWhitespace(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"osc hyperlink", "\x1b]8;;https://example.com\x07click\x1b]8;;\x07 here", "click here"},
+		{"csi and newlines", "\x1b[31mline1\x1b[0m\nline2", "line1 line2"},
+		{"control chars dropped", "a\x00b\x07c", "abc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Display(tc.in); got != tc.want {
+				t.Fatalf("Display(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/textsafe"
 )
 
 // EventDialogClosedMsg is emitted when the dialog requests to close.
@@ -1054,27 +1055,12 @@ func truncateTo(s string, w int) string {
 	return string(r[:cut]) + "…"
 }
 
+// stripANSI removes terminal escape sequences while preserving whitespace and
+// other runes, so truncation and width measurement see the visible text. It
+// delegates to textsafe.StripEscapes so OSC sequences (e.g. OSC 8 hyperlinks)
+// are handled the same way as in the rest of the codebase.
 func stripANSI(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); {
-		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
-			j := i + 2
-			for j < len(s) {
-				c := s[j]
-				if c >= 0x40 && c <= 0x7e {
-					j++
-					break
-				}
-				j++
-			}
-			i = j
-			continue
-		}
-		b.WriteByte(s[i])
-		i++
-	}
-	return b.String()
+	return textsafe.StripEscapes(s)
 }
 
 func wrapLine(s string, w int) []string {

--- a/internal/tui/strip_ansi_test.go
+++ b/internal/tui/strip_ansi_test.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// stripANSI must remove OSC sequences (ESC ]) just like CSI sequences,
+// matching textsafe.Display. A raw OSC byte left in the output counts as a
+// visible rune and leaks an escape to the terminal. See issue #262.
+func TestStripANSI_RemovesOSCSequences(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "OSC 8 hyperlink terminated by BEL",
+			in:   "\x1b]8;;https://example.com\x07Visible\x1b]8;;\x07",
+			want: "Visible",
+		},
+		{
+			name: "OSC terminated by ST (ESC backslash)",
+			in:   "\x1b]0;window title\x1b\\after",
+			want: "after",
+		},
+		{
+			name: "CSI still stripped",
+			in:   "\x1b[31mred\x1b[0m",
+			want: "red",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripANSI(tc.in)
+			if got != tc.want {
+				t.Fatalf("stripANSI(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.ContainsRune(got, '\x1b') {
+				t.Fatalf("stripANSI(%q) left an escape byte: %q", tc.in, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`stripANSI` in `internal/tui/event_dialog.go` only recognized **CSI** escape sequences (`ESC [`) and passed **OSC** sequences (`ESC ]`) through untouched, while `textsafe.Display` already stripped both. The two implementations had diverged.

This is a latent bug: `truncateTo` measures the plain text by stripping ANSI before counting runes. A stored title/description containing raw OSC bytes (e.g. a crafted iCal import, or an OSC 8 hyperlink) would leave the escape in the "plain" text — inflating the rune count so truncation cuts at the wrong place, and leaking a raw escape byte to the terminal.

## Fix

- Extract the escape-stripping logic into a new shared `textsafe.StripEscapes`, which handles CSI, OSC (BEL- or ST-terminated), and lone `ESC` bytes while preserving all other bytes (whitespace included, so callers can still measure/wrap text).
- Refactor `textsafe.Display` to build on `StripEscapes`.
- Make the tui `stripANSI` delegate to `textsafe.StripEscapes`, removing the divergent CSI-only copy so the two can no longer drift apart.
- Added a no-escape fast path to `StripEscapes` so the common case (no `ESC` byte) returns without allocating.

## Tests

- `internal/tui/strip_ansi_test.go` — TDD regression test: OSC 8 hyperlinks (BEL- and ST-terminated) and CSI sequences are fully stripped; confirmed it failed before the fix.
- `internal/textsafe/textsafe_test.go` — covers `StripEscapes` (CSI/OSC/lone-ESC/whitespace/multibyte) and that `Display` still strips escapes and collapses whitespace.
- `make test`, `go build ./...`, `go vet ./...`, `gofmt -l .` all green.

Closes #262
