### PR TITLE
fix(tui): unify truncation on a display-width-aware helper

### DIFF
--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/model"
-	"github.com/douglasdemoura/chroncal/internal/textsafe"
 )
 
 // EventDialogClosedMsg is emitted when the dialog requests to close.
@@ -1022,45 +1021,6 @@ func pluralize(n int, unit string) string {
 		return "1 " + unit
 	}
 	return fmt.Sprintf("%d %s", n, unit)
-}
-
-func truncateTo(s string, w int) string {
-	if w <= 0 {
-		return ""
-	}
-	if lipgloss.Width(s) <= w {
-		return s
-	}
-	if w == 1 {
-		return "…"
-	}
-
-	plain := s
-	if strings.ContainsRune(s, '\x1b') {
-		plain = stripANSI(s)
-	}
-	r := []rune(plain)
-	cut := min(w-1, len(r))
-
-	// Prefer breaking at whitespace within a small look-back window so
-	// truncation doesn't slice mid-word. If no whitespace is within reach
-	// (e.g., a single long token), fall back to a hard cut.
-	lookback := cut / 3
-	for i := cut; i > cut-lookback && i > 1; i-- {
-		if r[i-1] == ' ' || r[i-1] == '\t' {
-			trimmed := strings.TrimRight(string(r[:i-1]), " \t")
-			return trimmed + " …"
-		}
-	}
-	return string(r[:cut]) + "…"
-}
-
-// stripANSI removes terminal escape sequences while preserving whitespace and
-// other runes, so truncation and width measurement see the visible text. It
-// delegates to textsafe.StripEscapes so OSC sequences (e.g. OSC 8 hyperlinks)
-// are handled the same way as in the rest of the codebase.
-func stripANSI(s string) string {
-	return textsafe.StripEscapes(s)
 }
 
 func wrapLine(s string, w int) []string {

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -140,7 +140,7 @@ func (f FooterModel) renderCollapsed(ctx FooterContext, width int) string {
 		return help
 	}
 	line := keyStyle.Render(top.keys) + " " + descStyle.Render(top.desc) + sepStyle.Render(" · ") + help
-	return truncateFooter(line, width)
+	return truncateTo(line, width)
 }
 
 // joinFooter splits left/right into a single line, applying ellipsis
@@ -150,7 +150,7 @@ func (f FooterModel) joinFooter(left, right string, width int) string {
 		// Narrow-but-not-collapsed: show the right side only, truncated with
 		// ellipsis. Left (sync status) is dropped to preserve hint
 		// discoverability.
-		return truncateFooter(right, width)
+		return truncateTo(right, width)
 	}
 	lw := lipgloss.Width(left)
 	rw := lipgloss.Width(right)
@@ -177,7 +177,7 @@ func (f FooterModel) RenderMinimal(width int, syncStatus, toast string, showHelp
 		right = keyStyle.Render("?") + " " + descStyle.Render("help")
 	}
 	if width < footerEllipsisCols {
-		return truncateFooter(right, width)
+		return truncateTo(right, width)
 	}
 	return f.joinFooter(syncStatus, right, width)
 }
@@ -303,21 +303,4 @@ func collapsedTopHint(ctx FooterContext) footerHint {
 		return footerHint{"space", "toggle"}
 	}
 	return footerHint{}
-}
-
-func truncateFooter(s string, width int) string {
-	if lipgloss.Width(s) <= width {
-		return s
-	}
-	if width <= 1 {
-		return ""
-	}
-	// Lipgloss handles ANSI-aware width; trim one rune at a time from the
-	// rendered form. This isn't the fastest path but fires rarely — only
-	// when the terminal is under 60 columns.
-	runes := []rune(s)
-	for len(runes) > 0 && lipgloss.Width(string(runes)) > width-1 {
-		runes = runes[:len(runes)-1]
-	}
-	return string(runes) + "…"
 }

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -482,7 +482,7 @@ func renderPaletteRow(c PaletteCommand, width int, selected bool, theme Theme) s
 	title := c.Title
 	avail := width - prefixW - rightW
 	if avail < lipgloss.Width(title)+1 {
-		title = truncate(title, max(avail-1, 3))
+		title = truncateTo(title, max(avail-1, 3))
 	}
 	gap := max(avail-lipgloss.Width(title), 1)
 
@@ -556,18 +556,4 @@ func (m PaletteModel) renderFooter(width int) string {
 		Width(width).
 		Align(lipgloss.Center).
 		Render(hint)
-}
-
-func truncate(s string, n int) string {
-	if n <= 0 {
-		return ""
-	}
-	r := []rune(s)
-	if len(r) <= n {
-		return s
-	}
-	if n <= 1 {
-		return string(r[:n])
-	}
-	return string(r[:n-1]) + "…"
 }

--- a/internal/tui/text.go
+++ b/internal/tui/text.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"strings"
+
+	lipgloss "charm.land/lipgloss/v2"
+
+	"github.com/douglasdemoura/chroncal/internal/textsafe"
+)
+
+// truncateTo shortens s so its terminal display width is at most w cells,
+// appending "…" when truncation occurs. Width is measured with lipgloss so
+// full-width (CJK) runes and emoji count as the columns they actually occupy,
+// rather than as a single rune each. When the cut would land mid-word it backs
+// up to the nearest whitespace within a small look-back window so words aren't
+// sliced; a single long token is cut hard.
+//
+// When s fits, it is returned unchanged (styling intact). When it must be cut,
+// any ANSI styling is stripped and plain text is returned — callers that need
+// the result re-styled must do so themselves.
+//
+// This is the single truncation helper for the TUI: every column that needs to
+// fit text into a fixed width routes through here so clipping stays consistent
+// and never overflows on wide glyphs.
+func truncateTo(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= w {
+		return s
+	}
+	if w == 1 {
+		return "…"
+	}
+
+	plain := s
+	if strings.ContainsRune(s, '\x1b') {
+		plain = stripANSI(s)
+	}
+	r := []rune(plain)
+
+	// Reserve one cell for the ellipsis, then include as many leading runes as
+	// fit in the remaining budget by measured display width.
+	budget := w - 1
+	cut, width := 0, 0
+	for cut < len(r) {
+		rw := lipgloss.Width(string(r[cut]))
+		if width+rw > budget {
+			break
+		}
+		width += rw
+		cut++
+	}
+
+	// Prefer breaking at whitespace within a small look-back window so
+	// truncation doesn't slice mid-word. If no whitespace is within reach
+	// (e.g., a single long token), fall back to a hard cut.
+	lookback := cut / 3
+	for i := cut; i > cut-lookback && i > 1; i-- {
+		if r[i-1] == ' ' || r[i-1] == '\t' {
+			trimmed := strings.TrimRight(string(r[:i-1]), " \t")
+			return trimmed + " …"
+		}
+	}
+	return string(r[:cut]) + "…"
+}
+
+// stripANSI removes terminal escape sequences from s, leaving plain text. It is
+// used to measure and slice the visible content of already-styled strings. It
+// delegates to textsafe.StripEscapes so OSC sequences (e.g. OSC 8 hyperlinks)
+// are handled the same way as in the rest of the codebase.
+func stripANSI(s string) string {
+	return textsafe.StripEscapes(s)
+}

--- a/internal/tui/text_test.go
+++ b/internal/tui/text_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+func TestTruncateToRespectsDisplayWidth(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		w    int
+	}{
+		// A full-width (CJK) title is 8 runes but 16 display cells. Cutting
+		// by rune count would leave it far wider than the budget and overflow
+		// the column; truncation must respect display width.
+		{"cjk_full_width", "你好世界一二三四", 10},
+		{"cjk_tight", "你好世界一二三四", 5},
+		// Emoji are also wide; the budget is in display cells, not runes.
+		{"emoji", "😀😀😀😀😀😀", 7},
+		// Mixed ASCII + CJK.
+		{"mixed", "abc你好世界xyz", 8},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateTo(tc.in, tc.w)
+			if w := lipgloss.Width(got); w > tc.w {
+				t.Fatalf("truncateTo(%q, %d) = %q, display width %d exceeds budget %d",
+					tc.in, tc.w, got, w, tc.w)
+			}
+			if !strings.HasSuffix(got, "…") {
+				t.Fatalf("truncateTo(%q, %d) = %q, expected ellipsis suffix", tc.in, tc.w, got)
+			}
+		})
+	}
+}
+
+func TestTruncateToFitsUnchanged(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		w    int
+	}{
+		{"ascii", "hello", 10},
+		{"cjk_exact", "你好", 4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := truncateTo(tc.in, tc.w); got != tc.in {
+				t.Fatalf("truncateTo(%q, %d) = %q, want unchanged", tc.in, tc.w, got)
+			}
+		})
+	}
+}
+
+func TestTruncateToBreaksOnWhitespace(t *testing.T) {
+	got := truncateTo("hello world foo", 12)
+	if w := lipgloss.Width(got); w > 12 {
+		t.Fatalf("display width %d exceeds 12: %q", w, got)
+	}
+	if strings.Contains(got, "wor…") {
+		t.Fatalf("expected word-boundary break, got mid-word cut: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #261.

The TUI had **three overlapping** "shorten to width and append …" helpers:

- `palette.truncate` — rune-based
- `event_dialog.truncateTo` — `lipgloss.Width` guard but a **rune-based cut**
- `footer.truncateFooter` — width-aware (one-rune-at-a-time trim)

### Bug

The decision used display width but the cut used **rune count**. For a
full-width (CJK) title of 8 runes = 16 display cells with a 10-cell budget,
the width guard fired but `len(runes)=8 <= 9`, so the string was returned
**unchanged at 16 cells** and the palette row overflowed its column by ~6
cells. The latent variant in `truncateTo` (`cut := min(w-1, len(r))`) had the
same defect, so simply reusing it — as the issue suggested — would not have
fixed CJK/emoji on its own.

### Fix

Consolidate on a single display-width-aware `truncateTo` in a new
`internal/tui/text.go`. It accumulates leading runes by **measured cell
width** (reserving one cell for the ellipsis), preserving the existing
word-break lookback and ANSI strip. `palette.truncate` and
`footer.truncateFooter` are deleted and their call sites routed through
`truncateTo`; `stripANSI` moves alongside it.

Measurement stays on `lipgloss.Width` (backed by `charmbracelet/x/ansi`,
grapheme-cluster aware) rather than `mattn/go-runewidth`, so wide glyphs are
measured consistently with the guard and the rest of the TUI.

### Test

`internal/tui/text_test.go` reproduces the bug first (failed before the fix):

- CJK / emoji / mixed strings truncated to a cell budget must not exceed it
- the fits-unchanged fast path (ASCII and exact-width CJK)
- word-boundary breaking

`make test`, `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.

Reviewed with `/code-review` (no correctness bugs) and `/simplify`.
