### PR TITLE
fix(event): propagate MarkResourceDirty error in restoreFromInstance

### DIFF
--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -443,7 +443,9 @@ func (s *Service) restoreFromInstance(ctx context.Context, meta UndoMeta) error 
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, meta.UID, "event")
+	if err := storage.MarkResourceDirty(ctx, s.db, master.CalendarID, meta.UID, "event"); err != nil {
+		return fmt.Errorf("mark resource dirty after restore: %w", err)
+	}
 	return nil
 }
 

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -681,6 +681,44 @@ func TestSoftDelete_RestoreByUIDPreservesImportedEXDATE(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_RestoreFromInstanceSurfacesMarkDirtyError verifies that a
+// failure to mark the master resource dirty during a from-instance undo is
+// propagated to the caller instead of being silently swallowed. Without it the
+// restored occurrences reappear locally but are never re-synced to the server.
+// Regression test for #252.
+func TestSoftDelete_RestoreFromInstanceSurfacesMarkDirtyError(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "restore-from-instance-markdirty",
+		CalendarID:     1,
+		Title:          "Sprint Review",
+		StartTime:      time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=10",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	cutoff := time.Date(2026, 4, 22, 14, 0, 0, 0, time.UTC)
+	meta, err := svc.DeleteFromInstanceWithUndo(ctx, master.UID, cutoff)
+	if err != nil {
+		t.Fatalf("DeleteFromInstanceWithUndo: %v", err)
+	}
+
+	// Force the dirty-mark inside restoreFromInstance to fail.
+	if _, err := svc.db.ExecContext(ctx, "DROP TABLE sync_resources"); err != nil {
+		t.Fatalf("drop sync_resources: %v", err)
+	}
+
+	if err := svc.RestoreUndo(ctx, meta); err == nil {
+		t.Fatal("RestoreUndo returned nil, want error when MarkResourceDirty fails")
+	}
+}
+
 // TestSoftDelete_RestoreSurfacesTombstoneClearError verifies that a failure
 // to clear the queued tombstone during restore is propagated to the caller
 // instead of being silently swallowed. Regression test for #121.


### PR DESCRIPTION
## Bug

`restoreFromInstance` (`internal/event/soft_delete.go`) discarded the result of
`MarkResourceDirty` with a blank assignment (`_ = ...`). The call runs on
`s.db` *after* the restore transaction has already committed, so the
occurrences reappear locally. If the dirty-mark then fails (transient
busy/locked DB, or an error touching the `sync_resource` row), the function
returned `nil`: the resource was never marked dirty, the next CalDAV push
skipped it, and the restored occurrences stayed **missing on the server and
other devices** while appearing present locally — with no error surfaced.

The sibling `reconcileSyncAfterRestore` already treats the identical call as
fatal and wraps the error.

## Fix

Propagate the error from `MarkResourceDirty`, wrapping it to match
`reconcileSyncAfterRestore`.

## Test

Added `TestSoftDelete_RestoreFromInstanceSurfacesMarkDirtyError`, which links
the calendar to an account (so the dirty-mark actually fires), performs a
delete-from-instance, drops the `sync_resources` table to force the
`MarkResourceDirty` INSERT to fail, and asserts `RestoreUndo` returns an error
instead of swallowing it. The test fails before the fix and passes after.

`make test`, `go build ./...`, `go vet ./...`, and `gofmt -l .` all pass.

Closes #252
