### PR TITLE
fix(ical): discard sync note on stdout for `ical import --output json`

### DIFF
--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -122,8 +123,15 @@ again updates existing items instead of blindly duplicating them.`,
 			// Opportunistically push whatever landed to a CalDAV-linked
 			// calendar, mirroring the event/todo/journal write paths, so an
 			// import doesn't wait for the next `service run` tick (issue #115).
+			// In JSON mode the push seam's human-readable sync note must be
+			// discarded so it can't trail the JSON object on stdout and break
+			// downstream parsers (issue #255); text mode still shows it.
 			if len(summary.events)+len(summary.todos)+len(summary.journals) > 0 {
-				pushCalendarAfterWrite(a, calID, w)
+				pushWriter := w
+				if outputFmt != "text" {
+					pushWriter = io.Discard
+				}
+				pushCalendarAfterWrite(a, calID, pushWriter)
 			}
 
 			// A non-zero exit signals that the import was partial, but the

--- a/cmd/chroncal/ical_import_test.go
+++ b/cmd/chroncal/ical_import_test.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/ical"
 	"github.com/douglasdemoura/chroncal/internal/model"
@@ -132,6 +139,67 @@ func TestImportComponentsSurfacesChildFieldFailure(t *testing.T) {
 	// But the dropped alarm must be reported instead of only logged.
 	if !containsSubstring(result.Warnings, "alarms") {
 		t.Fatalf("warnings = %v, want a warning about the dropped alarm", result.Warnings)
+	}
+}
+
+// TestImportJSONOutputStaysValidWhenPushNotes is the regression test for
+// issue #255: `ical import --output json` passed the command's stdout writer
+// to the opportunistic push seam unconditionally, so the human-readable
+// "Synced to ..." note was appended after the JSON object, producing invalid
+// JSON on stdout. In JSON mode the note must go to io.Discard (matching the
+// event/todo/journal write paths) so stdout stays parseable.
+func TestImportJSONOutputStaysValidWhenPushNotes(t *testing.T) {
+	ctx := context.Background()
+	a := newImportTestApp(t)
+
+	if _, err := a.Calendars.Create(ctx, "Work", "", ""); err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	icsPath := filepath.Join(t.TempDir(), "in.ics")
+	ics := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//chroncal//test//EN\r\n" +
+		"BEGIN:VTODO\r\nUID:import-json-1\r\nSUMMARY:Imported task\r\nEND:VTODO\r\n" +
+		"END:VCALENDAR\r\n"
+	if err := os.WriteFile(icsPath, []byte(ics), 0o600); err != nil {
+		t.Fatalf("write ics: %v", err)
+	}
+
+	// Simulate a CalDAV-linked calendar that produces a pushable change: the
+	// real seam writes "Synced to ..." to the writer it is handed. In JSON
+	// mode it must be handed io.Discard, so this note must never reach stdout.
+	const syncNote = "Synced to Work · pushed 1 · deleted 0\n"
+	prev := pushCalendarAfterWrite
+	pushCalendarAfterWrite = func(_ *app.App, _ int64, w io.Writer) {
+		io.WriteString(w, syncNote)
+	}
+	t.Cleanup(func() { pushCalendarAfterWrite = prev })
+
+	prevFmt := outputFmt
+	outputFmt = "json"
+	t.Cleanup(func() { outputFmt = prevFmt })
+
+	root := &cobra.Command{
+		Use: "chroncal-test",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			cfg = config.Load()
+			return nil
+		},
+	}
+	root.AddCommand(icalCmd())
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"ical", "import", icsPath, "--calendar", "Work"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("ical import: %v", err)
+	}
+
+	if strings.Contains(out.String(), "Synced to") {
+		t.Fatalf("sync note leaked into JSON stdout:\n%s", out.String())
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(out.Bytes(), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput:\n%s", err, out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

`chroncal ical import <file.ics> --output json` against a CalDAV-linked calendar with pushable changes printed the JSON object and then appended the human-readable `Synced to … · pushed N · deleted M` note to the **same stdout stream**, producing invalid JSON and breaking downstream `--output json` parsers.

## Root cause

The import command passed the command's stdout writer to the opportunistic push seam unconditionally:

```go
pushCalendarAfterWrite(a, calID, w) // w == stdout, even in JSON mode
```

`pushCalendarAfterWrite` writes human-readable lines (`Synced to %s …`, `note: …`) to the writer it is handed. The event/todo/journal write paths already guard this by passing `io.Discard` in JSON mode and the command writer only in text mode; `ical import` copied the pattern inconsistently.

## Fix

Route the push note to `io.Discard` in JSON mode and to the command writer only in text mode, matching the established `event`/`todo`/`journal` write paths. JSON stdout now stays parseable; text mode is unchanged.

## Test

Added `TestImportJSONOutputStaysValidWhenPushNotes`: stubs the push seam to emit a `Synced to …` note, runs `ical import --output json`, and asserts stdout contains no sync note and parses as valid JSON. Verified it fails on the pre-fix code (the note trails the JSON object) and passes with the fix.

`make test`, `go test ./cmd/...`, `go build ./...`, `go vet ./...`, and `gofmt -l .` are all green.

Closes #255
