### PR TITLE
fix(recurrence): propagate override-fetch error instead of rendering stale masters

### DIFF
--- a/internal/recurrence/integration_test.go
+++ b/internal/recurrence/integration_test.go
@@ -2,15 +2,102 @@ package recurrence
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
+
+// faultyDBTX wraps a storage.DBTX and forces any query whose text contains
+// failOn to fail, simulating a transient SQLite error mid-expansion. sqlc keeps
+// the `-- name: <QueryName>` comment in the query string, so matching on the
+// query name targets exactly one statement.
+type faultyDBTX struct {
+	storage.DBTX
+	failOn string
+}
+
+func (f faultyDBTX) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	if strings.Contains(query, f.failOn) {
+		return nil, errors.New("injected query failure")
+	}
+	return f.DBTX.QueryContext(ctx, query, args...)
+}
+
+// TestExpand_OverrideFetchErrorPropagates locks in that a failure fetching a
+// recurring master's overrides surfaces as an error instead of silently
+// degrading to "no overrides" — which would suppress nothing and emit the stale
+// master RRULE instance at its original time while the real override vanishes.
+// Regression test for issue #251.
+func TestExpand_OverrideFetchErrorPropagates(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	eventsSvc := event.NewService(db, q)
+	ctx := context.Background()
+
+	// Weekly-Monday master whose Apr 6 occurrence is moved to Wed Apr 8 14:00.
+	master, err := eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID:     1,
+		Title:          "Weekly Standup",
+		StartTime:      time.Date(2026, 4, 6, 9, 0, 0, 0, time.UTC), // Monday
+		EndTime:        time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=MO",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	if _, err := eventsSvc.UpsertByUID(ctx, event.UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Standup (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: "2026-04-06T09:00:00Z",
+	}); err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// A recurrence service whose override fetch fails. The master itself still
+	// loads, so expansion reaches the override fetch.
+	faultySvc := NewService(db, storage.New(faultyDBTX{DBTX: db, failOn: "ListOverridesByUID"}))
+
+	// Original slot day (Apr 6): with overrides discarded the master would emit
+	// the stale Apr 6 instance here; the fix must surface the error instead.
+	from := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name string
+		run  func() (int, error)
+	}{
+		{"ListExpandedEvents", func() (int, error) {
+			e, err := faultySvc.ListExpandedEvents(ctx, from, to)
+			return len(e), err
+		}},
+		{"ListExpandedByDateRange", func() (int, error) {
+			e, err := faultySvc.ListExpandedByDateRange(ctx, from, to)
+			return len(e), err
+		}},
+		{"ListFilteredEvents", func() (int, error) {
+			e, err := faultySvc.ListFilteredEvents(ctx, EventListParams{From: from, To: to})
+			return len(e), err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n, err := tc.run()
+			if err == nil {
+				t.Fatalf("override fetch failed but %s returned nil error with %d events "+
+					"(stale master instance leaked instead of surfacing the error)", tc.name, n)
+			}
+		})
+	}
+}
 
 func TestListExpandedByDateRange(t *testing.T) {
 	db, q := testutil.NewTestDB(t)

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -337,7 +337,10 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 		expanded := ExpandEvent(evt, from, to)
 
 		// Fetch overrides for this master.
-		overrides, _ := s.q.ListOverridesByUID(ctx, row.Uid)
+		overrides, err := s.q.ListOverridesByUID(ctx, row.Uid)
+		if err != nil {
+			return nil, err
+		}
 		overridden := make(map[string]struct{}, len(overrides))
 		for _, o := range overrides {
 			overridden[canonicalRecurrenceID(o.RecurrenceID)] = struct{}{}
@@ -485,14 +488,17 @@ func eventFromRow(row storage.Event) event.Event {
 // expandRecurringRows expands recurring event rows into Event instances with
 // StartTime/EndTime adjusted to each occurrence. For each master, overrides
 // (rows with a matching RECURRENCE-ID) replace the original RRULE instance.
-func (s *Service) expandRecurringRows(ctx context.Context, rows []storage.Event, from, to time.Time) []event.Event {
+func (s *Service) expandRecurringRows(ctx context.Context, rows []storage.Event, from, to time.Time) ([]event.Event, error) {
 	var result []event.Event
 	for _, row := range rows {
 		evt := eventFromRow(row)
 		expanded := ExpandEvent(evt, from, to)
 
 		// Fetch overrides for this master.
-		overrides, _ := s.q.ListOverridesByUID(ctx, row.Uid)
+		overrides, err := s.q.ListOverridesByUID(ctx, row.Uid)
+		if err != nil {
+			return nil, err
+		}
 		overridden := make(map[string]struct{}, len(overrides))
 		for _, o := range overrides {
 			overridden[canonicalRecurrenceID(o.RecurrenceID)] = struct{}{}
@@ -528,7 +534,7 @@ func (s *Service) expandRecurringRows(ctx context.Context, rows []storage.Event,
 			result = append(result, oe)
 		}
 	}
-	return result
+	return result, nil
 }
 
 // ListExpandedByDateRange returns non-recurring events in [from,to) merged
@@ -554,7 +560,11 @@ func (s *Service) ListExpandedByDateRange(ctx context.Context, from, to time.Tim
 	if err != nil {
 		return nil, err
 	}
-	result = append(result, s.expandRecurringRows(ctx, recurringRows, from, to)...)
+	expanded, err := s.expandRecurringRows(ctx, recurringRows, from, to)
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, expanded...)
 
 	s.populateEventCategories(ctx, result)
 	sort.Slice(result, func(i, j int) bool {
@@ -891,7 +901,11 @@ func (s *Service) ListFilteredEvents(ctx context.Context, p EventListParams) ([]
 		return nil, err
 	}
 	if hasRange {
-		result = append(result, s.expandRecurringRows(ctx, recurringRows, p.From, p.To)...)
+		expanded, err := s.expandRecurringRows(ctx, recurringRows, p.From, p.To)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, expanded...)
 	} else {
 		for _, row := range recurringRows {
 			result = append(result, eventFromRow(row))


### PR DESCRIPTION
## Summary

`ListExpandedEvents` and `expandRecurringRows` fetched each recurring master's
overrides with `overrides, _ := s.q.ListOverridesByUID(ctx, row.Uid)`,
discarding the error.

**Bug.** On a transient query failure mid-expansion (e.g. SQLite busy), the
`overrides` slice is nil, so the suppression map is empty. Every overridden slot
then fails the `if _, ok := overridden[instKey]; ok { continue }` check, so the
**stale master RRULE instance** is emitted at its original time, while the
override-emit loop ranges over an empty slice and emits nothing. The user sees
the original (unrescheduled) occurrence and the actual moved/edited override
never appears — wrong times/days with **no error surfaced** to the caller.

## Fix

Propagate the error from the override fetch:

- `ListExpandedEvents` returns the error directly.
- `expandRecurringRows` now returns `([]event.Event, error)`; the error is
  threaded through both callers (`ListExpandedByDateRange`, `ListFilteredEvents`).

A failed override fetch now returns an error rather than silently degrading to
"no overrides" and rendering stale masters.

## Test

Adds `TestExpand_OverrideFetchErrorPropagates`: a `faultyDBTX` wrapper injects a
query failure scoped to `ListOverridesByUID` (the master fetch still succeeds, so
expansion reaches the override path), and the test asserts that every event
expansion entry point — `ListExpandedEvents`, `ListExpandedByDateRange`,
`ListFilteredEvents` — returns an error instead of a leaked stale master
instance. Confirmed failing before the fix, passing after.

## Scope

Focused on the event expansion paths named in the issue. The analogous
error-discard in the todo (`ListTodoOverridesByUID`) and journal
(`ListJournalOverridesByUID`) expansion paths is left untouched to keep this
change scoped to #251.

`make test`, `go build ./...`, `go vet ./...`, and `gofmt -l .` are all green.

Closes #251
