### PR TITLE
refactor(softdelete): centralize EXDATE-provenance restore contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,10 @@ n, err := svc.PurgeDeleted(ctx, cutoff) // all rows older than cutoff
 
 Restoring a recurring override also clears the matching EXDATE on the
 master in the same transaction, so expansion sees the occurrence again.
+The EXDATE-provenance rule (only strip EXDATEs a delete recorded, never
+imported ones — issue #86) lives in `softdelete.ClearMasterEXDATE`; each
+domain's `clearMasterEXDATE` is a thin wrapper that binds its sqlc queries
+to that shared helper. Fix the contract there, not per-domain.
 
 ### List or purge mixed trash
 The `internal/trash` package aggregates all three domains:

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/softdelete"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
@@ -364,49 +365,45 @@ func (s *Service) restoreEventsByUIDClearingExdates(ctx context.Context, uid str
 	return tx.Commit()
 }
 
+// clearMasterEXDATE reverses the EXDATE an instance-delete added for
+// recurrenceID on the master event with uid. The provenance contract lives in
+// softdelete.ClearMasterEXDATE; this wrapper only binds the event queries to
+// the active transaction so the override is never visible-but-excluded.
 func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
-	// Only strip an EXDATE that a delete operation added. EXDATEs that arrived
-	// via import (or a series delete, which never adds one) have no provenance
-	// row and must survive restore — otherwise RestoreByUID silently drops a
-	// legitimate imported EXDATE whose slot happens to match an override's
-	// recurrence_id (issue #86).
-	log, err := qtx.GetEventExdateDeleteByUIDRecurrence(ctx, storage.GetEventExdateDeleteByUIDRecurrenceParams{
-		Uid:          uid,
-		RecurrenceID: recurrenceID,
-	})
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil
-		}
-		return fmt.Errorf("get exdate log: %w", err)
-	}
-
-	master, err := qtx.GetEventByUID(ctx, uid)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// Master gone; drop the now-orphaned provenance row.
-			return qtx.DeleteEventExdateDelete(ctx, log.ID)
-		}
-		return fmt.Errorf("get master: %w", err)
-	}
-	target, err := timeutil.ParseRecurrenceID(recurrenceID)
-	if err != nil {
-		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
-	}
-	existing := ParseTimeList(storage.NullableToString(master.Exdates))
-	filtered := timeutil.RemoveTimeFromList(existing, target)
-	if len(filtered) != len(existing) {
-		if err := qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
-			Exdates: storage.StringToNullable(SerializeTimeList(filtered)),
-			ID:      master.ID,
-		}); err != nil {
-			return fmt.Errorf("update exdates: %w", err)
-		}
-	}
-	if err := qtx.DeleteEventExdateDelete(ctx, log.ID); err != nil {
-		return fmt.Errorf("delete exdate log: %w", err)
-	}
-	return nil
+	return softdelete.ClearMasterEXDATE(ctx, softdelete.ExdateProvenance{
+		GetDeleteLog: func(ctx context.Context) (int64, bool, error) {
+			log, err := qtx.GetEventExdateDeleteByUIDRecurrence(ctx, storage.GetEventExdateDeleteByUIDRecurrenceParams{
+				Uid:          uid,
+				RecurrenceID: recurrenceID,
+			})
+			if errors.Is(err, sql.ErrNoRows) {
+				return 0, false, nil
+			}
+			if err != nil {
+				return 0, false, err
+			}
+			return log.ID, true, nil
+		},
+		GetMaster: func(ctx context.Context) (int64, string, bool, error) {
+			master, err := qtx.GetEventByUID(ctx, uid)
+			if errors.Is(err, sql.ErrNoRows) {
+				return 0, "", false, nil
+			}
+			if err != nil {
+				return 0, "", false, err
+			}
+			return master.ID, storage.NullableToString(master.Exdates), true, nil
+		},
+		UpdateExdates: func(ctx context.Context, masterID int64, exdates string) error {
+			return qtx.UpdateEventExdates(ctx, storage.UpdateEventExdatesParams{
+				Exdates: storage.StringToNullable(exdates),
+				ID:      masterID,
+			})
+		},
+		DeleteDeleteLog: func(ctx context.Context, logID int64) error {
+			return qtx.DeleteEventExdateDelete(ctx, logID)
+		},
+	}, recurrenceID)
 }
 
 func (s *Service) restoreFromInstance(ctx context.Context, meta UndoMeta) error {

--- a/internal/journal/soft_delete.go
+++ b/internal/journal/soft_delete.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/softdelete"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
@@ -59,54 +60,45 @@ func (s *Service) RestoreByID(ctx context.Context, id int64) error {
 	return s.reconcileSyncAfterRestore(ctx, r.CalendarID, r.Uid)
 }
 
-// clearMasterEXDATE removes the EXDATE entry for recurrenceID from the
-// master journal with uid, reversing the exclusion that the instance-delete
-// path added. It only strips EXDATEs that a delete recorded in
-// journal_exdate_deletes; EXDATEs that arrived via import (or a series
-// delete, which never adds one) have no provenance row and survive restore —
-// otherwise RestoreByUID would silently drop a legitimate imported EXDATE
-// whose slot happens to match an override's recurrence_id (issue #86). A
-// malformed recurrence_id is a data-integrity error and is propagated rather
-// than swallowed. Must run inside the same transaction (qtx) that un-hides
-// the override so the row is never visible-but-excluded.
+// clearMasterEXDATE reverses the EXDATE an instance-delete added for
+// recurrenceID on the master journal with uid. The provenance contract lives
+// in softdelete.ClearMasterEXDATE; this wrapper only binds the journal queries
+// to the active transaction so the override is never visible-but-excluded.
 func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
-	log, err := qtx.GetJournalExdateDeleteByUIDRecurrence(ctx, storage.GetJournalExdateDeleteByUIDRecurrenceParams{
-		Uid:          uid,
-		RecurrenceID: recurrenceID,
-	})
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil
-		}
-		return fmt.Errorf("get exdate log: %w", err)
-	}
-
-	master, err := qtx.GetJournalByUID(ctx, uid)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// Master gone; drop the now-orphaned provenance row.
-			return qtx.DeleteJournalExdateDelete(ctx, log.ID)
-		}
-		return fmt.Errorf("get master: %w", err)
-	}
-	target, err := timeutil.ParseRecurrenceID(recurrenceID)
-	if err != nil {
-		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
-	}
-	existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
-	filtered := timeutil.RemoveTimeFromList(existing, target)
-	if len(filtered) != len(existing) {
-		if err := qtx.UpdateJournalExdates(ctx, storage.UpdateJournalExdatesParams{
-			Exdates: storage.StringToNullable(timeutil.SerializeTimeList(filtered)),
-			ID:      master.ID,
-		}); err != nil {
-			return fmt.Errorf("update exdates: %w", err)
-		}
-	}
-	if err := qtx.DeleteJournalExdateDelete(ctx, log.ID); err != nil {
-		return fmt.Errorf("delete exdate log: %w", err)
-	}
-	return nil
+	return softdelete.ClearMasterEXDATE(ctx, softdelete.ExdateProvenance{
+		GetDeleteLog: func(ctx context.Context) (int64, bool, error) {
+			log, err := qtx.GetJournalExdateDeleteByUIDRecurrence(ctx, storage.GetJournalExdateDeleteByUIDRecurrenceParams{
+				Uid:          uid,
+				RecurrenceID: recurrenceID,
+			})
+			if errors.Is(err, sql.ErrNoRows) {
+				return 0, false, nil
+			}
+			if err != nil {
+				return 0, false, err
+			}
+			return log.ID, true, nil
+		},
+		GetMaster: func(ctx context.Context) (int64, string, bool, error) {
+			master, err := qtx.GetJournalByUID(ctx, uid)
+			if errors.Is(err, sql.ErrNoRows) {
+				return 0, "", false, nil
+			}
+			if err != nil {
+				return 0, "", false, err
+			}
+			return master.ID, storage.NullableToString(master.Exdates), true, nil
+		},
+		UpdateExdates: func(ctx context.Context, masterID int64, exdates string) error {
+			return qtx.UpdateJournalExdates(ctx, storage.UpdateJournalExdatesParams{
+				Exdates: storage.StringToNullable(exdates),
+				ID:      masterID,
+			})
+		},
+		DeleteDeleteLog: func(ctx context.Context, logID int64) error {
+			return qtx.DeleteJournalExdateDelete(ctx, logID)
+		},
+	}, recurrenceID)
 }
 
 // RestoreByUID un-hides every soft-deleted row sharing uid — master plus

--- a/internal/softdelete/softdelete.go
+++ b/internal/softdelete/softdelete.go
@@ -1,0 +1,77 @@
+// Package softdelete holds reversible-delete logic shared by the event, todo,
+// and journal services. Centralizing it keeps the subtle EXDATE-provenance
+// restore contract (issue #86) encoded in exactly one place, so a correctness
+// fix can no longer drift between the three domains.
+package softdelete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
+)
+
+// ExdateProvenance adapts a single domain's generated queries (bound to the
+// active transaction, and to the uid/recurrenceID under restore) to the
+// operations ClearMasterEXDATE needs. Each domain wires its sqlc methods into
+// these closures.
+type ExdateProvenance struct {
+	// GetDeleteLog returns the provenance row id recorded when a delete added
+	// the EXDATE for the override under restore. found is false (with a nil
+	// error) when no provenance row exists — meaning the EXDATE arrived via
+	// import (or a series delete) and must survive restore.
+	GetDeleteLog func(ctx context.Context) (logID int64, found bool, err error)
+	// GetMaster returns the master row's id and its serialized EXDATE list.
+	// found is false (with a nil error) when the master row is gone.
+	GetMaster func(ctx context.Context) (masterID int64, exdates string, found bool, err error)
+	// UpdateExdates writes the filtered EXDATE list back to the master.
+	UpdateExdates func(ctx context.Context, masterID int64, exdates string) error
+	// DeleteDeleteLog removes the provenance row once its EXDATE is reversed
+	// (or once the master it pointed at is gone).
+	DeleteDeleteLog func(ctx context.Context, logID int64) error
+}
+
+// ClearMasterEXDATE removes the EXDATE entry for recurrenceID from the master
+// identified by uid, reversing the exclusion an instance-delete added. It only
+// strips EXDATEs that a delete recorded in the *_exdate_deletes provenance
+// table; EXDATEs that arrived via import (or a series delete, which never adds
+// one) have no provenance row and survive restore — otherwise a UID-wide
+// restore would silently drop a legitimate imported EXDATE whose slot happens
+// to match an override's recurrence_id (issue #86). A malformed recurrence_id
+// is a data-integrity error and is propagated rather than swallowed. Callers
+// must wire p to the same transaction that un-hides the override so the row is
+// never visible-but-excluded.
+func ClearMasterEXDATE(ctx context.Context, p ExdateProvenance, recurrenceID string) error {
+	logID, found, err := p.GetDeleteLog(ctx)
+	if err != nil {
+		return fmt.Errorf("get exdate log: %w", err)
+	}
+	if !found {
+		return nil
+	}
+
+	masterID, exdates, found, err := p.GetMaster(ctx)
+	if err != nil {
+		return fmt.Errorf("get master: %w", err)
+	}
+	if !found {
+		// Master gone; drop the now-orphaned provenance row.
+		return p.DeleteDeleteLog(ctx, logID)
+	}
+
+	target, err := timeutil.ParseRecurrenceID(recurrenceID)
+	if err != nil {
+		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
+	}
+	existing := timeutil.ParseTimeList(exdates)
+	filtered := timeutil.RemoveTimeFromList(existing, target)
+	if len(filtered) != len(existing) {
+		if err := p.UpdateExdates(ctx, masterID, timeutil.SerializeTimeList(filtered)); err != nil {
+			return fmt.Errorf("update exdates: %w", err)
+		}
+	}
+	if err := p.DeleteDeleteLog(ctx, logID); err != nil {
+		return fmt.Errorf("delete exdate log: %w", err)
+	}
+	return nil
+}

--- a/internal/softdelete/softdelete_test.go
+++ b/internal/softdelete/softdelete_test.go
@@ -1,0 +1,123 @@
+package softdelete
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeStore is an in-memory stand-in for one domain's *_exdate_deletes
+// provenance table plus its master row, wired into an ExdateProvenance below.
+type fakeStore struct {
+	logFound    bool
+	logID       int64
+	masterFound bool
+	masterID    int64
+	exdates     string
+
+	getLogErr error
+
+	updatedExdates *string
+	deletedLogID   *int64
+}
+
+func (f *fakeStore) provenance() ExdateProvenance {
+	return ExdateProvenance{
+		GetDeleteLog: func(ctx context.Context) (int64, bool, error) {
+			if f.getLogErr != nil {
+				return 0, false, f.getLogErr
+			}
+			return f.logID, f.logFound, nil
+		},
+		GetMaster: func(ctx context.Context) (int64, string, bool, error) {
+			return f.masterID, f.exdates, f.masterFound, nil
+		},
+		UpdateExdates: func(ctx context.Context, masterID int64, exdates string) error {
+			f.updatedExdates = &exdates
+			return nil
+		},
+		DeleteDeleteLog: func(ctx context.Context, logID int64) error {
+			f.deletedLogID = &logID
+			return nil
+		},
+	}
+}
+
+const testSlot = "2026-06-01T10:00:00Z"
+
+// No provenance row: the EXDATE arrived via import (or a series delete) and
+// must survive — nothing is updated or deleted (issue #86).
+func TestClearMasterEXDATE_NoProvenanceRowIsNoOp(t *testing.T) {
+	f := &fakeStore{logFound: false}
+	if err := ClearMasterEXDATE(context.Background(), f.provenance(), testSlot); err != nil {
+		t.Fatalf("ClearMasterEXDATE: %v", err)
+	}
+	if f.updatedExdates != nil {
+		t.Errorf("expected no EXDATE update, got %q", *f.updatedExdates)
+	}
+	if f.deletedLogID != nil {
+		t.Errorf("expected no provenance delete, got log id %d", *f.deletedLogID)
+	}
+}
+
+// Provenance row present: strip the matching EXDATE and drop the log row.
+func TestClearMasterEXDATE_StripsMatchingEXDATE(t *testing.T) {
+	f := &fakeStore{logFound: true, logID: 7, masterFound: true, masterID: 3, exdates: testSlot}
+	if err := ClearMasterEXDATE(context.Background(), f.provenance(), testSlot); err != nil {
+		t.Fatalf("ClearMasterEXDATE: %v", err)
+	}
+	if f.updatedExdates == nil || *f.updatedExdates != "" {
+		t.Errorf("expected EXDATE list emptied, got %v", f.updatedExdates)
+	}
+	if f.deletedLogID == nil || *f.deletedLogID != 7 {
+		t.Errorf("expected provenance log 7 deleted, got %v", f.deletedLogID)
+	}
+}
+
+// A duplicate exclusion at the same slot (e.g. an imported EXDATE alongside the
+// delete-added one) must keep exactly one entry: undo strips one, not all.
+func TestClearMasterEXDATE_PreservesDuplicateSlot(t *testing.T) {
+	f := &fakeStore{logFound: true, logID: 7, masterFound: true, masterID: 3, exdates: testSlot + "," + testSlot}
+	if err := ClearMasterEXDATE(context.Background(), f.provenance(), testSlot); err != nil {
+		t.Fatalf("ClearMasterEXDATE: %v", err)
+	}
+	if f.updatedExdates == nil || *f.updatedExdates != testSlot {
+		t.Errorf("expected one EXDATE preserved, got %v", f.updatedExdates)
+	}
+}
+
+// Master gone: drop the orphaned provenance row, update nothing.
+func TestClearMasterEXDATE_MasterGoneDropsOrphanLog(t *testing.T) {
+	f := &fakeStore{logFound: true, logID: 9, masterFound: false}
+	if err := ClearMasterEXDATE(context.Background(), f.provenance(), testSlot); err != nil {
+		t.Fatalf("ClearMasterEXDATE: %v", err)
+	}
+	if f.updatedExdates != nil {
+		t.Errorf("expected no EXDATE update, got %q", *f.updatedExdates)
+	}
+	if f.deletedLogID == nil || *f.deletedLogID != 9 {
+		t.Errorf("expected orphan log 9 deleted, got %v", f.deletedLogID)
+	}
+}
+
+// A malformed recurrence_id is a data-integrity error, propagated not swallowed.
+func TestClearMasterEXDATE_MalformedRecurrenceID(t *testing.T) {
+	f := &fakeStore{logFound: true, logID: 7, masterFound: true, masterID: 3, exdates: testSlot}
+	err := ClearMasterEXDATE(context.Background(), f.provenance(), "not-a-timestamp")
+	if err == nil {
+		t.Fatal("expected error for malformed recurrence_id, got nil")
+	}
+	if f.deletedLogID != nil {
+		t.Errorf("expected no provenance delete on error, got log id %d", *f.deletedLogID)
+	}
+}
+
+// A non-ErrNoRows lookup failure surfaces to the caller.
+func TestClearMasterEXDATE_GetDeleteLogError(t *testing.T) {
+	sentinel := errors.New("boom")
+	f := &fakeStore{getLogErr: sentinel}
+	err := ClearMasterEXDATE(context.Background(), f.provenance(), testSlot)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel error, got %v", err)
+	}
+}

--- a/internal/todo/soft_delete.go
+++ b/internal/todo/soft_delete.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/softdelete"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
@@ -65,54 +66,45 @@ func (s *Service) RestoreByID(ctx context.Context, id int64) error {
 	return s.reconcileSyncAfterRestore(ctx, r.CalendarID, r.Uid)
 }
 
-// clearMasterEXDATE removes the EXDATE entry for recurrenceID from the
-// master todo with uid, reversing the exclusion that the instance-delete
-// path added. It only strips EXDATEs that a delete recorded in
-// todo_exdate_deletes; EXDATEs that arrived via import (or a series delete,
-// which never adds one) have no provenance row and survive restore —
-// otherwise RestoreByUID would silently drop a legitimate imported EXDATE
-// whose slot happens to match an override's recurrence_id (issue #86). A
-// malformed recurrence_id is a data-integrity error and is propagated rather
-// than swallowed. Must run inside the same transaction (qtx) that un-hides
-// the override so the row is never visible-but-excluded.
+// clearMasterEXDATE reverses the EXDATE an instance-delete added for
+// recurrenceID on the master todo with uid. The provenance contract lives in
+// softdelete.ClearMasterEXDATE; this wrapper only binds the todo queries to
+// the active transaction so the override is never visible-but-excluded.
 func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenceID string) error {
-	log, err := qtx.GetTodoExdateDeleteByUIDRecurrence(ctx, storage.GetTodoExdateDeleteByUIDRecurrenceParams{
-		Uid:          uid,
-		RecurrenceID: recurrenceID,
-	})
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil
-		}
-		return fmt.Errorf("get exdate log: %w", err)
-	}
-
-	master, err := qtx.GetTodoByUID(ctx, uid)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// Master gone; drop the now-orphaned provenance row.
-			return qtx.DeleteTodoExdateDelete(ctx, log.ID)
-		}
-		return fmt.Errorf("get master: %w", err)
-	}
-	target, err := timeutil.ParseRecurrenceID(recurrenceID)
-	if err != nil {
-		return fmt.Errorf("parse recurrence_id %q: %w", recurrenceID, err)
-	}
-	existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
-	filtered := timeutil.RemoveTimeFromList(existing, target)
-	if len(filtered) != len(existing) {
-		if err := qtx.UpdateTodoExdates(ctx, storage.UpdateTodoExdatesParams{
-			Exdates: storage.StringToNullable(timeutil.SerializeTimeList(filtered)),
-			ID:      master.ID,
-		}); err != nil {
-			return fmt.Errorf("update exdates: %w", err)
-		}
-	}
-	if err := qtx.DeleteTodoExdateDelete(ctx, log.ID); err != nil {
-		return fmt.Errorf("delete exdate log: %w", err)
-	}
-	return nil
+	return softdelete.ClearMasterEXDATE(ctx, softdelete.ExdateProvenance{
+		GetDeleteLog: func(ctx context.Context) (int64, bool, error) {
+			log, err := qtx.GetTodoExdateDeleteByUIDRecurrence(ctx, storage.GetTodoExdateDeleteByUIDRecurrenceParams{
+				Uid:          uid,
+				RecurrenceID: recurrenceID,
+			})
+			if errors.Is(err, sql.ErrNoRows) {
+				return 0, false, nil
+			}
+			if err != nil {
+				return 0, false, err
+			}
+			return log.ID, true, nil
+		},
+		GetMaster: func(ctx context.Context) (int64, string, bool, error) {
+			master, err := qtx.GetTodoByUID(ctx, uid)
+			if errors.Is(err, sql.ErrNoRows) {
+				return 0, "", false, nil
+			}
+			if err != nil {
+				return 0, "", false, err
+			}
+			return master.ID, storage.NullableToString(master.Exdates), true, nil
+		},
+		UpdateExdates: func(ctx context.Context, masterID int64, exdates string) error {
+			return qtx.UpdateTodoExdates(ctx, storage.UpdateTodoExdatesParams{
+				Exdates: storage.StringToNullable(exdates),
+				ID:      masterID,
+			})
+		},
+		DeleteDeleteLog: func(ctx context.Context, logID int64) error {
+			return qtx.DeleteTodoExdateDelete(ctx, logID)
+		},
+	}, recurrenceID)
 }
 
 // RestoreByUID un-hides every soft-deleted row with the given UID —


### PR DESCRIPTION
Closes #259.

## Problem

`internal/event/soft_delete.go`, `internal/todo/soft_delete.go`, and
`internal/journal/soft_delete.go` each carried a near-identical
`clearMasterEXDATE`, encoding the subtle issue-#86 provenance rule three
times: *only strip an EXDATE that a delete recorded; EXDATEs that arrived
via import (or a series delete) have no provenance row and must survive
restore.* They also each defined an identical pure `removeTimeFromList`
(quad-duplicated, counting the copy in `event/trash.go`). A correctness
fix to one copy could silently diverge from the others, leaving a restored
todo/journal override dropping a legitimate imported EXDATE.

## Refactor

- New `internal/softdelete` package: `ClearMasterEXDATE` holds the policy
  (provenance gate, orphan-master cleanup, exactly-one EXDATE removal, log
  deletion). It takes an `ExdateProvenance` adapter of four closures that
  each domain wires to its own sqlc queries — the only per-domain part
  (distinct generated types, so the closure seam is irreducible in
  idiomatic Go).
- Each domain's `clearMasterEXDATE` is now a thin wrapper binding its
  queries to the shared helper.
- Moved the pure `removeTimeFromList` into `timeutil.RemoveTimeFromList`.
- Documented the shared helper in AGENTS.md so the contract has one
  discoverable home.

Scope is deliberately limited to the EXDATE-provenance contract — the one
piece whose silent divergence is a correctness bug. `RestoreByID` /
`RestoreByUID` / `Purge*` remain per-domain CRUD orchestration (safe to
diverge; genericizing across distinct sqlc return types would add
indirection without protecting an invariant).

## Tests

- No external behavior change. Existing soft-delete/restore/purge suites
  across all three domains stay green, including the provenance cases
  (`RestoreByUIDPreservesImportedExdate/EXDATE`, `RestoreOverrideClearsExdate`,
  `MalformedRecurrenceID`).
- Added `internal/softdelete/softdelete_test.go`: a DB-free unit test that
  locks the contract directly (no-op when no provenance row, strip matching
  EXDATE, preserve duplicate slot, drop orphan log when master gone,
  propagate malformed recurrence_id, propagate lookup errors).
- `make test`, `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.

Reviewed with the `code-review` and `simplify` skills; findings addressed
(removed redundant uid/recurrenceID parameter threading; guard-clause
closures instead of a clever `err == nil` idiom).
