### PR TITLE
fix(event): normalize stored start/end times to UTC

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -170,16 +170,44 @@ func applyEventDefaults(status, transp, class *string) {
 	}
 }
 
+// normalizeEventTimes coerces start/end to the storage invariant that all
+// database times are RFC 3339 in UTC (see AGENTS.md). Without it, times built
+// in a non-UTC zone (e.g. the CLI's time.Local or a --timezone value) persist
+// with an offset and sort incorrectly against the UTC bounds used by
+// date-range queries, silently dropping the event from list views (#254).
+//
+// Timed events keep their absolute instant. All-day events are pinned to UTC
+// midnight on their wall-clock date so they occupy exactly one calendar day
+// regardless of the zone they were built in (matching the TUI and iCal import);
+// a plain .UTC() would otherwise shift local midnight onto the previous or next
+// day and make the event surface on two days.
+func normalizeEventTimes(start, end *time.Time, allDay bool) {
+	*start = toStorageTime(*start, allDay)
+	*end = toStorageTime(*end, allDay)
+}
+
+func toStorageTime(t time.Time, allDay bool) time.Time {
+	if allDay {
+		// Take the wall-clock date in t's own location before dropping the
+		// zone, then pin to UTC midnight.
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	}
+	return t.UTC()
+}
+
 func (p *CreateParams) applyDefaults() {
 	applyEventDefaults(&p.Status, &p.Transp, &p.Class)
+	normalizeEventTimes(&p.StartTime, &p.EndTime, p.AllDay)
 }
 
 func (p *UpsertParams) applyDefaults() {
 	applyEventDefaults(&p.Status, &p.Transp, &p.Class)
+	normalizeEventTimes(&p.StartTime, &p.EndTime, p.AllDay)
 }
 
 func (p *UpdateParams) applyDefaults() {
 	applyEventDefaults(&p.Status, &p.Transp, &p.Class)
+	normalizeEventTimes(&p.StartTime, &p.EndTime, p.AllDay)
 }
 
 func (s *Service) CountByCalendar(ctx context.Context, calendarID int64) (int64, error) {

--- a/internal/event/utc_normalization_test.go
+++ b/internal/event/utc_normalization_test.go
@@ -1,0 +1,162 @@
+package event
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/testutil"
+)
+
+// storedTimes reads the raw start_time / end_time strings persisted for an
+// event, so tests can assert the on-disk representation rather than the parsed
+// time.Time (which would hide a stored offset).
+func storedTimes(t *testing.T, db *sql.DB, id int64) (string, string) {
+	t.Helper()
+	var start, end string
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT start_time, end_time FROM events WHERE id = ?", id,
+	).Scan(&start, &end); err != nil {
+		t.Fatalf("read raw row: %v", err)
+	}
+	return start, end
+}
+
+// occursOn reports how many times the event with the given id appears in the
+// half-open UTC date-range [from, to).
+func occursOn(t *testing.T, svc *Service, id int64, from, to time.Time) int {
+	t.Helper()
+	events, err := svc.ListByDateRange(context.Background(), from, to)
+	if err != nil {
+		t.Fatalf("list by date range: %v", err)
+	}
+	n := 0
+	for _, e := range events {
+		if e.ID == id {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCreate_NormalizesTimedToUTC reproduces issue #254 for timed events: when
+// the caller supplies start/end times carrying a non-UTC offset, the row must
+// be stored as RFC 3339 in UTC. Otherwise the persisted string sorts
+// incorrectly against the UTC "Z" bounds used by date-range queries (SQLite
+// compares TEXT lexicographically) and the event silently disappears from list
+// views.
+func TestCreate_NormalizesTimedToUTC(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	// 23:00 at UTC-4 == 03:00 the next day in UTC.
+	loc := time.FixedZone("EDT", -4*60*60)
+	start := time.Date(2026, 6, 26, 23, 0, 0, 0, loc)
+	end := start.Add(time.Hour)
+
+	created, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Title:      "Offset Event",
+		StartTime:  start,
+		EndTime:    end,
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	rawStart, rawEnd := storedTimes(t, db, created.ID)
+	if !strings.HasSuffix(rawStart, "Z") {
+		t.Errorf("stored start_time = %q, want UTC (suffix Z)", rawStart)
+	}
+	if !strings.HasSuffix(rawEnd, "Z") {
+		t.Errorf("stored end_time = %q, want UTC (suffix Z)", rawEnd)
+	}
+
+	// The event (03:00-04:00Z on Jun 27) must appear in the Jun 27 UTC window.
+	from := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+	if got := occursOn(t, svc, created.ID, from, to); got != 1 {
+		t.Errorf("timed event appears %d times in [%s, %s), want 1",
+			got, from.Format(time.RFC3339), to.Format(time.RFC3339))
+	}
+}
+
+// TestCreate_AllDayPinsToUTCMidnight guards against a naive .UTC() coercion of
+// all-day events. The CLI builds all-day events at local midnight; a plain
+// .UTC() in a positive-offset zone would shift them onto the previous UTC day
+// and make them surface on two calendar days. All-day events must be stored at
+// UTC midnight on their wall-clock date and occupy exactly one day.
+func TestCreate_AllDayPinsToUTCMidnight(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	loc := time.FixedZone("JST", 9*60*60)
+	start := time.Date(2026, 12, 25, 0, 0, 0, 0, loc)
+	end := start.AddDate(0, 0, 1)
+
+	created, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Title:      "Holiday",
+		StartTime:  start,
+		EndTime:    end,
+		AllDay:     true,
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	rawStart, rawEnd := storedTimes(t, db, created.ID)
+	if rawStart != "2026-12-25T00:00:00Z" {
+		t.Errorf("stored start_time = %q, want 2026-12-25T00:00:00Z", rawStart)
+	}
+	if rawEnd != "2026-12-26T00:00:00Z" {
+		t.Errorf("stored end_time = %q, want 2026-12-26T00:00:00Z", rawEnd)
+	}
+
+	dec24 := occursOn(t, svc, created.ID,
+		time.Date(2026, 12, 24, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 12, 25, 0, 0, 0, 0, time.UTC))
+	dec25 := occursOn(t, svc, created.ID,
+		time.Date(2026, 12, 25, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 12, 26, 0, 0, 0, 0, time.UTC))
+	if dec24 != 0 || dec25 != 1 {
+		t.Errorf("all-day event occurrences: Dec24=%d Dec25=%d, want 0 and 1", dec24, dec25)
+	}
+}
+
+// TestUpdate_NormalizesToUTC confirms the edit path enforces the same
+// invariant: re-saving with offset-bearing times stores them in UTC.
+func TestUpdate_NormalizesToUTC(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Title:      "Event",
+		StartTime:  time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	loc := time.FixedZone("EDT", -4*60*60)
+	if _, err := svc.Update(ctx, created.ID, UpdateParams{
+		CalendarID: 1,
+		Title:      "Event",
+		StartTime:  time.Date(2026, 6, 26, 23, 0, 0, 0, loc),
+		EndTime:    time.Date(2026, 6, 27, 0, 0, 0, 0, loc),
+	}); err != nil {
+		t.Fatalf("update event: %v", err)
+	}
+
+	rawStart, rawEnd := storedTimes(t, db, created.ID)
+	if !strings.HasSuffix(rawStart, "Z") || !strings.HasSuffix(rawEnd, "Z") {
+		t.Errorf("stored times after update = %q / %q, want UTC (suffix Z)", rawStart, rawEnd)
+	}
+}


### PR DESCRIPTION
## Summary

`event create` / `event edit` built start/end times in the caller's location
(`time.Local`, or a `--timezone` value) and persisted them verbatim with
`p.StartTime.Format(time.RFC3339)`, so rows kept a local offset
(e.g. `2026-06-26T23:00:00-04:00`) instead of UTC.

Date-range filters compare these as SQLite TEXT against UTC bounds. Once an
offset is present, lexicographic order diverges from chronological order, so
affected events **silently dropped out of month/week/list views or showed on
the wrong day**. This violated the AGENTS.md invariant that *all database
times are RFC 3339 strings in UTC*. The TUI and iCal import already call
`.UTC()`, so CLI- and TUI-created events were stored inconsistently.

## Fix

Enforce the invariant at the service gate. `CreateParams`/`UpdateParams`/
`UpsertParams.applyDefaults` now normalize the times, so every persistence
path is covered (`Create`, `Update`, `UpsertByUID`, and the recurring
override/split helpers, which all flow through `applyDefaults`):

- **Timed events** keep their absolute instant via `.UTC()`.
- **All-day events** are pinned to **UTC midnight on their wall-clock date**,
  so they occupy exactly one calendar day. A plain `.UTC()` on a
  local-midnight all-day value (the CLI builds all-day at local midnight)
  would shift it onto an adjacent UTC day in non-UTC zones and surface it on
  two days — this matches the TUI, which already builds all-day at UTC
  midnight.

## Tests

`internal/event/utc_normalization_test.go`:

- `TestCreate_NormalizesTimedToUTC` — offset-bearing timed event is stored
  with a `Z` suffix and appears in the correct UTC date-range window (fails
  before the fix).
- `TestCreate_AllDayPinsToUTCMidnight` — all-day event built at local
  midnight in a positive-offset zone (JST) stores as `...T00:00:00Z` and
  appears on exactly one day, not two.
- `TestUpdate_NormalizesToUTC` — the edit path enforces the same invariant.

`make test`, `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.

Closes #254
