### PR TITLE
fix(caldav): make tombstone DELETE conditional with If-Match

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -233,10 +233,20 @@ var ErrResourceGone = errors.New("caldav: resource already gone")
 
 // DeleteResource removes a resource by path. A 404/410 response is reported as
 // ErrResourceGone so callers can treat an already-absent resource as success.
-func (c *Client) DeleteResource(ctx context.Context, path string) error {
+//
+// If etag is non-empty, the DELETE is made conditional via an If-Match
+// precondition so the server rejects it (412 Precondition Failed) when the
+// resource was modified since we last saw it. This prevents a local
+// tombstone push from silently destroying a concurrent remote edit. A 412 is
+// returned as a typed conflict error (see IsConflict) so callers can preserve
+// the remote change instead of forcing the delete.
+func (c *Client) DeleteResource(ctx context.Context, path, etag string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.ResolveURL(path), nil)
 	if err != nil {
 		return fmt.Errorf("new DELETE request: %w", err)
+	}
+	if etag != "" {
+		req.Header.Set("If-Match", formatIfMatch(etag))
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -115,6 +115,9 @@ func TestClientDeleteResourceReportsGone(t *testing.T) {
 				if req.URL.String() != "https://example.com/cal/test.ics" {
 					t.Fatalf("url = %s, want https://example.com/cal/test.ics", req.URL.String())
 				}
+				if got := req.Header.Get("If-Match"); got != "" {
+					t.Fatalf("If-Match = %q, want empty for unconditional delete", got)
+				}
 				return &http.Response{
 					StatusCode: tc.statusCode,
 					Status:     http.StatusText(tc.statusCode),
@@ -126,7 +129,7 @@ func TestClientDeleteResourceReportsGone(t *testing.T) {
 				t.Fatalf("NewClient: %v", err)
 			}
 
-			err = client.DeleteResource(context.Background(), "/cal/test.ics")
+			err = client.DeleteResource(context.Background(), "/cal/test.ics", "")
 			if tc.wantErr != (err != nil) {
 				t.Fatalf("DeleteResource err = %v, wantErr = %v", err, tc.wantErr)
 			}
@@ -134,6 +137,62 @@ func TestClientDeleteResourceReportsGone(t *testing.T) {
 				t.Fatalf("errors.Is(err, ErrResourceGone) = %v, want %v (err = %v)", got, tc.wantGone, err)
 			}
 		})
+	}
+}
+
+func TestClientDeleteResourceSendsIfMatch(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(putTestHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", req.Method)
+		}
+		if got := req.Header.Get("If-Match"); got != `"etag-known"` {
+			t.Fatalf("If-Match = %q, want %q", got, `"etag-known"`)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Status:     "204 No Content",
+			Body:       io.NopCloser(http.NoBody),
+			Request:    req,
+		}, nil
+	}}, "https://example.com")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := client.DeleteResource(context.Background(), "/cal/test.ics", "etag-known"); err != nil {
+		t.Fatalf("DeleteResource: %v", err)
+	}
+}
+
+func TestClientDeleteResourceConflict(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(putTestHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("If-Match"); got != `"etag-known"` {
+			t.Fatalf("If-Match = %q, want %q", got, `"etag-known"`)
+		}
+		return &http.Response{
+			StatusCode: http.StatusPreconditionFailed,
+			Status:     "412 Precondition Failed",
+			Body:       io.NopCloser(http.NoBody),
+			Request:    req,
+		}, nil
+	}}, "https://example.com")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	err = client.DeleteResource(context.Background(), "/cal/test.ics", "etag-known")
+	if err == nil {
+		t.Fatal("DeleteResource err = nil, want conflict error")
+	}
+	if !IsConflict(err) {
+		t.Fatalf("IsConflict(%v) = false, want true", err)
+	}
+	if errors.Is(err, ErrResourceGone) {
+		t.Fatalf("a 412 must not be reported as ErrResourceGone (err = %v)", err)
 	}
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -192,6 +192,7 @@ func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy Co
 		result.Errors = append(result.Errors, fmt.Errorf("tombstones: %w", err))
 	} else {
 		result.Deleted += tombstoneResult.deleted
+		result.Conflicts += tombstoneResult.conflicts
 		result.Errors = append(result.Errors, tombstoneResult.errors...)
 	}
 
@@ -239,6 +240,7 @@ func (e *Engine) PushCalendar(ctx context.Context, calendarID int64, strategy Co
 		result.Errors = append(result.Errors, fmt.Errorf("tombstones: %w", err))
 	} else {
 		result.Deleted = tombstoneResult.deleted
+		result.Conflicts += tombstoneResult.conflicts
 		result.Errors = append(result.Errors, tombstoneResult.errors...)
 	}
 	return result, nil
@@ -1090,14 +1092,27 @@ func (e *Engine) lookupOwnerID(ctx context.Context, ownerType, uid string) int64
 }
 
 type tombstoneResult struct {
-	deleted int
-	errors  []error
+	deleted   int
+	conflicts int
+	errors    []error
 }
 
 func (e *Engine) processTombstones(ctx context.Context, client *caldav.Client, calendarID int64, remoteURL string) (*tombstoneResult, error) {
 	tombstones, err := e.q.ListTombstonesByCalendar(ctx, calendarID)
 	if err != nil {
 		return nil, fmt.Errorf("list tombstones: %w", err)
+	}
+
+	// Index the last-seen ETags so each DELETE can be made conditional. A real
+	// lookup failure must abort rather than silently degrade to unconditional
+	// DELETEs that could clobber a concurrent remote edit, so we surface it.
+	syncResources, err := e.q.ListSyncResourcesByCalendar(ctx, calendarID)
+	if err != nil {
+		return nil, fmt.Errorf("list sync resources: %w", err)
+	}
+	etagByUID := make(map[string]string, len(syncResources))
+	for _, sr := range syncResources {
+		etagByUID[sr.Uid] = sr.Etag
 	}
 
 	result := &tombstoneResult{}
@@ -1107,13 +1122,34 @@ func (e *Engine) processTombstones(ctx context.Context, client *caldav.Client, c
 			result.errors = append(result.errors, fmt.Errorf("validate tombstone %s: %w", ts.Uid, hrefErr))
 			continue
 		}
+		// Make the DELETE conditional on the ETag we last saw so the server
+		// rejects it (412) if the resource was edited remotely after our last
+		// sync. Without this, the tombstone push would silently destroy that
+		// concurrent edit. An untracked resource (never synced, or already
+		// cleaned up) has no ETag, which falls back to an unconditional DELETE.
+		etag := etagByUID[ts.Uid]
 		e.logger.Debug("deleting tombstone", "uid", ts.Uid, "remote_url", deletePath)
 		if _, err := caldav.Retry(ctx, syncRetryOptions, func(ctx context.Context) (struct{}, error) {
-			return struct{}{}, client.DeleteResource(ctx, deletePath)
+			return struct{}{}, client.DeleteResource(ctx, deletePath, etag)
 		}); err != nil && !errors.Is(err, caldav.ErrResourceGone) {
 			// A 404/410 means the resource is already absent server-side —
 			// the desired end state — so fall through and clear the local
 			// rows instead of re-issuing the DELETE on every sync.
+			if caldav.IsConflict(err) {
+				// 412: the resource was edited remotely after we last saw it.
+				// Honoring the delete would discard that edit, so abandon it.
+				// Drop the tombstone (stop re-issuing the DELETE every sync)
+				// but keep the sync_resource so the next pull re-imports the
+				// remote version, resurrecting the item with its remote edit.
+				// A delete-vs-edit conflict always preserves the remote edit
+				// (the non-destructive choice), independent of ConflictStrategy.
+				e.logger.Warn("tombstone delete conflict: remote edited, preserving remote version", "uid", ts.Uid)
+				if err := e.q.DeleteTombstone(ctx, ts.ID); err != nil {
+					e.logger.Warn("delete tombstone row after conflict failed", "uid", ts.Uid, "error", err)
+				}
+				result.conflicts++
+				continue
+			}
 			e.logger.Warn("delete remote resource failed", "uid", ts.Uid, "error", err)
 			result.errors = append(result.errors, fmt.Errorf("delete tombstone %s: %w", ts.Uid, err))
 			continue


### PR DESCRIPTION
## Summary

Closes #250.

`caldav.Client.DeleteResource` issued an **unconditional** `DELETE`. When the
sync engine pushed a local tombstone, that DELETE removed the server resource
even if it had been edited remotely after our last sync — silently destroying
the concurrent remote edit.

## Fix

- **`DeleteResource(ctx, path, etag)`** now sets an `If-Match` precondition when
  `etag` is non-empty (mirroring `PutResource`). A `412 Precondition Failed`
  flows back through the existing typed-error path, so `caldav.IsConflict`
  recognizes it.
- **`processTombstones`** threads the last-seen ETag (loaded once per calendar
  from `sync_resources` into a map, matching the pull/push paths) into each
  DELETE. On a `412` it abandons the delete: it drops the tombstone (so the
  DELETE is not re-issued every sync) but keeps the `sync_resource`, so the next
  pull re-imports the remote version and resurrects the item with its remote
  edit. A delete-vs-edit conflict always preserves the remote edit — the
  non-destructive choice — and is counted in `Result.Conflicts`.
- A failed ETag lookup aborts tombstone processing rather than silently
  degrading to unconditional DELETEs.

## Tests

- `TestClientDeleteResourceSendsIfMatch` — asserts `If-Match` is sent when an
  ETag is known (fails on the pre-fix code).
- `TestClientDeleteResourceConflict` — a `412` is reported as a conflict
  (`IsConflict` true) and not as `ErrResourceGone`.
- `TestClientDeleteResourceReportsGone` — extended to assert no `If-Match` is
  sent for an unconditional (empty-ETag) delete.

`make test`, `go build ./...`, `go vet ./...`, and `gofmt -l .` are all green.

Assisted-by: Claude:claude-opus-4-8 [code-review] [simplify]
