### PR TITLE
fix(trash): copy journal Categories into trash Entry

### DIFF
--- a/internal/trash/trash.go
+++ b/internal/trash/trash.go
@@ -364,6 +364,7 @@ func fromJournal(j journal.Journal) Entry {
 		StartTime:   startDate,
 		Description: j.Description,
 		Status:      j.Status,
+		Categories:  j.Categories,
 	}
 }
 

--- a/internal/trash/trash_test.go
+++ b/internal/trash/trash_test.go
@@ -79,6 +79,25 @@ func TestService_ListMergesAllThreeDomains(t *testing.T) {
 	}
 }
 
+// TestFromJournalCopiesCategories guards that fromJournal carries the
+// journal's Categories into the unified Entry, mirroring fromTodo and
+// fromEventTrash. Without it the trash detail "Tags" row can never render
+// for journals even after categories are populated upstream (issue #291).
+func TestFromJournalCopiesCategories(t *testing.T) {
+	j := journal.Journal{
+		ID:         7,
+		CalendarID: 1,
+		UID:        "journal-uid",
+		Summary:    "Tagged Journal",
+		Categories: "notes,personal",
+	}
+
+	got := fromJournal(j)
+	if got.Categories != j.Categories {
+		t.Errorf("fromJournal Categories = %q, want %q", got.Categories, j.Categories)
+	}
+}
+
 // TestService_RestoreDispatchesByKind exercises the Restore path for
 // each domain: the underlying service un-hides its own row and List no
 // longer returns it.


### PR DESCRIPTION
Closes #291

## Summary

`trash.fromJournal` built the unified trash `Entry` without copying `Categories`, unlike its sibling converters `fromTodo` (`Categories: td.Categories`) and `fromEventTrash` (`Categories: e.Categories`). As a result a journal trash entry's `Categories` was unconditionally empty, so the trash detail "Tags" row could never render for journals even after categories are populated upstream.

The fix adds the single missing field assignment, restoring symmetry with the todo and event converters:

```go
return Entry{
    Kind:        KindJournal,
    ...
    Status:      j.Status,
    Categories:  j.Categories, // was silently dropped
}
```

## Reproducing test

`TestFromJournalCopiesCategories` exercises `fromJournal` directly with a `journal.Journal{Categories: "notes,personal"}` and asserts the resulting `Entry.Categories`. It fails before the fix:

```
--- FAIL: TestFromJournalCopiesCategories (0.00s)
    trash_test.go:97: fromJournal Categories = "", want "notes,personal"
```

and passes after.

## Review outcomes

- **/code-review (high):** No findings. The change is a one-line, symmetric struct-field addition; the field name matches `Entry.Categories` and mirrors the two sibling converters.
- **/simplify:** Nothing to clean up. A reflection-based round-trip guard (like the event converter's `TestEventTrashRoundTripPreservesAllFields`, added by #266) would be the deeper generalization, but that is deliberately scoped to event-trash and out of scope for this minimal fix.

`go build ./... && go test ./...` passes.
