### PR TITLE
fix(recurrence): keep multi-day todo overrides via interval overlap

### DIFF
--- a/internal/recurrence/integration_test.go
+++ b/internal/recurrence/integration_test.go
@@ -1285,6 +1285,58 @@ func TestMovedOverride_Todo(t *testing.T) {
 	}
 }
 
+// TestMovedOverride_TodoMultiDaySpansWindow verifies that a multi-day todo
+// override whose START precedes the query window but whose DUE falls inside it
+// is kept. The override window check must use [START, DUE) interval overlap
+// (honoring todoDuration), matching the master-occurrence path and the event
+// override path -- not a point test on the anchor alone, which would drop the
+// override from every window after its start. Regression test for issue #288.
+func TestMovedOverride_TodoMultiDaySpansWindow(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	todoSvc := todo.NewService(db, q)
+	recurSvc := NewService(db, q)
+	ctx := context.Background()
+
+	master, err := todoSvc.Create(ctx, todo.CreateParams{
+		CalendarID:     1,
+		Summary:        "Weekly Review",
+		StartDate:      "2026-04-06T09:00:00Z", // Monday
+		DueDate:        "2026-04-06T10:00:00Z",
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=MO",
+	})
+	if err != nil {
+		t.Fatalf("create recurring todo: %v", err)
+	}
+	// Move the Apr 6 occurrence to a multi-day span: START Apr 5 10:00 ->
+	// DUE Apr 8 12:00.
+	if _, err := todoSvc.UpsertByUID(ctx, todo.UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Summary:      "Review Offsite (moved)",
+		StartDate:    "2026-04-05T10:00:00Z",
+		DueDate:      "2026-04-08T12:00:00Z",
+		RecurrenceID: "2026-04-06T09:00:00Z",
+	}); err != nil {
+		t.Fatalf("create multi-day todo override: %v", err)
+	}
+
+	// Query a single day (Apr 7) the override spans but does not start on, and
+	// on which the master produces no instance (Apr 7 is not a Monday).
+	from := time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC)
+
+	got, err := recurSvc.ListExpandedTodosByDueDateRange(ctx, from, to)
+	if err != nil {
+		t.Fatalf("expand spanning window: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d todos, want 1 (multi-day override overlapping the window)", len(got))
+	}
+	if got[0].StartDate != "2026-04-05T10:00:00Z" {
+		t.Errorf("start = %q, want %q", got[0].StartDate, "2026-04-05T10:00:00Z")
+	}
+}
+
 // TestListExpandedByDateRange_OverrideEmptyEndTime locks in that an override
 // persisted with a blank/zero end_time (e.g. a point-in-time or improperly
 // migrated override) still appears. Previously overlapsWindow required

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -970,11 +970,15 @@ func (s *Service) expandRecurringTodoRows(ctx context.Context, rows []storage.To
 			if anchor.IsZero() {
 				// No datable anchor: fall back to the replaced slot for the
 				// window check. An unparseable recurrence_id leaves anchor zero,
-				// which fails inWindow and is dropped (the orphan probe that
-				// follows would drop it too).
+				// which fails keepOccurrence and is dropped (the orphan probe
+				// that follows would drop it too).
 				anchor, _ = timeutil.ParseRecurrenceID(o.RecurrenceID)
 			}
-			return ot, inWindow(anchor, from, to)
+			// Keep on [START, DUE) interval overlap (honoring todoDuration), so a
+			// multi-day override whose START precedes the window but whose DUE
+			// falls inside it is not dropped -- matching the master-occurrence
+			// path (keepOccurrence/between) and the event override path.
+			return ot, keepOccurrence(anchor, todoDuration(ot), from, to)
 		},
 	}
 	return expandRecurringRowsBy(ctx, k, rows, from, to)


### PR DESCRIPTION
Closes #288

## Summary

The todo override window check used a point-in-window test on the anchor
alone (`inWindow`), while the master-occurrence path (`between`/`keepOccurrence`)
and the event override path (`overlapsWindow`) use `[start, end)` interval
overlap. As a result, a multi-day todo override whose START precedes the query
window but whose DUE falls inside it was dropped from a range view — even though
the equivalent master occurrence and the equivalent event override would be kept.

## Fix

In `expandRecurringTodoRows`'s `emitOverride`, replace
`inWindow(anchor, from, to)` with `keepOccurrence(anchor, todoDuration(ot), from, to)`.
This routes the override through the same shared helper the master path uses and
honors the START→DUE span:

- START + DUE present → `[START, DUE)` interval overlap (the fixed case).
- Due-only or unparseable-anchor fallback → `todoDuration` is 0, so behavior is
  identical to the previous `inWindow` test (no regression).

Journals have no DUE/duration concept (`newJournalRRuleSet` always passes
duration 0), so their existing point test is already equivalent to interval
overlap and is intentionally left untouched.

## Reproducing test

`TestMovedOverride_TodoMultiDaySpansWindow` (in `internal/recurrence/integration_test.go`):
a recurring todo's occurrence is moved to a multi-day span (START Apr 5 10:00 →
DUE Apr 8 12:00) and queried for a single day (Apr 7) that the override spans but
does not start on, and on which the master produces no instance. The test fails
before the fix (0 todos returned) and passes after (1 todo).

## Review outcomes

- `/code-review high`: no findings. The change reuses existing helpers
  (`keepOccurrence`, `todoDuration`), matches the master path exactly, and all
  zero-duration edge cases preserve prior behavior.
- `/simplify`: no changes needed — the fix is already at the right altitude
  (removes a special-case point test in favor of the shared mechanism) and
  introduces no duplication.

`go build ./... && go test ./...` all pass.
