### PR TITLE
fix(ical): capture RDATE;VALUE=PERIOD start on import

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -739,6 +739,12 @@ func parseDateListFromProps(props ical.Props, propName string) string {
 			if p == "" {
 				continue
 			}
+			// RDATE;VALUE=PERIOD values are "start/end" or "start/duration"
+			// (RFC 5545 §3.8.5.2). Keep the start instant; the period's
+			// duration is not represented in the comma-separated RDATE store.
+			if i := strings.IndexByte(p, '/'); i >= 0 {
+				p = p[:i]
+			}
 			if strings.EqualFold(prop.Params.Get("VALUE"), "DATE") {
 				if t, err := time.Parse("20060102", p); err == nil {
 					dates = append(dates, t.Format("2006-01-02"))

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -239,6 +239,36 @@ END:VCALENDAR`
 	}
 }
 
+// Regression test for issue #297: RDATE;VALUE=PERIOD values must not be
+// silently dropped. RFC 5545 §3.8.5.2 permits period-form RDATEs; at minimum
+// the start instant of each period must be captured as a recurrence date.
+func TestImport_EventRDATEPeriod(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:rdate-period
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T090000Z
+DTEND:20260401T100000Z
+RRULE:FREQ=WEEKLY;COUNT=2
+RDATE;VALUE=PERIOD:19960403T020000Z/19960403T040000Z,19960404T010000Z/PT3H
+SUMMARY:Period RDATE
+END:VEVENT
+END:VCALENDAR`
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	if got := result.Events[0].RDates; got != "1996-04-03T02:00:00Z,1996-04-04T01:00:00Z" {
+		t.Fatalf("RDates = %q, want %q", got, "1996-04-03T02:00:00Z,1996-04-04T01:00:00Z")
+	}
+}
+
 func TestImport_AllDayEvent(t *testing.T) {
 	t.Parallel()
 	result, _ := ImportFile(strings.NewReader(allDayEventICS))


### PR DESCRIPTION
Closes #297

## Problem
`RDATE;VALUE=PERIOD` values were silently dropped on import. RFC 5545 §3.8.5.2 permits period-form RDATEs such as `19960403T020000Z/19960403T040000Z`, but `parseDateListFromProps` (`internal/ical/import.go`) only tried fixed date-time layouts (`20060102T150405Z`, `20060102T150405`, `20060102`, RFC3339) against the full `start/end` token. The `/end` makes every `time.Parse` fail, so the element was skipped with no warning — well-formed recurrence instances were lost on import and never survived export.

## Fix
Strip the period's `/end` or `/duration` suffix before parsing so the start instant is captured:

```go
// RDATE;VALUE=PERIOD values are "start/end" or "start/duration"
// (RFC 5545 §3.8.5.2). Keep the start instant; the period's
// duration is not represented in the comma-separated RDATE store.
if i := strings.IndexByte(p, '/'); i >= 0 {
    p = p[:i]
}
```

This is safe because none of the date-time layouts the parser accepts ever contain a `/`, so the strip only affects period-form values. The duration is not preserved (it has no representation in the comma-separated RDATE store), matching the existing date-time RDATE model — consistent with the issue's "at minimum the start of each period should be captured".

## Reproducing test
`TestImport_EventRDATEPeriod` (in `internal/ical/import_test.go`) imports an event with `RDATE;VALUE=PERIOD:19960403T020000Z/19960403T040000Z,19960404T010000Z/PT3H` and asserts `RDates == "1996-04-03T02:00:00Z,1996-04-04T01:00:00Z"`. It fails before the fix (RDates empty) and passes after. It covers both `start/end` and `start/duration` period forms.

## Review outcomes
- **code-review (high):** no findings. Confirmed the shared EXDATE/RDATE parser cannot corrupt legitimate date-time tokens — none contain `/`.
- **simplify:** code already clean; `strings.IndexByte` is consistent with codebase conventions (16 `Index`-family uses vs 2 `Cut`).

`go build ./... && go test ./...` all pass.