### PR TITLE
fix(ical): omit VALARM REPEAT when DURATION is absent

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -694,7 +694,10 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 		p.Value = alarm.Duration
 		valarm.Props.Set(p)
 	}
-	if alarm.Repeat > 0 {
+	// RFC 5545 §3.8.6.2: REPEAT MUST be paired with DURATION. Emitting a
+	// bare REPEAT yields an invalid VALARM that strict CalDAV servers
+	// (e.g. Google) reject with HTTP 400, blocking the whole resource.
+	if alarm.Repeat > 0 && alarm.Duration != "" {
 		p := &ical.Prop{Name: "REPEAT"}
 		p.Value = strconv.Itoa(alarm.Repeat)
 		valarm.Props.Set(p)

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -438,6 +438,60 @@ func TestExport_EventWithAlarms(t *testing.T) {
 	}
 }
 
+// TestExport_AlarmRepeatWithoutDuration guards RFC 5545 §3.8.6.2: REPEAT
+// MUST be paired with DURATION. A Repeat with no Duration must not emit a
+// bare REPEAT, which strict CalDAV servers (e.g. Google) reject with 400.
+func TestExport_AlarmRepeatWithoutDuration(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{{
+		UID:       "alarm-repeat-no-duration",
+		Title:     "Alarm Event",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Alarms: []model.Alarm{
+			{Action: "DISPLAY", TriggerValue: "-PT15M", Description: "no interval", Repeat: 3},
+		},
+	}}
+
+	data, _ := ExportEvents(events, "")
+	ics := string(data)
+	if strings.Contains(ics, "REPEAT") {
+		t.Errorf("emitted REPEAT without DURATION (non-conformant per RFC 5545 §3.8.6.2):\n%s", ics)
+	}
+}
+
+// TestExport_AlarmRepeatWithDuration confirms the conformant pair still
+// round-trips when both REPEAT and DURATION are present.
+func TestExport_AlarmRepeatWithDuration(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{{
+		UID:       "alarm-repeat-with-duration",
+		Title:     "Alarm Event",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Alarms: []model.Alarm{
+			{Action: "DISPLAY", TriggerValue: "-PT15M", Description: "repeat", Duration: "PT5M", Repeat: 3},
+		},
+	}}
+
+	data, _ := ExportEvents(events, "")
+	ics := string(data)
+	if !strings.Contains(ics, "REPEAT:3") {
+		t.Errorf("missing REPEAT:3 when DURATION present:\n%s", ics)
+	}
+	if !strings.Contains(ics, "DURATION:PT5M") {
+		t.Errorf("missing DURATION:PT5M:\n%s", ics)
+	}
+}
+
 func TestExport_EventWithAttendees(t *testing.T) {
 	t.Parallel()
 	events := []event.Event{{


### PR DESCRIPTION
Closes #296

## Summary

`buildValarm` (`internal/ical/export.go`) emitted the `REPEAT` property
whenever `alarm.Repeat > 0`, independent of `DURATION`. RFC 5545 §3.8.6.2
requires `REPEAT` to be specified together with `DURATION`; a bare `REPEAT`
yields a non-conformant VALARM. Strict CalDAV servers (notably Google)
reject the entire resource with HTTP 400, so a single such alarm blocks the
push of its whole event/todo. The value round-trips in (import reads `REPEAT`
and `DURATION` independently) and back out unchanged, so the defect is
self-inflicted.

## Fix

Only emit `REPEAT` when `DURATION` is also present:

```go
if alarm.Repeat > 0 && alarm.Duration != "" {
    ...
}
```

The dropped value was already non-conformant and has no defined firing
schedule (repeat firings key off the `DURATION` interval), so no usable data
is lost. This aligns export with the existing CLI-side rule that `REPEAT` and
`DURATION` must be specified together. `buildValarm` is the single VALARM
producer for both event and todo export, so the one guard covers all paths.

## Reproducing test

Added to `internal/ical/export_test.go`:

- `TestExport_AlarmRepeatWithoutDuration` — an alarm with `Repeat: 3` and no
  `Duration` must not emit `REPEAT`. Fails before the fix (exported
  `REPEAT:3` with no `DURATION`), passes after.
- `TestExport_AlarmRepeatWithDuration` — the conformant pair still emits both
  `REPEAT:3` and `DURATION:PT5M`.

## Verification

- `go build ./... && go test ./...` — all green.
- **code-review (high):** no real issues. Confirmed `buildValarm` is the only
  REPEAT emitter, the test substring check is safe on the minimal event, the
  dropped bare-REPEAT is acceptable, and no conventions are violated.
- **simplify:** the guard is already minimal and the tests follow the file's
  established per-case style; no changes needed.
