### PR TITLE
fix(alarm): guard dismissed todo alarms from re-firing after snooze

### DIFF
--- a/db/queries/todo_alarm_state.sql
+++ b/db/queries/todo_alarm_state.sql
@@ -24,8 +24,11 @@ WHERE todo_id = ? AND fired_at IS NOT NULL AND acked_at IS NULL AND snoozed_to I
 ORDER BY fired_at DESC;
 
 -- name: ListExpiredTodoSnoozed :many
-SELECT * FROM todo_alarm_state 
-WHERE snoozed_to IS NOT NULL AND snoozed_to <= ?
+SELECT * FROM todo_alarm_state
+WHERE fired_at IS NOT NULL
+  AND acked_at IS NULL
+  AND snoozed_to IS NOT NULL
+  AND snoozed_to <= ?
 ORDER BY snoozed_to;
 
 -- name: RefireTodoAlarmState :execrows

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -416,6 +416,59 @@ func TestListExpiredTodoSnoozed(t *testing.T) {
 	}
 }
 
+// TestListExpiredTodoSnoozed_SkipsDismissed guards issue #295: a fired todo
+// alarm that is snoozed and then dismissed must NOT re-fire once the snooze
+// expires. DismissTodoAlarm sets acked_at but leaves snoozed_to intact, so
+// without an acked_at guard the expired-snooze scan returns the dismissed row
+// and a phantom notification fires for an alarm the user explicitly dismissed.
+// The event path is immune because ListExpiredSnoozedAlarmStates carries
+// acked_at IS NULL; this asserts the todo query matches that contract.
+func TestListExpiredTodoSnoozed_SkipsDismissed(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+
+	todoSvc := todo.NewService(db, q)
+	base := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	newTodo, _ := todoSvc.Create(context.Background(), todo.CreateParams{
+		CalendarID: 1,
+		Summary:    "Test Todo",
+		DueDate:    base.Format(time.RFC3339),
+	})
+	alarm, _ := q.CreateTodoAlarm(context.Background(), storage.CreateTodoAlarmParams{
+		TodoID:       newTodo.ID,
+		Uid:          storage.StringToNullable("test-alarm-uid"),
+		Action:       "DISPLAY",
+		TriggerValue: "-PT1H",
+		Related:      "START",
+	})
+
+	todoAlarmSvc := NewTodoService(db, q, &mockTodoAlarmLister{
+		alarms: []model.Alarm{{ID: alarm.ID, UID: "test-alarm-uid", Action: "DISPLAY", TriggerValue: "-PT1H"}},
+	})
+
+	// Fire, snooze, then dismiss the alarm.
+	triggerAt := time.Date(2026, 4, 1, 16, 0, 0, 0, time.UTC)
+	stateID, _ := todoAlarmSvc.MarkTodoAlarmFired(context.Background(), alarm.ID, newTodo.ID, triggerAt)
+
+	snoozeTime := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	if err := todoAlarmSvc.SnoozeTodoAlarm(context.Background(), stateID, snoozeTime); err != nil {
+		t.Fatalf("snooze: %v", err)
+	}
+	if err := todoAlarmSvc.DismissTodoAlarm(context.Background(), stateID); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+
+	// After the snooze expires, the dismissed alarm must not re-fire.
+	checkTime := time.Date(2026, 4, 1, 17, 30, 0, 0, time.UTC)
+	expired, err := todoAlarmSvc.ListExpiredTodoSnoozed(context.Background(), checkTime)
+	if err != nil {
+		t.Fatalf("list expired: %v", err)
+	}
+
+	if len(expired) != 0 {
+		t.Errorf("expired snoozed = %d, want 0 (dismissed alarm must not re-fire, issue #295)", len(expired))
+	}
+}
+
 // TestCheckTodos_FiresLongLeadTimeAlarm guards issue #98 on the todo path: a
 // todo due 7 days out with a "1 week before" alarm must fire now even though
 // the todo instance is far past the base forward window. Uses the real todo

--- a/internal/storage/todo_alarm_state.sql.go
+++ b/internal/storage/todo_alarm_state.sql.go
@@ -125,8 +125,11 @@ func (q *Queries) InsertTodoAlarmState(ctx context.Context, arg InsertTodoAlarmS
 }
 
 const listExpiredTodoSnoozed = `-- name: ListExpiredTodoSnoozed :many
-SELECT id, alarm_id, todo_id, trigger_at, fired_at, acked_at, snoozed_to FROM todo_alarm_state 
-WHERE snoozed_to IS NOT NULL AND snoozed_to <= ?
+SELECT id, alarm_id, todo_id, trigger_at, fired_at, acked_at, snoozed_to FROM todo_alarm_state
+WHERE fired_at IS NOT NULL
+  AND acked_at IS NULL
+  AND snoozed_to IS NOT NULL
+  AND snoozed_to <= ?
 ORDER BY snoozed_to
 `
 


### PR DESCRIPTION
Closes #295

## Problem
A dismissed (acknowledged) todo alarm re-fired once after its snooze expired. `ListExpiredTodoSnoozed` (`db/queries/todo_alarm_state.sql`) only filtered on `snoozed_to`, missing the `acked_at IS NULL` (and `fired_at IS NOT NULL`) guard that the event-side `ListExpiredSnoozedAlarmStates` carries.

`DismissTodoAlarm` stamps `acked_at` but leaves `snoozed_to` intact (same contract as the event path). So once `snoozed_to <= now`, the dismissed row was returned by the expired-snooze scan, `MarkTodoRefired` (which gates only on `snoozed_to IS NOT NULL`) won the claim, and a phantom notification fired exactly once for an alarm the user explicitly dismissed. The event path was already immune.

## Fix
Bring the todo query in line with the event query:

```sql
-- name: ListExpiredTodoSnoozed :many
SELECT * FROM todo_alarm_state
WHERE fired_at IS NOT NULL
  AND acked_at IS NULL
  AND snoozed_to IS NOT NULL
  AND snoozed_to <= ?
ORDER BY snoozed_to;
```

Regenerated `internal/storage/todo_alarm_state.sql.go` via `make generate` (no hand-edit of generated files). `fired_at IS NOT NULL` is always true for snoozed rows, so it adds no behavior change; `acked_at IS NULL` is the actual fix.

## Reproducing test
`TestListExpiredTodoSnoozed_SkipsDismissed` in `internal/alarm/todo_service_test.go`: fires a todo alarm, snoozes it, dismisses it, then asserts `ListExpiredTodoSnoozed` returns 0 once the snooze expires. Fails before the fix (`expired snoozed = 1, want 0`), passes after. The existing `TestListExpiredTodoSnoozed` (no dismiss) still passes.

## Review
- `/code-review` (high): no findings. The change mirrors the proven event-path contract; `fired_at IS NOT NULL` is redundant-but-harmless on snoozed rows, the only caller (`CheckTodos`) benefits from excluding dismissed rows.
- `/simplify`: no changes — the test reuses the sibling test's setup pattern and the fix reuses the event query shape verbatim.
- `go build ./... && go test ./...`: all pass.
