### PR TITLE
refactor(recurrence): route ListExpandedEvents through the merge engine

### DIFF
--- a/internal/recurrence/integration_test.go
+++ b/internal/recurrence/integration_test.go
@@ -506,23 +506,44 @@ func TestListExpandedByDateRange_CancelledOverride(t *testing.T) {
 	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
 
-	events, err := recurSvc.ListExpandedByDateRange(ctx, from, to)
-	if err != nil {
-		t.Fatalf("ListExpandedByDateRange: %v", err)
-	}
-
-	// Should get 2 instances (Apr 1, Apr 3). Apr 2 is cancelled.
-	if len(events) != 2 {
-		for i, e := range events {
-			t.Logf("  events[%d]: %s at %v (status=%s)", i, e.Title, e.StartTime, e.Status)
-		}
-		t.Fatalf("got %d events, want 2", len(events))
-	}
-
-	for _, e := range events {
-		if e.StartTime.Day() == 2 {
-			t.Error("cancelled Apr 2 instance appeared in results")
-		}
+	// Both expansion paths run the same merge engine and must drop the cancelled
+	// Apr 2 occurrence, leaving exactly Apr 1 and Apr 3.
+	for _, tc := range []struct {
+		name string
+		days func() ([]int, error)
+	}{
+		{"ListExpandedByDateRange", func() ([]int, error) {
+			events, err := recurSvc.ListExpandedByDateRange(ctx, from, to)
+			days := make([]int, len(events))
+			for i, e := range events {
+				days[i] = e.StartTime.Day()
+			}
+			return days, err
+		}},
+		{"ListExpandedEvents", func() ([]int, error) {
+			events, err := recurSvc.ListExpandedEvents(ctx, from, to)
+			days := make([]int, len(events))
+			for i, e := range events {
+				days[i] = e.InstanceTime.Day()
+			}
+			return days, err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			days, err := tc.days()
+			if err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			// Should get 2 instances (Apr 1, Apr 3). Apr 2 is cancelled.
+			if len(days) != 2 {
+				t.Fatalf("got %d events (days %v), want 2", len(days), days)
+			}
+			for _, d := range days {
+				if d == 2 {
+					t.Error("cancelled Apr 2 instance appeared in results")
+				}
+			}
+		})
 	}
 }
 

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -413,62 +413,17 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 		})
 	}
 
-	// Batch-fetch every master's overrides in one query, then group by UID. A
-	// failed override fetch must not render the master as if it had none —
-	// propagate so callers don't silently show a stale, un-overridden series.
-	overridesByUID, err := s.eventOverridesByUID(ctx, recurRows)
+	// Merge recurring masters with their overrides through the shared engine.
+	// expandedEventKind keeps ExpandedEvent as both the master Model and the
+	// emitted output, so each occurrence's InstanceTime survives (unlike
+	// expandRecurringRows, which folds the occurrence time into Event.Start/End).
+	// The engine batch-fetches overrides and propagates any fetch error, so a
+	// failed lookup never renders a master as if it had none.
+	recurResults, err := expandRecurringRowsBy(ctx, expandedEventKind(s), recurRows, from, to)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, row := range recurRows {
-		evt := event.FromStorage(row)
-		expanded := ExpandEvent(evt, from, to)
-
-		overrides := overridesByUID[row.Uid]
-		overridden := make(map[string]struct{}, len(overrides))
-		for _, ov := range overrides {
-			overridden[canonicalRecurrenceID(ov.RecurrenceID)] = struct{}{}
-		}
-
-		// Emit master instances, skipping any slot that has been overridden;
-		// the override is emitted separately below at its own occurrence time.
-		for _, inst := range expanded {
-			instKey := inst.InstanceTime.UTC().Format(time.RFC3339)
-			if _, ok := overridden[instKey]; ok {
-				continue
-			}
-			results = append(results, inst)
-		}
-
-		// Overrides are the exception, not the rule; skip the override work
-		// (including the second RRULE parse the checker needs) for the common
-		// case of a master with none.
-		if len(overrides) == 0 {
-			continue
-		}
-
-		// Emit overrides whose own occurrence falls within [from, to). A moved
-		// occurrence belongs to its new day, not the day of the slot it replaced.
-		// The master's RRULE is parsed once for all of its overrides.
-		checker := newEventOccChecker(evt)
-		for _, ov := range overrides {
-			if strings.EqualFold(ov.Status, "CANCELLED") {
-				continue
-			}
-			oe := event.FromStorage(ov)
-			if !overlapsWindow(oe.StartTime, oe.EndTime, from, to) {
-				continue
-			}
-			if !checker.occursAt(ov.RecurrenceID) {
-				continue // orphan override (no matching master occurrence)
-			}
-			results = append(results, ExpandedEvent{
-				Event:        oe,
-				InstanceTime: oe.StartTime,
-			})
-		}
-	}
+	results = append(results, recurResults...)
 
 	if len(results) > 0 {
 		ids := make([]int64, len(results))
@@ -635,6 +590,33 @@ func expandRecurringRowsBy[Row any, Model any, Inst any](ctx context.Context, k 
 		}
 	}
 	return result, nil
+}
+
+// expandedEventKind drives expandRecurringRowsBy for ListExpandedEvents, which
+// needs each occurrence's InstanceTime preserved. ExpandedEvent serves as both
+// the master Model and the emitted output, so applyInstance is identity: the
+// per-occurrence InstanceTime that expandRecurringRows discards (it collapses
+// the occurrence into Event.Start/End) is kept here.
+func expandedEventKind(s *Service) recurringKind[storage.Event, ExpandedEvent, ExpandedEvent] {
+	return recurringKind[storage.Event, ExpandedEvent, ExpandedEvent]{
+		fromRow: func(r storage.Event) ExpandedEvent {
+			return ExpandedEvent{Event: event.FromStorage(r)}
+		},
+		expand: func(m ExpandedEvent, from, to time.Time) []ExpandedEvent {
+			return ExpandEvent(m.Event, from, to)
+		},
+		instTime:       func(i ExpandedEvent) time.Time { return i.InstanceTime },
+		applyInstance:  func(i ExpandedEvent) ExpandedEvent { return i },
+		uid:            func(r storage.Event) string { return r.Uid },
+		status:         func(r storage.Event) string { return r.Status },
+		recurrenceID:   func(r storage.Event) string { return r.RecurrenceID },
+		overridesByUID: s.eventOverridesByUID,
+		newOccChecker:  func(m ExpandedEvent) occChecker { return newEventOccChecker(m.Event) },
+		emitOverride: func(o storage.Event, from, to time.Time) (ExpandedEvent, bool) {
+			oe := event.FromStorage(o)
+			return ExpandedEvent{Event: oe, InstanceTime: oe.StartTime}, overlapsWindow(oe.StartTime, oe.EndTime, from, to)
+		},
+	}
 }
 
 // expandRecurringRows expands recurring event rows into Event instances with


### PR DESCRIPTION
Closes #289

## Summary

`recurrence.ListExpandedEvents` carried its own open-coded copy of the
master-instance-suppression + override-emit loop that `expandRecurringRowsBy`
exists to be the single home for (the engine introduced in #258 to unify
event/todo/journal expansion). It was never migrated because it additionally
preserves each occurrence's `InstanceTime` and batch-loads attendees/categories.

The duplicate merge loop was a maintainability risk: a correctness fix applied
to `expandRecurringRowsBy` would not reach the display/alarm path through
`ListExpandedEvents`, and vice versa.

This migrates `ListExpandedEvents` onto the shared engine via a new
`expandedEventKind`, where `ExpandedEvent` serves as **both** the master `Model`
and the emitted output. That makes `applyInstance` an identity, so the
per-occurrence `InstanceTime` survives -- the one property that `expandRecurringRows`
discards when it folds the occurrence time into `Event.Start/End`. No change to
the generic engine signature; only `ListExpandedEvents` is touched.

Behavior is preserved byte-for-byte: same `ExpandEvent` master emit, same
overridden-slot suppression, same CANCELLED skip, same window + orphan checks
for moved overrides, same single batched override query, and the same
override-fetch error propagation (#251).

Net: ~50 lines of duplicated loop removed.

## Tests

- Extended `TestListExpandedByDateRange_CancelledOverride` to also assert the
  cancelled instance is dropped through the `ListExpandedEvents` path (added as
  a characterization test that passes on the pre-refactor code, closing the one
  branch only `ListExpandedByDateRange` covered).
- Existing parametrized tests already exercise `ListExpandedEvents` for moved
  overrides, orphan drop, all-day date-only ids, and override-fetch error
  propagation.
- `go build ./...` and `go test ./...` all green.

## Review

- **/code-review high**: no correctness, reuse, simplification, efficiency,
  altitude, or convention findings.
- **/simplify**: code already clean; the change itself is the altitude fix
  (special-case loop removed in favor of the shared engine). The only candidate
  -- three trivial duplicated `storage.Event` field accessors shared with the
  pre-existing inline kind -- was skipped to avoid scope creep into
  `expandRecurringRows`.
