### PR TITLE
fix(sync): report incomplete pulls so a stuck calendar shows unhealthy

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -185,6 +185,7 @@ func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy Co
 	} else {
 		result.Pulled = pullResult.pulled
 		result.Deleted = pullResult.deleted
+		result.Errors = append(result.Errors, pullResult.errors...)
 	}
 
 	// Phase 3: Process tombstones
@@ -527,6 +528,7 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 type pullResult struct {
 	pulled  int
 	deleted int
+	errors  []error
 }
 
 func (e *Engine) pull(ctx context.Context, client *caldav.Client, calendarID int64, remoteURL string) (*pullResult, error) {
@@ -1084,6 +1086,14 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 		e.logger.Warn("not advancing sync-token: incomplete pull",
 			"calendar_id", calendarID, "multiget_misses", multigetMisses,
 			"persist_failures", persistFailures)
+		// Surface the incompleteness so the calendar is recorded unhealthy
+		// (LastSyncError) rather than healthy. A pull that can never converge
+		// — a permanent persist failure or an href that always 404s on
+		// multiget — otherwise only logs, leaving LastSyncError clear and the
+		// ambient ⚠ sidebar glyph dark while sync stays silently stuck.
+		result.errors = append(result.errors, fmt.Errorf(
+			"incomplete pull: not advancing sync-token (%d multiget miss(es), %d persist failure(s))",
+			multigetMisses, persistFailures))
 	}
 
 	return result, nil

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -853,6 +853,118 @@ END:VCALENDAR
 	}
 }
 
+// TestEnginePullIncompletePullMarksCalendarUnhealthy reproduces issue #293: a
+// pull that can never converge (here, an href the server keeps reporting as
+// changed but that 404s on every multiget) used to only log and return no
+// error, so SyncResult.Errors stayed empty and updateSyncHealth recorded the
+// calendar as healthy — the ambient ⚠ glyph never lit up despite sync being
+// permanently stuck. The incomplete pull must surface an error so the calendar
+// is recorded unhealthy.
+func TestEnginePullIncompletePullMarksCalendarUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	insertTestEvent(t, db, calendarID, "stuck-uid")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "stuck-uid",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/stuck.ics",
+		Etag:         "etag-old",
+		Dirty:        0,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	// The server reports stuck.ics as changed (new etag) but 404s it on
+	// multiget — a multiget miss that never converges.
+	const syncBody = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/calendar/stuck.ics</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>&quot;etag-new&quot;</d:getetag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:sync-token>https://example.com/sync/stuck</d:sync-token>
+</d:multistatus>`
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Method != "REPORT" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read req body: %v", err)
+		}
+		if !strings.Contains(string(raw), "calendar-multiget") {
+			return &http.Response{
+				StatusCode: http.StatusMultiStatus,
+				Status:     "207 Multi-Status",
+				Header:     http.Header{"Content-Type": []string{"application/xml"}},
+				Body:       io.NopCloser(strings.NewReader(syncBody)),
+				Request:    r,
+			}, nil
+		}
+		multigetBody := `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/calendar/stuck.ics</d:href>
+    <d:status>HTTP/1.1 404 Not Found</d:status>
+  </d:response>
+</d:multistatus>`
+		return &http.Response{
+			StatusCode: http.StatusMultiStatus,
+			Status:     "207 Multi-Status",
+			Header:     http.Header{"Content-Type": []string{"application/xml"}},
+			Body:       io.NopCloser(strings.NewReader(multigetBody)),
+			Request:    r,
+		}, nil
+	})
+
+	result, err := engine.pull(ctx, client, calendarID, "/calendar/")
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if len(result.errors) == 0 {
+		t.Fatal("incomplete pull surfaced no error: SyncResult.Errors stays empty and the calendar is recorded healthy")
+	}
+
+	// Mirror SyncCalendar's health bookkeeping: an incomplete pull's errors
+	// flow into SyncResult.Errors, which updateSyncHealth uses to decide
+	// healthy vs. stuck.
+	sr := &SyncResult{CalendarID: calendarID}
+	sr.Errors = append(sr.Errors, result.errors...)
+	attemptedAt := time.Now().UTC().Format(time.RFC3339)
+	if err := engine.updateSyncHealth(ctx, calendarID, attemptedAt, sr, nil); err != nil {
+		t.Fatalf("updateSyncHealth: %v", err)
+	}
+
+	calRow, err := q.GetCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if got := storage.NullableToString(calRow.LastSyncError); got == "" {
+		t.Fatal("LastSyncError empty: a permanently stuck calendar still shows healthy")
+	}
+	if got := storage.NullableToString(calRow.LastSyncAt); got != "" {
+		t.Fatalf("LastSyncAt = %q, want empty for an unconverged pull", got)
+	}
+}
+
 func TestEnginePushRecordsConflictOnPreconditionFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #293

## Problem

When a pull can never converge — a permanent persist failure, or an href the server keeps reporting as changed that always 404s on multiget — `applySyncCollection` only logged `not advancing sync-token: incomplete pull` and returned with `pullResult` carrying no error. `SyncCalendar` never put anything into `SyncResult.Errors` for that case, so `updateSyncHealth` saw an empty `Errors` slice, set `LastSyncAt = now`, and cleared `LastSyncError` — marking the calendar healthy. The ambient ⚠ sidebar glyph keys off `LastSyncError`, so the user got no signal that sync was permanently stuck.

## Fix

- Add `errors []error` to `pullResult` (mirroring `pushResult`/`tombstoneResult`).
- In `applySyncCollection`'s incomplete-pull branch, append a descriptive error alongside the existing warn log.
- In `SyncCalendar`, surface `pullResult.errors` into `SyncResult.Errors` — the same path push and tombstone errors already take.

`updateSyncHealth` then sees a non-empty `Errors` slice and records the calendar unhealthy (`LastSyncError` set, `LastSyncAt` left empty) instead of healthy. The fix routes through the existing health mechanism rather than adding a special-case health write.

`pullFullSnapshot` is unchanged: it uses `QueryAll`, which is complete by construction, so it has no silent-incomplete path.

## Reproducing test

`TestEnginePullIncompletePullMarksCalendarUnhealthy` (in `internal/sync/engine_test.go`) sets up a calendar with a local resource, then a fake CalDAV server that reports the resource as changed in sync-collection but returns 404 for it on every multiget — a miss that never converges. It asserts:

1. `pull` surfaces a non-empty `pullResult.errors`.
2. After running the `SyncCalendar` health bookkeeping, `LastSyncError` is set and `LastSyncAt` is empty.

Verified red before the fix: reverting only the two behavioral lines (keeping the new field so it still compiles) fails with `incomplete pull surfaced no error: SyncResult.Errors stays empty and the calendar is recorded healthy`. Green after.

## Review

- `/code-review high`: no findings. Only `SyncCalendar` consumes `pullResult` in production and it now surfaces the errors; no other call site needs updating.
- `/simplify`: code already clean — considered reusing `absenceWithholdReason` for the message but rejected it (it's scoped to the absence-withhold log and returns `"complete"` on zero counts, coupling unrelated concerns). No edits applied.

`go build ./... && go test ./...` all pass.
