### PR TITLE
fix(auth): treat legacy cleanup as best-effort in migrating Get

### DIFF
--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -234,9 +234,11 @@ func (s *migratingCredentialStore) Get(accountID int64) (Credential, error) {
 	if setErr := s.primary.Set(legacyCred); setErr != nil {
 		return Credential{}, setErr
 	}
-	if deleteErr := s.legacy.Delete(accountID); deleteErr != nil {
-		return Credential{}, deleteErr
-	}
+	// Migration succeeded: the caller now has the credential and the primary
+	// store owns it. Cleaning up the legacy copy is best-effort — a failure
+	// here must not turn a successful read into an error. A surviving legacy
+	// copy is reclaimed on the next Set or Delete.
+	_ = s.legacy.Delete(accountID)
 	return legacyCred, nil
 }
 

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -318,6 +319,54 @@ func TestMigratingCredentialStore_DeleteIgnoresLegacyNotFound(t *testing.T) {
 
 	if err := store.Delete(7); err != nil {
 		t.Fatalf("Delete should ignore a missing legacy credential, got %v", err)
+	}
+}
+
+func TestMigratingCredentialStore_GetIgnoresLegacyCleanupError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the directory write permission that forces the cleanup failure")
+	}
+	dir := t.TempDir()
+	legacy := &PlaintextFileStore{dir: dir, warn: io.Discard}
+
+	legacyCred := Credential{
+		AccountID: 42,
+		Username:  "legacy",
+		Password:  "plaintext-secret",
+	}
+	if err := legacy.Set(legacyCred); err != nil {
+		t.Fatalf("legacy Set: %v", err)
+	}
+
+	// Make the legacy directory read-only so the credential file stays
+	// readable but the post-migration cleanup (os.Remove needs write on the
+	// parent dir) fails. Restore write permission afterwards so t.TempDir can
+	// clean up.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod legacy dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	backing := map[string]string{}
+	overrideKeyringForTest(t, true, backing)
+
+	store := &migratingCredentialStore{
+		primary: &KeyringStore{},
+		legacy:  legacy,
+	}
+
+	// Migration succeeds (primary.Set writes to the keyring) but cleaning up
+	// the legacy copy fails. Get must still return the migrated credential
+	// rather than a spurious cleanup error.
+	got, err := store.Get(42)
+	if err != nil {
+		t.Fatalf("Get should ignore a legacy cleanup failure after a successful migration, got %v", err)
+	}
+	if got.Username != "legacy" || got.Password != "plaintext-secret" {
+		t.Fatalf("Get returned %+v, want the migrated legacy credential", got)
+	}
+	if len(backing) == 0 {
+		t.Fatal("expected the credential to be migrated into the keyring backing store")
 	}
 }
 


### PR DESCRIPTION
Closes #301

## Problem

`migratingCredentialStore.Get` lazily migrates a credential that exists only in
the legacy plaintext store into the primary keyring, then deletes the now-redundant
legacy copy. The legacy delete was treated as fatal:

```go
if setErr := s.primary.Set(legacyCred); setErr != nil {
    return Credential{}, setErr
}
if deleteErr := s.legacy.Delete(accountID); deleteErr != nil {
    return Credential{}, deleteErr   // spurious failure
}
return legacyCred, nil
```

Once `primary.Set` succeeds the credential has been read and migrated — the
primary store owns it. If the subsequent legacy cleanup fails (e.g. the legacy
file is unremovable due to a read-only parent directory), `Get` returned that
cleanup error even though the read succeeded, breaking callers that depend on a
credential which is in fact fully available.

## Fix

Make the legacy delete best-effort in `Get`, matching how `Set` already handles
legacy cleanup (`_ = s.legacy.Delete(...)`). A surviving legacy copy is reclaimed
on the next `Set` or `Delete`.

`Delete` is intentionally left unchanged: it still surfaces legacy-delete
failures, because there the whole point of the call is to remove the credential.

## Reproducing test

`TestMigratingCredentialStore_GetIgnoresLegacyCleanupError` seeds a legacy
credential, then chmods the legacy directory to `0o500` so the file stays readable
but `os.Remove` (which needs write on the parent dir) fails deterministically. It
asserts `Get` still returns the migrated credential and that it landed in the
keyring backing store. The test skips under root (CAP_DAC_OVERRIDE bypasses the
permission). It fails before the fix and passes after.

## Review

- `/code-review high`: no findings. The change removes a conditional and mirrors
  the existing best-effort pattern in `Set`; the test is deterministic.
- `/simplify`: no changes needed — code already minimal and consistent.

`go build ./... && go test ./...` all green.
