### PR TITLE
fix(sync): withhold sync-token when a server-reported deletion fails to apply

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -746,7 +746,10 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 	// a partial view without flipping the complete flag.
 	deletions := newPendingDeletions(e.logger)
 	deletions.inferFromAbsence(calendarID, localResources, remoteUIDs, true, "complete (QueryAll)")
-	result.deleted += deletions.apply(ctx, e, calendarID)
+	// The full-snapshot path stores no sync-token, so a failed deletion here is
+	// self-healing: the next snapshot re-infers the absence and retries.
+	deleted, _ := deletions.apply(ctx, e, calendarID)
+	result.deleted += deleted
 
 	return result, nil
 }
@@ -817,12 +820,17 @@ func (p *pendingDeletions) inferFromAbsence(calendarID int64, locals []storage.S
 }
 
 // apply executes the accumulated deletions: soft-delete each local owner row
-// and drop its sync_resource. Returns the count actually deleted.
-func (p *pendingDeletions) apply(ctx context.Context, e *Engine, calendarID int64) int {
-	deleted := 0
+// and drop its sync_resource. Returns the count actually deleted and the count
+// that failed. A failed soft-delete (e.g. a transient SQLITE_BUSY) leaves the
+// local row orphaned: the server has dropped it but we haven't. The caller
+// must treat failed > 0 as an incomplete pull and withhold the sync-token, or
+// the server — now past the old token — never re-reports the deletion and the
+// orphan survives forever with no retry.
+func (p *pendingDeletions) apply(ctx context.Context, e *Engine, calendarID int64) (deleted, failed int) {
 	for uid, ownerType := range p.owner {
 		if err := e.deleteLocalResourceByUID(ctx, ownerType, uid); err != nil {
 			e.logger.Error("delete local resource", "uid", uid, "owner_type", ownerType, "error", err)
+			failed++
 			continue
 		}
 		if err := e.q.DeleteSyncResource(ctx, storage.DeleteSyncResourceParams{
@@ -833,7 +841,7 @@ func (p *pendingDeletions) apply(ctx context.Context, e *Engine, calendarID int6
 		}
 		deleted++
 	}
-	return deleted
+	return deleted, failed
 }
 
 // absenceWithholdReason describes why an absence sweep was (or wasn't) safe,
@@ -1064,9 +1072,10 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 			inventoryComplete, absenceWithholdReason(syncResult.Truncated, multigetMisses, persistFailures))
 	}
 
-	result.deleted += deletions.apply(ctx, e, calendarID)
+	deleted, deleteFailures := deletions.apply(ctx, e, calendarID)
+	result.deleted += deleted
 
-	if syncResult.SyncToken != "" && inventoryComplete {
+	if syncResult.SyncToken != "" && inventoryComplete && deleteFailures == 0 {
 		token := syncResult.SyncToken
 		if err := e.q.UpdateCalendarSyncState(ctx, storage.UpdateCalendarSyncStateParams{
 			ID:        calendarID,
@@ -1075,25 +1084,28 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 		}); err != nil {
 			e.logger.Warn("update sync token", "calendar_id", calendarID, "error", err)
 		}
-	} else if multigetMisses > 0 || persistFailures > 0 {
+	} else if multigetMisses > 0 || persistFailures > 0 || deleteFailures > 0 {
 		// Pull made partial progress: some hrefs the server reported in
 		// sync-collection 404'd on multiget, or a fetched body failed to
-		// persist locally. We don't know if the 404s are real deletions or
-		// transient errors, so we don't soft-delete them; and the persist
-		// failures left those resources behind the server. We don't advance
-		// the sync-token, so the next sync re-lists the same change set and
-		// gets another shot at fetching and storing the bodies. Slow but safe.
+		// persist locally, or a server-reported deletion failed to apply
+		// locally. We don't know if the multiget 404s are real deletions or
+		// transient errors, so we don't soft-delete them; the persist failures
+		// left those resources behind the server; and the failed deletions left
+		// orphaned rows the server has already dropped. We don't advance the
+		// sync-token, so the next sync re-lists the same change set and gets
+		// another shot at fetching, storing, and deleting. Slow but safe.
 		e.logger.Warn("not advancing sync-token: incomplete pull",
 			"calendar_id", calendarID, "multiget_misses", multigetMisses,
-			"persist_failures", persistFailures)
+			"persist_failures", persistFailures, "delete_failures", deleteFailures)
 		// Surface the incompleteness so the calendar is recorded unhealthy
 		// (LastSyncError) rather than healthy. A pull that can never converge
-		// — a permanent persist failure or an href that always 404s on
-		// multiget — otherwise only logs, leaving LastSyncError clear and the
-		// ambient ⚠ sidebar glyph dark while sync stays silently stuck.
+		// — a permanent persist failure, an href that always 404s on
+		// multiget, or a server-reported deletion that won't apply locally —
+		// otherwise only logs, leaving LastSyncError clear and the ambient ⚠
+		// sidebar glyph dark while sync stays silently stuck.
 		result.errors = append(result.errors, fmt.Errorf(
-			"incomplete pull: not advancing sync-token (%d multiget miss(es), %d persist failure(s))",
-			multigetMisses, persistFailures))
+			"incomplete pull: not advancing sync-token (%d multiget miss(es), %d persist failure(s), %d delete failure(s))",
+			multigetMisses, persistFailures, deleteFailures))
 	}
 
 	return result, nil

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1923,6 +1923,80 @@ func TestEnginePullDeletesLocalResourceWhenServerRemovesIt(t *testing.T) {
 	}
 }
 
+// A server-reported deletion (a top-level 404 in the sync-collection report)
+// whose local apply() fails — e.g. a transient SQLITE_BUSY, simulated here by
+// dropping the events table — must NOT advance the sync-token. Otherwise the
+// orphaned local row survives forever: the server is now behind the new token
+// and never re-reports the deletion, so there is no retry. The token must be
+// withheld so the next sync re-lists the same 404 and apply gets another shot.
+func TestEnginePullHoldsTokenWhenDeletionApplyFails(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "orphan",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/orphan.ics",
+		Etag:         "etag-orphan",
+		Dirty:        0,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	cal, err := q.GetCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+
+	// Drop the events table so SoftDeleteEventsByUID errors, deterministically
+	// reproducing a failed apply() (the issue cites a transient SQLITE_BUSY).
+	// The calendars and sync_resources tables stay intact, so the token-write
+	// path is still reachable — only the deletion fails.
+	if _, err := db.ExecContext(ctx, "DROP TABLE events"); err != nil {
+		t.Fatalf("DROP TABLE events: %v", err)
+	}
+
+	// No multiget is expected: the only change is a deletion.
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected HTTP %s %s", r.Method, r.URL.Path)
+		return nil, nil
+	})
+
+	syncResult := &caldav.SyncCollectionResult{
+		SyncToken: "https://example.com/sync/next",
+		Changes: []caldav.SyncChange{
+			{Path: "/calendar/orphan.ics", Deleted: true},
+		},
+	}
+
+	result, err := engine.applySyncCollection(ctx, client, calendarID, "/calendar/", cal, syncResult, false)
+	if err != nil {
+		t.Fatalf("applySyncCollection: %v", err)
+	}
+	if result.deleted != 0 {
+		t.Fatalf("deleted = %d, want 0 (apply failed)", result.deleted)
+	}
+
+	// Token withheld so the next sync re-lists and retries the deletion.
+	calRow, err := q.GetCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if tok := storage.NullableToString(calRow.SyncToken); tok != "" {
+		t.Fatalf("sync_token = %q, want empty (held back on deletion-apply failure)", tok)
+	}
+}
+
 // GMX (and other Cosmo-derived CalDAV servers) rewrite object hrefs on the
 // server side — a resource PUT at /cal/<user>/... is later reported under
 // /cal/<uuid>/... in REPORT responses. Pull must recognise the resource by


### PR DESCRIPTION
Closes #292

## Problem

A failed local apply of a server-reported deletion still advanced the CalDAV sync-token, permanently orphaning the local row with no retry.

When a server deletion arrives via the incremental sync-collection path as a top-level 404 and `deleteLocalResourceByUID` (SoftDelete*ByUID) fails transiently — e.g. `SQLITE_BUSY` under a concurrent TUI/CLI write — `pendingDeletions.apply` logged the failure and dropped it. The completeness gate that guards token advancement (`inventoryComplete`) only considered truncation, multiget misses, and persist failures, never deletion-apply failures. So the token advanced, the server (now past the old token) never re-reported the deletion, and the locally-orphaned row survived forever: a silent, non-self-healing divergence.

This is the symmetric gap to #103, which added `persistFailures` to the gate for the import side; the deletion side was never added.

## Fix

- `pendingDeletions.apply` now returns `(deleted, failed int)`, incrementing `failed` when a soft-delete errors.
- `applySyncCollection` captures `deleteFailures` and adds `&& deleteFailures == 0` to the sync-token advancement gate, plus `|| deleteFailures > 0` to the "incomplete pull" warning. A failed deletion now withholds the token, so the next sync re-lists the same change set and retries.
- The full-snapshot path (`pullFullSnapshot`) stores no token and self-heals by re-inferring absence next run, so it ignores the failure count (`deleted, _ :=`).

A separate gate term (rather than folding into `inventoryComplete`) is required because `deleteFailures` is only known after `apply()` runs, whereas `inventoryComplete` is computed earlier and also gates absence inference.

## Reproducing test

`TestEnginePullHoldsTokenWhenDeletionApplyFails` seeds a tracked `sync_resource`, drops the `events` table to deterministically force `SoftDeleteEventsByUID` to error (standing in for a transient SQLITE_BUSY), then feeds a sync-collection result with a new token and a top-level deletion. It asserts `result.deleted == 0` and that the sync-token stays empty. The test fails before the fix (token advanced to the new value) and passes after.

## Review

- `/code-review high`: confirmed only two callers of `apply` (both updated), the token gate withholds on failure while still advancing normally, `result.deleted` still counts only actually-deleted rows, and no compile/type errors. The persistent-failure stall is the intended tradeoff: a loud, recoverable stall beats a silent permanent orphan. Fixed one stale comment in the test surfaced during review.
- `/simplify`: all four angles (reuse, simplification, efficiency, altitude) returned clean — the change reuses the established `multigetMisses`/`persistFailures` counter idiom and the separate gate term is at the correct depth.

`go build ./... && go test ./...` all pass.
