### PR TITLE
fix(softdelete): propagate genuine master-lookup errors in todo/journal delete

### DIFF
--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -3,6 +3,7 @@ package journal
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -419,6 +420,14 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		qtx := s.q.WithTx(tx)
 
 		master, err := qtx.GetJournalByUID(ctx, j.UID)
+		// A genuine lookup error (e.g. SQLITE_BUSY) must not collapse into the
+		// "no master" path: that would soft-delete the override while skipping
+		// its EXDATE/provenance bookkeeping, resurrecting the occurrence via
+		// series expansion (issue #290). Only a missing master (ErrNoRows)
+		// legitimately skips the bookkeeping.
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("get master: %w", err)
+		}
 		if err == nil {
 			existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
 			recIDTime, parseErr := timeutil.ParseRecurrenceID(j.RecurrenceID)
@@ -484,6 +493,12 @@ func (s *Service) DeleteSeries(ctx context.Context, uid string) error {
 	// whose next sync would DELETE it from the server (issue #107). A missing
 	// master means there is nothing to track.
 	master, mErr := qtx.GetJournalByUID(ctx, uid)
+	// Only ErrNoRows means "no master to track"; a genuine lookup error must
+	// abort so the series isn't soft-deleted locally without a tombstone or
+	// dirty mark, which would let it resurface on the next pull (issue #290).
+	if mErr != nil && !errors.Is(mErr, sql.ErrNoRows) {
+		return fmt.Errorf("get master: %w", mErr)
+	}
 	haveMaster := mErr == nil
 	if haveMaster {
 		if _, err := storage.CreateTombstoneIfSynced(ctx, tx, master.CalendarID, uid); err != nil {

--- a/internal/journal/soft_delete_test.go
+++ b/internal/journal/soft_delete_test.go
@@ -497,3 +497,88 @@ func TestSoftDelete_RestoreSurfacesTombstoneClearError(t *testing.T) {
 		t.Fatal("RestoreByID returned nil, want error when tombstone clear fails")
 	}
 }
+
+// TestSoftDelete_OverrideMasterLookupError is a regression test for issue
+// #290: deleting an override must not collapse a genuine DB error from the
+// master lookup into the "no master" path. On a non-ErrNoRows error the old
+// code soft-deleted the override while silently skipping the EXDATE and
+// provenance bookkeeping, resurrecting the occurrence via series expansion.
+func TestSoftDelete_OverrideMasterLookupError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "weekly-uid", CalendarID: 1, Summary: "Weekly Review",
+		StartDate:      time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: master.UID, CalendarID: 1, Summary: "Weekly Review (moved)",
+		StartDate:    time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceID: time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Force the master lookup (GetJournalByUID) to fail with a genuine, non-
+	// ErrNoRows error by writing non-numeric text into the master's integer
+	// sequence column so its row scan fails. The override row that the initial
+	// Get(id) loads is untouched, and SoftDeleteJournal never scans, so the
+	// buggy path would still soft-delete the override and return nil.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE journals SET sequence = 'corrupt' WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("corrupt master sequence: %v", err)
+	}
+
+	if err := svc.Delete(ctx, override.ID); err == nil {
+		t.Fatal("Delete should propagate a non-ErrNoRows master-lookup error, got nil")
+	}
+
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE journals SET sequence = 0 WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("repair master sequence: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("override should still be live after failed delete: %v", err)
+	}
+}
+
+// TestDeleteSeries_MasterLookupError is a regression test for issue #290:
+// DeleteSeries must not treat a genuine DB error from the master lookup as
+// "no master". On a non-ErrNoRows error the old code soft-deleted the series
+// locally with no tombstone and no dirty mark, so the next push never DELETEd
+// the server copy and the series resurfaced on the next pull.
+func TestDeleteSeries_MasterLookupError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "weekly-uid", CalendarID: 1, Summary: "Weekly",
+		StartDate:      time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE journals SET sequence = 'corrupt' WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("corrupt master sequence: %v", err)
+	}
+
+	if err := svc.DeleteSeries(ctx, master.UID); err == nil {
+		t.Fatal("DeleteSeries should propagate a non-ErrNoRows master-lookup error, got nil")
+	}
+
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE journals SET sequence = 0 WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("repair master sequence: %v", err)
+	}
+	if _, err := svc.GetByUID(ctx, master.UID); err != nil {
+		t.Fatalf("series should still be live after failed DeleteSeries: %v", err)
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -525,6 +525,14 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		qtx := s.q.WithTx(tx)
 
 		master, err := qtx.GetTodoByUID(ctx, td.UID)
+		// A genuine lookup error (e.g. SQLITE_BUSY) must not collapse into the
+		// "no master" path: that would soft-delete the override while skipping
+		// its EXDATE/provenance bookkeeping, resurrecting the occurrence via
+		// series expansion (issue #290). Only a missing master (ErrNoRows)
+		// legitimately skips the bookkeeping.
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("get master: %w", err)
+		}
 		if err == nil {
 			existing := timeutil.ParseTimeList(storage.NullableToString(master.Exdates))
 			recIDTime, parseErr := timeutil.ParseRecurrenceID(td.RecurrenceID)
@@ -590,6 +598,12 @@ func (s *Service) DeleteSeries(ctx context.Context, uid string) error {
 	// whose next sync would DELETE it from the server (issue #107). A missing
 	// master means there is nothing to track.
 	master, mErr := qtx.GetTodoByUID(ctx, uid)
+	// Only ErrNoRows means "no master to track"; a genuine lookup error must
+	// abort so the series isn't soft-deleted locally without a tombstone or
+	// dirty mark, which would let it resurface on the next pull (issue #290).
+	if mErr != nil && !errors.Is(mErr, sql.ErrNoRows) {
+		return fmt.Errorf("get master: %w", mErr)
+	}
 	haveMaster := mErr == nil
 	if haveMaster {
 		if _, err := storage.CreateTombstoneIfSynced(ctx, tx, master.CalendarID, uid); err != nil {

--- a/internal/todo/soft_delete_test.go
+++ b/internal/todo/soft_delete_test.go
@@ -528,3 +528,91 @@ func TestSoftDelete_RestoreSurfacesTombstoneClearError(t *testing.T) {
 		t.Fatal("RestoreByID returned nil, want error when tombstone clear fails")
 	}
 }
+
+// TestSoftDelete_OverrideMasterLookupError is a regression test for issue
+// #290: deleting an override must not collapse a genuine DB error from the
+// master lookup into the "no master" path. On a non-ErrNoRows error the old
+// code soft-deleted the override while silently skipping the EXDATE and
+// provenance bookkeeping, resurrecting the occurrence via series expansion —
+// the same failure mode as #120, via a swallowed lookup error.
+func TestSoftDelete_OverrideMasterLookupError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "weekly-uid", CalendarID: 1, Summary: "Weekly Review",
+		DueDate:        time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: master.UID, CalendarID: 1, Summary: "Weekly Review (moved)",
+		DueDate:      time.Date(2026, 4, 15, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceID: time.Date(2026, 4, 15, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Force the master lookup (GetTodoByUID) to fail with a genuine, non-
+	// ErrNoRows error by writing non-numeric text into the master's integer
+	// sequence column so its row scan fails. The override row that the initial
+	// Get(id) loads is untouched, and SoftDeleteTodo never scans, so the buggy
+	// path would still soft-delete the override and return nil.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE todos SET sequence = 'corrupt' WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("corrupt master sequence: %v", err)
+	}
+
+	if err := svc.Delete(ctx, override.ID); err == nil {
+		t.Fatal("Delete should propagate a non-ErrNoRows master-lookup error, got nil")
+	}
+
+	// Repair the master so reads work, then confirm the override is still
+	// live: the transaction must have rolled back.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE todos SET sequence = 0 WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("repair master sequence: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("override should still be live after failed delete: %v", err)
+	}
+}
+
+// TestDeleteSeries_MasterLookupError is a regression test for issue #290:
+// DeleteSeries must not treat a genuine DB error from the master lookup as
+// "no master". On a non-ErrNoRows error the old code soft-deleted the series
+// locally with no tombstone and no dirty mark, so the next push never DELETEd
+// the server copy and the series resurfaced on the next pull.
+func TestDeleteSeries_MasterLookupError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID: "weekly-uid", CalendarID: 1, Summary: "Weekly",
+		DueDate:        time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE todos SET sequence = 'corrupt' WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("corrupt master sequence: %v", err)
+	}
+
+	if err := svc.DeleteSeries(ctx, master.UID); err == nil {
+		t.Fatal("DeleteSeries should propagate a non-ErrNoRows master-lookup error, got nil")
+	}
+
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE todos SET sequence = 0 WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("repair master sequence: %v", err)
+	}
+	if _, err := svc.GetByUID(ctx, master.UID); err != nil {
+		t.Fatalf("series should still be live after failed DeleteSeries: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #290

## Summary

Instance and series deletes in the **todo** and **journal** services collapsed
`sql.ErrNoRows` and a genuine driver error from the master lookup
(`GetTodoByUID` / `GetJournalByUID`) into the same "no master" path. These
queries are `SELECT ... WHERE ... deleted_at IS NULL`, so they can return
either `ErrNoRows` **or** a real error (e.g. `SQLITE_BUSY` under a concurrent
writer — plausible with WAL + the 5s busy timeout).

Two failure modes resulted:

- **Override `Delete`** (`internal/todo/service.go`, `internal/journal/service.go`):
  on a transient lookup error the override was still soft-deleted, but **no
  EXDATE and no provenance row** were written. The deleted occurrence
  reappeared via series expansion — the same resurrection mode as #120, via a
  different swallowed error.
- **`DeleteSeries`**: on a real error the series was soft-deleted locally with
  **no tombstone and no dirty mark**, so the next push never sent DELETE to the
  server and the series resurfaced on the next pull.

### Fix

Branch on `errors.Is(err, sql.ErrNoRows)`: only a missing master legitimately
skips the bookkeeping; any other lookup error now aborts the transaction with a
wrapped `get master:` error. This mirrors the guard the **event** service
already uses (`internal/event/soft_delete.go:170,289`), bringing todo/journal
in line — no new abstraction, matching the established inline idiom used across
the codebase.

## Reproducing tests

Added four regression tests (`TestSoftDelete_OverrideMasterLookupError` and
`TestDeleteSeries_MasterLookupError` in both `internal/todo` and
`internal/journal`). Each writes non-numeric text into the master row's integer
`sequence` column so its row scan fails with a genuine, non-`ErrNoRows` error
(the override row loaded by the initial `Get(id)` is untouched, and the
soft-delete UPDATE never scans). The tests assert the delete now fails loudly
and rolls back, leaving the row live. All four **fail before** the fix and
**pass after**.

## Review

- `go build ./... && go test ./...` — all green.
- `/code-review high`: no correctness, reuse, simplification, efficiency,
  altitude, or convention findings survived verification.
- `/simplify`: code already clean; the guard matches the dominant
  `errors.Is(err, sql.ErrNoRows)` idiom (incl. the event service), so no
  helper extraction was warranted.
