### PR TITLE
fix(calendar): propagate transient GetAccount error on Connect re-link

### DIFF
--- a/internal/calendar/remote.go
+++ b/internal/calendar/remote.go
@@ -2,6 +2,8 @@ package calendar
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -41,6 +43,13 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 
 	if cal.AccountID != 0 {
 		existing, err := s.q.GetAccount(ctx, cal.AccountID)
+		// Only sql.ErrNoRows (the account row is genuinely gone) may fall
+		// through to the create-new path. A transient read failure must be
+		// propagated; treating it as not-found would repoint the calendar to a
+		// brand-new hidden account and orphan the old credential (issue #300).
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("get account: %w", err)
+		}
 		if err == nil && strings.HasPrefix(existing.Name, hiddenAccountPrefix) {
 			cred.AccountID = existing.ID
 

--- a/internal/calendar/remote_test.go
+++ b/internal/calendar/remote_test.go
@@ -2,11 +2,28 @@ package calendar
 
 import (
 	"context"
+	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
+
+// failGetAccountDB wraps a DBTX and turns the GetAccount read into a
+// non-ErrNoRows failure (a "no such column" scan error), simulating a
+// transient DB error while leaving every other query untouched.
+type failGetAccountDB struct {
+	storage.DBTX
+}
+
+func (d failGetAccountDB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	if strings.Contains(query, "FROM accounts WHERE id = ?") {
+		return d.DBTX.QueryRowContext(ctx, "SELECT no_such_column FROM accounts WHERE id = ?", args...)
+	}
+	return d.DBTX.QueryRowContext(ctx, query, args...)
+}
 
 type memCredStore struct {
 	creds map[int64]auth.Credential
@@ -195,6 +212,71 @@ func TestConnect_RelinkRestoresCredentialOnTxFailure(t *testing.T) {
 	}
 	if got.Password != "old-pass" {
 		t.Errorf("stored password = %q, want %q: a failed re-link must not leave the keyring holding the new credential", got.Password, "old-pass")
+	}
+}
+
+func TestConnect_RelinkPropagatesTransientGetAccountError(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	// Calendar 1 is already linked to a hidden account whose name differs from
+	// hiddenAccountName(1), so the buggy create-new path would NOT collide on
+	// the UNIQUE(name) constraint and would happily spawn a duplicate account.
+	account, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      "__calendar_99",
+		ServerUrl: "https://example.com",
+		AuthType:  "basic",
+		Username:  "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		ID:        1,
+		AccountID: &account.ID,
+		RemoteUrl: storage.StringToNullable("https://example.com/dav/calendars/work/"),
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+
+	// The keyring already holds the credential for the linked account.
+	store := &memCredStore{}
+	if err := store.Set(auth.Credential{AccountID: account.ID, Username: "user", Password: "old-pass"}); err != nil {
+		t.Fatalf("seed old credential: %v", err)
+	}
+
+	cal, err := svc.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	// A Service whose GetAccount read fails transiently (a non-ErrNoRows
+	// error). Transactional writes still go through the real *sql.Tx, so the
+	// create-new path can succeed if the code reaches it.
+	faulty := NewService(db, storage.New(failGetAccountDB{db}))
+
+	link := RemoteLink{
+		RemoteURL:     "https://example.com/dav/calendars/work/",
+		Username:      "user",
+		AuthType:      "basic",
+		AllowInsecure: false,
+	}
+	newCred := auth.Credential{Username: "user", Password: "new-pass"}
+
+	if err := faulty.Connect(ctx, cal, link, newCred, store); err == nil {
+		t.Fatal("Connect: expected a transient GetAccount error to propagate, got nil (fell through to create a duplicate hidden account)")
+	}
+
+	accounts, err := q.ListAccounts(ctx)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Errorf("account count = %d, want 1: a transient read error must not spawn a duplicate hidden account", len(accounts))
+	}
+	if len(store.creds) != 1 {
+		t.Errorf("credential count = %d, want 1: a transient read error must not orphan the old credential behind a new one", len(store.creds))
 	}
 }
 


### PR DESCRIPTION
Closes #300

## Problem

`calendar.Service.Connect` re-link conflated a transient `GetAccount`
error with "account not found". The re-link branch was guarded only by
`if err == nil && strings.HasPrefix(...)`, so **any** non-nil error from
`GetAccount` (a transient DB lock/read failure, not just `sql.ErrNoRows`)
fell through to the create-new-account path. On such a failure the
calendar was repointed to a brand-new hidden account with a new
credential, while the previous hidden account row and its keyring/plaintext
credential were left orphaned — a duplicate account plus a stranded secret.

## Fix

`internal/calendar/remote.go`: branch the re-link read on
`errors.Is(err, sql.ErrNoRows)`. Only a genuinely absent account row may
fall through to the create-new path; any other error is wrapped and
returned (`get account: %w`). One-line guard, no behavior change for the
not-found and happy paths.

## Reproducing test

`TestConnect_RelinkPropagatesTransientGetAccountError` injects a
non-`ErrNoRows` failure into the `GetAccount` read via a `DBTX` wrapper
(`failGetAccountDB`) that rewrites only the `GetAccount` query into a
"no such column" scan error, while transactional writes still go through
the real `*sql.Tx`. The existing hidden account is named `__calendar_99`
so the buggy create-new path would not collide on `UNIQUE(name)` and
would actually spawn a duplicate. The test asserts the error propagates,
exactly one account remains, and no credential is orphaned.

- Before the fix: `Connect` returns `nil`, a second hidden account is
  created, and the old credential is stranded (test fails).
- After the fix: the error is returned, the account and credential are
  untouched (test passes).

## Verification

- `go build ./...` and `go test ./...` both pass.
- `/code-review high` on the diff: no findings.
- `/simplify`: code already clean, nothing to apply.

Distinct from #118 (commit-failure rollback compensation), which remains
in place.

Assisted-by: Claude:claude-opus-4-8 [code-review] [simplify]
