### PR TITLE
fix(ical): preserve inline BASE64 VALARM ATTACH on import

### DIFF
--- a/db/migrations/037_alarm_attach_binary.sql
+++ b/db/migrations/037_alarm_attach_binary.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+
+-- Store an inline (ENCODING=BASE64;VALUE=BINARY) ATTACH payload for AUDIO
+-- alarms so an embedded sound survives import/export round-trips (issue #298).
+ALTER TABLE event_alarms ADD COLUMN attach_binary BLOB;
+ALTER TABLE todo_alarms ADD COLUMN attach_binary BLOB;
+
+-- +goose Down
+ALTER TABLE todo_alarms DROP COLUMN attach_binary;
+ALTER TABLE event_alarms DROP COLUMN attach_binary;

--- a/db/queries/alarms.sql
+++ b/db/queries/alarms.sql
@@ -1,6 +1,6 @@
 -- name: CreateAlarm :one
-INSERT INTO event_alarms (event_id, uid, action, trigger_value, description, summary, repeat, duration, related, acknowledged, attach_uri, attach_fmttype)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
+INSERT INTO event_alarms (event_id, uid, action, trigger_value, description, summary, repeat, duration, related, acknowledged, attach_uri, attach_fmttype, attach_binary)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 
 -- name: ListAlarmsByEventID :many
 SELECT * FROM event_alarms WHERE event_id = ? ORDER BY id;
@@ -29,5 +29,6 @@ SELECT * FROM event_alarms WHERE uid IS NULL;
 -- name: UpdateAlarmContentByID :exec
 UPDATE event_alarms
 SET action = ?, trigger_value = ?, description = ?, summary = ?, repeat = ?,
-    duration = ?, related = ?, acknowledged = ?, attach_uri = ?, attach_fmttype = ?
+    duration = ?, related = ?, acknowledged = ?, attach_uri = ?, attach_fmttype = ?,
+    attach_binary = ?
 WHERE id = ? AND event_id = ?;

--- a/db/queries/todo_alarms.sql
+++ b/db/queries/todo_alarms.sql
@@ -1,6 +1,6 @@
 -- name: CreateTodoAlarm :one
-INSERT INTO todo_alarms (todo_id, uid, action, trigger_value, description, summary, repeat, duration, related, acknowledged, attach_uri, attach_fmttype)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
+INSERT INTO todo_alarms (todo_id, uid, action, trigger_value, description, summary, repeat, duration, related, acknowledged, attach_uri, attach_fmttype, attach_binary)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 
 -- name: ListTodoAlarmsByTodoID :many
 SELECT * FROM todo_alarms WHERE todo_id = ? ORDER BY id;
@@ -17,7 +17,8 @@ DELETE FROM todo_alarms WHERE id = ?;
 -- name: UpdateTodoAlarmContentByID :exec
 UPDATE todo_alarms
 SET action = ?, trigger_value = ?, description = ?, summary = ?, repeat = ?,
-    duration = ?, related = ?, acknowledged = ?, attach_uri = ?, attach_fmttype = ?
+    duration = ?, related = ?, acknowledged = ?, attach_uri = ?, attach_fmttype = ?,
+    attach_binary = ?
 WHERE id = ? AND todo_id = ?;
 
 -- name: ListTodoAlarmsWithEmptyUID :many

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1282,6 +1282,7 @@ func updateAlarmInPlace(ctx context.Context, qtx *storage.Queries, eventID int64
 		Acknowledged:  storage.StringToNullable(ack),
 		AttachUri:     storage.StringToNullable(a.AttachURI),
 		AttachFmttype: storage.StringToNullable(a.AttachFmtType),
+		AttachBinary:  a.AttachBinary,
 		ID:            ex.ID,
 		EventID:       eventID,
 	}); err != nil {
@@ -1365,6 +1366,7 @@ func createNewAlarm(ctx context.Context, qtx *storage.Queries, eventID int64, a 
 		Acknowledged:  storage.StringToNullable(a.Acknowledged),
 		AttachUri:     storage.StringToNullable(a.AttachURI),
 		AttachFmttype: storage.StringToNullable(a.AttachFmtType),
+		AttachBinary:  a.AttachBinary,
 	}
 	row, err := qtx.CreateAlarm(ctx, params)
 	if isUniqueUIDViolation(err) {
@@ -1883,6 +1885,7 @@ func fromStorageAlarm(r storage.EventAlarm) model.Alarm {
 		Related:       r.Related,
 		Acknowledged:  storage.NullableToString(r.Acknowledged),
 		AttachURI:     storage.NullableToString(r.AttachUri),
+		AttachBinary:  r.AttachBinary,
 		AttachFmtType: storage.NullableToString(r.AttachFmttype),
 	}
 }

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -719,10 +719,16 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 		valarm.Props.Add(p)
 	}
 
-	// ATTACH (sound URI for AUDIO alarms only)
-	if alarm.AttachURI != "" && alarm.Action == "AUDIO" {
+	// ATTACH (sound for AUDIO alarms only): inline BASE64 blob or URI.
+	if alarm.Action == "AUDIO" && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
 		p := &ical.Prop{Name: ical.PropAttach, Params: make(ical.Params)}
-		p.Value = alarm.AttachURI
+		if len(alarm.AttachBinary) > 0 {
+			p.Value = base64.StdEncoding.EncodeToString(alarm.AttachBinary)
+			p.Params.Set("ENCODING", "BASE64")
+			p.Params.Set("VALUE", "BINARY")
+		} else {
+			p.Value = alarm.AttachURI
+		}
 		if alarm.AttachFmtType != "" {
 			p.Params.Set("FMTTYPE", alarm.AttachFmtType)
 		}

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -624,9 +624,16 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		}
 	}
 
-	// ATTACH (sound URI for AUDIO alarms)
+	// ATTACH (sound for AUDIO alarms): either a URI or an inline BASE64 blob.
 	if prop := comp.Props.Get(ical.PropAttach); prop != nil {
-		if prop.Params.Get("ENCODING") != "BASE64" {
+		if prop.Params.Get("ENCODING") == "BASE64" {
+			if data, err := decodeInlineAttachment(prop.Value); err != nil {
+				warn = fmt.Sprintf("VALARM ATTACH: %v", err)
+			} else {
+				alarm.AttachBinary = data
+				alarm.AttachFmtType = prop.Params.Get("FMTTYPE")
+			}
+		} else {
 			alarm.AttachURI = prop.Value
 			alarm.AttachFmtType = prop.Params.Get("FMTTYPE")
 		}
@@ -853,20 +860,31 @@ func addDuration(t time.Time, dur string) time.Time {
 	return duration.Add(t, dur)
 }
 
+// decodeInlineAttachment decodes a BASE64 ATTACH value, enforcing the inline
+// size limit. The length is checked before decoding so a deliberately oversized
+// payload is rejected without allocating a large buffer.
+func decodeInlineAttachment(value string) ([]byte, error) {
+	if base64.StdEncoding.DecodedLen(len(value)) > maxInlineAttachmentBytes {
+		return nil, fmt.Errorf("%w: inline attachment exceeds %d bytes", errImportLimitExceeded, maxInlineAttachmentBytes)
+	}
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("decode inline attachment: %w", err)
+	}
+	if len(data) > maxInlineAttachmentBytes {
+		return nil, fmt.Errorf("%w: inline attachment exceeds %d bytes", errImportLimitExceeded, maxInlineAttachmentBytes)
+	}
+	return data, nil
+}
+
 func parseAttachmentsFromProps(props ical.Props) ([]model.Attachment, error) {
 	var out []model.Attachment
 	for _, prop := range props.Values(ical.PropAttach) {
 		fmttype := prop.Params.Get("FMTTYPE")
 		if prop.Params.Get("ENCODING") == "BASE64" {
-			if base64.StdEncoding.DecodedLen(len(prop.Value)) > maxInlineAttachmentBytes {
-				return nil, fmt.Errorf("%w: inline attachment exceeds %d bytes", errImportLimitExceeded, maxInlineAttachmentBytes)
-			}
-			data, err := base64.StdEncoding.DecodeString(prop.Value)
+			data, err := decodeInlineAttachment(prop.Value)
 			if err != nil {
-				return nil, fmt.Errorf("decode inline attachment: %w", err)
-			}
-			if len(data) > maxInlineAttachmentBytes {
-				return nil, fmt.Errorf("%w: inline attachment exceeds %d bytes", errImportLimitExceeded, maxInlineAttachmentBytes)
+				return nil, err
 			}
 			out = append(out, model.Attachment{
 				FmtType:  fmttype,

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -1751,6 +1751,65 @@ func TestRoundtrip_AlarmAttachURI(t *testing.T) {
 	}
 }
 
+func TestRoundtrip_AlarmAttachBinary(t *testing.T) {
+	t.Parallel()
+	// AUDIO alarm with an inline BASE64 ATTACH (embedded sound) should
+	// roundtrip without losing the binary payload (issue #298).
+	sound := []byte("fake-wav-bytes\x00\x01\x02\xff")
+	original := event.Event{
+		UID:       "roundtrip-alarm-attach-binary",
+		Title:     "Event with Embedded Audio Alarm",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		Alarms: []model.Alarm{
+			{
+				Action:        "AUDIO",
+				TriggerValue:  "-PT15M",
+				Description:   "Alarm",
+				AttachBinary:  sound,
+				AttachFmtType: "audio/basic",
+			},
+		},
+		CreatedAt: time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC),
+	}
+
+	data, err := ExportEvents([]event.Event{original}, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	ics := string(data)
+	if !strings.Contains(ics, "ENCODING=BASE64") {
+		t.Errorf("exported ICS missing ENCODING=BASE64:\n%s", ics)
+	}
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("reimported %d events, want 1", len(result.Events))
+	}
+
+	got := result.Events[0]
+	if len(got.Alarms) != 1 {
+		t.Fatalf("Alarms: got %d, want 1", len(got.Alarms))
+	}
+	alarm := got.Alarms[0]
+	if !bytes.Equal(alarm.AttachBinary, sound) {
+		t.Errorf("AttachBinary: got %v, want %v", alarm.AttachBinary, sound)
+	}
+	if alarm.AttachFmtType != "audio/basic" {
+		t.Errorf("AttachFmtType: got %q, want %q", alarm.AttachFmtType, "audio/basic")
+	}
+	if alarm.AttachURI != "" {
+		t.Errorf("AttachURI: got %q, want empty", alarm.AttachURI)
+	}
+}
+
 func TestRoundtrip_EventDuration(t *testing.T) {
 	t.Parallel()
 	original := event.Event{

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -25,6 +26,7 @@ type Alarm struct {
 	Related       string // trigger anchor: START or END
 	Acknowledged  string // RFC 9074 ACKNOWLEDGED UTC timestamp (round-trip only, does not affect local alarm_state)
 	AttachURI     string // optional sound URI for AUDIO alarms (RFC 5545 Section 3.6.6)
+	AttachBinary  []byte // optional inline (ENCODING=BASE64;VALUE=BINARY) sound for AUDIO alarms
 	AttachFmtType string // FMTTYPE param for ATTACH (e.g. "audio/basic")
 	Attendees     []AlarmAttendee
 	XProperties   []XProperty // X-* extension props, round-trip only
@@ -53,6 +55,9 @@ func (a Alarm) ContentEqual(b Alarm) bool {
 		return false
 	}
 	if a.AttachURI != b.AttachURI || a.AttachFmtType != b.AttachFmtType {
+		return false
+	}
+	if !bytes.Equal(a.AttachBinary, b.AttachBinary) {
 		return false
 	}
 	return attendeesEqual(a.Attendees, b.Attendees)

--- a/internal/storage/alarms.sql.go
+++ b/internal/storage/alarms.sql.go
@@ -11,8 +11,8 @@ import (
 )
 
 const createAlarm = `-- name: CreateAlarm :one
-INSERT INTO event_alarms (event_id, uid, action, trigger_value, description, summary, repeat, duration, related, acknowledged, attach_uri, attach_fmttype)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype
+INSERT INTO event_alarms (event_id, uid, action, trigger_value, description, summary, repeat, duration, related, acknowledged, attach_uri, attach_fmttype, attach_binary)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary
 `
 
 type CreateAlarmParams struct {
@@ -28,6 +28,7 @@ type CreateAlarmParams struct {
 	Acknowledged  *string
 	AttachUri     *string
 	AttachFmttype *string
+	AttachBinary  []byte
 }
 
 func (q *Queries) CreateAlarm(ctx context.Context, arg CreateAlarmParams) (EventAlarm, error) {
@@ -44,6 +45,7 @@ func (q *Queries) CreateAlarm(ctx context.Context, arg CreateAlarmParams) (Event
 		arg.Acknowledged,
 		arg.AttachUri,
 		arg.AttachFmttype,
+		arg.AttachBinary,
 	)
 	var i EventAlarm
 	err := row.Scan(
@@ -60,6 +62,7 @@ func (q *Queries) CreateAlarm(ctx context.Context, arg CreateAlarmParams) (Event
 		&i.Acknowledged,
 		&i.AttachUri,
 		&i.AttachFmttype,
+		&i.AttachBinary,
 	)
 	return i, err
 }
@@ -83,7 +86,7 @@ func (q *Queries) DeleteAlarmsByEventID(ctx context.Context, eventID int64) erro
 }
 
 const listAlarmsByEventID = `-- name: ListAlarmsByEventID :many
-SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype FROM event_alarms WHERE event_id = ? ORDER BY id
+SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM event_alarms WHERE event_id = ? ORDER BY id
 `
 
 func (q *Queries) ListAlarmsByEventID(ctx context.Context, eventID int64) ([]EventAlarm, error) {
@@ -109,6 +112,7 @@ func (q *Queries) ListAlarmsByEventID(ctx context.Context, eventID int64) ([]Eve
 			&i.Acknowledged,
 			&i.AttachUri,
 			&i.AttachFmttype,
+			&i.AttachBinary,
 		); err != nil {
 			return nil, err
 		}
@@ -124,7 +128,7 @@ func (q *Queries) ListAlarmsByEventID(ctx context.Context, eventID int64) ([]Eve
 }
 
 const listAlarmsByEventIDs = `-- name: ListAlarmsByEventIDs :many
-SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype FROM event_alarms WHERE event_id IN (/*SLICE:event_ids*/?) ORDER BY event_id, id
+SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM event_alarms WHERE event_id IN (/*SLICE:event_ids*/?) ORDER BY event_id, id
 `
 
 func (q *Queries) ListAlarmsByEventIDs(ctx context.Context, eventIds []int64) ([]EventAlarm, error) {
@@ -160,6 +164,7 @@ func (q *Queries) ListAlarmsByEventIDs(ctx context.Context, eventIds []int64) ([
 			&i.Acknowledged,
 			&i.AttachUri,
 			&i.AttachFmttype,
+			&i.AttachBinary,
 		); err != nil {
 			return nil, err
 		}
@@ -175,7 +180,7 @@ func (q *Queries) ListAlarmsByEventIDs(ctx context.Context, eventIds []int64) ([
 }
 
 const listAlarmsWithEmptyUID = `-- name: ListAlarmsWithEmptyUID :many
-SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype FROM event_alarms WHERE uid IS NULL
+SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM event_alarms WHERE uid IS NULL
 `
 
 func (q *Queries) ListAlarmsWithEmptyUID(ctx context.Context) ([]EventAlarm, error) {
@@ -201,6 +206,7 @@ func (q *Queries) ListAlarmsWithEmptyUID(ctx context.Context) ([]EventAlarm, err
 			&i.Acknowledged,
 			&i.AttachUri,
 			&i.AttachFmttype,
+			&i.AttachBinary,
 		); err != nil {
 			return nil, err
 		}
@@ -260,7 +266,8 @@ func (q *Queries) UpdateAlarmAcknowledged(ctx context.Context, arg UpdateAlarmAc
 const updateAlarmContentByID = `-- name: UpdateAlarmContentByID :exec
 UPDATE event_alarms
 SET action = ?, trigger_value = ?, description = ?, summary = ?, repeat = ?,
-    duration = ?, related = ?, acknowledged = ?, attach_uri = ?, attach_fmttype = ?
+    duration = ?, related = ?, acknowledged = ?, attach_uri = ?, attach_fmttype = ?,
+    attach_binary = ?
 WHERE id = ? AND event_id = ?
 `
 
@@ -275,6 +282,7 @@ type UpdateAlarmContentByIDParams struct {
 	Acknowledged  *string
 	AttachUri     *string
 	AttachFmttype *string
+	AttachBinary  []byte
 	ID            int64
 	EventID       int64
 }
@@ -291,6 +299,7 @@ func (q *Queries) UpdateAlarmContentByID(ctx context.Context, arg UpdateAlarmCon
 		arg.Acknowledged,
 		arg.AttachUri,
 		arg.AttachFmttype,
+		arg.AttachBinary,
 		arg.ID,
 		arg.EventID,
 	)

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -89,6 +89,7 @@ type EventAlarm struct {
 	Acknowledged  *string
 	AttachUri     *string
 	AttachFmttype *string
+	AttachBinary  []byte
 }
 
 type EventAlarmAttendee struct {
@@ -340,6 +341,7 @@ type TodoAlarm struct {
 	Acknowledged  *string
 	AttachUri     *string
 	AttachFmttype *string
+	AttachBinary  []byte
 }
 
 type TodoAlarmAttendee struct {

--- a/internal/storage/todo_alarms.sql.go
+++ b/internal/storage/todo_alarms.sql.go
@@ -10,8 +10,8 @@ import (
 )
 
 const createTodoAlarm = `-- name: CreateTodoAlarm :one
-INSERT INTO todo_alarms (todo_id, uid, action, trigger_value, description, summary, repeat, duration, related, acknowledged, attach_uri, attach_fmttype)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype
+INSERT INTO todo_alarms (todo_id, uid, action, trigger_value, description, summary, repeat, duration, related, acknowledged, attach_uri, attach_fmttype, attach_binary)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary
 `
 
 type CreateTodoAlarmParams struct {
@@ -27,6 +27,7 @@ type CreateTodoAlarmParams struct {
 	Acknowledged  *string
 	AttachUri     *string
 	AttachFmttype *string
+	AttachBinary  []byte
 }
 
 func (q *Queries) CreateTodoAlarm(ctx context.Context, arg CreateTodoAlarmParams) (TodoAlarm, error) {
@@ -43,6 +44,7 @@ func (q *Queries) CreateTodoAlarm(ctx context.Context, arg CreateTodoAlarmParams
 		arg.Acknowledged,
 		arg.AttachUri,
 		arg.AttachFmttype,
+		arg.AttachBinary,
 	)
 	var i TodoAlarm
 	err := row.Scan(
@@ -59,6 +61,7 @@ func (q *Queries) CreateTodoAlarm(ctx context.Context, arg CreateTodoAlarmParams
 		&i.Acknowledged,
 		&i.AttachUri,
 		&i.AttachFmttype,
+		&i.AttachBinary,
 	)
 	return i, err
 }
@@ -109,7 +112,7 @@ func (q *Queries) ListDistinctTodoAlarmTriggers(ctx context.Context) ([]string, 
 }
 
 const listTodoAlarmsByTodoID = `-- name: ListTodoAlarmsByTodoID :many
-SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype FROM todo_alarms WHERE todo_id = ? ORDER BY id
+SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM todo_alarms WHERE todo_id = ? ORDER BY id
 `
 
 func (q *Queries) ListTodoAlarmsByTodoID(ctx context.Context, todoID int64) ([]TodoAlarm, error) {
@@ -135,6 +138,7 @@ func (q *Queries) ListTodoAlarmsByTodoID(ctx context.Context, todoID int64) ([]T
 			&i.Acknowledged,
 			&i.AttachUri,
 			&i.AttachFmttype,
+			&i.AttachBinary,
 		); err != nil {
 			return nil, err
 		}
@@ -150,7 +154,7 @@ func (q *Queries) ListTodoAlarmsByTodoID(ctx context.Context, todoID int64) ([]T
 }
 
 const listTodoAlarmsWithEmptyUID = `-- name: ListTodoAlarmsWithEmptyUID :many
-SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype FROM todo_alarms WHERE uid IS NULL
+SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM todo_alarms WHERE uid IS NULL
 `
 
 func (q *Queries) ListTodoAlarmsWithEmptyUID(ctx context.Context) ([]TodoAlarm, error) {
@@ -176,6 +180,7 @@ func (q *Queries) ListTodoAlarmsWithEmptyUID(ctx context.Context) ([]TodoAlarm, 
 			&i.Acknowledged,
 			&i.AttachUri,
 			&i.AttachFmttype,
+			&i.AttachBinary,
 		); err != nil {
 			return nil, err
 		}
@@ -207,7 +212,8 @@ func (q *Queries) UpdateTodoAlarmAcknowledged(ctx context.Context, arg UpdateTod
 const updateTodoAlarmContentByID = `-- name: UpdateTodoAlarmContentByID :exec
 UPDATE todo_alarms
 SET action = ?, trigger_value = ?, description = ?, summary = ?, repeat = ?,
-    duration = ?, related = ?, acknowledged = ?, attach_uri = ?, attach_fmttype = ?
+    duration = ?, related = ?, acknowledged = ?, attach_uri = ?, attach_fmttype = ?,
+    attach_binary = ?
 WHERE id = ? AND todo_id = ?
 `
 
@@ -222,6 +228,7 @@ type UpdateTodoAlarmContentByIDParams struct {
 	Acknowledged  *string
 	AttachUri     *string
 	AttachFmttype *string
+	AttachBinary  []byte
 	ID            int64
 	TodoID        int64
 }
@@ -238,6 +245,7 @@ func (q *Queries) UpdateTodoAlarmContentByID(ctx context.Context, arg UpdateTodo
 		arg.Acknowledged,
 		arg.AttachUri,
 		arg.AttachFmttype,
+		arg.AttachBinary,
 		arg.ID,
 		arg.TodoID,
 	)

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -683,6 +683,7 @@ func fromStorageTodoAlarm(r storage.TodoAlarm) model.Alarm {
 		Related:       r.Related,
 		Acknowledged:  storage.NullableToString(r.Acknowledged),
 		AttachURI:     storage.NullableToString(r.AttachUri),
+		AttachBinary:  r.AttachBinary,
 		AttachFmtType: storage.NullableToString(r.AttachFmttype),
 	}
 }
@@ -877,6 +878,7 @@ func updateTodoAlarmInPlace(ctx context.Context, qtx *storage.Queries, todoID in
 		Acknowledged:  storage.StringToNullable(ack),
 		AttachUri:     storage.StringToNullable(a.AttachURI),
 		AttachFmttype: storage.StringToNullable(a.AttachFmtType),
+		AttachBinary:  a.AttachBinary,
 		ID:            ex.ID,
 		TodoID:        todoID,
 	}); err != nil {
@@ -932,6 +934,7 @@ func createNewTodoAlarm(ctx context.Context, qtx *storage.Queries, todoID int64,
 		Acknowledged:  storage.StringToNullable(a.Acknowledged),
 		AttachUri:     storage.StringToNullable(a.AttachURI),
 		AttachFmttype: storage.StringToNullable(a.AttachFmtType),
+		AttachBinary:  a.AttachBinary,
 	}
 	row, err := qtx.CreateTodoAlarm(ctx, params)
 	if isUniqueUIDViolation(err) {

--- a/internal/tui/alarm_editor.go
+++ b/internal/tui/alarm_editor.go
@@ -302,6 +302,7 @@ func (m *AlarmListEditorModel) applyEditForm() {
 		alarm.Duration = orig.Duration
 		alarm.Acknowledged = orig.Acknowledged
 		alarm.AttachURI = orig.AttachURI
+		alarm.AttachBinary = orig.AttachBinary
 		alarm.AttachFmtType = orig.AttachFmtType
 		alarm.Attendees = orig.Attendees
 		alarm.Description = orig.Description


### PR DESCRIPTION
Closes #298

## Problem

Inline (`ENCODING=BASE64;VALUE=BINARY`) VALARM `ATTACH` was silently discarded on import. `parseAlarm` explicitly skipped any base64 ATTACH, and the alarm's catch-all preservation only captured `X-*` names, so an AUDIO alarm carrying an embedded sound (`ATTACH;ENCODING=BASE64;VALUE=BINARY`) lost it entirely and could not round-trip.

## Fix

- Add `model.Alarm.AttachBinary []byte`, persisted via a new `attach_binary` BLOB column on both `event_alarms` and `todo_alarms` (migration `037_alarm_attach_binary.sql`, queries updated + `make generate`).
- `parseAlarm` now decodes the inline payload into `AttachBinary` instead of dropping it, and stores `AttachURI` only for the URI form (the two are mutually exclusive).
- Decode logic is factored into a shared `decodeInlineAttachment` helper that also backs `parseAttachmentsFromProps`, enforcing the same `maxInlineAttachmentBytes` limit (pre-checked before allocating, so an oversized payload is rejected cheaply).
- Export re-emits the blob as `ATTACH;ENCODING=BASE64;VALUE=BINARY` (binary takes precedence over URI), mirroring how event/todo blob attachments are exported.
- `Alarm.ContentEqual` compares `AttachBinary` (so sync create/update matching stays correct) and the TUI alarm editor preserves it across edits.

## Reproducing test

`TestRoundtrip_AlarmAttachBinary` in `internal/ical/roundtrip_test.go`: builds an AUDIO alarm with an inline binary sound, exports it (asserting `ENCODING=BASE64` is emitted), re-imports, and asserts the exact bytes and FMTTYPE survive while `AttachURI` stays empty. It fails against the old code path (which skipped base64 ATTACH and had no field to hold it) and passes with this change.

## Review

- `/code-review high`: traced line-by-line, removed-behavior, cross-file (sync `ContentEqual` matching, all service call sites), reuse/simplify/efficiency, altitude, and CLAUDE.md conventions. No correctness bugs; the oversized-rejection behavior of `parseAttachmentsFromProps` is preserved.
- `/simplify`: the shared `decodeInlineAttachment` helper is itself the de-duplication; no further cleanup needed.
- `go build ./... && go test ./...` pass.
