### PR TITLE
fix(event): record truncation override provenance to stop resurrection

### DIFF
--- a/db/migrations/038_event_truncate_hidden_overrides.sql
+++ b/db/migrations/038_event_truncate_hidden_overrides.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Record which overrides a "this and following" truncation actually hid, so
+-- restore re-shows only those and never resurrects an override the user had
+-- already deleted independently (issue #287). Comma-separated RFC 3339
+-- recurrence_ids; '' means the truncation hid no overrides. NULL marks
+-- pre-#287 log rows that recorded no provenance, so restore falls back to the
+-- old "un-hide every override at/after the cutoff" behavior for those.
+ALTER TABLE event_truncate_deletes ADD COLUMN hidden_overrides TEXT;
+
+-- +goose Down
+ALTER TABLE event_truncate_deletes DROP COLUMN hidden_overrides;

--- a/db/queries/event_truncate_deletes.sql
+++ b/db/queries/event_truncate_deletes.sql
@@ -1,9 +1,10 @@
 -- name: RecordEventTruncateDelete :exec
 -- Idempotent: truncating the same cutoff twice keeps one log row. Stores
--- only the FIRST previous_rrule seen so re-truncating doesn't overwrite
--- the original pre-truncation state with an already-truncated rule.
-INSERT INTO event_truncate_deletes (calendar_id, uid, cutoff_time, previous_rrule)
-VALUES (?, ?, ?, ?)
+-- only the FIRST previous_rrule and hidden_overrides seen so re-truncating
+-- doesn't overwrite the original pre-truncation state with an already-
+-- truncated rule or an empty override set.
+INSERT INTO event_truncate_deletes (calendar_id, uid, cutoff_time, previous_rrule, hidden_overrides)
+VALUES (?, ?, ?, ?, ?)
 ON CONFLICT(uid, cutoff_time) DO UPDATE SET
     deleted_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now');
 

--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -107,6 +107,13 @@ UPDATE events SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE uid = ? AND deleted_at IS NULL;
 
+-- name: ListLiveOverrideRecurrenceIDsAtOrAfter :many
+-- The recurrence_ids a truncation is about to hide: live overrides at/after
+-- the cutoff. Captured before SoftDeleteOverridesAtOrAfter so restore can
+-- re-show only these and not overrides deleted independently (issue #287).
+SELECT recurrence_id FROM events
+WHERE uid = ? AND recurrence_id != '' AND recurrence_id >= ? AND deleted_at IS NULL;
+
 -- name: SoftDeleteOverridesAtOrAfter :exec
 UPDATE events SET
     deleted_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -681,6 +681,40 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 	return err
 }
 
+// softDeleteOverridesAndRecordTruncation hides every live override at/after
+// cutoff and records the truncation so the trash view can restore it. It
+// captures the recurrence_ids it hides BEFORE soft-deleting them, so restore
+// re-shows exactly those overrides and never resurrects one the user deleted
+// independently (issue #287). Pairs with restoreTruncatedOverrides.
+func softDeleteOverridesAndRecordTruncation(ctx context.Context, qtx *storage.Queries, calendarID int64, uid, cutoff, prevRRule string) error {
+	hidden, err := qtx.ListLiveOverrideRecurrenceIDsAtOrAfter(ctx, storage.ListLiveOverrideRecurrenceIDsAtOrAfterParams{
+		Uid:          uid,
+		RecurrenceID: cutoff,
+	})
+	if err != nil {
+		return fmt.Errorf("list future overrides: %w", err)
+	}
+	hiddenList := strings.Join(hidden, ",")
+
+	if err := qtx.SoftDeleteOverridesAtOrAfter(ctx, storage.SoftDeleteOverridesAtOrAfterParams{
+		Uid:          uid,
+		RecurrenceID: cutoff,
+	}); err != nil {
+		return fmt.Errorf("soft-delete future overrides: %w", err)
+	}
+
+	if err := qtx.RecordEventTruncateDelete(ctx, storage.RecordEventTruncateDeleteParams{
+		CalendarID:      calendarID,
+		Uid:             uid,
+		CutoffTime:      cutoff,
+		PreviousRrule:   prevRRule,
+		HiddenOverrides: &hiddenList,
+	}); err != nil {
+		return fmt.Errorf("record truncate: %w", err)
+	}
+	return nil
+}
+
 // deleteFromInstance performs the truncation and returns the master's
 // updated_at as written by this operation, read back inside the same
 // transaction. Returning the in-tx value (rather than a post-commit read)
@@ -715,20 +749,8 @@ func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTi
 	}
 
 	cutoff := instanceTime.UTC().Format(time.RFC3339)
-	if err := qtx.SoftDeleteOverridesAtOrAfter(ctx, storage.SoftDeleteOverridesAtOrAfterParams{
-		Uid:          uid,
-		RecurrenceID: cutoff,
-	}); err != nil {
-		return "", fmt.Errorf("soft-delete future overrides: %w", err)
-	}
-
-	if err := qtx.RecordEventTruncateDelete(ctx, storage.RecordEventTruncateDeleteParams{
-		CalendarID:    master.CalendarID,
-		Uid:           uid,
-		CutoffTime:    cutoff,
-		PreviousRrule: prevRRule,
-	}); err != nil {
-		return "", fmt.Errorf("record truncate: %w", err)
+	if err := softDeleteOverridesAndRecordTruncation(ctx, qtx, master.CalendarID, uid, cutoff, prevRRule); err != nil {
+		return "", err
 	}
 
 	// Read the master's updated_at back inside the transaction so the value we
@@ -1020,20 +1042,8 @@ func updateFromInstanceTx(ctx context.Context, qtx *storage.Queries, uid string,
 	}
 
 	cutoff := instanceTime.UTC().Format(time.RFC3339)
-	if err := qtx.SoftDeleteOverridesAtOrAfter(ctx, storage.SoftDeleteOverridesAtOrAfterParams{
-		Uid:          uid,
-		RecurrenceID: cutoff,
-	}); err != nil {
-		return Event{}, 0, fmt.Errorf("soft-delete future overrides: %w", err)
-	}
-
-	if err := qtx.RecordEventTruncateDelete(ctx, storage.RecordEventTruncateDeleteParams{
-		CalendarID:    master.CalendarID,
-		Uid:           uid,
-		CutoffTime:    cutoff,
-		PreviousRrule: prevRRule,
-	}); err != nil {
-		return Event{}, 0, fmt.Errorf("record truncate: %w", err)
+	if err := softDeleteOverridesAndRecordTruncation(ctx, qtx, master.CalendarID, uid, cutoff, prevRRule); err != nil {
+		return Event{}, 0, err
 	}
 
 	// Caller is the source of truth for categories. An empty p.Categories

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/storage"
@@ -314,10 +315,7 @@ func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) err
 	}); err != nil {
 		return fmt.Errorf("restore rrule: %w", err)
 	}
-	if err := qtx.RestoreOverridesAtOrAfter(ctx, storage.RestoreOverridesAtOrAfterParams{
-		Uid:          log.Uid,
-		RecurrenceID: log.CutoffTime,
-	}); err != nil {
+	if err := restoreTruncatedOverrides(ctx, qtx, log); err != nil {
 		return fmt.Errorf("restore overrides: %w", err)
 	}
 	if err := qtx.DeleteEventTruncateDelete(ctx, logID); err != nil {
@@ -327,4 +325,31 @@ func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) err
 		return fmt.Errorf("mark resource dirty: %w", err)
 	}
 	return tx.Commit()
+}
+
+// restoreTruncatedOverrides un-hides the overrides a truncation soft-deleted.
+// When the log recorded provenance (hidden_overrides is non-NULL), it restores
+// only those specific overrides, so an override the user deleted independently
+// before the truncation stays deleted (issue #287). Pre-#287 log rows store
+// NULL provenance; for those it falls back to un-hiding every soft-deleted
+// override at/after the cutoff.
+func restoreTruncatedOverrides(ctx context.Context, qtx *storage.Queries, log storage.EventTruncateDelete) error {
+	if log.HiddenOverrides == nil {
+		return qtx.RestoreOverridesAtOrAfter(ctx, storage.RestoreOverridesAtOrAfterParams{
+			Uid:          log.Uid,
+			RecurrenceID: log.CutoffTime,
+		})
+	}
+	if *log.HiddenOverrides == "" {
+		return nil
+	}
+	for _, recID := range strings.Split(*log.HiddenOverrides, ",") {
+		if err := qtx.RestoreEventByUIDAndRecurrenceID(ctx, storage.RestoreEventByUIDAndRecurrenceIDParams{
+			Uid:          log.Uid,
+			RecurrenceID: recID,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/event/trash_test.go
+++ b/internal/event/trash_test.go
@@ -288,6 +288,82 @@ func TestTrash_PurgeTruncationKeepsRRuleTruncated(t *testing.T) {
 	}
 }
 
+// TestTrash_TruncationRestoreKeepsIndependentlyDeletedOverride reproduces
+// issue #287: an override deleted independently (before the truncation) must
+// stay deleted when the truncation is restored. The truncation only hides
+// overrides that were live at truncation time, so restoring it must not
+// resurrect an override the user had already deleted on its own.
+func TestTrash_TruncationRestoreKeepsIndependentlyDeletedOverride(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "standup",
+		CalendarID:     1,
+		Title:          "Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=10",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	// User customizes the Apr 22 instance (creates an override).
+	overrideTime := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Standup (moved)",
+		StartTime:    time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 22, 10, 30, 0, 0, time.UTC),
+		RecurrenceID: overrideTime.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// User then deletes that single customized instance on its own. This
+	// soft-deletes the override row and adds an EXDATE on the master.
+	if err := svc.DeleteInstance(ctx, master.UID, overrideTime); err != nil {
+		t.Fatalf("DeleteInstance: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err == nil {
+		t.Fatalf("override should be soft-deleted after DeleteInstance")
+	}
+
+	// Later, user truncates the series "this and following" from an earlier
+	// cutoff (Apr 8). The already-deleted Apr 22 override is untouched.
+	cutoff := time.Date(2026, 4, 8, 9, 0, 0, 0, time.UTC)
+	if err := svc.DeleteFromInstance(ctx, master.UID, cutoff); err != nil {
+		t.Fatalf("DeleteFromInstance: %v", err)
+	}
+
+	entries, err := svc.ListTrash(ctx, 1)
+	if err != nil {
+		t.Fatalf("ListTrash: %v", err)
+	}
+	var trunc TrashEntry
+	for _, e := range entries {
+		if e.Kind == TrashKindTruncation {
+			trunc = e
+			break
+		}
+	}
+	if trunc.ID == 0 {
+		t.Fatalf("no truncation entry: %+v", entries)
+	}
+
+	// Restore the truncation. This must NOT resurrect the override the user
+	// independently deleted before the truncation.
+	if err := svc.RestoreTrash(ctx, trunc); err != nil {
+		t.Fatalf("RestoreTrash: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err == nil {
+		t.Fatalf("issue #287: independently-deleted override resurrected by truncation restore")
+	}
+}
+
 // TestTrash_PurgeInstanceKeepsExdate verifies that purging an instance-kind
 // entry drops the log row but leaves the EXDATE on the master — the
 // "forever delete" semantics for per-instance deletes.

--- a/internal/storage/event_truncate_deletes.sql.go
+++ b/internal/storage/event_truncate_deletes.sql.go
@@ -19,7 +19,7 @@ func (q *Queries) DeleteEventTruncateDelete(ctx context.Context, id int64) error
 }
 
 const getEventTruncateDelete = `-- name: GetEventTruncateDelete :one
-SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at FROM event_truncate_deletes WHERE id = ?
+SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at, hidden_overrides FROM event_truncate_deletes WHERE id = ?
 `
 
 func (q *Queries) GetEventTruncateDelete(ctx context.Context, id int64) (EventTruncateDelete, error) {
@@ -32,12 +32,13 @@ func (q *Queries) GetEventTruncateDelete(ctx context.Context, id int64) (EventTr
 		&i.CutoffTime,
 		&i.PreviousRrule,
 		&i.DeletedAt,
+		&i.HiddenOverrides,
 	)
 	return i, err
 }
 
 const listEventTruncateDeletesByCalendar = `-- name: ListEventTruncateDeletesByCalendar :many
-SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at FROM event_truncate_deletes
+SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at, hidden_overrides FROM event_truncate_deletes
 WHERE calendar_id = ?
 ORDER BY deleted_at DESC
 `
@@ -58,6 +59,7 @@ func (q *Queries) ListEventTruncateDeletesByCalendar(ctx context.Context, calend
 			&i.CutoffTime,
 			&i.PreviousRrule,
 			&i.DeletedAt,
+			&i.HiddenOverrides,
 		); err != nil {
 			return nil, err
 		}
@@ -85,28 +87,31 @@ func (q *Queries) PurgeOldEventTruncateDeletes(ctx context.Context, deletedAt st
 }
 
 const recordEventTruncateDelete = `-- name: RecordEventTruncateDelete :exec
-INSERT INTO event_truncate_deletes (calendar_id, uid, cutoff_time, previous_rrule)
-VALUES (?, ?, ?, ?)
+INSERT INTO event_truncate_deletes (calendar_id, uid, cutoff_time, previous_rrule, hidden_overrides)
+VALUES (?, ?, ?, ?, ?)
 ON CONFLICT(uid, cutoff_time) DO UPDATE SET
     deleted_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 `
 
 type RecordEventTruncateDeleteParams struct {
-	CalendarID    int64
-	Uid           string
-	CutoffTime    string
-	PreviousRrule string
+	CalendarID      int64
+	Uid             string
+	CutoffTime      string
+	PreviousRrule   string
+	HiddenOverrides *string
 }
 
 // Idempotent: truncating the same cutoff twice keeps one log row. Stores
-// only the FIRST previous_rrule seen so re-truncating doesn't overwrite
-// the original pre-truncation state with an already-truncated rule.
+// only the FIRST previous_rrule and hidden_overrides seen so re-truncating
+// doesn't overwrite the original pre-truncation state with an already-
+// truncated rule or an empty override set.
 func (q *Queries) RecordEventTruncateDelete(ctx context.Context, arg RecordEventTruncateDeleteParams) error {
 	_, err := q.db.ExecContext(ctx, recordEventTruncateDelete,
 		arg.CalendarID,
 		arg.Uid,
 		arg.CutoffTime,
 		arg.PreviousRrule,
+		arg.HiddenOverrides,
 	)
 	return err
 }

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -527,6 +527,42 @@ func (q *Queries) ListEventsByDateRange(ctx context.Context, arg ListEventsByDat
 	return items, nil
 }
 
+const listLiveOverrideRecurrenceIDsAtOrAfter = `-- name: ListLiveOverrideRecurrenceIDsAtOrAfter :many
+SELECT recurrence_id FROM events
+WHERE uid = ? AND recurrence_id != '' AND recurrence_id >= ? AND deleted_at IS NULL
+`
+
+type ListLiveOverrideRecurrenceIDsAtOrAfterParams struct {
+	Uid          string
+	RecurrenceID string
+}
+
+// The recurrence_ids a truncation is about to hide: live overrides at/after
+// the cutoff. Captured before SoftDeleteOverridesAtOrAfter so restore can
+// re-show only these and not overrides deleted independently (issue #287).
+func (q *Queries) ListLiveOverrideRecurrenceIDsAtOrAfter(ctx context.Context, arg ListLiveOverrideRecurrenceIDsAtOrAfterParams) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listLiveOverrideRecurrenceIDsAtOrAfter, arg.Uid, arg.RecurrenceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var recurrence_id string
+		if err := rows.Scan(&recurrence_id); err != nil {
+			return nil, err
+		}
+		items = append(items, recurrence_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listOverridesByUID = `-- name: ListOverridesByUID :many
 SELECT id, uid, calendar_id, title, description, location, start_time, end_time, all_day, recurrence_rule, timezone, status, transp, sequence, priority, class, url, exdates, rdates, recurrence_id, geo, created_at, updated_at, duration, dtstamp, conference_uri, deleted_at FROM events
 WHERE uid = ? AND recurrence_id != '' AND deleted_at IS NULL

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -165,12 +165,13 @@ type EventResource struct {
 }
 
 type EventTruncateDelete struct {
-	ID            int64
-	CalendarID    int64
-	Uid           string
-	CutoffTime    string
-	PreviousRrule string
-	DeletedAt     string
+	ID              int64
+	CalendarID      int64
+	Uid             string
+	CutoffTime      string
+	PreviousRrule   string
+	DeletedAt       string
+	HiddenOverrides *string
 }
 
 type EventsFt struct {


### PR DESCRIPTION
Closes #287

## Problem
Restoring a "this and following" truncation from trash called
`RestoreOverridesAtOrAfter`, which un-hides **every** soft-deleted override at/after
the cutoff. But the truncation that created the log row only soft-deleted overrides
that were live at the time (`deleted_at IS NULL`) and never recorded *which* ones it
hid. Sequence that triggers the bug:

1. User customizes a recurring instance (creates an override).
2. User separately deletes that single instance (`DeleteInstance` soft-deletes the
   override row + adds an EXDATE on the master).
3. User later truncates the series "this and following" from an **earlier** cutoff.
4. Restoring the truncation from trash resurrects the independently-deleted override —
   data the user explicitly deleted silently reappears. The surviving master EXDATE
   does not re-hide it because restore's `occChecker` runs with `includeExDates=false`.

Same *class* of provenance gap as #86, but for the truncate-override mechanism.

## Fix
- New nullable `hidden_overrides` column on `event_truncate_deletes` (migration 037)
  stores the comma-separated RFC 3339 `recurrence_id`s the truncation actually hid,
  captured **before** the soft-delete via the new
  `ListLiveOverrideRecurrenceIDsAtOrAfter` query.
- Restore (`restoreTruncatedOverrides`) re-shows **only** those recorded overrides, so
  an override the user deleted independently stays deleted.
- A `NULL` column marks pre-fix log rows with no recorded provenance; for those,
  restore falls back to the old un-hide-everything behavior (empty string means "hid
  none" — distinct from NULL).
- Both record sites (`DeleteFromInstance` and the `UpdateFromInstance` split) go
  through one `softDeleteOverridesAndRecordTruncation` helper, paired with
  `restoreTruncatedOverrides`, so the provenance contract lives in one place.
- SQL queries added to `db/queries/*.sql` and regenerated via `sqlc generate` (no
  hand-edits to `*.sql.go`).

## Reproducing test
`TestTrash_TruncationRestoreKeepsIndependentlyDeletedOverride` in
`internal/event/trash_test.go` walks the exact sequence above and asserts the
independently-deleted override is **not** resurrected after restoring the truncation.
It fails before the fix and passes after.

## Review outcomes
- **/code-review (high):** traced both record sites (both set provenance), the single
  `RestoreOverridesAtOrAfter` usage (now only the NULL legacy fallback), the
  NULL-vs-empty-string distinction, ON-CONFLICT idempotency (preserves the original
  list like `previous_rrule`), RFC-3339 comma-safety, and conventions (column added to
  `event_truncate_deletes`, not `events`/`todos`, so no `scan_helpers.go` change). No
  findings.
- **/simplify:** extracted the duplicated three-step truncation-record block into one
  `softDeleteOverridesAndRecordTruncation` helper.

`go build ./... && go test ./...` all pass; `gofmt` clean.
