### PR TITLE
fix(storage): chunk and de-dupe IN(...) batch loaders

### DIFF
--- a/internal/storage/attendees_dynamic.go
+++ b/internal/storage/attendees_dynamic.go
@@ -2,32 +2,33 @@ package storage
 
 import "context"
 
-// ListAttendeesByEventIDs returns attendees for the given event IDs.
+// ListAttendeesByEventIDs returns attendees for the given event IDs. The ids
+// are de-duplicated and chunked so the IN clause never exceeds SQLite's
+// host-parameter cap on wide recurrence expansions (issue #303).
 // Hand-written because database/sql does not support slice parameters.
 func (q *Queries) ListAttendeesByEventIDs(ctx context.Context, ids []int64) ([]EventAttendee, error) {
-	if len(ids) == 0 {
-		return nil, nil
-	}
-	placeholders, args := expandInPlaceholders(ids)
-	query := "SELECT id, event_id, email, name, rsvp_status, role, organizer, cutype, rsvp, sent_by, delegated_to, delegated_from, member, dir, language FROM event_attendees WHERE event_id IN (" + placeholders + ") ORDER BY event_id, organizer DESC, name"
+	return loadByIDChunks(ctx, ids, func(ctx context.Context, chunk []int64) ([]EventAttendee, error) {
+		placeholders, args := expandInPlaceholders(chunk)
+		query := "SELECT id, event_id, email, name, rsvp_status, role, organizer, cutype, rsvp, sent_by, delegated_to, delegated_from, member, dir, language FROM event_attendees WHERE event_id IN (" + placeholders + ") ORDER BY event_id, organizer DESC, name"
 
-	rows, err := q.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []EventAttendee
-	for rows.Next() {
-		var i EventAttendee
-		if err := rows.Scan(
-			&i.ID, &i.EventID, &i.Email, &i.Name,
-			&i.RsvpStatus, &i.Role, &i.Organizer, &i.Cutype,
-			&i.Rsvp, &i.SentBy, &i.DelegatedTo, &i.DelegatedFrom,
-			&i.Member, &i.Dir, &i.Language,
-		); err != nil {
+		rows, err := q.db.QueryContext(ctx, query, args...)
+		if err != nil {
 			return nil, err
 		}
-		items = append(items, i)
-	}
-	return items, rows.Err()
+		defer rows.Close()
+		var items []EventAttendee
+		for rows.Next() {
+			var i EventAttendee
+			if err := rows.Scan(
+				&i.ID, &i.EventID, &i.Email, &i.Name,
+				&i.RsvpStatus, &i.Role, &i.Organizer, &i.Cutype,
+				&i.Rsvp, &i.SentBy, &i.DelegatedTo, &i.DelegatedFrom,
+				&i.Member, &i.Dir, &i.Language,
+			); err != nil {
+				return nil, err
+			}
+			items = append(items, i)
+		}
+		return items, rows.Err()
+	})
 }

--- a/internal/storage/categories_dynamic.go
+++ b/internal/storage/categories_dynamic.go
@@ -2,77 +2,78 @@ package storage
 
 import "context"
 
-// ListCategoriesByEventIDs returns categories for the given event IDs.
+// ListCategoriesByEventIDs returns categories for the given event IDs. The ids
+// are de-duplicated and chunked so the IN clause never exceeds SQLite's
+// host-parameter cap on wide recurrence expansions (issue #303).
 // Hand-written because database/sql does not support slice parameters.
 func (q *Queries) ListCategoriesByEventIDs(ctx context.Context, ids []int64) ([]EventCategory, error) {
-	if len(ids) == 0 {
-		return nil, nil
-	}
-	placeholders, args := expandInPlaceholders(ids)
-	query := "SELECT event_id, category FROM event_categories WHERE event_id IN (" + placeholders + ") ORDER BY event_id, category"
+	return loadByIDChunks(ctx, ids, func(ctx context.Context, chunk []int64) ([]EventCategory, error) {
+		placeholders, args := expandInPlaceholders(chunk)
+		query := "SELECT event_id, category FROM event_categories WHERE event_id IN (" + placeholders + ") ORDER BY event_id, category"
 
-	rows, err := q.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []EventCategory
-	for rows.Next() {
-		var i EventCategory
-		if err := rows.Scan(&i.EventID, &i.Category); err != nil {
+		rows, err := q.db.QueryContext(ctx, query, args...)
+		if err != nil {
 			return nil, err
 		}
-		items = append(items, i)
-	}
-	return items, rows.Err()
+		defer rows.Close()
+		var items []EventCategory
+		for rows.Next() {
+			var i EventCategory
+			if err := rows.Scan(&i.EventID, &i.Category); err != nil {
+				return nil, err
+			}
+			items = append(items, i)
+		}
+		return items, rows.Err()
+	})
 }
 
-// ListCategoriesByTodoIDs returns categories for the given todo IDs.
+// ListCategoriesByTodoIDs returns categories for the given todo IDs. See
+// ListCategoriesByEventIDs for the de-dup/chunk rationale.
 // Hand-written because database/sql does not support slice parameters.
 func (q *Queries) ListCategoriesByTodoIDs(ctx context.Context, ids []int64) ([]TodoCategory, error) {
-	if len(ids) == 0 {
-		return nil, nil
-	}
-	placeholders, args := expandInPlaceholders(ids)
-	query := "SELECT todo_id, category FROM todo_categories WHERE todo_id IN (" + placeholders + ") ORDER BY todo_id, category"
+	return loadByIDChunks(ctx, ids, func(ctx context.Context, chunk []int64) ([]TodoCategory, error) {
+		placeholders, args := expandInPlaceholders(chunk)
+		query := "SELECT todo_id, category FROM todo_categories WHERE todo_id IN (" + placeholders + ") ORDER BY todo_id, category"
 
-	rows, err := q.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []TodoCategory
-	for rows.Next() {
-		var i TodoCategory
-		if err := rows.Scan(&i.TodoID, &i.Category); err != nil {
+		rows, err := q.db.QueryContext(ctx, query, args...)
+		if err != nil {
 			return nil, err
 		}
-		items = append(items, i)
-	}
-	return items, rows.Err()
+		defer rows.Close()
+		var items []TodoCategory
+		for rows.Next() {
+			var i TodoCategory
+			if err := rows.Scan(&i.TodoID, &i.Category); err != nil {
+				return nil, err
+			}
+			items = append(items, i)
+		}
+		return items, rows.Err()
+	})
 }
 
-// ListCategoriesByJournalIDs returns categories for the given journal IDs.
+// ListCategoriesByJournalIDs returns categories for the given journal IDs. See
+// ListCategoriesByEventIDs for the de-dup/chunk rationale.
 // Hand-written because database/sql does not support slice parameters.
 func (q *Queries) ListCategoriesByJournalIDs(ctx context.Context, ids []int64) ([]JournalCategory, error) {
-	if len(ids) == 0 {
-		return nil, nil
-	}
-	placeholders, args := expandInPlaceholders(ids)
-	query := "SELECT journal_id, category FROM journal_categories WHERE journal_id IN (" + placeholders + ") ORDER BY journal_id, category"
+	return loadByIDChunks(ctx, ids, func(ctx context.Context, chunk []int64) ([]JournalCategory, error) {
+		placeholders, args := expandInPlaceholders(chunk)
+		query := "SELECT journal_id, category FROM journal_categories WHERE journal_id IN (" + placeholders + ") ORDER BY journal_id, category"
 
-	rows, err := q.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []JournalCategory
-	for rows.Next() {
-		var i JournalCategory
-		if err := rows.Scan(&i.JournalID, &i.Category); err != nil {
+		rows, err := q.db.QueryContext(ctx, query, args...)
+		if err != nil {
 			return nil, err
 		}
-		items = append(items, i)
-	}
-	return items, rows.Err()
+		defer rows.Close()
+		var items []JournalCategory
+		for rows.Next() {
+			var i JournalCategory
+			if err := rows.Scan(&i.JournalID, &i.Category); err != nil {
+				return nil, err
+			}
+			items = append(items, i)
+		}
+		return items, rows.Err()
+	})
 }

--- a/internal/storage/categories_dynamic_test.go
+++ b/internal/storage/categories_dynamic_test.go
@@ -1,0 +1,51 @@
+package storage
+
+import (
+	"context"
+	"testing"
+)
+
+// TestListCategoriesByEventIDs_OverParameterCap reproduces issue #303: the
+// category batch loader built a single unbounded `IN (?,?,…)` clause. When the
+// recurrence expander feeds one id per expanded instance, the slice can exceed
+// SQLite's 32766 host-parameter cap, tripping "too many SQL variables". The
+// loader must chunk the IN clause (as the override loader already does) so a
+// wide id slice still succeeds.
+func TestListCategoriesByEventIDs_OverParameterCap(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	evt := insertEventRow(t, q, ctx, "uid-cat", "", "2026-01-01T09:00:00Z")
+	if _, err := q.CreateEventCategory(ctx, CreateEventCategoryParams{
+		EventID:  evt.ID,
+		Category: "work",
+	}); err != nil {
+		t.Fatalf("CreateEventCategory: %v", err)
+	}
+
+	// Build an id slice that overflows SQLite's 32766 parameter cap. The real
+	// event id is included so a correct, chunked loader still returns its
+	// category; the remaining ids are distinct and non-existent so chunking
+	// (not just de-duplication) is exercised.
+	const n = 40000
+	ids := make([]int64, 0, n)
+	ids = append(ids, evt.ID)
+	for i := int64(1); int64(len(ids)) < n; i++ {
+		if i == evt.ID {
+			continue
+		}
+		ids = append(ids, i)
+	}
+
+	cats, err := q.ListCategoriesByEventIDs(ctx, ids)
+	if err != nil {
+		t.Fatalf("ListCategoriesByEventIDs with %d ids: %v", len(ids), err)
+	}
+	if len(cats) != 1 || cats[0].EventID != evt.ID || cats[0].Category != "work" {
+		t.Fatalf("got %+v, want one {EventID:%d, Category:work}", cats, evt.ID)
+	}
+}

--- a/internal/storage/overrides_dynamic.go
+++ b/internal/storage/overrides_dynamic.go
@@ -17,7 +17,7 @@ const overrideUIDBatch = 500
 // support.
 func (q *Queries) ListOverridesByUIDs(ctx context.Context, uids []string) ([]Event, error) {
 	var out []Event
-	for _, chunk := range chunkStrings(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListOverridesByUIDs */"
 		rows, err := q.queryEvents(ctx, where, args, "uid ASC, recurrence_id ASC")
@@ -32,7 +32,7 @@ func (q *Queries) ListOverridesByUIDs(ctx context.Context, uids []string) ([]Eve
 // ListTodoOverridesByUIDs is the batched form of ListTodoOverridesByUID.
 func (q *Queries) ListTodoOverridesByUIDs(ctx context.Context, uids []string) ([]Todo, error) {
 	var out []Todo
-	for _, chunk := range chunkStrings(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListTodoOverridesByUIDs */"
 		rows, err := q.queryTodos(ctx, where, args, "uid ASC, recurrence_id ASC")
@@ -47,7 +47,7 @@ func (q *Queries) ListTodoOverridesByUIDs(ctx context.Context, uids []string) ([
 // ListJournalOverridesByUIDs is the batched form of ListJournalOverridesByUID.
 func (q *Queries) ListJournalOverridesByUIDs(ctx context.Context, uids []string) ([]Journal, error) {
 	var out []Journal
-	for _, chunk := range chunkStrings(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListJournalOverridesByUIDs */"
 		rows, err := q.queryJournals(ctx, where, args, "uid ASC, recurrence_id ASC")
@@ -59,13 +59,13 @@ func (q *Queries) ListJournalOverridesByUIDs(ctx context.Context, uids []string)
 	return out, nil
 }
 
-// chunkStrings splits vals into consecutive slices of at most size elements.
+// chunkSlice splits vals into consecutive slices of at most size elements.
 // Returns nil for empty input. The returned slices alias vals (no copy).
-func chunkStrings(vals []string, size int) [][]string {
+func chunkSlice[T any](vals []T, size int) [][]T {
 	if len(vals) == 0 {
 		return nil
 	}
-	var chunks [][]string
+	var chunks [][]T
 	for i := 0; i < len(vals); i += size {
 		end := i + size
 		if end > len(vals) {

--- a/internal/storage/query_builder.go
+++ b/internal/storage/query_builder.go
@@ -51,6 +51,47 @@ func expandInPlaceholders(ids []int64) (string, []interface{}) {
 	return placeholders, args
 }
 
+// loaderIDBatch bounds how many ids go into a single `id IN (...)` batch loader
+// query (categories, attendees). Like overrideUIDBatch it stays well under
+// SQLite's 32766 host-parameter cap so the IN clause never overflows on wide
+// recurrence expansions, at the cost of a few extra queries instead of one.
+const loaderIDBatch = 500
+
+// dedupeInt64s returns ids with duplicates removed, preserving first-seen
+// order. Recurrence expansion feeds one id per expanded instance, so the same
+// master row id repeats once per occurrence; collapsing the duplicates shrinks
+// the IN-clause loaders from O(instances) back to O(distinct rows).
+func dedupeInt64s(ids []int64) []int64 {
+	if len(ids) < 2 {
+		return ids
+	}
+	seen := make(map[int64]struct{}, len(ids))
+	out := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+// loadByIDChunks de-duplicates ids and runs load once per chunk that fits under
+// SQLite's host-parameter cap, concatenating the results. Each chunk passed to
+// load is small enough for a single `IN (...)` query.
+func loadByIDChunks[T any](ctx context.Context, ids []int64, load func(context.Context, []int64) ([]T, error)) ([]T, error) {
+	var out []T
+	for _, chunk := range chunkSlice(dedupeInt64s(ids), loaderIDBatch) {
+		rows, err := load(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rows...)
+	}
+	return out, nil
+}
+
 // expandStringPlaceholders is the string analogue of expandInPlaceholders,
 // building the "?,?,?" list and matching positional args for a SQL `IN (...)`
 // clause over string values (e.g. UIDs). Callers must ensure len(vals) > 0.


### PR DESCRIPTION
Closes #303

## Problem

The category and attendee batch loaders (`internal/storage/categories_dynamic.go`, `internal/storage/attendees_dynamic.go`) built a single unbounded `IN (?,?,…)` clause with one placeholder per id and no chunking. The recurrence expander feeds these loaders **one id per expanded instance** (`internal/recurrence/service.go`), so the slice length scales with occurrence count. A single daily-recurring event over a wide/unbounded window (agenda auto-fill, wide `--from/--to` export) reaches 32766+ entries on its own and trips SQLite's `too many SQL variables` cap — the very limit `overrides_dynamic.go` already chunks around.

Because the error is swallowed in recurrence expansion (`if err == nil`) and logged-then-dropped in `populateCategories`, instances silently lose categories/attendees: data quietly missing from views/exports on large/wide-window calendars.

## Fix

Route the int64 loaders through a shared `loadByIDChunks` helper that:
- **De-duplicates** ids first — expansion repeats the same master row id once per occurrence, so de-duping collapses most expansion queries from O(instances) back to O(distinct rows). (De-dup is output-neutral: SQLite `IN` is set membership, so duplicate ids never produced duplicate rows.)
- **Chunks** the remaining ids under the parameter cap (`loaderIDBatch = 500`), mirroring `ListOverridesByUIDs`.

`chunkStrings` is generalized into a generic `chunkSlice[T any]` so the string (UID) and int64 (id) loaders share one chunker. The previous `if len(ids) == 0 { return nil, nil }` guards are preserved by `loadByIDChunks` (empty input → no chunks → `nil, nil`).

## Reproducing test

`internal/storage/categories_dynamic_test.go::TestListCategoriesByEventIDs_OverParameterCap` inserts one event+category, then calls `ListCategoriesByEventIDs` with 40000 distinct ids (including the real one). Before the fix it fails with `too many SQL variables (1)`; after the fix it returns the single expected category. Distinct (not duplicate) ids ensure chunking — not just de-duplication — is exercised.

## Review outcomes

- `go build ./... && go test ./...` — all packages pass.
- **code-review (high):** no findings survived. Verified empty-ids behavior preserved, de-dup is output-neutral, no stray `chunkStrings` references, `go vet` clean.
- **simplify:** no existing dedup helper to reuse; chunking/dedup already factored into `loadByIDChunks`; per-loader scan loops are inherent to their distinct row types. Already clean.
