### PR TITLE
fix(auth): enforce --allow-plaintext gate instead of hardcoding it on

### DIFF
--- a/cmd/chroncal/calendar_remote.go
+++ b/cmd/chroncal/calendar_remote.go
@@ -63,7 +63,7 @@ func validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID st
 }
 
 func connectCalendarRemote(ctx context.Context, a *app.App, cal calendarpkg.Calendar, flags calendarRemoteFlags) error {
-	credStore, err := newCalendarCredentialStore(true)
+	credStore, err := newCalendarCredentialStore(a.AllowPlaintext)
 	if err != nil {
 		return fmt.Errorf("credential store: %w", err)
 	}
@@ -95,12 +95,12 @@ func connectCalendarRemote(ctx context.Context, a *app.App, cal calendarpkg.Cale
 }
 
 func disconnectCalendarRemote(ctx context.Context, a *app.App, cal calendarpkg.Calendar) error {
-	credStore, _ := newCalendarCredentialStore(true)
+	credStore, _ := newCalendarCredentialStore(a.AllowPlaintext)
 	return a.Calendars.Disconnect(ctx, cal, credStore)
 }
 
 func deleteCalendarWithCleanup(ctx context.Context, a *app.App, id, newDefaultID int64) error {
-	credStore, _ := newCalendarCredentialStore(true)
+	credStore, _ := newCalendarCredentialStore(a.AllowPlaintext)
 	return a.Calendars.DeleteWithRemoteCleanup(ctx, id, newDefaultID, credStore)
 }
 

--- a/cmd/chroncal/calendar_remote_test.go
+++ b/cmd/chroncal/calendar_remote_test.go
@@ -147,6 +147,57 @@ func TestConnectCalendarRemote_RollsBackExistingHiddenAccountUpdateWhenCredentia
 	}
 }
 
+// TestConnectCalendarRemote_GatesPlaintextOnAppFlag is the regression guard
+// for issue #299: the credential store must be constructed with the app's
+// AllowPlaintext value, not a hardcoded true. Before the fix every call site
+// passed true unconditionally, so the --allow-plaintext gate was dead code
+// and secrets were silently written in cleartext when no keyring was present.
+func TestConnectCalendarRemote_GatesPlaintextOnAppFlag(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+
+	ctx := context.Background()
+	cal, err := a.Calendars.Create(ctx, "Work", "#7C3AED", "")
+	if err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	var gotAllowPlaintext bool
+	prevFactory := newCalendarCredentialStore
+	newCalendarCredentialStore = func(allowPlaintext bool) (auth.CredentialStore, error) {
+		gotAllowPlaintext = allowPlaintext
+		// Return an error to short-circuit connectCalendarRemote right after
+		// the store is constructed; we only care about the argument.
+		return nil, errors.New("stop after store construction")
+	}
+	t.Cleanup(func() {
+		newCalendarCredentialStore = prevFactory
+	})
+
+	flags := calendarRemoteFlags{
+		RemoteURL: "https://cal.example.com/dav/calendars/work/",
+		Username:  "alice",
+		AuthType:  "bearer",
+	}
+
+	a.AllowPlaintext = false
+	_ = connectCalendarRemote(ctx, a, cal, flags)
+	if gotAllowPlaintext {
+		t.Fatal("credential store built with allowPlaintext=true while App.AllowPlaintext=false; --allow-plaintext gate not enforced")
+	}
+
+	a.AllowPlaintext = true
+	_ = connectCalendarRemote(ctx, a, cal, flags)
+	if !gotAllowPlaintext {
+		t.Fatal("credential store built with allowPlaintext=false while App.AllowPlaintext=true; flag not threaded")
+	}
+}
+
 func TestDeleteCalendarWithCleanup_RemovesHiddenAccountAndCredential(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 

--- a/cmd/chroncal/freebusy.go
+++ b/cmd/chroncal/freebusy.go
@@ -83,7 +83,7 @@ queries the connected remote CalDAV calendar instead.`,
 					return errInvalidInputf("calendar %q is not connected to a remote calendar", calendarRef.Name)
 				}
 
-				credStore, err := auth.NewCredentialStore(true)
+				credStore, err := auth.NewCredentialStore(a.AllowPlaintext)
 				if err != nil {
 					return fmt.Errorf("credential store: %w", err)
 				}

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -87,8 +87,9 @@ func printCLIError(err error) {
 }
 
 var (
-	outputFmt string
-	cfg       config.Config
+	outputFmt      string
+	allowPlaintext bool
+	cfg            config.Config
 )
 
 // groupRunE is RunE for a parent command with subcommands. Pairing it
@@ -239,11 +240,19 @@ func initApp() (*app.App, error) {
 			return nil, fmt.Errorf("default db path: %w", err)
 		}
 	}
-	return app.New(path)
+	a, err := app.New(path)
+	if err != nil {
+		return nil, err
+	}
+	// Permit the plaintext credential-store fallback only on explicit
+	// opt-in, via config or the --allow-plaintext flag. Either one suffices.
+	a.AllowPlaintext = cfg.Security.AllowPlaintext || allowPlaintext
+	return a, nil
 }
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "text", "output format (text, json)")
+	rootCmd.PersistentFlags().BoolVar(&allowPlaintext, "allow-plaintext", false, "permit storing credentials in plaintext when no OS keyring is available")
 
 	rootCmd.AddGroup(
 		&cobra.Group{ID: groupPlanning, Title: "Planning and Scheduling"},

--- a/cmd/chroncal/push.go
+++ b/cmd/chroncal/push.go
@@ -32,7 +32,7 @@ var pushCalendarAfterWrite = func(a *app.App, calendarID int64, w io.Writer) {
 		return
 	}
 
-	credStore, err := auth.NewCredentialStore(true)
+	credStore, err := auth.NewCredentialStore(a.AllowPlaintext)
 	if err != nil {
 		fmt.Fprintf(w, "note: skipped auto-sync (%v)\n", err)
 		return

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -78,7 +78,7 @@ run to a single local calendar.`,
 			ctx, cancel := context.WithTimeout(context.Background(), syncRunTimeout)
 			defer cancel()
 
-			credStore, err := auth.NewCredentialStore(true)
+			credStore, err := auth.NewCredentialStore(a.AllowPlaintext)
 			if err != nil {
 				return fmt.Errorf("credential store: %w", err)
 			}
@@ -143,7 +143,7 @@ for each connected calendar.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(true)
+			credStore, _ := auth.NewCredentialStore(a.AllowPlaintext)
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			statuses, err := svc.Status(context.Background())
@@ -202,7 +202,7 @@ func syncConflictsCmd() *cobra.Command {
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(true)
+			credStore, _ := auth.NewCredentialStore(a.AllowPlaintext)
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			conflicts, err := svc.ListConflicts(context.Background())
@@ -268,7 +268,7 @@ Use "chroncal sync conflicts" first to find the conflict ID.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(true)
+			credStore, _ := auth.NewCredentialStore(a.AllowPlaintext)
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			if err := svc.ResolveConflict(context.Background(), id, pick); err != nil {
@@ -305,7 +305,7 @@ This does not delete your local calendars or entries.`,
 			defer a.Close()
 			ctx := context.Background()
 
-			credStore, _ := auth.NewCredentialStore(true)
+			credStore, _ := auth.NewCredentialStore(a.AllowPlaintext)
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			cals, err := a.Calendars.List(ctx)

--- a/cmd/chroncal/tick.go
+++ b/cmd/chroncal/tick.go
@@ -52,7 +52,7 @@ func runTick(ctx context.Context, w io.Writer, now time.Time, policy alarmExecut
 		return nil
 	}
 
-	credStore, err := auth.NewCredentialStore(true)
+	credStore, err := auth.NewCredentialStore(a.AllowPlaintext)
 	if err != nil {
 		return fmt.Errorf("credential store: %w", err)
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,6 +27,12 @@ type App struct {
 	Alarms      *alarm.Service
 	Recurrences *recurrence.Service
 	Trash       *trash.Service
+
+	// AllowPlaintext gates the plaintext credential-store fallback. It
+	// defaults to false so that, when no OS keyring is available, credential
+	// writes fail loudly instead of silently persisting secrets in cleartext.
+	// The CLI sets it from config/--allow-plaintext; the TUI inherits it.
+	AllowPlaintext bool
 }
 
 func New(dbPath string) (*App, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,11 @@ type SyncConfig struct {
 type SecurityConfig struct {
 	AllowUnsafeAlarmAudioAttach    bool `mapstructure:"allow_unsafe_alarm_audio_attach"`
 	AllowUnsafeAlarmEmailAttendees bool `mapstructure:"allow_unsafe_alarm_email_attendees"`
+	// AllowPlaintext opts in to the plaintext credential-store fallback when
+	// no OS keyring is available. Defaults to false: without it, credential
+	// writes fail rather than silently persisting secrets in cleartext. The
+	// --allow-plaintext flag also enables it.
+	AllowPlaintext bool `mapstructure:"allow_plaintext"`
 }
 
 // SoftDeleteConfig tunes the soft-delete retention window. Rows soft-deleted
@@ -111,6 +116,7 @@ func newViper() *viper.Viper {
 	v.BindEnv("sync.conflict_strategy")
 	v.BindEnv("security.allow_unsafe_alarm_audio_attach")
 	v.BindEnv("security.allow_unsafe_alarm_email_attendees")
+	v.BindEnv("security.allow_plaintext")
 	v.BindEnv("soft_delete.purge_days")
 	v.BindEnv("ui.theme")
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -939,7 +939,7 @@ func syncHealthFor(info CalendarInfo) SyncHealth {
 // token-refresh persistence mid-run) doesn't clobber the rendered TUI; users
 // run `chroncal sync run` from a shell if they need verbose output.
 func (m Model) newSyncService() (*syncpkg.Service, error) {
-	credStore, err := auth.NewCredentialStoreWithWarnings(true, io.Discard)
+	credStore, err := auth.NewCredentialStoreWithWarnings(m.app.AllowPlaintext, io.Discard)
 	if err != nil {
 		return nil, fmt.Errorf("credential store: %w", err)
 	}
@@ -1029,7 +1029,7 @@ func (m Model) startOAuthFlow(clientID, clientSecret string) (Model, tea.Cmd) {
 func (m Model) finishOAuthReauth(result *auth.GoogleOAuthResult) tea.Cmd {
 	p := m.oauthPurpose
 	return func() tea.Msg {
-		credStore, err := auth.NewCredentialStoreWithWarnings(true, io.Discard)
+		credStore, err := auth.NewCredentialStoreWithWarnings(m.app.AllowPlaintext, io.Discard)
 		if err != nil {
 			return oauthCredentialStoredMsg{calendarID: p.calendarID, name: p.calendarName, err: err}
 		}
@@ -1059,7 +1059,7 @@ func (m Model) finishOAuthConnect(result *auth.GoogleOAuthResult) tea.Cmd {
 	p := m.oauthPurpose
 	return func() tea.Msg {
 		ctx := context.Background()
-		credStore, err := auth.NewCredentialStoreWithWarnings(true, io.Discard)
+		credStore, err := auth.NewCredentialStoreWithWarnings(m.app.AllowPlaintext, io.Discard)
 		if err != nil {
 			return oauthConnectFinishedMsg{calendarID: p.cal.ID, name: p.cal.Name, err: err}
 		}
@@ -2314,7 +2314,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// mid-frame corrupt the renderer. Plaintext is an explicit
 				// opt-in whose warning the user saw at setup; the keyring
 				// is the default store and emits nothing.
-				credStore, storeErr := auth.NewCredentialStoreWithWarnings(true, io.Discard)
+				credStore, storeErr := auth.NewCredentialStoreWithWarnings(m.app.AllowPlaintext, io.Discard)
 				if storeErr != nil {
 					return calendarMutationDoneMsg{err: storeErr}
 				}
@@ -2376,7 +2376,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if cal.AccountID == 0 {
 				return calendarReauthReadyMsg{err: fmt.Errorf("calendar %q is not linked to an account", cal.Name)}
 			}
-			credStore, err := auth.NewCredentialStoreWithWarnings(true, io.Discard)
+			credStore, err := auth.NewCredentialStoreWithWarnings(m.app.AllowPlaintext, io.Discard)
 			if err != nil {
 				return calendarReauthReadyMsg{err: err}
 			}
@@ -2531,7 +2531,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if err != nil {
 				return calendarMutationDoneMsg{err: err}
 			}
-			credStore, _ := auth.NewCredentialStoreWithWarnings(true, io.Discard)
+			credStore, _ := auth.NewCredentialStoreWithWarnings(m.app.AllowPlaintext, io.Discard)
 			return calendarMutationDoneMsg{err: m.app.Calendars.Disconnect(ctx, cal, credStore)}
 		}
 
@@ -2950,7 +2950,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Delete confirmed: close the edit dialog too.
 			m.calendarDialogOpen = false
 			return m, func() tea.Msg {
-				credStore, _ := auth.NewCredentialStoreWithWarnings(true, io.Discard)
+				credStore, _ := auth.NewCredentialStoreWithWarnings(m.app.AllowPlaintext, io.Discard)
 				err := m.app.Calendars.DeleteWithRemoteCleanup(context.Background(), id, newDefaultID, credStore)
 				return calendarMutationDoneMsg{err: err}
 			}


### PR DESCRIPTION
## Summary

Closes #299.

The documented `--allow-plaintext` opt-in gate was never enforced. Every
credential-store call site constructed the store with a hardcoded
`allowPlaintext=true`, and the flag did not exist. On hosts without an OS
keyring (headless Linux, CI, containers), the app silently wrote CalDAV
passwords, bearer tokens, OAuth refresh tokens, and OAuth client secrets
to plaintext JSON. In the TUI the warning sink is `io.Discard`, so the
user got zero indication. The `false` branch in
`auth.NewCredentialStoreWithWarnings` was dead code.

## Fix

- Add `AllowPlaintext bool` to `app.App` (every credential-store call
  site already holds the app), defaulting to `false`.
- The CLI sets it in `initApp()` from a new `--allow-plaintext`
  persistent flag **or** the `security.allow_plaintext` config key (env:
  `CHRONCAL_SECURITY_ALLOW_PLAINTEXT`). Either one enables it.
- The TUI inherits the value via `m.app.AllowPlaintext`.
- Replace every hardcoded `true` at the CLI (`push`, `sync`, `tick`,
  `freebusy`, `calendar` connect/disconnect/delete) and TUI call sites
  with the threaded value.

With neither flag nor config set and no keyring available, credential
writes now fail loudly instead of falling back to cleartext.

## Reproducing test

`TestConnectCalendarRemote_GatesPlaintextOnAppFlag` in
`cmd/chroncal/calendar_remote_test.go` stubs the credential-store seam to
capture the `allowPlaintext` argument and asserts it tracks
`App.AllowPlaintext` (false then true). It **fails before** the fix
(store built with `allowPlaintext=true` while `App.AllowPlaintext=false`)
and **passes after**. Verified by temporarily reverting the call site.

## Review

- `/code-review high`: no surviving findings. The four `sync.go` sites
  ignore the constructor error (`credStore, _ :=`), so a nil store is now
  reachable when plaintext is disabled and no keyring exists — but
  `Status`, `ListConflicts`, `ResolveConflict`, and `ResetCalendar` are
  local-DB-only and never dereference the store, so this is harmless.
  Confirmed all production `app.New` callers route through `initApp`.
- `/simplify`: changed code already clean; threading via one `App` field
  (vs. per-site special-casing or `auth` global state) is the right
  altitude. No changes applied.

`go build ./... && go test ./...` all green.
