### PR TITLE
fix(sync): recover lost-PUT response instead of false 412 conflict

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -412,9 +412,28 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 			}
 		}
 
-		// PUT to server
+		// PUT to server. A PUT can reach the server and mutate the resource
+		// even when its response is lost (e.g. connection reset while reading
+		// the body), which Retry classifies as transient. The retried PUT then
+		// re-sends the stale pre-PUT If-Match and the server — whose ETag has
+		// already advanced — answers 412, masquerading as a conflict. When an
+		// earlier attempt failed transiently, treat a 412 whose server body
+		// equals what we PUT as the success that actually happened. See #294.
+		priorAttemptMayHaveLanded := false
 		newEtag, putErr := caldav.Retry(ctx, syncRetryOptions, func(ctx context.Context) (string, error) {
-			return client.PutResource(ctx, putPath, cal, res.Etag)
+			etag, err := client.PutResource(ctx, putPath, cal, res.Etag)
+			if err == nil {
+				return etag, nil
+			}
+			// A 412 is never transient, so these branches are exclusive.
+			if caldav.IsTransient(err) {
+				priorAttemptMayHaveLanded = true
+			} else if priorAttemptMayHaveLanded && caldav.IsConflict(err) {
+				if landedEtag, ok := e.putAlreadyLanded(ctx, client, putPath, cal); ok {
+					return landedEtag, nil
+				}
+			}
+			return etag, err
 		})
 		if putErr != nil {
 			// Check for 412 Precondition Failed (ETag conflict)
@@ -522,6 +541,34 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 	}
 
 	return result, nil
+}
+
+// putAlreadyLanded reports whether the server's current body for path equals
+// the calendar we just PUT, returning the server's ETag when it matches. It
+// distinguishes a genuine 412 conflict from one caused by a retried PUT whose
+// predecessor actually landed before its response was lost: if the server now
+// holds exactly our payload, that earlier write won, so we adopt its ETag
+// instead of surfacing a false conflict. A mismatch (a real concurrent edit)
+// or any fetch/encode failure conservatively falls back to the 412. See #294.
+func (e *Engine) putAlreadyLanded(ctx context.Context, client *caldav.Client, path string, sent *ical.Calendar) (string, bool) {
+	serverRes, err := client.GetResource(ctx, path)
+	if err != nil {
+		return "", false
+	}
+	sentBody, err := caldav.EncodeCalendar(sent)
+	if err != nil {
+		return "", false
+	}
+	serverBody, err := caldav.EncodeCalendar(serverRes.Data)
+	if err != nil {
+		return "", false
+	}
+	// An empty ETag would disable the next push's If-Match precondition, so
+	// fall back to the 412 rather than adopt it as a successful write.
+	if serverRes.ETag == "" || !bytes.Equal(sentBody, serverBody) {
+		return "", false
+	}
+	return serverRes.ETag, true
 }
 
 type pullResult struct {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1,9 +1,11 @@
 package sync
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -984,6 +986,115 @@ END:VCALENDAR
 	}
 	if dirty[0].Uid != "conflict-event" {
 		t.Fatalf("remaining dirty uid = %q, want conflict-event", dirty[0].Uid)
+	}
+}
+
+// TestEnginePushLostPutResponseIsNotFalseConflict reproduces issue #294: the
+// first PUT reaches the server and mutates the resource, but the response is
+// lost (a transient "connection reset"). Retry re-issues the PUT with the
+// stale pre-PUT If-Match, which the server now 412s because its ETag already
+// advanced. Without idempotency-aware recovery this surfaces as a spurious
+// conflict even though our write actually won. The push must instead detect
+// that the server holds exactly our payload and finalize it as a success.
+func TestEnginePushLostPutResponseIsNotFalseConflict(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	insertTestEvent(t, db, calendarID, "lost-put")
+
+	var putBody []byte
+	putCount := 0
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			putBody = body
+			putCount++
+			if putCount == 1 {
+				// The PUT landed server-side, but the response is lost on the
+				// wire while reading it back. Classified transient.
+				return nil, fmt.Errorf("read response: connection reset by peer")
+			}
+			// The retried conditional PUT carries the stale If-Match, so the
+			// server (whose ETag already advanced) rejects it.
+			return &http.Response{
+				StatusCode: http.StatusPreconditionFailed,
+				Status:     "412 Precondition Failed",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("precondition failed")),
+				Request:    r,
+			}, nil
+		case http.MethodGet:
+			// The server now holds exactly the body we PUT on the first try.
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/calendar; charset=utf-8"},
+					"Etag":         []string{`"etag-after"`},
+				},
+				Body:    io.NopCloser(bytes.NewReader(putBody)),
+				Request: r,
+			}, nil
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "lost-put",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/lost-put.ics",
+		Etag:         `"etag-before"`,
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource lost-put: %v", err)
+	}
+
+	result, err := engine.push(ctx, client, calendarID, "", "", ConflictPrompt)
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if result.conflicts != 0 {
+		t.Fatalf("conflicts = %d, want 0 (lost response is not a real conflict)", result.conflicts)
+	}
+	if len(result.errors) != 0 {
+		t.Fatalf("errors = %v, want none", result.errors)
+	}
+	if result.pushed != 1 {
+		t.Fatalf("pushed = %d, want 1 (our write actually landed)", result.pushed)
+	}
+
+	// No spurious conflict row recorded.
+	conflicts, err := q.ListSyncConflictsByCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("ListSyncConflictsByCalendar: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("sync conflicts = %d, want 0", len(conflicts))
+	}
+
+	// The resource is finalized with the server's advanced ETag and no longer dirty.
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: calendarID, Uid: "lost-put"})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Etag != "etag-after" {
+		t.Fatalf("Etag = %q, want %q (adopted from the landed write)", res.Etag, "etag-after")
+	}
+	if res.Dirty != 0 {
+		t.Fatalf("Dirty = %d, want 0 (write succeeded)", res.Dirty)
 	}
 }
 


### PR DESCRIPTION
Closes #294

## Problem

Push wraps `PutResource` in `caldav.Retry`, always re-sending the original
captured ETag as `If-Match`. If the first PUT reaches the server and mutates
the resource but the response is lost on the wire (e.g. `connection reset`
while reading the body — classified transient by `IsTransient`), `Retry`
issues a second PUT with the stale `If-Match: <old etag>`. The server's ETag
has already advanced, so it returns 412. 412 is not retryable, so push treats
it as a real conflict and either records a `sync_conflicts` row (prompt mode)
or runs an unnecessary server-wins re-fetch — user-visible noise and wasted
work for a write that actually succeeded.

## Fix

`internal/sync/engine.go`: the PUT retry closure now tracks whether an earlier
attempt failed transiently (`priorAttemptMayHaveLanded`). When a later attempt
returns a 412 conflict after such a transient failure, the new
`putAlreadyLanded` helper GETs the resource and compares the server's current
body to exactly what we PUT:

- If the bodies match **and** the server returned a non-empty ETag, the earlier
  PUT landed — adopt that ETag and finalize the push as a success (no conflict).
- On a body mismatch (a real concurrent edit), an empty ETag, or any
  fetch/encode failure, fall back to surfacing the 412, preserving genuine
  conflict detection.

The recovery lives in the engine (which owns ETag/conflict semantics), not in
the low-level `caldav` client. The change is gated on a prior transient failure,
so the normal first-attempt 412 path is untouched.

## Reproducing test

`TestEnginePushLostPutResponseIsNotFalseConflict` (in `engine_test.go`):
first PUT returns a transient `connection reset` (after capturing the body),
the retried PUT returns 412, and GET serves back the captured body with an
advanced ETag. The test asserts `conflicts == 0`, `pushed == 1`, no
`sync_conflicts` row, and that the resource is finalized with the advanced
ETag and `dirty == 0`. It fails before the fix (records a false conflict) and
passes after.

## Review outcomes

- `/code-review high`: surfaced one worth-fixing finding — an empty server
  ETag would be stored and disable the next push's `If-Match`. Hardened
  `putAlreadyLanded` to fall back to the 412 when the ETag is empty. Other
  candidates were pre-existing patterns (nil `Data` matches the existing
  `EncodeCalendar` call), benign (identical bytes from another client means the
  server already holds our intended state), or conservative-by-design fallbacks.
- `/simplify`: no duplication found; engine confirmed as the right altitude.
  Flattened the mutually-exclusive transient/conflict branches into an
  `if/else if` for clarity.

`go build ./... && go test ./...` pass; `go vet ./internal/sync/` clean.
