### PR TITLE
fix(freebusy): exclude owner-DECLINED instances from busy time

### DIFF
--- a/cmd/chroncal/freebusy.go
+++ b/cmd/chroncal/freebusy.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/douglasdemoura/chroncal/internal/app"
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/calendar"
@@ -111,7 +112,11 @@ queries the connected remote CalDAV calendar instead.`,
 				if calendarRef.ID != 0 {
 					calendarIDs = []int64{calendarRef.ID}
 				}
-				result, err = freebusy.Compute(ctx, a.Recurrences, from.UTC(), to.UTC(), calendarIDs)
+				ownerEmails, err := freebusyOwnerEmails(ctx, a, calendarRef)
+				if err != nil {
+					return err
+				}
+				result, err = freebusy.Compute(ctx, a.Recurrences, from.UTC(), to.UTC(), calendarIDs, ownerEmails)
 				if err != nil {
 					return fmt.Errorf("compute freebusy: %w", err)
 				}
@@ -149,6 +154,32 @@ queries the connected remote CalDAV calendar instead.`,
 	_ = cmd.MarkFlagRequired("from")
 	_ = cmd.MarkFlagRequired("to")
 	return cmd
+}
+
+// freebusyOwnerEmails returns calendar ID -> owner email for the calendars
+// in scope, so Compute can drop instances the owner has DECLINED (issue
+// #302). For a single named calendar it uses the already-loaded ref; for
+// "All Calendars" it lists every calendar. Calendars without an owner email
+// are omitted, which leaves their PARTSTAT gate disabled.
+func freebusyOwnerEmails(ctx context.Context, a *app.App, calendarRef calendar.Calendar) (map[int64]string, error) {
+	owners := map[int64]string{}
+	add := func(id int64, email string) {
+		if id != 0 && email != "" {
+			owners[id] = email
+		}
+	}
+	if calendarRef.ID != 0 {
+		add(calendarRef.ID, calendarRef.OwnerEmail)
+		return owners, nil
+	}
+	calendars, err := a.Calendars.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list calendars: %w", err)
+	}
+	for _, c := range calendars {
+		add(c.ID, c.OwnerEmail)
+	}
+	return owners, nil
 }
 
 // parseFreeBusyTime parses a free/busy range bound that may be a date-only

--- a/internal/freebusy/compute.go
+++ b/internal/freebusy/compute.go
@@ -15,7 +15,13 @@ type ExpandedEventSource interface {
 }
 
 // Compute derives local busy time from expanded VEVENT instances.
-func Compute(ctx context.Context, source ExpandedEventSource, from, to time.Time, calendarIDs []int64) (Result, error) {
+//
+// ownerEmails maps a calendar ID to the email address of that calendar's
+// owner (calendar.OwnerEmail). When an instance lists a matching attendee
+// whose PARTSTAT is DECLINED, the instance is excluded from busy time:
+// declining a meeting frees the slot. A nil or empty map disables the
+// PARTSTAT gate, preserving the prior STATUS/TRANSP-only behavior.
+func Compute(ctx context.Context, source ExpandedEventSource, from, to time.Time, calendarIDs []int64, ownerEmails map[int64]string) (Result, error) {
 	expanded, err := source.ListExpandedEvents(ctx, from, to)
 	if err != nil {
 		return Result{}, err
@@ -34,6 +40,9 @@ func Compute(ctx context.Context, source ExpandedEventSource, from, to time.Time
 			}
 		}
 		if strings.EqualFold(evt.Status, "CANCELLED") || strings.EqualFold(evt.Transp, "TRANSPARENT") {
+			continue
+		}
+		if ownerDeclined(evt, ownerEmails[evt.CalendarID]) {
 			continue
 		}
 
@@ -75,6 +84,34 @@ func eventWindow(evt recurrence.ExpandedEvent) (time.Time, time.Time) {
 		start = evt.StartTime
 	}
 	return start.UTC(), start.Add(evt.EndTime.Sub(evt.StartTime)).UTC()
+}
+
+// ownerDeclined reports whether the calendar owner has DECLINED this
+// instance. It matches ownerEmail against the instance's attendees
+// (case-insensitive, mailto: prefix tolerated) and returns true only when
+// that attendee's PARTSTAT is DECLINED. An empty ownerEmail or a missing
+// owner attendee yields false, so unknown identity never frees a slot.
+func ownerDeclined(evt recurrence.ExpandedEvent, ownerEmail string) bool {
+	ownerEmail = stripMailtoPrefix(ownerEmail)
+	if ownerEmail == "" {
+		return false
+	}
+	for _, a := range evt.Attendees {
+		if strings.EqualFold(stripMailtoPrefix(a.Email), ownerEmail) {
+			return strings.EqualFold(a.RSVPStatus, "DECLINED")
+		}
+	}
+	return false
+}
+
+// stripMailtoPrefix trims surrounding space and a leading "mailto:" so
+// attendee values and configured owner emails compare on bare addresses.
+func stripMailtoPrefix(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 7 && strings.EqualFold(s[:7], "mailto:") {
+		return s[7:]
+	}
+	return s
 }
 
 func normalizePeriods(periods []Period) []Period {

--- a/internal/freebusy/compute_test.go
+++ b/internal/freebusy/compute_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/recurrence"
 )
 
@@ -53,7 +54,7 @@ func TestCompute_UsesExpandedEventsAndFiltersCalendars(t *testing.T) {
 		},
 	}
 
-	result, err := Compute(context.Background(), source, from, to, []int64{2})
+	result, err := Compute(context.Background(), source, from, to, []int64{2}, nil)
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
@@ -112,7 +113,7 @@ func TestCompute_RecurringInstancesUseInstanceTimeAndMergeOverlaps(t *testing.T)
 		},
 	}
 
-	result, err := Compute(context.Background(), source, from, to, nil)
+	result, err := Compute(context.Background(), source, from, to, nil, nil)
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
@@ -170,7 +171,7 @@ func TestCompute_SkipsTransparentAndCancelledAndMapsTentative(t *testing.T) {
 		},
 	}
 
-	result, err := Compute(context.Background(), source, from, to, nil)
+	result, err := Compute(context.Background(), source, from, to, nil, nil)
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
@@ -202,7 +203,7 @@ func TestCompute_PreservesAllDayIntervals(t *testing.T) {
 		},
 	}
 
-	result, err := Compute(context.Background(), source, from, to, nil)
+	result, err := Compute(context.Background(), source, from, to, nil, nil)
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
@@ -214,5 +215,58 @@ func TestCompute_PreservesAllDayIntervals(t *testing.T) {
 	}
 	if !result.Periods[0].End.Equal(time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)) {
 		t.Fatalf("end = %s", result.Periods[0].End)
+	}
+}
+
+// TestCompute_SkipsOwnerDeclinedInstances reproduces issue #302: an event
+// the calendar owner has DECLINED (attendee PARTSTAT=DECLINED) must not
+// count as busy, while a still-accepted event on the same range does.
+func TestCompute_SkipsOwnerDeclinedInstances(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+	source := &stubExpandedEventSource{
+		events: []recurrence.ExpandedEvent{
+			{
+				Event: event.Event{
+					CalendarID: 1,
+					StartTime:  time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+					EndTime:    time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC),
+					Status:     "CONFIRMED",
+					Transp:     "OPAQUE",
+					Attendees: []model.Attendee{
+						{Email: "mailto:me@example.com", RSVPStatus: "DECLINED"},
+						{Email: "organizer@example.com", RSVPStatus: "ACCEPTED", Organizer: true},
+					},
+				},
+				InstanceTime: time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+			},
+			{
+				Event: event.Event{
+					CalendarID: 1,
+					StartTime:  time.Date(2026, 4, 10, 11, 0, 0, 0, time.UTC),
+					EndTime:    time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+					Status:     "CONFIRMED",
+					Transp:     "OPAQUE",
+					Attendees: []model.Attendee{
+						{Email: "me@example.com", RSVPStatus: "ACCEPTED"},
+					},
+				},
+				InstanceTime: time.Date(2026, 4, 10, 11, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	ownerEmails := map[int64]string{1: "me@example.com"}
+	result, err := Compute(context.Background(), source, from, to, nil, ownerEmails)
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if len(result.Periods) != 1 {
+		t.Fatalf("periods = %d, want 1 (declined instance excluded)", len(result.Periods))
+	}
+	if !result.Periods[0].Start.Equal(time.Date(2026, 4, 10, 11, 0, 0, 0, time.UTC)) {
+		t.Fatalf("period start = %s, want 2026-04-10 11:00 UTC (accepted instance)", result.Periods[0].Start)
 	}
 }


### PR DESCRIPTION
Closes #302

## Problem

`freebusy.Compute` only excluded instances via the VEVENT `STATUS`
(CANCELLED) and `TRANSP` (TRANSPARENT). It never consulted the user's
attendee `PARTSTAT`, so a meeting the calendar owner had **DECLINED**
still reported as **BUSY**. This over-states busy time to every local
free/busy consumer and to the VFREEBUSY export; standard CalDAV
free/busy omits declined instances.

## Fix

- `Compute` takes a new `ownerEmails map[int64]string` (calendar ID ->
  `calendar.OwnerEmail`). For each instance it looks up the owning
  calendar's owner email, matches it against the instance's attendees
  (case-insensitive, `mailto:` tolerant), and skips the instance when
  that attendee's `PARTSTAT` is `DECLINED`.
- A nil/empty map disables the gate, preserving the prior
  STATUS/TRANSP-only behavior (existing callers/tests pass `nil`).
- The `freebusy` CLI builds the map from `calendar.OwnerEmail` for the
  calendars in scope (the single named calendar, or all calendars).

Attendees are already populated on every expanded instance by
`recurrence.ListExpandedEvents` (it attaches attendees by event ID), so
the gate works for single events, recurring instances, and overrides
alike.

## Reproducing test

`TestCompute_SkipsOwnerDeclinedInstances` in
`internal/freebusy/compute_test.go`: two CONFIRMED/OPAQUE events on the
same day, one with the owner attendee `PARTSTAT=DECLINED` and one
`ACCEPTED`. Expects a single busy period (the accepted one).

- Before the fix (gate removed): `periods = 2, want 1` — FAILS.
- After the fix: PASSES.

`go build ./... && go test ./...` is green.

## Review

- **code-review (high):** no confirmed correctness bugs. Verified the
  fix is not a silent no-op for recurring series (attendees are attached
  to all expanded instances), and all call sites were updated.
- **simplify:** code already clean for this scope. The local
  `stripMailtoPrefix` duplicates copies in `sync`/`ical`, but that
  matches the existing per-package convention; a shared helper would be
  a broader cross-package refactor outside this fix.
