### PR TITLE
fix(cmd): resolve --calendar by ID or name

### DIFF
--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -346,12 +346,11 @@ func resolveCalendarID(ctx context.Context, a *app.App, name string) (int64, err
 	if err != nil {
 		return 0, fmt.Errorf("list calendars: %w", err)
 	}
-	for _, c := range cals {
-		if strings.EqualFold(c.Name, name) {
-			return c.ID, nil
-		}
+	cal, err := findCalendarByRef(cals, name)
+	if err != nil {
+		return 0, err
 	}
-	return 0, fmt.Errorf("calendar %q not found", name)
+	return cal.ID, nil
 }
 
 // resolveJournal looks up a journal by numeric ID, string UID, or UID + recurrence-id.

--- a/cmd/chroncal/resolve_calendar_test.go
+++ b/cmd/chroncal/resolve_calendar_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+)
+
+// resolveCalendarID must accept a numeric calendar ID, matching the
+// reference grammar of sibling commands (sync run/reset, calendar
+// update/delete/set-default) which route through findCalendarByRef. Before
+// the fix it only matched by name, so `--calendar 2` failed with
+// `calendar "2" not found` even when calendar ID 2 existed. See issue #308.
+func TestResolveCalendarIDAcceptsNumericID(t *testing.T) {
+	dir := t.TempDir()
+	a, err := app.New(filepath.Join(dir, "chroncal.db"))
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+
+	ctx := context.Background()
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	gotByID, err := resolveCalendarID(ctx, a, strconv.FormatInt(cal.ID, 10))
+	if err != nil {
+		t.Fatalf("resolveCalendarID by numeric ID: %v", err)
+	}
+	if gotByID != cal.ID {
+		t.Fatalf("resolveCalendarID by ID = %d, want %d", gotByID, cal.ID)
+	}
+
+	gotByName, err := resolveCalendarID(ctx, a, "Work")
+	if err != nil {
+		t.Fatalf("resolveCalendarID by name: %v", err)
+	}
+	if gotByName != cal.ID {
+		t.Fatalf("resolveCalendarID by name = %d, want %d", gotByName, cal.ID)
+	}
+}


### PR DESCRIPTION
Closes #308

## Summary
`--calendar` on `event`/`todo`/`journal`/`ical`/`freebusy` resolved by name
only, while sibling commands (`sync run/reset`, `calendar
update/delete/set-default`) accept a numeric ID *or* name via
`findCalendarByRef`. As a result `chroncal event add --calendar 2` failed with
`calendar "2" not found` even when calendar ID 2 existed — an inconsistent
reference grammar that surprised scripted callers.

The fix routes `resolveCalendarID` (`cmd/chroncal/main.go`) through the shared
`findCalendarByRef` resolver, so numeric IDs and names work uniformly across
the CLI. The `name`-empty default-calendar fallback is unchanged, and the
not-found error message is identical.

## Reproducing test
`cmd/chroncal/resolve_calendar_test.go` — `TestResolveCalendarIDAcceptsNumericID`
creates a calendar, then asserts `resolveCalendarID` resolves it by both its
numeric ID and its name. It FAILS before the fix (`calendar "2" not found`) and
passes after.

## Review outcomes
- `/code-review high`: no findings. The only behavioral delta (a calendar
  literally *named* "2" with no ID 2 now resolving by ID-miss instead of
  name-match) is the intended unified grammar and matches the sibling commands.
- `/simplify`: code already clean — the change removes a hand-rolled
  `EqualFold` loop in favor of the existing shared helper (reuse + correct
  altitude), with no redundant state to trim.

`go build ./... && go test ./...` all green.
