### PR TITLE
fix(cmd): honor --output json in sync resolve and sync reset

### DIFF
--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -275,8 +275,7 @@ Use "chroncal sync conflicts" first to find the conflict ID.`,
 				return err
 			}
 
-			fmt.Printf("Conflict #%d resolved (picked %s)\n", id, pick)
-			return nil
+			return renderSyncResolve(cmd, id, pick)
 		},
 	}
 	cmd.Flags().StringVar(&pick, "pick", "", "Which version to keep: local or server (required)")
@@ -327,6 +326,7 @@ This does not delete your local calendars or entries.`,
 				targetID = target.ID
 			}
 
+			var outcomes []syncResetOutcome
 			for _, c := range cals {
 				if targetID != 0 && c.ID != targetID {
 					continue
@@ -335,16 +335,19 @@ This does not delete your local calendars or entries.`,
 					continue
 				}
 				connected++
+				outcome := syncResetOutcome{Name: c.Name}
 				if err := svc.ResetCalendar(ctx, c.ID); err != nil {
 					failed++
-					fmt.Fprintf(os.Stderr, "reset %s: %s\n", safeText(c.Name), safeText(err.Error()))
-					continue
+					outcome.Err = err.Error()
 				}
-				fmt.Printf("Reset sync state for %q\n", safeText(c.Name))
+				outcomes = append(outcomes, outcome)
 			}
 
 			if calendarName != "" && connected == 0 {
 				return &cliError{Code: "invalid_input", Msg: fmt.Sprintf("calendar %q is not connected to a remote; no sync state to reset", calendarName)}
+			}
+			if err := renderSyncReset(cmd, outcomes); err != nil {
+				return err
 			}
 			if failed > 0 {
 				return &cliError{Code: "error", Msg: fmt.Sprintf("failed to reset %d calendar(s)", failed)}
@@ -397,5 +400,56 @@ func renderSyncRunResults(cmd *cobra.Command, results []*syncPkg.SyncResult, cal
 		writeSyncResult(w, cmd.ErrOrStderr(), r)
 	}
 	fmt.Fprintf(w, "Synced %d calendar(s).\n", len(results))
+	return nil
+}
+
+// renderSyncResolve confirms a resolved conflict using the active --output
+// format so machine consumers get JSON/YAML instead of the prose line.
+func renderSyncResolve(cmd *cobra.Command, id int64, pick string) error {
+	w := cmd.OutOrStdout()
+	if outputFmt != "text" {
+		return printOutput(w, map[string]any{
+			"id":       id,
+			"picked":   pick,
+			"resolved": true,
+		})
+	}
+	fmt.Fprintf(w, "Conflict #%d resolved (picked %s)\n", id, pick)
+	return nil
+}
+
+// syncResetOutcome records the per-calendar result of a reset so both the
+// text and JSON views render from the same data. Err is empty on success.
+type syncResetOutcome struct {
+	Name string
+	Err  string
+}
+
+// renderSyncReset emits per-calendar reset results using --output. Text mode
+// keeps failures on stderr; JSON/YAML fold them into each item's "error" so a
+// script can read the whole batch from stdout.
+func renderSyncReset(cmd *cobra.Command, outcomes []syncResetOutcome) error {
+	w := cmd.OutOrStdout()
+	if outputFmt != "text" {
+		items := make([]map[string]any, 0, len(outcomes))
+		for _, o := range outcomes {
+			item := map[string]any{
+				"calendar_name": o.Name,
+				"reset":         o.Err == "",
+			}
+			if o.Err != "" {
+				item["error"] = o.Err
+			}
+			items = append(items, item)
+		}
+		return printOutput(w, items)
+	}
+	for _, o := range outcomes {
+		if o.Err != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "reset %s: %s\n", safeText(o.Name), safeText(o.Err))
+			continue
+		}
+		fmt.Fprintf(w, "Reset sync state for %q\n", safeText(o.Name))
+	}
 	return nil
 }

--- a/cmd/chroncal/sync_json_cli_test.go
+++ b/cmd/chroncal/sync_json_cli_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// seedSyncConflictForTest inserts one unresolved conflict for the given
+// calendar and returns its ID so the resolve command can target it.
+func seedSyncConflictForTest(t *testing.T, dbPath string, calendarID int64) int64 {
+	t.Helper()
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+
+	ctx := context.Background()
+	if err := a.Queries.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
+		CalendarID: calendarID,
+		OwnerType:  "event",
+		OwnerID:    1,
+		Uid:        "conflict-uid-1",
+		LocalIcal:  "BEGIN:VEVENT\r\nUID:conflict-uid-1\r\nEND:VEVENT\r\n",
+		ServerIcal: "BEGIN:VEVENT\r\nUID:conflict-uid-1\r\nEND:VEVENT\r\n",
+		ServerEtag: "\"etag-1\"",
+	}); err != nil {
+		t.Fatalf("create sync conflict: %v", err)
+	}
+
+	conflicts, err := a.Queries.ListSyncConflicts(ctx)
+	if err != nil {
+		t.Fatalf("list sync conflicts: %v", err)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("seeded conflicts = %d, want 1", len(conflicts))
+	}
+	return conflicts[0].ID
+}
+
+// TestSyncResolveOutputJSON guards issue #307: `sync resolve --output json`
+// must emit machine-readable JSON, not the plain-text confirmation line.
+func TestSyncResolveOutputJSON(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	calID, _ := createLinkedCalendarForTest(t, dbPath)
+	id := seedSyncConflictForTest(t, dbPath, calID)
+
+	stdout, stderr, err := runChroncalCommand(t,
+		"sync", "resolve", strconv.FormatInt(id, 10), "--pick", "local", "--output", "json")
+	if err != nil {
+		t.Fatalf("sync resolve -o json: %v (stderr: %s)", err, stderr)
+	}
+
+	var out map[string]any
+	if jerr := json.Unmarshal([]byte(stdout), &out); jerr != nil {
+		t.Fatalf("sync resolve -o json produced non-JSON stdout %q: %v", stdout, jerr)
+	}
+}
+
+// TestSyncResetOutputJSON guards issue #307: `sync reset --output json` must
+// emit machine-readable JSON, not the plain-text "Reset sync state" line.
+func TestSyncResetOutputJSON(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	createLinkedCalendarForTest(t, dbPath)
+
+	stdout, stderr, err := runChroncalCommand(t,
+		"sync", "reset", "--calendar", "Work", "--output", "json")
+	if err != nil {
+		t.Fatalf("sync reset -o json: %v (stderr: %s)", err, stderr)
+	}
+
+	var out []map[string]any
+	if jerr := json.Unmarshal([]byte(stdout), &out); jerr != nil {
+		t.Fatalf("sync reset -o json produced non-JSON stdout %q: %v", stdout, jerr)
+	}
+}


### PR DESCRIPTION
Closes #307

## Problem
`sync resolve` and `sync reset` ignored the global `--output json` flag and
always emitted plain text to the process-global `os.Stdout`/`os.Stderr`:

- `resolve`: `fmt.Printf("Conflict #%d resolved (picked %s)\n", id, pick)`
- `reset`: `fmt.Printf("Reset sync state for %q\n", ...)` / `fmt.Fprintf(os.Stderr, ...)`

Every other sync subcommand (`run`, `status`, `conflicts`) branches on
`outputFmt` and writes through `cmd.OutOrStdout()`. These two did not, so
`chroncal sync resolve 12 --pick local -o json` and `chroncal sync reset -o json`
produced non-JSON stdout, breaking machine consumers — the same class of defect
already fixed for ical import (#255) and alarm check (#217).

## Fix
Added two render helpers (`renderSyncResolve`, `renderSyncReset`) that mirror the
existing per-command render functions: they branch on `outputFmt` and write via
`cmd.OutOrStdout()` / `cmd.ErrOrStderr()` instead of the process globals. The
reset loop now collects per-calendar outcomes (`syncResetOutcome`) and renders
once, so JSON folds failures into each item's `error` field while text mode keeps
the existing stdout-success / stderr-failure split. Text output is byte-for-byte
unchanged; JSON/YAML now emit structured results.

## Reproducing test
`cmd/chroncal/sync_json_cli_test.go`:
- `TestSyncResolveOutputJSON` — seeds a conflict, runs `sync resolve <id> --pick local -o json`, asserts stdout parses as JSON.
- `TestSyncResetOutputJSON` — links a calendar, runs `sync reset --calendar Work -o json`, asserts stdout parses as JSON.

Both fail before the fix (stdout was `Conflict #1 resolved (picked local)` / `Reset sync state for "Work"`) and pass after.

## Review
- `/code-review high`: no correctness or cleanup findings — text-mode stream semantics preserved, new symbols unique, pattern matches existing sync render helpers.
- `/simplify`: code already consistent with the codebase idiom; no changes applied.
- `go build ./... && go test ./...` all green.
