### PR TITLE
fix(tui): resize calendar dialog on WindowSizeMsg

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1633,6 +1633,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.viewDialog = m.viewDialog.SetSize(m.width, m.height)
 		m.confirmDialog = m.confirmDialog.SetSize(m.width, m.height)
 		m.choiceDialog = m.choiceDialog.SetSize(m.width, m.height)
+		m.calendarDialog = m.calendarDialog.SetSize(m.width, m.height)
 		m.form = m.form.SetSize(m.width, m.height)
 		m.palette = m.palette.SetSize(m.width, m.height)
 		m.calendarListDialog = m.calendarListDialog.SetSize(m.width, m.height)

--- a/internal/tui/app_calendar_dialog_resize_test.go
+++ b/internal/tui/app_calendar_dialog_resize_test.go
@@ -1,0 +1,27 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestWindowSizeResizesCalendarDialog reproduces issue #310: a WindowSizeMsg
+// resizes every overlay except the calendar create/edit dialog. With the
+// calendar dialog open, resizing the terminal must propagate the new
+// dimensions to m.calendarDialog so it stops rendering at the old size.
+func TestWindowSizeResizesCalendarDialog(t *testing.T) {
+	m := Model{}
+	m.calendarDialog = NewCalendarDialogModel(CalendarDialogParams{}, m.theme).SetSize(80, 24)
+	m.calendarDialogOpen = true
+
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	got := next.(Model)
+
+	if w := got.calendarDialog.dialog.width; w != 120 {
+		t.Fatalf("calendar dialog width not resized: got %d, want 120 (issue #310)", w)
+	}
+	if h := got.calendarDialog.dialog.height; h != 40 {
+		t.Fatalf("calendar dialog height not resized: got %d, want 40 (issue #310)", h)
+	}
+}


### PR DESCRIPTION
## Summary

`WindowSizeMsg` resized every overlay model except `m.calendarDialog`. The
calendar create/edit dialog (`calendar_dialog.go`) is a width-dependent
text-entry form, so resizing the terminal while it was open left it rendering
at the old width — mis-clipping or overflowing until reopened. The
`calendarDialogOpen` routing block at `app.go:1540` also lets
`tea.WindowSizeMsg` fall through to the main switch rather than routing it to
`m.calendarDialog.Update`, so the dialog received new dimensions by no other
path.

## Fix

Add the single missing call to the resize handler, alongside the other ten
overlays:

```go
m.calendarDialog = m.calendarDialog.SetSize(m.width, m.height)
```

`SetSize` is safe on a zero-value (never-opened) dialog, matching how the
sibling overlays are resized unconditionally on every `WindowSizeMsg`.

## Reproducing test

`internal/tui/app_calendar_dialog_resize_test.go` —
`TestWindowSizeResizesCalendarDialog` opens the calendar dialog at 80x24,
drives a `WindowSizeMsg{120, 40}` through `Model.Update`, and asserts the
dialog's width/height became 120/40. It **fails before** the fix (width stays
80) and passes after. A zero-value startup-resize check confirmed `SetSize` on
a never-opened dialog does not panic.

## Review

- `/code-review high`: no findings. Verified the new call is safe on a
  zero-value model (the app's startup state before any dialog opens).
- `/simplify`: code already clean — the fix reuses the existing `SetSize`
  method and the standard `WindowSizeMsg` test pattern; one line, no added
  state, correct altitude (filling a gap in the existing per-overlay list
  rather than restructuring resize handling).

`go build ./... && go test ./...` pass.

Closes #310
