### PR TITLE
fix(tui): guard against double-press re-dispatching the same undo restore

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -463,6 +463,14 @@ type Model struct {
 	// (pushDeferralToken bumped) and skip pushing.
 	pushDeferralToken int
 
+	// undoRestoreInFlight is true between dispatching an undo restore and the
+	// eventRestoredMsg landing. The restore runs in an async tea.Cmd while
+	// Peek leaves the entry on the stack, so without this guard a reflexive
+	// second press of the undo key would Peek the same entry and dispatch a
+	// second RestoreUndo (issue #309) — a spurious "Undo failed" toast plus two
+	// overlapping restore transactions. Cleared when the message arrives.
+	undoRestoreInFlight bool
+
 	// trash is the "Recently deleted" overlay. While trashOpen is true
 	// the main content renders trash.View() instead of the active
 	// viewMode's model, and key input routes through m.trash.Update.
@@ -1381,6 +1389,7 @@ func (m Model) interceptGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 			// Bumping the token invalidates any delete-push that was still
 			// waiting for the 6-second window to elapse.
 			m.pushDeferralToken++
+			m.undoRestoreInFlight = true
 			m.toast.Restoring()
 			meta := entry.Meta
 			title := meta.Label
@@ -1458,6 +1467,9 @@ func (m Model) undoIsAllowed() bool {
 		return false
 	}
 	if m.anyOverlayOpen() {
+		return false
+	}
+	if m.undoRestoreInFlight {
 		return false
 	}
 	return m.undoStack != nil && m.undoStack.Len() > 0
@@ -3003,6 +3015,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case eventRestoredMsg:
+		// The restore has landed; allow the next undo to dispatch.
+		m.undoRestoreInFlight = false
 		if msg.err != nil {
 			// Route the dismiss tick — previously dropped, so failed toasts
 			// never auto-cleared in the live app.

--- a/internal/tui/undo_test.go
+++ b/internal/tui/undo_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/douglasdemoura/chroncal/internal/event"
 )
 
@@ -74,6 +75,36 @@ func TestUndoStack_DepthEviction(t *testing.T) {
 
 func labelFor(i int) string {
 	return string([]byte{byte('A' + i)})
+}
+
+// TestUndoDoublePress_DoesNotReDispatch reproduces issue #309: a reflexive
+// double-press of the undo key must not dispatch a second restore for the same
+// entry. Peek() does not pop, and the entry is only removed in the async
+// eventRestoredMsg success handler, so without an in-flight guard a second 'u'
+// before that message lands Peeks the same entry and fires a second
+// RestoreUndo (spurious "Undo failed" toast + two overlapping transactions).
+func TestUndoDoublePress_DoesNotReDispatch(t *testing.T) {
+	m := Model{
+		keys:      defaultAppKeys(),
+		focus:     focusCalendar,
+		undoStack: NewUndoStack(),
+	}
+	m.undoStack.Push(entry("A"))
+
+	undo := tea.KeyPressMsg{Code: 'u', Text: "u"}
+
+	// First press dispatches the restore.
+	m1, cmd1, handled1 := m.interceptGlobalKeys(undo)
+	if !handled1 || cmd1 == nil {
+		t.Fatalf("first undo press: handled=%v cmd!=nil=%v, want both true", handled1, cmd1 != nil)
+	}
+
+	// Second press, before the async eventRestoredMsg lands, must NOT dispatch
+	// another restore.
+	_, cmd2, _ := m1.interceptGlobalKeys(undo)
+	if cmd2 != nil {
+		t.Fatal("second undo press re-dispatched a restore while the first was still in flight")
+	}
 }
 
 // TestEventRestoredMsg_RemovesRestoredEntryNotTop reproduces issue #144: the


### PR DESCRIPTION
Closes #309

## Problem

A reflexive double-press of the undo key (`u`) re-dispatched the same restore. `Peek()` does not pop, and the undo entry is only removed in the async `eventRestoredMsg` success handler. Between pressing `u` and that message landing, `undoIsAllowed()` was still true, so a second `u` `Peek`ed the **same** entry and dispatched a **second** `RestoreUndo` for the same `meta`.

The two restore goroutines ran concurrently against the same rows: the first succeeded and removed the entry; the second hit an already-live row (stale-master guard or `ErrNotDeleted`), so its `eventRestoredMsg` carried `err != nil` and rendered a spurious "Undo failed" toast right after a successful restore — plus two overlapping restore transactions.

## Fix

Add an `undoRestoreInFlight` bool on the `Model`:
- set when an undo restore is dispatched (`interceptGlobalKeys`),
- checked in `undoIsAllowed()` so a second `u` is a no-op while a restore is pending,
- cleared in the `eventRestoredMsg` handler on **both** success and failure paths, so it can never get stuck `true` (`RestoreUndo` always returns an `eventRestoredMsg`).

The flag lives next to the existing `pushDeferralToken`, which already tracks the same async-undo window. This is distinct from #144 (which fixes `Remove`-by-identity for a *delete* interleaving an in-flight restore); that change did not prevent the second dispatch or the spurious toast.

## Reproducing test

`TestUndoDoublePress_DoesNotReDispatch` in `internal/tui/undo_test.go` presses the undo key, then presses it again before the async `eventRestoredMsg` lands, and asserts the second press dispatches no command. It **fails before** the fix (second press re-dispatches) and **passes after**.

## Review outcomes

- `go build ./... && go test ./...` — all packages pass.
- **code-review (high)**: no findings. Verified the flag is set on dispatch and propagated via the returned model (caller at `app.go:1505` uses `newM`), gated in `undoIsAllowed`, and always cleared since `RestoreUndo` always emits an `eventRestoredMsg`.
- **simplify**: code already clean. A single model-level bool is the minimal correct state at the right altitude (guards dispatch alongside the other input guards rather than special-casing `UndoStack`); no reuse/efficiency issues.
