### PR TITLE
fix(cmd): show overdue todos and past journal entries in default list window

### DIFF
--- a/cmd/chroncal/date_range_test.go
+++ b/cmd/chroncal/date_range_test.go
@@ -32,3 +32,33 @@ func TestParseDateRangeDefaultToFollowsFrom(t *testing.T) {
 		t.Fatalf("default to = %s, want %s (from+30)", to, wantTo)
 	}
 }
+
+// TestParseListDateRangeNoFlagsIsOpen guards issue #304: with neither --from
+// nor --to, the retrospective todo/journal lists must use an open (zero) range
+// so overdue todos and past journal entries are not filtered out.
+func TestParseListDateRangeNoFlagsIsOpen(t *testing.T) {
+	from, to, err := parseListDateRange("", "")
+	if err != nil {
+		t.Fatalf("parseListDateRange returned error: %v", err)
+	}
+	if !from.IsZero() || !to.IsZero() {
+		t.Fatalf("no-flags range = [%s, %s), want both zero (open)", from, to)
+	}
+}
+
+// TestParseListDateRangeWithFlagIsFinite guards against an open upper bound
+// once any flag is set: a half-open zero `to` would make recurrence expansion
+// (which appends only expanded instances, never masters) drop recurring
+// todos/journals entirely. Setting --from must yield a finite forward window.
+func TestParseListDateRangeWithFlagIsFinite(t *testing.T) {
+	from, to, err := parseListDateRange("2026-09-01", "")
+	if err != nil {
+		t.Fatalf("parseListDateRange returned error: %v", err)
+	}
+	if from.IsZero() || to.IsZero() {
+		t.Fatalf("range with --from = [%s, %s), want both non-zero (finite)", from, to)
+	}
+	if !to.After(from) {
+		t.Fatalf("expected to (%s) after from (%s)", to, from)
+	}
+}

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -70,7 +70,7 @@ CANCELLED entries.`,
 			defer a.Close()
 			ctx := context.Background()
 
-			from, to, err := parseDateRange(fromStr, toStr)
+			from, to, err := parseListDateRange(fromStr, toStr)
 			if err != nil {
 				return err
 			}
@@ -116,8 +116,8 @@ CANCELLED entries.`,
 	cmd.Flags().StringVar(&calendarName, "calendar", "", "filter by calendar name")
 	cmd.Flags().StringVar(&status, "status", "", "filter by status (DRAFT, FINAL, CANCELLED)")
 	cmd.Flags().BoolVar(&all, "all", false, "include cancelled entries (hidden by default)")
-	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD, default: today)")
-	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days from now)")
+	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD); with no date flags, past entries are included")
+	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days after --from)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "one line per entry (DATE  SUMMARY)")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted journals (see `journal restore`)")
 	return cmd

--- a/cmd/chroncal/list_default_window_test.go
+++ b/cmd/chroncal/list_default_window_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTodoListDefaultWindowShowsOverdue verifies that `todo list` with no date
+// flags surfaces overdue (past-due) todos. Regression test for issue #304: the
+// default window anchored its lower bound to today, silently hiding every
+// incomplete todo whose due date was in the past — exactly the items the user
+// most needs to see.
+func TestTodoListDefaultWindowShowsOverdue(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	if _, _, err := runChroncalCommand(t,
+		"todo", "add", "Overdue task",
+		"--calendar", "Work",
+		"--due", "2020-01-01",
+	); err != nil {
+		t.Fatalf("todo add: %v", err)
+	}
+
+	// No --from/--to: the default window must still include the overdue todo.
+	stdout, _, err := runChroncalCommand(t, "todo", "list", "--compact")
+	if err != nil {
+		t.Fatalf("todo list: %v", err)
+	}
+	if !strings.Contains(stdout, "Overdue task") {
+		t.Fatalf("todo list (no flags) = %q, want it to contain overdue todo %q", stdout, "Overdue task")
+	}
+}
+
+// TestJournalListDefaultWindowShowsPast verifies that `journal list` with no
+// date flags surfaces past-dated entries. Regression test for issue #304:
+// journal entries are inherently retrospective, but the forward-only default
+// window hid essentially every real entry.
+func TestJournalListDefaultWindowShowsPast(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	if _, _, err := runChroncalCommand(t,
+		"journal", "add", "Past entry",
+		"--calendar", "Work",
+		"--date", "2020-01-01",
+		"--status", "FINAL",
+	); err != nil {
+		t.Fatalf("journal add: %v", err)
+	}
+
+	// No --from/--to: the default window must still include the past entry.
+	stdout, _, err := runChroncalCommand(t, "journal", "list", "--compact")
+	if err != nil {
+		t.Fatalf("journal list: %v", err)
+	}
+	if !strings.Contains(stdout, "Past entry") {
+		t.Fatalf("journal list (no flags) = %q, want it to contain past entry %q", stdout, "Past entry")
+	}
+}

--- a/cmd/chroncal/list_window_help_test.go
+++ b/cmd/chroncal/list_window_help_test.go
@@ -26,14 +26,14 @@ func defaultWindowDays(t *testing.T) int {
 // TestListToFlagHelpMatchesDefaultWindow guards against the --to flag help text
 // drifting from the actual default window in parseDateRange. The todo and
 // journal list commands previously advertised "14 days" while the code
-// defaulted to 30 (issue #139).
+// defaulted to 30 (issue #139). Those retrospective lists now use an open
+// default window (issue #304); only `event list` keeps the forward
+// parseDateRange window this guard covers.
 func TestListToFlagHelpMatchesDefaultWindow(t *testing.T) {
 	want := fmt.Sprintf("%d days from now", defaultWindowDays(t))
 
 	cases := map[string]*cobra.Command{
-		"todo":    todoListCmd(),
-		"journal": journalListCmd(),
-		"event":   eventListCmd(),
+		"event": eventListCmd(),
 	}
 
 	for name, cmd := range cases {

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -386,6 +386,21 @@ func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
 	return from, to, nil
 }
 
+// parseListDateRange parses the optional --from/--to window for the
+// retrospective `todo list` / `journal list` views. With no flags it returns
+// an open (zero) range so overdue todos and past journal entries stay visible
+// by default (issue #304): the non-recurring rows are then listed unfiltered
+// and recurring masters are returned as-is. When either flag is set it
+// delegates to parseDateRange, preserving the finite forward window those
+// explicit queries expect (and which recurrence expansion requires, since a
+// half-open zero bound would expand to nothing — issue #111).
+func parseListDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
+	if fromStr == "" && toStr == "" {
+		return time.Time{}, time.Time{}, nil
+	}
+	return parseDateRange(fromStr, toStr)
+}
+
 // parseCLIDate parses a YYYY-MM-DD flag value, replacing time.Parse's
 // verbose "parsing time ... cannot parse / out of range" surface with a
 // clean "--<flag>: invalid date ..." message.

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -69,7 +69,7 @@ By default completed and cancelled todos are hidden unless you pass
 			defer a.Close()
 			ctx := context.Background()
 
-			from, to, err := parseDateRange(fromStr, toStr)
+			from, to, err := parseListDateRange(fromStr, toStr)
 			if err != nil {
 				return err
 			}
@@ -115,8 +115,8 @@ By default completed and cancelled todos are hidden unless you pass
 	cmd.Flags().StringVar(&calendarName, "calendar", "", "filter by calendar name")
 	cmd.Flags().StringVar(&status, "status", "", "filter by status (NEEDS-ACTION, IN-PROCESS, COMPLETED, CANCELLED)")
 	cmd.Flags().BoolVar(&all, "all", false, "include completed and cancelled")
-	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD, default: today)")
-	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days from now)")
+	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD); with no date flags, overdue todos are included")
+	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days after --from)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "one line per todo ([STATUS] DUE  TITLE)")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted todos (see `todo restore`)")
 	return cmd


### PR DESCRIPTION
Closes #304

## Problem

`chroncal todo list` and `chroncal journal list` with no date flags
silently hid every overdue todo and essentially all past journal
entries. `parseDateRange` defaults the lower bound (`from`) to **today**,
and the dynamic filters apply it (`due_date >= from`, `start_date >=
from`). Both commands exit 0 and print results, so the omission was
invisible — exactly the overdue/retrospective items the user most needs
to see were dropped. (Undated todos still showed via the `IS NULL`
branch.)

## Fix

Add a dedicated `parseListDateRange` for the two retrospective lists:

- **No `--from`/`--to`:** returns an open (zero) range. Non-recurring
  rows are listed unfiltered (overdue/past included) and recurring
  masters are returned as-is, instead of being expanded over an
  arbitrary 30-day forward window.
- **Either flag set:** delegates to the existing `parseDateRange`, which
  yields a finite forward window. This is deliberate: `ListFiltered*`
  recurrence expansion appends only expanded instances (never masters),
  so a half-open *zero* upper bound (`to`) would expand to nothing and
  drop recurring todos/journals entirely. Keeping the finite window
  preserves issue #111 behavior and avoids that regression.

Forward-looking `event list` / export / freebusy keep `parseDateRange`
unchanged. Flag help text and the `--to` help-window guard test are
updated accordingly.

## Reproducing test

`cmd/chroncal/list_default_window_test.go` adds:
- `TestTodoListDefaultWindowShowsOverdue` — adds a todo due `2020-01-01`,
  runs `todo list` with no flags, asserts the overdue todo appears.
- `TestJournalListDefaultWindowShowsPast` — adds a `2020-01-01` journal
  entry, runs `journal list` with no flags, asserts it appears.

Both fail on `master` (output `No todos found.` / `No journal entries
found.`) and pass with the fix. `cmd/chroncal/date_range_test.go` adds
unit tests locking the `parseListDateRange` contract (open when no flags;
finite when any flag is set) so a future refactor can't silently
reintroduce the recurring-drop bug.

## Review

- `/code-review high`: surfaced one real bug in my first implementation
  (a both-bounds-open helper made recurring todos/journals vanish on
  `--from`-only queries, since expansion drops masters and a zero `to`
  expands to nothing). Fixed by switching to the delegating design above.
- `/simplify`: helper already minimal and at the right altitude
  (retrospective variant that leaves `parseDateRange` untouched); no
  further changes.

`go build ./... && go test ./...` all green.
