### PR TITLE
fix(tui): clip calendar grid pills by display width, not rune count

### DIFF
--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -1155,13 +1155,7 @@ func renderTimeCellContent(p placedEvent, row, width int) string {
 		}
 	}
 
-	if lipgloss.Width(text) > width {
-		r := []rune(text)
-		limit := max(width-1, 1)
-		if len(r) > limit {
-			text = string(r[:limit]) + "…"
-		}
-	}
+	text = truncateTo(text, width)
 
 	return lipgloss.NewStyle().Background(bg).Foreground(fg).Width(width).Render(text)
 }
@@ -1223,14 +1217,7 @@ func renderTimeLabel(row, lph int, isNowRow bool, nowTimeLabel string) string {
 }
 
 func renderEventPill(ev CalendarEvent, cellW int, faint bool) string {
-	text := " " + ev.Title
-	if lipgloss.Width(text) > cellW {
-		r := []rune(text)
-		limit := max(cellW-1, 1)
-		if len(r) > limit {
-			text = string(r[:limit]) + "…"
-		}
-	}
+	text := truncateTo(" "+ev.Title, cellW)
 
 	bg := ActiveTheme().Muted
 	if ev.Color != "" {

--- a/internal/tui/format_pill_width_test.go
+++ b/internal/tui/format_pill_width_test.go
@@ -1,0 +1,50 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+// Wide glyphs (CJK/emoji) measure two display cells each, so a title whose rune
+// count fits the cell-width budget can still overflow it. The pill renderers
+// must clip by display width, not rune count, or the styled cell soft-wraps onto
+// a second line and corrupts the surrounding grid row (#312).
+func TestRenderEventPill_WideGlyphsDoNotWrap(t *testing.T) {
+	const cellW = 10
+	ev := CalendarEvent{Title: "会議会議会議会議"} // 8 CJK runes = 16 display cells
+
+	out := renderEventPill(ev, cellW, false)
+
+	if h := lipgloss.Height(out); h != 1 {
+		t.Fatalf("pill wrapped to %d lines; want 1 (out=%q)", h, out)
+	}
+	if strings.Contains(out, "\n") {
+		t.Fatalf("pill contains a newline, breaking the grid row: %q", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(line); w > cellW {
+			t.Fatalf("pill line width %d exceeds cell width %d: %q", w, cellW, line)
+		}
+	}
+}
+
+func TestRenderTimeCellContent_WideGlyphsDoNotWrap(t *testing.T) {
+	const cellW = 10
+	p := placedEvent{event: CalendarEvent{Title: "会議会議会議会議"}}
+
+	out := renderTimeCellContent(p, 0, cellW)
+
+	if h := lipgloss.Height(out); h != 1 {
+		t.Fatalf("time cell wrapped to %d lines; want 1 (out=%q)", h, out)
+	}
+	if strings.Contains(out, "\n") {
+		t.Fatalf("time cell contains a newline, breaking the grid row: %q", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(line); w > cellW {
+			t.Fatalf("time cell line width %d exceeds cell width %d: %q", w, cellW, line)
+		}
+	}
+}


### PR DESCRIPTION
Closes #312

## Problem

`renderEventPill` (`internal/tui/format.go`) and `renderTimeCellContent` clipped
calendar-grid event pills with inline rune-slicing:

```go
if lipgloss.Width(text) > cellW {
    r := []rune(text)
    limit := max(cellW-1, 1)
    if len(r) > limit {
        text = string(r[:limit]) + "…"
    }
}
```

The budget (`cellW-1`) is measured in display cells, but the slice is by rune
count (`len(r)`). A title of N full-width CJK/emoji runes where `N <= cellW-1`
passed the width guard untouched even though it occupied ~2N cells. `Width(cellW).Render`
then soft-wrapped it onto a second line, and since these pills are written with
raw `WriteString` into a single horizontal grid row, the injected newline
corrupted the whole week/month/day layout.

This is exactly the class of bug already fixed for the other TUI truncators in
#261, but these two call sites bypassed `truncateTo` and did their own slicing,
so the earlier fix never reached them.

## Fix

Route both call sites through the existing display-width-aware `truncateTo`
helper instead of inline rune-slicing:

```go
text = truncateTo(text, width)          // renderTimeCellContent
text := truncateTo(" "+ev.Title, cellW) // renderEventPill
```

Minimal, behavior-preserving for ASCII; wide glyphs now clip at the cell
boundary like every other TUI column.

## Reproducing test

`internal/tui/format_pill_width_test.go` renders a pill from an 8-rune CJK title
(`会議会議会議会議` = 16 display cells) into a 10-cell column and asserts the
result is a single line no wider than the cell. Both tests (`renderEventPill`
and `renderTimeCellContent`) **failed before** the fix (wrapped to 3 lines) and
**pass after**.

## Review

- `/code-review high`: no correctness, reuse, simplification, or convention
  findings. No external callers/tests depend on the old hard-cut output; all
  call sites pass positive widths; the leading-space title is plain text so the
  helper's ANSI-strip path is a no-op.
- `/simplify`: change is already the simplified/reuse form (two inline slices
  collapsed to one shared helper call); nothing to apply.

`go build ./... && go test ./...` all green.
