### PR TITLE
fix(tui): route monthly recurrence 'On' arrow clicks to nested select

### DIFF
--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -2265,6 +2265,24 @@ func (f Form) FormStaticField(i int) *StaticField {
 
 // Private
 
+// focusedSelect returns the SelectField behind a generic "select:prev/next"
+// arrow click for the given field, or nil if the field doesn't currently own
+// a focused select. It unwraps the RecurrenceOnField composite, whose nested
+// monthly select renders those same generic targets.
+func focusedSelect(field FormField) *SelectField {
+	switch fld := field.(type) {
+	case *SelectField:
+		if fld.focused {
+			return fld
+		}
+	case *RecurrenceOnField:
+		if fld.mode == RecurrenceOnMonthly && fld.monthly.focused {
+			return fld.monthly
+		}
+	}
+	return nil
+}
+
 func (f Form) handleClick(target string) (Form, tea.Cmd) {
 	if target == "" {
 		return f, nil
@@ -2273,19 +2291,23 @@ func (f Form) handleClick(target string) (Form, tea.Cmd) {
 	// Select arrow clicks: find the SelectField that owns the arrow,
 	// focus it, and simulate the corresponding keypress.
 	if target == "select:prev" || target == "select:next" {
+		key := "right"
+		if target == "select:prev" {
+			key = "left"
+		}
 		for i := range f.items {
-			if sf, ok := f.items[i].Field.(*SelectField); ok && sf.focused {
-				var cmd tea.Cmd
-				if target == "select:prev" {
-					cmd = sf.Update(keyMsg("left"))
-				} else {
-					cmd = sf.Update(keyMsg("right"))
-				}
-				if f.onRebuild != nil {
-					f.onRebuild(&f)
-				}
-				return f, cmd
+			// A focused RecurrenceOnField in monthly mode renders its nested
+			// monthly select's arrows with these same generic targets, so
+			// resolve against it too — not only top-level SelectFields.
+			sf := focusedSelect(f.items[i].Field)
+			if sf == nil {
+				continue
 			}
+			cmd := sf.Update(keyMsg(key))
+			if f.onRebuild != nil {
+				f.onRebuild(&f)
+			}
+			return f, cmd
 		}
 		return f, nil
 	}

--- a/internal/tui/recurrence_editor_test.go
+++ b/internal/tui/recurrence_editor_test.go
@@ -70,6 +70,35 @@ func TestRecurrenceEditor_MonthlyOnFieldUpdatesRule(t *testing.T) {
 	assert.Equal(t, "FREQ=MONTHLY;BYDAY=4FR", m.BuildRule())
 }
 
+func TestRecurrenceEditor_MonthlyOnFieldArrowClickAdvancesSelection(t *testing.T) {
+	m := NewRecurrenceEditorModel(time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC), 120, 40, Theme{})
+	m.eachField.SetSelected(2) // Monthly
+	m.syncFromForm()
+
+	onIdx := -1
+	for i, item := range m.form.items {
+		if item.Label == "On" {
+			onIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, onIdx)
+
+	// Focus the On field so its nested monthly select is focused, matching
+	// the state when the user clicks its ◀ / ▶ arrows.
+	m.form, _ = m.form.focusIndex(onIdx)
+	require.Equal(t, RecurrenceOnMonthly, m.onField.Mode())
+	require.Equal(t, 0, m.onField.MonthlyMode())
+
+	// Clicking the ▶ arrow must advance the selection (day N → Nth-weekday).
+	m.form, _ = m.form.handleClick("select:next")
+	assert.Equal(t, 1, m.onField.MonthlyMode())
+
+	// Clicking the ◀ arrow must move it back.
+	m.form, _ = m.form.handleClick("select:prev")
+	assert.Equal(t, 0, m.onField.MonthlyMode())
+}
+
 func TestRecurrenceEditor_EachFieldIntervalAndUnitUpdateRule(t *testing.T) {
 	m := NewRecurrenceEditorModel(time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC), 120, 40, Theme{})
 	m.eachField.SetAmount("2")


### PR DESCRIPTION
## Summary

In the Custom Repeat editor with frequency = Monthly, clicking the ◀ / ▶ arrows
on the "day N / Nth-weekday" selector did nothing. Keyboard left/right worked, so
only the mouse affordance was broken — inconsistent with every other arrow control
in the form.

Root cause: in MONTHLY mode `RecurrenceOnField.View` delegates to its nested
`monthly` SelectField, which renders arrows with the generic `select:prev` /
`select:next` mouse targets. `Form.handleClick` resolved those targets only
against *top-level* `*SelectField` items, so the composite's nested select was
never matched and the click was swallowed.

## Fix

Add a small `focusedSelect` helper that returns the focused select behind an
arrow click, unwrapping the `RecurrenceOnField` composite's `monthly` select in
MONTHLY mode. `handleClick` resolves `select:prev` / `select:next` against it, so
the nested select now receives the simulated keypress. The top-level
`*SelectField` path is unchanged.

## Reproducing test

`TestRecurrenceEditor_MonthlyOnFieldArrowClickAdvancesSelection` in
`internal/tui/recurrence_editor_test.go`: focuses the monthly On field and calls
`handleClick("select:next")` / `("select:prev")`, asserting `MonthlyMode()`
advances 0 → 1 and back. It FAILS before the fix (selection stays 0, click
dropped) and passes after.

## Validation

- `go build ./... && go test ./...` — all packages pass.
- `/code-review high` — no findings (nil-safe: `monthly` is always constructed;
  single-focus invariant preserves first-match behavior; top-level path intact).
- `/simplify` — code already clean; helper generalizes the lookup rather than
  special-casing the composite inline. No changes applied.

Closes #313
