### PR TITLE
fix(tui): refresh open event-view dialog after RSVP change

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -116,7 +116,8 @@ type calendarsLoadedMsg struct {
 }
 
 type eventRSVPUpdatedMsg struct {
-	err error
+	event event.Event
+	err   error
 }
 
 type eventCreatedMsg struct {
@@ -2058,14 +2059,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					break
 				}
 			}
-			err = m.app.Events.ReplaceAttendees(ctx, ev.ID, attendees)
-			return eventRSVPUpdatedMsg{err: err}
+			if err := m.app.Events.ReplaceAttendees(ctx, ev.ID, attendees); err != nil {
+				return eventRSVPUpdatedMsg{err: err}
+			}
+			ev.Attendees = attendees
+			return eventRSVPUpdatedMsg{event: ev}
 		}
 
 	case eventRSVPUpdatedMsg:
 		if msg.err != nil {
 			m.err = msg.err
 			return m, nil
+		}
+		// Rebuild the open view dialog so the user sees their new RSVP
+		// status immediately; loadEvents only repaints the grid behind it.
+		if m.viewDialogOpen && m.viewDialog.event.ID == msg.event.ID {
+			cal := m.calendars[msg.event.CalendarID]
+			m.viewDialog = NewEventViewDialogModel(msg.event, cal, m.theme).
+				SetSize(m.width, m.height)
 		}
 		return m, m.loadEvents()
 

--- a/internal/tui/event_view_dialog_test.go
+++ b/internal/tui/event_view_dialog_test.go
@@ -363,6 +363,39 @@ func TestEventViewDialog_MouseWheelScrollsBody(t *testing.T) {
 	assert.Less(t, m.body.YOffset(), prev, "wheel up should scroll the body back")
 }
 
+// Regression for #311: after a successful RSVP, the open view dialog must
+// repaint with the new status. Previously the handler only called
+// loadEvents() (the grid behind the dialog), so the dialog kept showing the
+// stale status until the user closed and reopened it.
+func TestEventRSVPUpdated_RefreshesOpenViewDialog(t *testing.T) {
+	ev := testViewEvent()
+	ev.Attendees = []model.Attendee{
+		{Email: "me@example.com", RSVPStatus: "NEEDS-ACTION"},
+	}
+	cal := CalendarInfo{Name: "Work", Color: "#a6e3a1", OwnerEmail: "me@example.com"}
+
+	m := Model{
+		width:          120,
+		height:         40,
+		viewDialogOpen: true,
+		viewDialog:     NewEventViewDialogModel(ev, cal, Theme{}).SetSize(120, 40),
+		calendars:      map[int64]CalendarInfo{ev.CalendarID: cal},
+	}
+	require.NotContains(t, m.viewDialog.View(), "Yes ✓",
+		"precondition: dialog should show the pending status, not ACCEPTED")
+
+	// Simulate the DB write completing with the owner now ACCEPTED.
+	updated := ev
+	updated.Attendees = []model.Attendee{
+		{Email: "me@example.com", RSVPStatus: "ACCEPTED"},
+	}
+	next, _ := m.Update(eventRSVPUpdatedMsg{event: updated})
+	m = next.(Model)
+
+	assert.Contains(t, m.viewDialog.View(), "Yes ✓",
+		"open view dialog must reflect the new RSVP status without reopening")
+}
+
 func TestEventViewDialog_XKeyTriggersDelete(t *testing.T) {
 	// The x key (and the Delete key) must trigger the delete binding across
 	// all three dialogs after the t→x sweep.


### PR DESCRIPTION
Closes #311.

## Problem
Pressing `y`/`n`/`m` in the open event-view dialog emitted `EventRSVPMsg`, whose handler rewrote the owner's `RSVPStatus` in the DB and returned `eventRSVPUpdatedMsg`. That handler only called `loadEvents()`, which repaints the calendar grid *behind* the dialog. The dialog (`m.viewDialog`) kept its stale event snapshot, so the user's own RSVP status appeared unchanged until they closed and reopened it — the action looked like a no-op.

## Fix
- `eventRSVPUpdatedMsg` now carries the updated `event.Event` (the dialog's snapshot with the new attendee status applied in-memory).
- When the view dialog is open and showing that event, the `eventRSVPUpdatedMsg` handler rebuilds `m.viewDialog` from the updated event, mirroring how `eventViewLoadedMsg` constructs it.
- Reusing the in-memory snapshot (rather than re-fetching the master row) preserves the expanded recurring-instance start time.

The fix is scoped to the view dialog: when an RSVP originates elsewhere (e.g. the day-events dialog) `viewDialogOpen` is false, so behavior there is unchanged. The `m.viewDialog.event.ID == msg.event.ID` guard prevents refreshing a dialog that has since switched to a different event.

## Reproducing test
`TestEventRSVPUpdated_RefreshesOpenViewDialog` (internal/tui/event_view_dialog_test.go) builds a `Model` with the view dialog open showing an attendee at `NEEDS-ACTION`, sends `eventRSVPUpdatedMsg` with the owner now `ACCEPTED`, and asserts the rendered dialog shows `Yes ✓`. Verified it FAILS before the handler change (renders `Yes`, no checkmark) and PASSES after.

## Review outcomes
- **/code-review (high):** no actionable findings. The ID guard is correct, the error path is preserved, and using the in-memory snapshot is safer for recurring instances than re-fetching the master.
- **/simplify:** code already clean; nothing to apply. The rebuild matches the existing `eventViewLoadedMsg` pattern, no extra DB I/O, right altitude.

`go build ./... && go test ./...` all pass.
