### PR TITLE
fix(tui): pluralize "Repeat every N" unit label

### DIFF
--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -252,7 +252,11 @@ func (f *TextAreaField) IsFocusable() bool { return true }
 // SelectOption is a single entry in a SelectField.
 type SelectOption struct {
 	Label string
-	Value string
+	// PluralLabel, when set, is shown by QuantitySelectField in place of
+	// Label whenever the amount is not exactly 1 (e.g. "Days" for "2").
+	// Empty means the option has no separate plural form.
+	PluralLabel string
+	Value       string
 }
 
 // selectHighlight tracks which arrow was just pressed.
@@ -327,6 +331,14 @@ func (f *SelectField) updateMaxWidth() {
 	for _, o := range f.options {
 		if w := lipgloss.Width(f.renderOptionLabel(o, false)); w > maxW {
 			maxW = w
+		}
+		// Reserve room for the plural form too so the unit column does
+		// not shift when QuantitySelectField swaps "Day" for "Days".
+		if o.PluralLabel != "" {
+			plural := SelectOption{Label: o.PluralLabel, Value: o.Value}
+			if w := lipgloss.Width(f.renderOptionLabel(plural, false)); w > maxW {
+				maxW = w
+			}
 		}
 	}
 	f.maxWidth = maxW
@@ -473,6 +485,18 @@ func (f *QuantitySelectField) amountText() string {
 	return mouseMark("quantityselect:amount", style.Render(v))
 }
 
+// amountIsOne reports whether the entered amount is exactly 1, which
+// governs singular/plural agreement of the unit label. An empty input
+// falls back to the placeholder ("1"), matching what amountText shows.
+func (f *QuantitySelectField) amountIsOne() bool {
+	v := strings.TrimSpace(f.amount.Value())
+	if v == "" {
+		v = f.amount.input.Placeholder
+	}
+	n, err := strconv.Atoi(v)
+	return err == nil && n == 1
+}
+
 func (f *QuantitySelectField) unitText() string {
 	if len(f.unit.options) == 0 {
 		return ""
@@ -482,7 +506,11 @@ func (f *QuantitySelectField) unitText() string {
 	if unitFocused && f.unit.renderLabel == nil {
 		labelStyle = labelStyle.Reverse(true)
 	}
-	label := labelStyle.Render(f.unit.renderOptionLabel(f.unit.options[f.unit.selected], unitFocused))
+	opt := f.unit.options[f.unit.selected]
+	if opt.PluralLabel != "" && !f.amountIsOne() {
+		opt.Label = opt.PluralLabel
+	}
+	label := labelStyle.Render(f.unit.renderOptionLabel(opt, unitFocused))
 
 	flash := lipgloss.NewStyle().Foreground(activeTheme.FormHighlight)
 	prev := Glyphs["select.prev"]

--- a/internal/tui/recurrence_editor.go
+++ b/internal/tui/recurrence_editor.go
@@ -68,8 +68,11 @@ type RecurrenceEditorModel struct {
 func NewRecurrenceEditorModel(startDate time.Time, w, h int, theme Theme) RecurrenceEditorModel {
 	eachOpts := make([]SelectOption, len(recFrequencies))
 	for i, freq := range recFrequencies {
-		label := strings.ToUpper(freq.Unit[0][:1]) + freq.Unit[0][1:]
-		eachOpts[i] = SelectOption{Label: label, Value: freq.Freq}
+		eachOpts[i] = SelectOption{
+			Label:       titleCase(freq.Unit[0]),
+			PluralLabel: titleCase(freq.Unit[1]),
+			Value:       freq.Freq,
+		}
 	}
 
 	endsField := NewSelectField(nil)

--- a/internal/tui/recurrence_editor_test.go
+++ b/internal/tui/recurrence_editor_test.go
@@ -164,6 +164,36 @@ func TestQuantitySelectField_DefaultsToOneWeek(t *testing.T) {
 	assert.Equal(t, "WEEKLY", f.Value())
 }
 
+func TestQuantitySelectField_PluralizesUnitByAmount(t *testing.T) {
+	f := NewQuantitySelectField([]SelectOption{
+		{Label: "Day", PluralLabel: "Days", Value: "DAILY"},
+		{Label: "Week", PluralLabel: "Weeks", Value: "WEEKLY"},
+	}, 1) // default Week
+
+	f.SetAmount("1")
+	one := mouseSweep(f.View())
+	assert.Contains(t, one, "Week")
+	assert.NotContains(t, one, "Weeks")
+
+	f.SetAmount("2")
+	many := mouseSweep(f.View())
+	assert.Contains(t, many, "Weeks")
+}
+
+func TestRecurrenceEditor_RepeatEveryPluralizesUnit(t *testing.T) {
+	m := NewRecurrenceEditorModel(time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC), 120, 40, Theme{})
+	m.eachField.SetSelected(0) // Daily
+
+	m.eachField.SetAmount("1")
+	one := mouseSweep(m.eachField.View())
+	assert.Contains(t, one, "Day")
+	assert.NotContains(t, one, "Days")
+
+	m.eachField.SetAmount("2")
+	many := mouseSweep(m.eachField.View())
+	assert.Contains(t, many, "Days")
+}
+
 func TestQuantitySelectField_ValidateRequiresPositiveInteger(t *testing.T) {
 	f := NewQuantitySelectField([]SelectOption{
 		{Label: "Day", Value: "DAILY"},


### PR DESCRIPTION
Closes #314

## Problem

The recurrence editor's "Repeat every N" inline control built its unit
label from the singular `SelectOption.Label` only, so the rendered text
read "Repeat every 2 Day", "Repeat every 3 Week", etc. — no agreement
with the amount. The generated RRULE and the summary string were already
correct; this was purely the editor's inline label.

## Fix

- Add an optional `PluralLabel` to `SelectOption`.
- `QuantitySelectField` now shows `PluralLabel` whenever the amount is
  not exactly 1 (empty input falls back to the placeholder "1", matching
  what the amount field displays).
- `SelectField.updateMaxWidth` reserves room for the plural form too, so
  the unit column / arrows do not shift when "Day" becomes "Days".
- The recurrence editor supplies both singular and plural forms from the
  existing `recFrequencies` table via the existing `titleCase` helper.

The alarm editor also uses `QuantitySelectField` but keeps its
plural-only labels (no `PluralLabel`), so its rendering is unchanged.

## Reproducing test

`internal/tui/recurrence_editor_test.go`:

- `TestQuantitySelectField_PluralizesUnitByAmount` — amount 1 shows
  "Week" (not "Weeks"); amount 2 shows "Weeks".
- `TestRecurrenceEditor_RepeatEveryPluralizesUnit` — drives the real
  `NewRecurrenceEditorModel` "Repeat every" field: amount 1 shows "Day"
  (not "Days"); amount 2 shows "Days".

Both fail before the fix (the singular label was the only one rendered)
and pass after.

## Review

- `/code-review high`: flagged that a new `capitalize` helper duplicated
  the existing `titleCase` (badge.go). Fixed by reusing `titleCase`. No
  correctness findings.
- `/simplify`: no further changes — the fix is generalized on the shared
  `SelectOption`/`SelectField` infra rather than special-cased, and the
  width reservation keeps the column stable.

`go build ./... && go test ./...` all pass.
