### PR TITLE
fix(cmd): normalize event date-range bounds to UTC before lexical compare

### DIFF
--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -324,8 +324,10 @@ to stdout.`,
 				if derr != nil {
 					return derr
 				}
-				fromTime = from.Format(time.RFC3339)
-				toTime = to.Format(time.RFC3339)
+				// Normalize to UTC so the RFC3339 bounds compare lexically
+				// against UTC-stored start/end strings (issue #305).
+				fromTime = from.UTC().Format(time.RFC3339)
+				toTime = to.UTC().Format(time.RFC3339)
 			}
 
 			// Load events

--- a/cmd/chroncal/ical_export_utc_test.go
+++ b/cmd/chroncal/ical_export_utc_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	// Embed the timezone database so the re-executed helper subprocess can
+	// resolve a fixed non-UTC zone regardless of the host's tzdata.
+	_ "time/tzdata"
+)
+
+// TestICalExportRangeBoundsUseUTC guards issue #305 on the export path: the CLI
+// builds date-range bounds in time.Local, so on a non-UTC host they must be
+// normalized to UTC before being compared lexically against the UTC-stored
+// start/end strings. The CLI subprocess runs in Etc/GMT+3 (UTC-03:00).
+//
+// The seeded event ends 2026-04-01T02:00:00Z (= 2026-03-31 23:00 local), before
+// the requested window opening 2026-04-01 (= 2026-04-01T03:00:00Z), so it must
+// not be exported. With the local-offset bound it lexically out-sorts the UTC
+// end string and is wrongly included.
+func TestICalExportRangeBoundsUseUTC(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "Etc/GMT+3") // UTC-03:00, no DST
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	ics := "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//chroncal//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:before-window@test\r\n" +
+		"DTSTART:20260401T010000Z\r\n" +
+		"DTEND:20260401T020000Z\r\n" +
+		"SUMMARY:Before window\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+	icsPath := filepath.Join(t.TempDir(), "before.ics")
+	if err := os.WriteFile(icsPath, []byte(ics), 0o644); err != nil {
+		t.Fatalf("write ics: %v", err)
+	}
+
+	if _, _, err := runChroncalCommand(t, "ical", "import", icsPath, "--calendar", "Work"); err != nil {
+		t.Fatalf("ical import: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t, "ical", "export", "--calendar", "Work", "--from", "2026-04-01")
+	if err != nil {
+		t.Fatalf("ical export: %v", err)
+	}
+
+	if strings.Contains(stdout, "Before window") {
+		t.Fatalf("export included an event ending before the window; local-offset bound leaked into lexical comparison\noutput:\n%s", stdout)
+	}
+}

--- a/internal/recurrence/daterange_utc_test.go
+++ b/internal/recurrence/daterange_utc_test.go
@@ -1,0 +1,92 @@
+package recurrence
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/testutil"
+)
+
+// TestListFilteredEvents_NonUTCBoundsLexicalComparison guards issue #305: CLI
+// date-range bounds arrive as time.Time values in a non-UTC location (the CLI
+// builds them in time.Local). They must be normalized to UTC before being
+// formatted and compared lexically against the UTC-stored start/end strings,
+// otherwise the local offset in the RFC3339 string breaks the comparison near
+// window edges.
+//
+// The bound is built in a fixed -03:00 zone so the test is deterministic
+// regardless of the host timezone (CI runs in UTC).
+func TestListFilteredEvents_NonUTCBoundsLexicalComparison(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	eventsSvc := event.NewService(db, q)
+	recurSvc := NewService(db, q)
+	ctx := context.Background()
+
+	// Event entirely before the requested window: it ends 2026-04-01T02:00:00Z,
+	// which is 2026-03-31 23:00 in -03:00 local time — before 2026-04-01.
+	_, err := eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Before window",
+		StartTime:  time.Date(2026, 4, 1, 1, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 2, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	// Window opens 2026-04-01 00:00 in -03:00 (= 2026-04-01T03:00:00Z). The
+	// event ends at 02:00Z, before the window opens, so it must NOT appear.
+	loc := time.FixedZone("test-0300", -3*60*60)
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, loc)
+	to := from.AddDate(0, 0, 30)
+
+	events, err := recurSvc.ListFilteredEvents(ctx, EventListParams{
+		From: from,
+		To:   to,
+	})
+	if err != nil {
+		t.Fatalf("ListFilteredEvents: %v", err)
+	}
+
+	if len(events) != 0 {
+		t.Fatalf("got %d events, want 0 (event ends before window; local-offset bound leaked into lexical comparison)", len(events))
+	}
+}
+
+// TestExportExpandedByDateRange_NonUTCBoundsLexicalComparison is the export-path
+// (ical export) sibling of the test above: the same local-offset bound must be
+// normalized to UTC before the SQL string comparison.
+func TestExportExpandedByDateRange_NonUTCBoundsLexicalComparison(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	eventsSvc := event.NewService(db, q)
+	recurSvc := NewService(db, q)
+	ctx := context.Background()
+
+	_, err := eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Before window",
+		StartTime:  time.Date(2026, 4, 1, 1, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 2, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	loc := time.FixedZone("test-0300", -3*60*60)
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, loc)
+	to := from.AddDate(0, 0, 30)
+
+	events, err := recurSvc.ExportExpandedByDateRange(ctx, ExportFilterParams{
+		From: from,
+		To:   to,
+	})
+	if err != nil {
+		t.Fatalf("ExportExpandedByDateRange: %v", err)
+	}
+
+	if len(events) != 0 {
+		t.Fatalf("got %d events, want 0 (event ends before window; local-offset bound leaked into lexical comparison)", len(events))
+	}
+}

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -710,6 +710,18 @@ type ExportFilterParams struct {
 	To         time.Time
 }
 
+// rangeBoundUTC formats a date-range query bound as an RFC3339 string in UTC,
+// or "" for the zero time. Normalizing to UTC is required because these bounds
+// are compared lexically against the UTC-stored start/end strings (issue #305):
+// a non-UTC offset left in the formatted string breaks that comparison near
+// window edges.
+func rangeBoundUTC(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
 // ExportExpandedByDateRange returns recurring event masters (not expanded
 // instances) that have at least one occurrence in [from,to), merged with
 // non-recurring events whose start_time is in range. This is for ICS export
@@ -717,14 +729,8 @@ type ExportFilterParams struct {
 // instances. All filters (calendar, category, status) are applied at the
 // SQL level.
 func (s *Service) ExportExpandedByDateRange(ctx context.Context, p ExportFilterParams) ([]event.Event, error) {
-	fromStr := ""
-	toStr := ""
-	if !p.From.IsZero() {
-		fromStr = p.From.Format(time.RFC3339)
-	}
-	if !p.To.IsZero() {
-		toStr = p.To.Format(time.RFC3339)
-	}
+	fromStr := rangeBoundUTC(p.From)
+	toStr := rangeBoundUTC(p.To)
 
 	rangeRows, err := s.q.ListEventsForExport(ctx, storage.EventFilterParams{
 		CalendarID:   p.CalendarID,
@@ -1054,15 +1060,9 @@ type EventListParams struct {
 // otherwise recurring masters are returned as-is, matching the
 // todo/journal contract.
 func (s *Service) ListFilteredEvents(ctx context.Context, p EventListParams) ([]event.Event, error) {
-	fromStr := ""
-	toStr := ""
-	hasRange := !p.From.IsZero() || !p.To.IsZero()
-	if !p.From.IsZero() {
-		fromStr = p.From.Format(time.RFC3339)
-	}
-	if !p.To.IsZero() {
-		toStr = p.To.Format(time.RFC3339)
-	}
+	fromStr := rangeBoundUTC(p.From)
+	toStr := rangeBoundUTC(p.To)
+	hasRange := fromStr != "" || toStr != ""
 
 	rangeRows, err := s.q.ListEventsFiltered(ctx, storage.EventFilterParams{
 		CalendarID:     p.CalendarID,


### PR DESCRIPTION
Closes #305.

## Problem

`event list` and `ical export` build their `--from`/`--to` bounds in `time.Local` (via `parseDateRange`), then formatted them with `Format(time.RFC3339)` — leaving the host's UTC offset in the string, e.g. `2026-04-01T00:00:00-03:00`. Those bounds are compared **lexically** in SQL (`end_time > ?` / `start_time < ?`) against start/end strings stored in UTC (`...Z`, per AGENTS.md "All database times are RFC 3339 strings in UTC").

On any non-UTC host the string comparison no longer matches the intended instant comparison near window edges. Concrete case (TZ -03:00): an event ending `2026-04-01T02:00:00Z` (= 2026-03-31 23:00 local, before the window) satisfies `"2026-04-01T02:00:00Z" > "2026-04-01T00:00:00-03:00"` lexically and wrongly appears in `event list --from 2026-04-01`. Symmetric false-negatives also occur. Invisible in CI because tests run in UTC.

## Fix

Normalize every read-side range bound to UTC before formatting.

- New `rangeBoundUTC(t)` helper in `internal/recurrence/service.go` is the single chokepoint for the invariant, shared by `ListFilteredEvents` (`event list`) and `ExportExpandedByDateRange` (the recurring-master export probe).
- The primary `ical export` load formats its bounds at the CLI before passing them to `event.ExportFiltered` (which feeds the SQL filter directly), so `cmd/chroncal/ical.go` is fixed there too — this path does **not** go through the recurrence service and was the gap surfaced by code review.

`ListExpandedEvents` / `ListExpandedByDateRange` (used by alarm/TUI/freebusy with already-UTC times) are intentionally out of scope for this list/export issue.

## Reproducing tests

All deterministic, independent of the host timezone:

- `internal/recurrence/daterange_utc_test.go`
  - `TestListFilteredEvents_NonUTCBoundsLexicalComparison` — builds a bound in a fixed `-03:00` zone; an event ending before the window must be excluded. Fails before the fix (got 1, want 0).
  - `TestExportExpandedByDateRange_NonUTCBoundsLexicalComparison` — same for the export probe path.
- `cmd/chroncal/ical_export_utc_test.go`
  - `TestICalExportRangeBoundsUseUTC` — runs the `ical export` subprocess under `TZ=Etc/GMT+3` (UTC-03:00), seeds a before-window event via `ical import` with explicit `Z` times, and asserts it is not exported. Embeds `time/tzdata` so the zone resolves regardless of host tzdata. Verified to fail when the `ical.go` fix is reverted.

## Review outcomes

- **/code-review (high):** found one CONFIRMED additional defect beyond the issue's cited locations — the `ical export` primary load (`event.ExportFiltered`) formats bounds at the CLI and bypasses the recurrence service, so the initial recurrence-only fix missed it. Fixed and covered with the CLI test.
- **/simplify:** extracted the duplicated `if !IsZero { x.UTC().Format(...) }` branches into the single `rangeBoundUTC` helper — removes copy-paste and centralizes the UTC-normalization invariant so it is harder to regress.

`go build ./...` and `go test ./...` pass (25 packages).
