### PR TITLE
fix(tui): measure RSVP button width through rendered style

### DIFF
--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -710,7 +710,10 @@ func rsvpMaxLabelWidth() int {
 }
 
 func rsvpButtonWidth() int {
-	return rsvpMaxLabelWidth() + 2 // +2 for button padding
+	// Measure through the actual rendered style (Padding(0,2).MarginRight(1))
+	// so that hitRSVPBtn computes hit zones and advances with the correct width.
+	label := strings.Repeat(" ", rsvpMaxLabelWidth())
+	return lipgloss.Width(DefaultButtonStyles().Normal.Render(label, false))
 }
 
 func rsvpButtonLabel(baseLabel, rsvpStatus string) string {

--- a/internal/tui/event_dialog_test.go
+++ b/internal/tui/event_dialog_test.go
@@ -1,0 +1,29 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+// TestRsvpButtonWidthMatchesRendered is a regression test for issue #346.
+//
+// rsvpButtonWidth() was returning rsvpMaxLabelWidth()+2, which only accounted
+// for one side of the button padding.  DefaultButtonStyles uses
+// Padding(0,2).MarginRight(1), so the real rendered cell-width of a button
+// whose label has been padded to rsvpMaxLabelWidth() is label_w+2+2+1 = label_w+5.
+//
+// hitRSVPBtn computes hit zones as [cx, cx+btnW) and advances by btnW+1 (the
+// +1 is the join-space from strings.Join).  Both the zone width and the
+// advance must use the same measured value, so rsvpButtonWidth() must equal
+// the lipgloss.Width of a freshly rendered button.
+func TestRsvpButtonWidthMatchesRendered(t *testing.T) {
+	fixedW := rsvpMaxLabelWidth()
+	label := strings.Repeat(" ", fixedW)
+	want := lipgloss.Width(DefaultButtonStyles().Normal.Render(label, false))
+	got := rsvpButtonWidth()
+	if got != want {
+		t.Errorf("rsvpButtonWidth() = %d, want %d (rendered width including padding+margin)", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #346

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8