### PR TITLE
fix(tui): sync footer spinner freezes when overlay is open

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1535,11 +1535,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	// When the palette is open, it captures all input. Only specific
-	// parent-level messages (size, theme, palette-result) fall through.
+	// parent-level messages (size, theme, palette-result, and
+	// spinner ticks) fall through.
 	if m.paletteOpen {
 		switch msg.(type) {
 		case PaletteSelectedMsg, PaletteClosedMsg,
-			tea.BackgroundColorMsg, tea.WindowSizeMsg:
+			tea.BackgroundColorMsg, tea.WindowSizeMsg,
+			spinner.TickMsg:
 			// fall through to main switch
 		default:
 			var cmd tea.Cmd
@@ -1563,7 +1565,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tea.BackgroundColorMsg, tea.WindowSizeMsg,
 			eventsLoadedMsg, calendarsLoadedMsg,
 			calendarMutationDoneMsg,
-			calendarOAuthConnectPendingMsg:
+			calendarOAuthConnectPendingMsg,
+			spinner.TickMsg:
 			// fall through to main switch
 		default:
 			var cmd tea.Cmd
@@ -1579,7 +1582,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case EventFormSaveMsg, EventFormClosedMsg,
 			tea.BackgroundColorMsg, tea.WindowSizeMsg,
 			eventsLoadedMsg, calendarsLoadedMsg,
-			eventCreatedMsg, eventUpdatedMsg:
+			eventCreatedMsg, eventUpdatedMsg,
+			spinner.TickMsg:
 			// fall through to main switch
 		default:
 			var cmd tea.Cmd
@@ -2756,13 +2760,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.runSyncCalendar(msg.ID, msg.Name), m.syncSpinner.Tick)
 
 	case spinner.TickMsg:
-		// Two spinners can be live: the sync footer's and the OAuth pending
-		// modal's. Each bubbles spinner ignores ticks that aren't its own,
-		// so routing to both is safe.
+		// Multiple spinners can be live simultaneously: the sync footer's, the
+		// OAuth pending modal's, and the palette's search spinner. Each bubbles
+		// spinner ignores ticks that aren't its own (ID check), so routing to
+		// all active sub-components is safe. Spinner ticks are whitelisted
+		// through every overlay guard so they always reach this handler rather
+		// than being silently consumed by the overlay.
 		var cmds []tea.Cmd
 		if m.oauthFlowOpen {
 			var c tea.Cmd
 			m.oauthFlow, c = m.oauthFlow.Update(msg)
+			if c != nil {
+				cmds = append(cmds, c)
+			}
+		}
+		if m.paletteOpen {
+			var c tea.Cmd
+			m.palette, c = m.palette.Update(msg)
 			if c != nil {
 				cmds = append(cmds, c)
 			}

--- a/internal/tui/app_sync_spinner_test.go
+++ b/internal/tui/app_sync_spinner_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/spinner"
+)
+
+// TestSyncSpinnerTickNotBlockedByOverlays verifies that spinner.TickMsg always
+// reaches m.syncSpinner.Update even when a palette, event-form, or
+// calendar-dialog overlay is open. These overlays capture input, but a
+// spinner.TickMsg is a background animation tick — blocking it kills the
+// footer sync-spinner for the rest of that sync operation.
+//
+// Regression test for issue #348.
+func TestSyncSpinnerTickNotBlockedByOverlays(t *testing.T) {
+	// spinner.TickMsg with zero ID is accepted by any spinner (the ID check
+	// inside spinner.Update is "ID > 0 && ID != m.id", so ID==0 bypasses it).
+	tick := spinner.TickMsg{}
+
+	overlays := []struct {
+		name  string
+		setup func(*Model)
+	}{
+		{
+			name: "paletteOpen",
+			setup: func(m *Model) {
+				m.paletteOpen = true
+			},
+		},
+		{
+			name: "formOpen",
+			setup: func(m *Model) {
+				m.formOpen = true
+			},
+		},
+		{
+			name: "calendarDialogOpen",
+			setup: func(m *Model) {
+				m.calendarDialogOpen = true
+			},
+		},
+	}
+
+	for _, ov := range overlays {
+		t.Run(ov.name, func(t *testing.T) {
+			sp := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+			m := Model{
+				syncing:     true,
+				syncSpinner: sp,
+			}
+			ov.setup(&m)
+
+			_, cmd := m.Update(tick)
+			if cmd == nil {
+				t.Fatalf("%s: spinner.TickMsg broke the sync-spinner tick chain (cmd == nil)", ov.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #348

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8