### PR TITLE
fix(tui): apply rangeColor to in-range days in mini-calendar View

### DIFF
--- a/internal/tui/minicalendar.go
+++ b/internal/tui/minicalendar.go
@@ -410,14 +410,24 @@ func (m MiniMonthModel) View() string {
 				Foreground(activeTheme.Surface).
 				Bold(true).
 				Render(num)
-		case isEndpoint, isInRange:
-			// Range days share the selected-day style so the range reads as
-			// one continuous selection.
+		case isEndpoint:
+			// Endpoints use the same strong accent as the cursor so they read
+			// as the pinned start/end of the selection.
 			cell = lipgloss.NewStyle().
 				Background(activeTheme.Text).
 				Foreground(activeTheme.Surface).
 				Bold(true).
 				Render(num)
+		case isInRange:
+			// Middle days use the configured rangeColor so the interior of the
+			// selection is visually distinct from the endpoints. When rangeColor
+			// has not been set the cell is left unstyled.
+			if m.rangeColor != nil {
+				cell = lipgloss.NewStyle().
+					Background(m.rangeColor).
+					Foreground(activeTheme.SelectedText).
+					Render(num)
+			}
 		case isToday:
 			// Match the month view's today cell: red background with
 			// surface-color text. Explicit fg/bg (no Reverse) for the
@@ -440,9 +450,18 @@ func (m MiniMonthModel) View() string {
 			// continuous ribbon instead of isolated reversed cells.
 			next := cur.AddDate(0, 0, 1)
 			if next.Month() == first.Month() && m.inRangeInclusive(cur) && m.inRangeInclusive(next) {
-				b.WriteString(lipgloss.NewStyle().
-					Background(activeTheme.Text).
-					Render(" "))
+				nextEndpoint, _ := m.rangePosition(next)
+				if !isEndpoint && !nextEndpoint && m.rangeColor != nil {
+					// Gap between two middle days: use rangeColor ribbon.
+					b.WriteString(lipgloss.NewStyle().
+						Background(m.rangeColor).
+						Render(" "))
+				} else {
+					// Gap adjacent to an endpoint: use the stronger accent.
+					b.WriteString(lipgloss.NewStyle().
+						Background(activeTheme.Text).
+						Render(" "))
+				}
 			} else {
 				b.WriteString(" ")
 			}

--- a/internal/tui/minicalendar_test.go
+++ b/internal/tui/minicalendar_test.go
@@ -1,8 +1,12 @@
 package tui
 
 import (
+	"image/color"
+	"strings"
 	"testing"
 	"time"
+
+	lipgloss "charm.land/lipgloss/v2"
 )
 
 func TestMiniMonth_ArrowAdvancesMonthAtBoundary(t *testing.T) {
@@ -41,5 +45,39 @@ func TestMiniMonth_TodayKeySnapsBoth(t *testing.T) {
 	}
 	if m.displayMonth.Year() != today.Year() || m.displayMonth.Month() != today.Month() {
 		t.Errorf("displayMonth not today: got %s", m.displayMonth.Format("2006-01"))
+	}
+}
+
+// TestMiniMonth_RangeColorAppliedToMiddleDays verifies that SetRangeColor is
+// honoured by View: in-range (non-endpoint) days must render with the
+// configured rangeColor background, not with the same cursor/endpoint style.
+//
+// Before the fix, View collapsed the isEndpoint and isInRange cases into one
+// identical Background(activeTheme.Text) block and never consulted
+// m.rangeColor, so the rangeColor ANSI escape code never appeared in the
+// output. After the fix the two cases are separate and middle days use
+// m.rangeColor.
+func TestMiniMonth_RangeColorAppliedToMiddleDays(t *testing.T) {
+	// April 2026, cursor at Apr 10 (outside the range so it does not
+	// interfere with endpoint styling). Range: Apr 16 – Apr 20.
+	// Middle days Apr 17–Apr 19 must use rangeColor; endpoints Apr 16
+	// and Apr 20 use the accent style.
+	rangeColor := color.RGBA{R: 0x80, G: 0x00, B: 0xff, A: 0xff} // #8000ff – distinctive purple
+	mm := NewMiniMonthModel(time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)).
+		SetRangeColor(rangeColor).
+		SetRange(true,
+			time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC))
+
+	out := mm.View()
+
+	// Derive the expected ANSI background escape from a lipgloss dry-run so
+	// the test stays independent of the exact SGR byte sequence.
+	rangeStyled := lipgloss.NewStyle().Background(rangeColor).Render("x")
+	bgEsc := strings.SplitN(rangeStyled, "x", 2)[0]
+
+	if !strings.Contains(out, bgEsc) {
+		t.Errorf("View() does not apply rangeColor to in-range days;\n"+
+			"ANSI code %q not found in output:\n%q", bgEsc, out)
 	}
 }


### PR DESCRIPTION
Fixes #349

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8