### PR TITLE
fix(tui): preserve ANSI styling when truncateTo clips a string

### DIFF
--- a/internal/tui/text.go
+++ b/internal/tui/text.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	lipgloss "charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/douglasdemoura/chroncal/internal/textsafe"
 )
@@ -13,11 +14,8 @@ import (
 // full-width (CJK) runes and emoji count as the columns they actually occupy,
 // rather than as a single rune each. When the cut would land mid-word it backs
 // up to the nearest whitespace within a small look-back window so words aren't
-// sliced; a single long token is cut hard.
-//
-// When s fits, it is returned unchanged (styling intact). When it must be cut,
-// any ANSI styling is stripped and plain text is returned — callers that need
-// the result re-styled must do so themselves.
+// sliced; a single long token is cut hard. ANSI escape sequences are preserved
+// in the returned string regardless of whether truncation was necessary.
 //
 // This is the single truncation helper for the TUI: every column that needs to
 // fit text into a fixed width routes through here so clipping stays consistent
@@ -33,6 +31,9 @@ func truncateTo(s string, w int) string {
 		return "…"
 	}
 
+	// Detect word-boundary break positions using plain text so we don't have
+	// to count invisible ANSI bytes. The actual cut is then delegated to
+	// ansi.Truncate / ansi.Cut so the original escape sequences are preserved.
 	plain := s
 	if strings.ContainsRune(s, '\x1b') {
 		plain = stripANSI(s)
@@ -59,10 +60,11 @@ func truncateTo(s string, w int) string {
 	for i := cut; i > cut-lookback && i > 1; i-- {
 		if r[i-1] == ' ' || r[i-1] == '\t' {
 			trimmed := strings.TrimRight(string(r[:i-1]), " \t")
-			return trimmed + " …"
+			trimmedWidth := lipgloss.Width(trimmed)
+			return ansi.Truncate(s, trimmedWidth, "") + " …"
 		}
 	}
-	return string(r[:cut]) + "…"
+	return ansi.Truncate(s, w, "…")
 }
 
 // stripANSI removes terminal escape sequences from s, leaving plain text. It is

--- a/internal/tui/text_test.go
+++ b/internal/tui/text_test.go
@@ -7,6 +7,41 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 )
 
+// TestTruncateToPreservesANSIStyling reproduces issue #350: truncateTo used to
+// strip all ANSI escapes from lines it actually truncated. Both the hard-cut
+// path (no whitespace in content) and the word-boundary path must preserve the
+// original ANSI styling in the returned string.
+func TestTruncateToPreservesANSIStyling(t *testing.T) {
+	t.Run("hard_cut_preserves_styling", func(t *testing.T) {
+		// "\x1b[31m...\x1b[0m" wraps "helloworldfoobar" (16 cells) in red.
+		// w=8 forces a hard cut; the result must still contain escape bytes.
+		styled := "\x1b[31mhelloworldfoobar\x1b[0m"
+		got := truncateTo(styled, 8)
+		if !strings.ContainsRune(got, '\x1b') {
+			t.Fatalf("truncateTo stripped ANSI on hard cut: got %q", got)
+		}
+		if w := lipgloss.Width(got); w > 8 {
+			t.Fatalf("display width %d > 8: %q", w, got)
+		}
+		// The plain content must end with "…"; ANSI reset sequences may follow it.
+		if plain := stripANSI(got); !strings.HasSuffix(plain, "…") {
+			t.Fatalf("expected ellipsis in plain content: got %q (raw: %q)", plain, got)
+		}
+	})
+	t.Run("word_boundary_preserves_styling", func(t *testing.T) {
+		// "hello world" (11 cells) styled red; w=8 triggers the word-boundary
+		// lookback path. The result must still contain escape bytes.
+		styled := "\x1b[31mhello world\x1b[0m"
+		got := truncateTo(styled, 8)
+		if !strings.ContainsRune(got, '\x1b') {
+			t.Fatalf("truncateTo stripped ANSI on word-boundary cut: got %q", got)
+		}
+		if w := lipgloss.Width(got); w > 8 {
+			t.Fatalf("display width %d > 8: %q", w, got)
+		}
+	})
+}
+
 func TestTruncateToRespectsDisplayWidth(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Fixes #350

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8