### PR TITLE
fix(tui): truncate palette row shortcut at narrow widths

### DIFF
--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -479,6 +479,21 @@ func renderPaletteRow(c PaletteCommand, width int, selected bool, theme Theme) s
 	right := c.Shortcut
 	rightW := lipgloss.Width(right)
 
+	// Budget the shortcut: guarantee the title zone has at least minTitleZone
+	// cells (room for a 3-cell clipped title plus a 1-cell gap). Without this
+	// cap a wide date label (e.g. "[Event] Jan 2 15:04-18:30" = 25 cells) fills
+	// the row at minimum palette width (listW=26), leaving the title truncated
+	// but the shortcut still appended at full width — overflowing the column.
+	const minTitleZone = 4
+	if maxRightW := width - prefixW - minTitleZone; rightW > maxRightW {
+		if maxRightW <= 0 {
+			right = ""
+		} else {
+			right = truncateTo(right, maxRightW)
+		}
+		rightW = lipgloss.Width(right)
+	}
+
 	title := c.Title
 	avail := width - prefixW - rightW
 	if avail < lipgloss.Width(title)+1 {

--- a/internal/tui/palette_row_test.go
+++ b/internal/tui/palette_row_test.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+// TestRenderPaletteRowShortcutNeverOverflows reproduces issue #353:
+// the right-hand Shortcut segment was never truncated, so at minimum
+// palette width (listW=26) an event date label (~25 cells) overflowed.
+// The rendered row must never exceed the requested width.
+func TestRenderPaletteRowShortcutNeverOverflows(t *testing.T) {
+	cases := []struct {
+		name     string
+		width    int
+		title    string
+		shortcut string
+	}{
+		{
+			// Minimum palette width (listW = max(boxW-4,10) where boxW=30).
+			// "[Event] Jan 2 15:04-18:30" is 25 cells — wider than avail.
+			name:     "event_date_at_minimum_width",
+			width:    26,
+			title:    "Team standup",
+			shortcut: "[Event] Jan 2 15:04-18:30",
+		},
+		{
+			// shortcut exactly fills the non-prefix space
+			name:     "shortcut_fills_non_prefix",
+			width:    26,
+			title:    "X",
+			shortcut: strings.Repeat("A", 24), // 24 cells = width - prefixW
+		},
+		{
+			// shortcut wider than the whole row
+			name:     "shortcut_wider_than_row",
+			width:    26,
+			title:    "Title",
+			shortcut: strings.Repeat("B", 30),
+		},
+		{
+			// Normal wide palette — no truncation should happen at all
+			name:     "normal_width_no_overflow",
+			width:    60,
+			title:    "Team standup",
+			shortcut: "[Event] Jan 2 15:04-18:30",
+		},
+		{
+			// 1-cell shortcut (typical command palette entry) — must be unchanged
+			name:     "single_char_shortcut",
+			width:    26,
+			title:    "Create event",
+			shortcut: "t",
+		},
+		{
+			// No shortcut at all
+			name:     "no_shortcut",
+			width:    26,
+			title:    "Today",
+			shortcut: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := PaletteCommand{
+				Title:    tc.title,
+				Shortcut: tc.shortcut,
+			}
+			got := renderPaletteRow(cmd, tc.width, false, Theme{})
+			w := lipgloss.Width(got)
+			if w > tc.width {
+				t.Fatalf("renderPaletteRow width = %d, want ≤ %d\n  title=%q shortcut=%q row=%q",
+					w, tc.width, tc.title, tc.shortcut, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #353

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8