### PR TITLE
fix(tui): iterate all runes in FilterDigits to block mixed-content paste

### DIFF
--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -186,8 +186,15 @@ func (f *TextField) SetDisabled(v bool) {
 func (f *TextField) SetDimStyle(s lipgloss.Style) { f.dimStyle = s }
 
 // FilterDigits allows only digit characters (0-9).
+// Every rune in the key text must be a digit; a multi-rune event (e.g. a
+// paste) is rejected if any rune fails the check.
 func FilterDigits(k tea.Key) bool {
-	return k.Text == "" || unicode.IsDigit(rune(k.Text[0]))
+	for _, r := range k.Text {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tui/form_test.go
+++ b/internal/tui/form_test.go
@@ -34,6 +34,34 @@ func TestTextField_DigitsOnly(t *testing.T) {
 	assert.Equal(t, "53", f.Value())
 }
 
+func TestFilterDigits_MultiRuneText(t *testing.T) {
+	// FilterDigits must inspect every rune in a multi-character key event
+	// (e.g. a paste delivered as a single KeyPressMsg). The old implementation
+	// only checked k.Text[0] cast to rune, so a paste like "12ab" slipped
+	// through because the leading '1' is a digit.
+
+	tests := []struct {
+		text    string
+		wantVal string
+		desc    string
+	}{
+		{"12ab", "", "leading digit followed by letters must be rejected"},
+		{"1a2", "", "non-digit in the middle must be rejected"},
+		{"123", "123", "all-digit paste must be accepted"},
+		{"a12", "", "leading non-digit must be rejected"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := NewTextField("n")
+			f.SetDigitsOnly()
+			f.Focus()
+			f.Update(keyPressMsg(tc.text))
+			assert.Equal(t, tc.wantVal, f.Value(), tc.desc)
+		})
+	}
+}
+
 func TestTextField_CustomFilter(t *testing.T) {
 	f := NewTextField("hex")
 	f.SetFilter(func(k tea.Key) bool {


### PR DESCRIPTION
Fixes #357

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8