### PR TITLE
fix(cmd): treat --from/--to independently in ical export

### DIFF
--- a/cmd/chroncal/date_range_test.go
+++ b/cmd/chroncal/date_range_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	// Embed the timezone database so the re-executed helper subprocess can
+	// resolve a fixed non-UTC zone regardless of the host's tzdata.
+	_ "time/tzdata"
 )
 
 // TestParseDateRangeFromBeyondDefaultWindow guards against issue #111:
@@ -60,5 +65,128 @@ func TestParseListDateRangeWithFlagIsFinite(t *testing.T) {
 	}
 	if !to.After(from) {
 		t.Fatalf("expected to (%s) after from (%s)", to, from)
+	}
+}
+
+// TestParseExportDateBoundsOnlyFrom guards issue #358: supplying only --from
+// must leave the upper bound open (zero), not default it to from+30 days.
+func TestParseExportDateBoundsOnlyFrom(t *testing.T) {
+	from, to, err := parseExportDateBounds("2026-01-01", "")
+	if err != nil {
+		t.Fatalf("parseExportDateBounds: %v", err)
+	}
+	if from.IsZero() {
+		t.Fatal("from must not be zero when --from is given")
+	}
+	if !to.IsZero() {
+		t.Fatalf("to must be zero (unbounded) when --to is omitted, got %s", to)
+	}
+}
+
+// TestParseExportDateBoundsOnlyTo guards issue #358: supplying only --to must
+// leave the lower bound open (zero), not default it to today.
+func TestParseExportDateBoundsOnlyTo(t *testing.T) {
+	from, to, err := parseExportDateBounds("", "2026-12-31")
+	if err != nil {
+		t.Fatalf("parseExportDateBounds: %v", err)
+	}
+	if !from.IsZero() {
+		t.Fatalf("from must be zero (unbounded) when --from is omitted, got %s", from)
+	}
+	if to.IsZero() {
+		t.Fatal("to must not be zero when --to is given")
+	}
+}
+
+// TestParseExportDateBoundsBoth verifies that when both flags are present the
+// returned window is non-zero and to is strictly after from.
+func TestParseExportDateBoundsBoth(t *testing.T) {
+	from, to, err := parseExportDateBounds("2026-04-01", "2026-04-30")
+	if err != nil {
+		t.Fatalf("parseExportDateBounds: %v", err)
+	}
+	if from.IsZero() || to.IsZero() {
+		t.Fatalf("both bounds must be non-zero, got from=%s to=%s", from, to)
+	}
+	if !to.After(from) {
+		t.Fatalf("to (%s) must be after from (%s)", to, from)
+	}
+}
+
+// TestParseExportDateBoundsNeither verifies that with no flags both bounds are
+// zero (unbounded).
+func TestParseExportDateBoundsNeither(t *testing.T) {
+	from, to, err := parseExportDateBounds("", "")
+	if err != nil {
+		t.Fatalf("parseExportDateBounds: %v", err)
+	}
+	if !from.IsZero() || !to.IsZero() {
+		t.Fatalf("both bounds must be zero when no flags given, got from=%s to=%s", from, to)
+	}
+}
+
+// TestICalExportOnlyFromIsUnboundedAbove guards issue #358: when only --from is
+// given the export must include events beyond from+30 days (no silent upper
+// bound). Before the fix, parseDateRange silently set to=from+30.
+func TestICalExportOnlyFromIsUnboundedAbove(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	// This event starts more than 30 days after the --from date below.
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Far future event",
+		"--calendar", "Work",
+		"--date", "2026-09-01",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t, "ical", "export",
+		"--calendar", "Work",
+		"--from", "2026-06-01")
+	if err != nil {
+		t.Fatalf("ical export: %v", err)
+	}
+
+	if !strings.Contains(stdout, "Far future event") {
+		t.Fatalf("ical export --from 2026-06-01 should include event on 2026-09-01 "+
+			"(beyond the old 30-day default window) but did not\noutput:\n%s", stdout)
+	}
+}
+
+// TestICalExportOnlyToIsUnboundedBelow guards issue #358: when only --to is
+// given the export must include events before today (no silent lower bound at
+// today). Before the fix, parseDateRange silently set from=today.
+func TestICalExportOnlyToIsUnboundedBelow(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	// This event is well in the past.
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Past event",
+		"--calendar", "Work",
+		"--date", "2020-01-01",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t, "ical", "export",
+		"--calendar", "Work",
+		"--to", "2026-12-31")
+	if err != nil {
+		t.Fatalf("ical export: %v", err)
+	}
+
+	if !strings.Contains(stdout, "Past event") {
+		t.Fatalf("ical export --to 2026-12-31 should include event on 2020-01-01 "+
+			"(before the old today lower bound) but did not\noutput:\n%s", stdout)
 	}
 }

--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -317,17 +317,26 @@ to stdout.`,
 				}
 			}
 
-			// Parse date range for event filtering
+			// Parse date bounds for event filtering. Use parseExportDateBounds
+			// (not parseDateRange) so each flag is treated independently:
+			// omitting --from leaves the lower bound open and omitting --to
+			// leaves the upper bound open. parseDateRange derives defaults
+			// (today / from+30d) that are correct for the bounded list view but
+			// silently clip the export window when only one flag is given
+			// (issue #358).
+			fromT, toT, derr := parseExportDateBounds(fromStr, toStr)
+			if derr != nil {
+				return derr
+			}
+			// Normalize to UTC so the RFC3339 bounds compare lexically against
+			// UTC-stored start/end strings (issue #305). Zero time → empty
+			// string → no constraint on that side.
 			var fromTime, toTime string
-			if fromStr != "" || toStr != "" {
-				from, to, derr := parseDateRange(fromStr, toStr)
-				if derr != nil {
-					return derr
-				}
-				// Normalize to UTC so the RFC3339 bounds compare lexically
-				// against UTC-stored start/end strings (issue #305).
-				fromTime = from.UTC().Format(time.RFC3339)
-				toTime = to.UTC().Format(time.RFC3339)
+			if !fromT.IsZero() {
+				fromTime = fromT.UTC().Format(time.RFC3339)
+			}
+			if !toT.IsZero() {
+				toTime = toT.UTC().Format(time.RFC3339)
 			}
 
 			// Load events
@@ -348,13 +357,12 @@ to stdout.`,
 				// start_time predates the window are missed by the SQL
 				// filter.  Include them if any instance falls in range.
 				if fromStr != "" || toStr != "" {
-					from, to, _ := parseDateRange(fromStr, toStr)
 					extra, eerr := a.Recurrences.ExportExpandedByDateRange(ctx, recurrence.ExportFilterParams{
 						CalendarID: calID,
 						Category:   category,
 						Status:     status,
-						From:       from,
-						To:         to,
+						From:       fromT,
+						To:         toT,
 					})
 					if eerr == nil {
 						seen := make(map[int64]bool, len(events))

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -398,6 +398,33 @@ func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
 	return from, to, nil
 }
 
+// parseExportDateBounds parses the optional --from/--to flags for export
+// commands, treating each bound independently. An omitted bound returns a zero
+// time.Time (open/unbounded), so only --from or only --to is honoured without
+// silently deriving the missing end from today or from+30 days. This corrects
+// issue #358 where the export command shared parseDateRange (designed for the
+// "today..+30d" list default) and silently clipped the window whenever exactly
+// one flag was given.
+func parseExportDateBounds(fromStr, toStr string) (time.Time, time.Time, error) {
+	var from, to time.Time
+	if fromStr != "" {
+		var err error
+		from, err = parseCLIDate("from", fromStr, time.Local)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
+	}
+	if toStr != "" {
+		var err error
+		to, err = parseCLIDate("to", toStr, time.Local)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
+		to = to.AddDate(0, 0, 1) // half-open: include the entire end day
+	}
+	return from, to, nil
+}
+
 // parseListDateRange parses the optional --from/--to window for the
 // retrospective `todo list` / `journal list` views. With no flags it returns
 // an open (zero) range so overdue todos and past journal entries stay visible


### PR DESCRIPTION
Fixes #358

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8