### PR TITLE
fix(cmd): sync run exits non-zero when calendars report per-phase errors

### DIFF
--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -367,6 +367,10 @@ This does not delete your local calendars or entries.`,
 // using the active --output format. A run with no connected calendars
 // reports synced=0 rather than producing empty stdout so an agent can
 // distinguish "nothing to do" from "command crashed."
+//
+// Returns a non-nil error when any calendar reported per-phase sync errors
+// so that `sync run` exits non-zero, consistent with `ical import` and
+// `sync reset` (issue #359).
 func renderSyncRunResults(cmd *cobra.Command, results []*syncPkg.SyncResult, calNames map[int64]string) error {
 	w := cmd.OutOrStdout()
 
@@ -389,21 +393,32 @@ func renderSyncRunResults(cmd *cobra.Command, results []*syncPkg.SyncResult, cal
 				"errors":        errMsgs,
 			})
 		}
-		return printOutput(w, map[string]any{
+		if err := printOutput(w, map[string]any{
 			"synced":  len(results),
 			"errors":  totalErrors,
 			"results": items,
-		})
+		}); err != nil {
+			return err
+		}
+		if totalErrors > 0 {
+			return &cliError{Code: "error", Msg: fmt.Sprintf("sync run completed with %d error(s)", totalErrors)}
+		}
+		return nil
 	}
 
 	if len(results) == 0 {
 		fmt.Fprintln(w, "No connected calendars. Use 'chroncal calendar update <name> --remote-url ...' to set up sync.")
 		return nil
 	}
+	totalErrors := 0
 	for _, r := range results {
 		writeSyncResult(w, cmd.ErrOrStderr(), r)
+		totalErrors += len(r.Errors)
 	}
 	fmt.Fprintf(w, "Synced %d calendar(s).\n", len(results))
+	if totalErrors > 0 {
+		return &cliError{Code: "error", Msg: fmt.Sprintf("sync run completed with %d error(s)", totalErrors)}
+	}
 	return nil
 }
 

--- a/cmd/chroncal/sync_run_exit_test.go
+++ b/cmd/chroncal/sync_run_exit_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	syncPkg "github.com/douglasdemoura/chroncal/internal/sync"
+)
+
+// TestRenderSyncRunResultsExitsNonZeroOnPerPhaseErrors guards issue #359:
+// renderSyncRunResults must return a non-nil error when any SyncResult
+// carries per-phase errors so that `sync run` exits non-zero and scripts
+// can detect a partial sync failure via exit code.
+//
+// Consistent with `ical import` (non-zero when failed > 0) and
+// `sync reset` (non-zero when failed > 0).
+func TestRenderSyncRunResultsExitsNonZeroOnPerPhaseErrors(t *testing.T) {
+	for _, format := range []string{"text", "json"} {
+		t.Run(format, func(t *testing.T) {
+			orig := outputFmt
+			outputFmt = format
+			defer func() { outputFmt = orig }()
+
+			results := []*syncPkg.SyncResult{
+				{
+					CalendarID: 1,
+					Pushed:     2,
+					Pulled:     1,
+					Errors:     []error{fmt.Errorf("push phase: 503 Service Unavailable")},
+				},
+			}
+
+			cmd := &cobra.Command{}
+			var out, errOut bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&errOut)
+
+			err := renderSyncRunResults(cmd, results, map[int64]string{1: "Work"})
+			if err == nil {
+				t.Fatalf("renderSyncRunResults(%s) returned nil; want non-nil error when SyncResult.Errors is non-empty", format)
+			}
+		})
+	}
+}
+
+// TestRenderSyncRunResultsExitsZeroOnSuccess guards that renderSyncRunResults
+// still returns nil when no per-phase errors occurred.
+func TestRenderSyncRunResultsExitsZeroOnSuccess(t *testing.T) {
+	for _, format := range []string{"text", "json"} {
+		t.Run(format, func(t *testing.T) {
+			orig := outputFmt
+			outputFmt = format
+			defer func() { outputFmt = orig }()
+
+			results := []*syncPkg.SyncResult{
+				{CalendarID: 1, Pushed: 2, Pulled: 1},
+			}
+
+			cmd := &cobra.Command{}
+			var out, errOut bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&errOut)
+
+			err := renderSyncRunResults(cmd, results, map[int64]string{1: "Work"})
+			if err != nil {
+				t.Fatalf("renderSyncRunResults(%s) returned %v; want nil when no errors", format, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #359

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8