### PR TITLE
fix(cmd): collect bearer token before storing calendar credential

### DIFF
--- a/cmd/chroncal/calendar_cli_test.go
+++ b/cmd/chroncal/calendar_cli_test.go
@@ -53,6 +53,7 @@ func TestCalendarCreateCreatesLocalOnlyCalendar(t *testing.T) {
 
 func TestCalendarCreateCanConnectRemoteCalendar(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "test-token")
 
 	_, _, err := runChroncalCommand(t,
 		"calendar", "create", "Work",
@@ -96,6 +97,7 @@ func TestCalendarCreateCanConnectRemoteCalendar(t *testing.T) {
 
 func TestCalendarUpdateCanConnectRemoteCalendar(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "test-token")
 
 	_, _, err := runChroncalCommand(t, "calendar", "create", "Work")
 	if err != nil {

--- a/cmd/chroncal/calendar_remote.go
+++ b/cmd/chroncal/calendar_remote.go
@@ -106,8 +106,14 @@ func deleteCalendarWithCleanup(ctx context.Context, a *app.App, id, newDefaultID
 
 func buildCalendarCredential(ctx context.Context, flags calendarRemoteFlags) (auth.Credential, error) {
 	switch normalizeAuthType(flags.AuthType) {
-	case "", "bearer":
+	case "":
 		return auth.Credential{Username: flags.Username}, nil
+	case "bearer":
+		token, err := readBearerToken()
+		if err != nil {
+			return auth.Credential{}, err
+		}
+		return auth.Credential{Username: flags.Username, AccessToken: token}, nil
 	case "basic":
 		fmt.Print("Password: ")
 		passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
@@ -140,6 +146,32 @@ func buildCalendarCredential(ctx context.Context, flags calendarRemoteFlags) (au
 
 func normalizeAuthType(authType string) string {
 	return calendarpkg.NormalizeAuthType(authType)
+}
+
+// readBearerToken obtains the bearer token for --auth bearer. We never accept
+// it as a CLI flag to avoid exposing secrets in /proc/<pid>/cmdline and shell
+// history. Sources, in order:
+//
+//  1. CHRONCAL_BEARER_TOKEN env var (handy for scripted/CI setup).
+//  2. Interactive prompt via terminal (echo disabled), matching basic-auth UX.
+func readBearerToken() (string, error) {
+	if s := strings.TrimSpace(os.Getenv("CHRONCAL_BEARER_TOKEN")); s != "" {
+		return s, nil
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", fmt.Errorf("a bearer token is required: set CHRONCAL_BEARER_TOKEN or run interactively")
+	}
+	fmt.Print("Bearer token: ")
+	tokenBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if err != nil {
+		return "", fmt.Errorf("read bearer token: %w", err)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+	if token == "" {
+		return "", fmt.Errorf("bearer token is required")
+	}
+	return token, nil
 }
 
 // readGoogleClientSecret obtains the Desktop OAuth client secret. Google's

--- a/cmd/chroncal/calendar_remote_test.go
+++ b/cmd/chroncal/calendar_remote_test.go
@@ -10,6 +10,53 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/auth"
 )
 
+// TestBuildCalendarCredential_BearerReadsFromEnvVar verifies that --auth bearer
+// picks up a token from CHRONCAL_BEARER_TOKEN and stores it as AccessToken.
+// This is the regression test for issue #360: previously bearer was grouped with
+// the empty-auth branch and returned a Credential with no token, causing every
+// subsequent sync call to fail with "credential has no password or access token".
+func TestBuildCalendarCredential_BearerReadsFromEnvVar(t *testing.T) {
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "test-token-abc123")
+
+	cred, err := buildCalendarCredential(context.Background(), calendarRemoteFlags{
+		RemoteURL: "https://cal.example.com/dav/calendars/work/",
+		Username:  "alice",
+		AuthType:  "bearer",
+	})
+	if err != nil {
+		t.Fatalf("buildCalendarCredential: %v", err)
+	}
+	if cred.AccessToken != "test-token-abc123" {
+		t.Fatalf("AccessToken = %q, want %q", cred.AccessToken, "test-token-abc123")
+	}
+	if cred.Username != "alice" {
+		t.Fatalf("Username = %q, want %q", cred.Username, "alice")
+	}
+	// Password must not be set — bearer tokens are not basic-auth passwords.
+	if cred.Password != "" {
+		t.Fatalf("Password = %q, want empty for bearer auth", cred.Password)
+	}
+}
+
+// TestBuildCalendarCredential_BearerRequiresToken verifies that --auth bearer
+// without a token source returns a clear error rather than silently producing a
+// non-functional credential.
+func TestBuildCalendarCredential_BearerRequiresToken(t *testing.T) {
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "")
+
+	_, err := buildCalendarCredential(context.Background(), calendarRemoteFlags{
+		RemoteURL: "https://cal.example.com/dav/calendars/work/",
+		Username:  "alice",
+		AuthType:  "bearer",
+	})
+	if err == nil {
+		t.Fatal("buildCalendarCredential should return an error when no bearer token is available")
+	}
+	if !strings.Contains(err.Error(), "bearer") && !strings.Contains(err.Error(), "token") {
+		t.Fatalf("error = %v, want a message mentioning bearer or token", err)
+	}
+}
+
 type failingCredentialStore struct {
 	setErr error
 }
@@ -45,6 +92,7 @@ func (s *recordingCredentialStore) Delete(accountID int64) error {
 
 func TestConnectCalendarRemote_RollsBackNewLinkWhenCredentialStoreFails(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "test-token")
 
 	a, err := app.New(dbPath)
 	if err != nil {
@@ -92,6 +140,7 @@ func TestConnectCalendarRemote_RollsBackNewLinkWhenCredentialStoreFails(t *testi
 
 func TestConnectCalendarRemote_RollsBackExistingHiddenAccountUpdateWhenCredentialStoreFails(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "test-token")
 
 	a, err := app.New(dbPath)
 	if err != nil {


### PR DESCRIPTION
Fixes #360

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8