### PR TITLE
fix(cmd): reject --completed and --incomplete together in todo search

### DIFF
--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -192,6 +192,7 @@ and categories.`,
 	cmd.Flags().StringVar(&status, "status", "", "status filter (NEEDS-ACTION, IN-PROCESS, COMPLETED, CANCELLED)")
 	cmd.Flags().BoolVar(&completed, "completed", false, "show only completed todos")
 	cmd.Flags().BoolVar(&incomplete, "incomplete", false, "show only incomplete todos")
+	mutuallyExclusive(cmd, "completed", "incomplete")
 	return cmd
 }
 

--- a/cmd/chroncal/todo_cli_test.go
+++ b/cmd/chroncal/todo_cli_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTodoSearchCompletedAndIncompleteAreMutuallyExclusive reproduces issue
+// #361: passing both --completed and --incomplete to `todo search` was
+// silently accepted. The second flag was ignored rather than an error being
+// returned, leaving the user with misleading results.
+func TestTodoSearchCompletedAndIncompleteAreMutuallyExclusive(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	_, _, err := runChroncalCommand(t,
+		"todo", "search", "anything",
+		"--completed", "--incomplete",
+	)
+	if err == nil {
+		t.Fatal("todo search --completed --incomplete: expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("todo search --completed --incomplete: error = %q, want it to mention %q",
+			err.Error(), "mutually exclusive")
+	}
+}


### PR DESCRIPTION
Fixes #361

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8