### PR TITLE
fix(ical): suppress lone DURATION in VALARM when Repeat is zero

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -689,18 +689,16 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	if alarm.Summary != "" {
 		valarm.Props.SetText(ical.PropSummary, alarm.Summary)
 	}
-	if alarm.Duration != "" {
+	// RFC 5545 §3.8.6.3: DURATION and REPEAT MUST appear together; emitting
+	// either one without the other yields an invalid VALARM that strict CalDAV
+	// servers (e.g. Google) reject with HTTP 400, blocking the whole resource.
+	if alarm.Repeat > 0 && alarm.Duration != "" {
 		p := &ical.Prop{Name: ical.PropDuration}
 		p.Value = alarm.Duration
 		valarm.Props.Set(p)
-	}
-	// RFC 5545 §3.8.6.2: REPEAT MUST be paired with DURATION. Emitting a
-	// bare REPEAT yields an invalid VALARM that strict CalDAV servers
-	// (e.g. Google) reject with HTTP 400, blocking the whole resource.
-	if alarm.Repeat > 0 && alarm.Duration != "" {
-		p := &ical.Prop{Name: "REPEAT"}
-		p.Value = strconv.Itoa(alarm.Repeat)
-		valarm.Props.Set(p)
+		p2 := &ical.Prop{Name: "REPEAT"}
+		p2.Value = strconv.Itoa(alarm.Repeat)
+		valarm.Props.Set(p2)
 	}
 	// ACKNOWLEDGED (RFC 9074) — round-trip only.
 	if alarm.Acknowledged != "" {

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -492,6 +492,34 @@ func TestExport_AlarmRepeatWithDuration(t *testing.T) {
 	}
 }
 
+// TestExport_AlarmDurationWithoutRepeat guards RFC 5545 §3.8.6.3: DURATION
+// MUST be paired with REPEAT. An alarm with Duration set but Repeat == 0 must
+// not emit a bare DURATION, which strict CalDAV servers (e.g. Google) reject
+// with HTTP 400, blocking the whole resource. This is the inverse of the bug
+// fixed for bare REPEAT (issue #363).
+func TestExport_AlarmDurationWithoutRepeat(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{{
+		UID:       "alarm-duration-no-repeat",
+		Title:     "Alarm Event",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Alarms: []model.Alarm{
+			{Action: "DISPLAY", TriggerValue: "-PT15M", Description: "no repeat count", Duration: "PT5M"},
+		},
+	}}
+
+	data, _ := ExportEvents(events, "")
+	ics := string(data)
+	if strings.Contains(ics, "\nDURATION:") {
+		t.Errorf("emitted DURATION without REPEAT (non-conformant per RFC 5545 §3.8.6.3):\n%s", ics)
+	}
+}
+
 func TestExport_EventWithAttendees(t *testing.T) {
 	t.Parallel()
 	events := []event.Event{{


### PR DESCRIPTION
Fixes #363

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8