### PR TITLE
fix(ical): timed VEVENT with no DTEND/DURATION imports as zero duration

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -385,11 +385,17 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 			durationValue = prop.Value
 			endTime = addDuration(startTime, prop.Value)
 			explicitEnd = true
-		} else {
-			// No DURATION, or a malformed one (go-ical stores the raw value
-			// without validating). Fall back to a 1h span and drop the bad
-			// value so it is neither persisted nor re-exported.
+		} else if prop != nil {
+			// Malformed DURATION (go-ical stores the raw value without validating).
+			// Fall back to a 1h span and drop the bad value so it is neither
+			// persisted nor re-exported.
 			endTime = startTime.Add(time.Hour)
+		} else {
+			// RFC 5545 §3.6.1: a VEVENT with DTSTART as DATE-TIME and no
+			// DTEND/DURATION is instantaneous (zero duration). The all-day
+			// case (VALUE=DATE) is handled below to apply the implicit one-day
+			// span instead.
+			endTime = startTime
 		}
 	} else {
 		explicitEnd = true
@@ -411,9 +417,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 				endTime = time.Date(endTime.Year(), endTime.Month(), endTime.Day(), 0, 0, 0, 0, time.UTC)
 			} else {
 				// RFC 5545 §3.6.1: an all-day VEVENT with no DTEND/DURATION has
-				// an implicit duration of one day. The timed +1h default above
-				// would otherwise be truncated back to startTime, storing a
-				// zero-length event.
+				// an implicit duration of one day.
 				endTime = startTime.AddDate(0, 0, 1)
 			}
 		}

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -637,6 +637,44 @@ END:VCALENDAR`
 	}
 }
 
+// Regression test for issue #364: a timed (DATE-TIME) VEVENT with DTSTART but
+// no DTEND and no DURATION property must be imported as a zero-duration
+// (instantaneous) event, not a fabricated 1-hour block.
+// RFC 5545 §3.6.1: "If neither the 'dtend' nor the 'duration' property is not
+// present, then the event has a zero duration."
+func TestImport_TimedEvent_NoDTEND_NoDuration_ZeroLength(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:no-end-timed@example.com\r\n" +
+		"DTSTART:20260415T140000Z\r\n" +
+		"SUMMARY:Timed, no end\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	evt := result.Events[0]
+	if evt.AllDay {
+		t.Error("AllDay = true, want false")
+	}
+	wantTime := time.Date(2026, 4, 15, 14, 0, 0, 0, time.UTC)
+	if !evt.StartTime.Equal(wantTime) {
+		t.Errorf("StartTime = %v, want %v", evt.StartTime, wantTime)
+	}
+	// RFC 5545 §3.6.1: DTSTART DATE-TIME with no DTEND/DURATION → zero duration.
+	if !evt.EndTime.Equal(evt.StartTime) {
+		t.Errorf("EndTime = %v, want %v (zero duration per RFC 5545 §3.6.1)", evt.EndTime, evt.StartTime)
+	}
+}
+
 func TestImport_MalformedDuration(t *testing.T) {
 	t.Parallel()
 	ics := `BEGIN:VCALENDAR


### PR DESCRIPTION
Fixes #364

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8