### PR TITLE
fix(alarm): suppress overridden master slots in todo alarm check

### DIFF
--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -163,6 +163,11 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			return missed, nil, err
 		}
 
+		// Same override-suppression as CheckTodos: skip master instances for
+		// slots that have an override row so we don't report the master's
+		// trigger as missed when the override fired at a rescheduled time.
+		overrideKeys := buildOverrideSuppressionKeys(rows)
+
 		for _, row := range rows {
 			td := todoFromRow(row)
 			if td.Status == "COMPLETED" || td.Status == "CANCELLED" {
@@ -175,6 +180,17 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			}
 
 			instances := recurrence.ExpandTodo(td, windowStart, windowEnd)
+			if td.RecurrenceRule != "" && td.RecurrenceID == "" {
+				if suppressed := overrideKeys[td.UID]; len(suppressed) > 0 {
+					kept := instances[:0]
+					for _, inst := range instances {
+						if _, ok := suppressed[inst.InstanceTime.UTC().Format(time.RFC3339)]; !ok {
+							kept = append(kept, inst)
+						}
+					}
+					instances = kept
+				}
+			}
 			for _, inst := range instances {
 				for _, a := range alarms {
 					triggerAt, err := computeTodoTriggerTimeForInstance(inst, a)

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/recurrence"
 	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
@@ -61,6 +62,12 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 		return nil, fmt.Errorf("list todos: %w", err)
 	}
 
+	// Build per-UID suppression sets from override rows so the master's RRULE
+	// expansion skips any slot that has been overridden. The override row itself
+	// is still iterated below and produces the correct single instance at its own
+	// (possibly rescheduled) time with its own alarm definition.
+	overrideKeys := buildOverrideSuppressionKeys(rows)
+
 	var due []TodoDueAlarm
 
 	for _, row := range rows {
@@ -78,6 +85,21 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 
 		// Expand recurring instances (returns single instance for non-recurring)
 		instances := recurrence.ExpandTodo(t, windowStart, windowEnd)
+
+		// For recurring masters, suppress occurrences that have been overridden.
+		// Without this, the master fires its alarm for the overridden slot while
+		// the override row also fires its own alarm — causing a duplicate.
+		if t.RecurrenceRule != "" && t.RecurrenceID == "" {
+			if suppressed := overrideKeys[t.UID]; len(suppressed) > 0 {
+				kept := instances[:0]
+				for _, inst := range instances {
+					if _, ok := suppressed[inst.InstanceTime.UTC().Format(time.RFC3339)]; !ok {
+						kept = append(kept, inst)
+					}
+				}
+				instances = kept
+			}
+		}
 
 		for _, inst := range instances {
 			for _, a := range alarms {
@@ -143,6 +165,32 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 	due = append(due, snoozed...)
 
 	return due, nil
+}
+
+// buildOverrideSuppressionKeys returns a per-UID set of canonical instance-time
+// keys (UTC RFC 3339) derived from override rows in the full todo list. When
+// expanding a recurring master, any instance whose time is in the set for its
+// UID must be skipped: the slot has been overridden and the override row itself
+// carries the alarm definition to fire at its own (possibly rescheduled) time.
+// A malformed recurrence_id is silently skipped — the master will fire for
+// that slot, which is preferable to silently dropping a legitimate alarm.
+func buildOverrideSuppressionKeys(rows []storage.Todo) map[string]map[string]struct{} {
+	m := make(map[string]map[string]struct{})
+	for _, row := range rows {
+		if row.RecurrenceID == "" {
+			continue
+		}
+		t, err := timeutil.ParseRecurrenceID(row.RecurrenceID)
+		if err != nil {
+			continue
+		}
+		key := t.UTC().Format(time.RFC3339)
+		if m[row.Uid] == nil {
+			m[row.Uid] = make(map[string]struct{})
+		}
+		m[row.Uid][key] = struct{}{}
+	}
+	return m
 }
 
 // todoFromRow converts a storage view row to a todo.Todo

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -469,6 +469,83 @@ func TestListExpiredTodoSnoozed_SkipsDismissed(t *testing.T) {
 	}
 }
 
+// TestCheckTodos_OverrideAwareness is the regression test for issue #366:
+// when a recurring todo has an override (a row with the same UID but a
+// non-empty recurrence_id), CheckTodos must not fire the master's alarm for
+// the overridden slot in addition to the override's own alarm.
+//
+// Without the fix, ExpandTodo on the master still produces the overridden
+// occurrence (no EXDATE is set when a CalDAV override arrives), while
+// ExpandTodo on the override row emits a single instance at the same time.
+// Because the master and override have distinct alarm_ids, the unique
+// (alarm_id, trigger_at) state index does not prevent the double firing.
+func TestCheckTodos_OverrideAwareness(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	ctx := context.Background()
+	todoSvc := todo.NewService(db, q)
+
+	// Master: daily recurring, first occurrence Apr 1 17:00 UTC.
+	firstOcc := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	master, err := todoSvc.UpsertByUID(ctx, todo.UpsertParams{
+		UID:            "override-alarm-test",
+		CalendarID:     1,
+		Summary:        "Daily Stand-up",
+		DueDate:        firstOcc.Format(time.RFC3339),
+		RecurrenceRule: "FREQ=DAILY",
+	})
+	if err != nil {
+		t.Fatalf("upsert master todo: %v", err)
+	}
+	if err := todoSvc.ReplaceAlarms(ctx, master.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT1H"},
+	}); err != nil {
+		t.Fatalf("replace master alarms: %v", err)
+	}
+
+	// Override for the Apr 2 occurrence at the same due time, different summary.
+	// No EXDATE is added to the master — matching CalDAV sync behaviour where the
+	// server pushes an override without also updating the master's EXDATE list.
+	apr2 := time.Date(2026, 4, 2, 17, 0, 0, 0, time.UTC)
+	override, err := todoSvc.UpsertByUID(ctx, todo.UpsertParams{
+		UID:          "override-alarm-test",
+		CalendarID:   1,
+		Summary:      "Daily Stand-up (rescheduled)",
+		DueDate:      apr2.Format(time.RFC3339),
+		RecurrenceID: apr2.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("upsert override todo: %v", err)
+	}
+	if err := todoSvc.ReplaceAlarms(ctx, override.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT1H"},
+	}); err != nil {
+		t.Fatalf("replace override alarms: %v", err)
+	}
+
+	// Check at Apr 2 17:30 UTC.  The Apr 2 16:00 trigger is 1.5 h old, well
+	// within StaleThreshold=24 h.  The master expands Apr 2 via RRULE (no EXDATE),
+	// so without the fix both the master alarm and the override alarm fire — 2 due
+	// alarms.  With the fix the master's Apr 2 slot is suppressed and only the
+	// override's alarm fires — 1 due alarm.
+	checkTime := time.Date(2026, 4, 2, 17, 30, 0, 0, time.UTC)
+	todoAlarmSvc := NewTodoService(db, q, todoSvc)
+	due, err := todoAlarmSvc.CheckTodos(ctx, checkTime)
+	if err != nil {
+		t.Fatalf("check todos: %v", err)
+	}
+
+	if len(due) != 1 {
+		t.Errorf("CheckTodos = %d due alarms, want 1; master must not fire for overridden slot (issue #366)", len(due))
+		for i, d := range due {
+			t.Logf("  [%d] todo_id=%d summary=%q trigger=%v", i, d.Todo.ID, d.Todo.Summary, d.TriggerAt)
+		}
+		return
+	}
+	if due[0].Todo.ID != override.ID {
+		t.Errorf("due alarm is for todo ID %d (master=%d), want override ID %d", due[0].Todo.ID, master.ID, override.ID)
+	}
+}
+
 // TestCheckTodos_FiresLongLeadTimeAlarm guards issue #98 on the todo path: a
 // todo due 7 days out with a "1 week before" alarm must fire now even though
 // the todo instance is far past the base forward window. Uses the real todo


### PR DESCRIPTION
Fixes #366

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8