### PR TITLE
fix(textsafe): strip Unicode Cf bidi/format controls in Display

### DIFF
--- a/internal/textsafe/textsafe.go
+++ b/internal/textsafe/textsafe.go
@@ -60,9 +60,10 @@ func StripEscapes(s string) string {
 	return b.String()
 }
 
-// Display removes terminal escape sequences and collapses control characters
-// into safe plain text for human-facing terminal, notification, and email
-// rendering.
+// Display removes terminal escape sequences, drops Unicode control characters
+// (Cc) and format/bidi controls (Cf), and collapses whitespace into safe plain
+// text for human-facing terminal, notification, and email rendering.  Stripping
+// Cf prevents Trojan-Source spoofing via directional overrides such as U+202E.
 func Display(s string) string {
 	s = StripEscapes(s)
 
@@ -76,8 +77,12 @@ func Display(s string) string {
 		switch {
 		case r == '\r' || r == '\n' || r == '\t':
 			b.WriteByte(' ')
-		case unicode.IsControl(r):
-			// Drop remaining control characters entirely.
+		case unicode.IsControl(r) || unicode.Is(unicode.Cf, r):
+			// Drop control characters (Cc) and Unicode format/bidi controls (Cf),
+			// which include directional overrides/isolates, zero-width spaces, and
+			// BOM.  Cf characters are not matched by IsControl and would otherwise
+			// pass through unchanged, enabling Trojan-Source spoofing
+			// (CVE-2021-42574).
 		default:
 			b.WriteRune(r)
 		}

--- a/internal/textsafe/textsafe_test.go
+++ b/internal/textsafe/textsafe_test.go
@@ -43,3 +43,53 @@ func TestDisplayStripsEscapesAndCollapsesWhitespace(t *testing.T) {
 		})
 	}
 }
+
+// TestDisplayStripsBidiFormatControls verifies that Display removes Unicode
+// category Cf characters (bidi overrides/isolates, zero-width spaces, BOM) to
+// prevent Trojan-Source spoofing (CVE-2021-42574).  unicode.IsControl only
+// covers category Cc; Cf characters were previously written through unchanged.
+func TestDisplayStripsBidiFormatControls(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// U+202E RIGHT-TO-LEFT OVERRIDE — canonical Trojan Source char.
+		{"RLO stripped", "hello‮world", "helloworld"},
+		// U+202A LEFT-TO-RIGHT EMBEDDING.
+		{"LRE stripped", "‪hello‬", "hello"},
+		// U+202B RIGHT-TO-LEFT EMBEDDING.
+		{"RLE stripped", "‫hello‬", "hello"},
+		// U+202D LEFT-TO-RIGHT OVERRIDE.
+		{"LRO stripped", "‭hello", "hello"},
+		// U+202C POP DIRECTIONAL FORMATTING (closes embeddings/overrides).
+		{"PDF stripped", "ab‬cd", "abcd"},
+		// U+200E LEFT-TO-RIGHT MARK.
+		{"LRM stripped", "a‎b", "ab"},
+		// U+200F RIGHT-TO-LEFT MARK.
+		{"RLM stripped", "a‏b", "ab"},
+		// U+200B ZERO WIDTH SPACE.
+		{"ZWSP stripped", "a​b", "ab"},
+		// U+FEFF BOM / ZERO WIDTH NO-BREAK SPACE.
+		{"BOM stripped", "\uFEFFfoo", "foo"},
+		// U+2066 LEFT-TO-RIGHT ISOLATE / U+2069 POP DIRECTIONAL ISOLATE.
+		{"LRI and PDI stripped", "⁦hello⁩", "hello"},
+		// U+2067 RIGHT-TO-LEFT ISOLATE.
+		{"RLI stripped", "⁧hello⁩", "hello"},
+		// U+2068 FIRST STRONG ISOLATE.
+		{"FSI stripped", "⁨hello⁩", "hello"},
+		// U+2069 POP DIRECTIONAL ISOLATE standalone.
+		{"PDI stripped", "a⁩b", "ab"},
+		// Combination that would spoof a filename extension in terminals.
+		{"trojan-source filename spoof", "evil‮⁦gnp.exe", "evilgnp.exe"},
+		// Legitimate accented/non-ASCII text must not be touched.
+		{"plain text preserved", "Meeting with Ángela at café", "Meeting with Ángela at café"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Display(tc.in); got != tc.want {
+				t.Fatalf("Display(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #369

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8