### PR TITLE
fix(notify): support implicit-TLS SMTP (SMTPS / port 465)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,17 @@ type SMTPConfig struct {
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
 	From     string `mapstructure:"from"`
+	// TLSMode controls how TLS is established for the SMTP connection.
+	// Valid values:
+	//   ""           – auto-detect: port 465 uses implicit TLS (SMTPS), all
+	//                  other ports use STARTTLS via smtp.SendMail.
+	//   "implicit"   – always use implicit TLS (tls.Dial before the SMTP
+	//                  handshake); required for SMTPS / port 465.
+	//   "starttls"   – always use STARTTLS (smtp.SendMail); explicit override
+	//                  that disables the port-465 auto-detection.
+	//   "none"       – skip implicit TLS; delegates to smtp.SendMail which
+	//                  still negotiates STARTTLS when the server offers it.
+	TLSMode string `mapstructure:"tls"`
 }
 
 type SyncConfig struct {
@@ -126,6 +137,7 @@ func newViper() *viper.Viper {
 	v.BindEnv("smtp.username")
 	v.BindEnv("smtp.password")
 	v.BindEnv("smtp.from")
+	v.BindEnv("smtp.tls")
 	v.BindEnv("sync.interval")
 	v.BindEnv("sync.conflict_strategy")
 	v.BindEnv("security.allow_unsafe_alarm_audio_attach")

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -2,8 +2,10 @@ package notify
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"mime"
+	"net"
 	"net/mail"
 	"net/smtp"
 	"net/url"
@@ -161,6 +163,70 @@ func playSystemSound() error {
 	}
 }
 
+// smtpsPort is the IANA-assigned port for SMTPS (implicit-TLS submission).
+const smtpsPort = 465
+
+// dialTLS opens a TLS connection for SMTPS (implicit TLS). Tests may replace
+// this to inject a custom *tls.Config, e.g. one with InsecureSkipVerify set.
+var dialTLS = func(addr, serverName string) (net.Conn, error) {
+	return tls.Dial("tcp", addr, &tls.Config{ServerName: serverName})
+}
+
+// useImplicitTLS reports whether smtpCfg requires implicit TLS (SMTPS).
+// An explicit TLSMode always wins; when TLSMode is empty the port decides.
+func useImplicitTLS(smtpCfg config.SMTPConfig) bool {
+	switch smtpCfg.TLSMode {
+	case "implicit":
+		return true
+	case "starttls", "none":
+		return false
+	default: // "" or unrecognised: auto-detect by port
+		return smtpCfg.Port == smtpsPort
+	}
+}
+
+// sendMailImplicitTLS delivers a message over an already-TLS-wrapped connection
+// (SMTPS). It dials with tls.Dial so the TLS handshake happens before any SMTP
+// traffic, which is what port-465 servers expect.
+func sendMailImplicitTLS(addr, host string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	conn, err := dialTLS(addr, host)
+	if err != nil {
+		return fmt.Errorf("dial SMTPS %s: %w", addr, err)
+	}
+	defer conn.Close()
+
+	c, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return fmt.Errorf("smtp client: %w", err)
+	}
+	defer c.Close()
+
+	if auth != nil {
+		if err := c.Auth(auth); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+	if err := c.Mail(from); err != nil {
+		return fmt.Errorf("smtp MAIL FROM: %w", err)
+	}
+	for _, r := range to {
+		if err := c.Rcpt(r); err != nil {
+			return fmt.Errorf("smtp RCPT TO <%s>: %w", r, err)
+		}
+	}
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("smtp DATA: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("smtp write body: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("smtp end DATA: %w", err)
+	}
+	return c.Quit()
+}
+
 // Email sends an email notification for an EMAIL action alarm.
 // It sends to the alarm's attendees using the provided SMTP configuration.
 // Returns an error if no attendees are configured or SMTP is not configured.
@@ -207,6 +273,9 @@ func Email(da alarm.DueAlarm, smtpCfg config.SMTPConfig, policy ExecutionPolicy)
 		auth = smtp.PlainAuth("", smtpCfg.Username, smtpCfg.Password, smtpCfg.Host)
 	}
 
+	if useImplicitTLS(smtpCfg) {
+		return sendMailImplicitTLS(addr, smtpCfg.Host, auth, smtpCfg.From, to, []byte(msg))
+	}
 	return smtp.SendMail(addr, auth, smtpCfg.From, to, []byte(msg))
 }
 

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,6 +1,17 @@
 package notify
 
 import (
+	"bufio"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -319,4 +330,223 @@ func TestEmail_RequiresExplicitUnsafeOptInForStoredAttendees(t *testing.T) {
 	if !strings.Contains(strings.ToLower(err.Error()), "unsafe") {
 		t.Fatalf("Email err = %q, want unsafe opt-in message", err)
 	}
+}
+
+// TestUseImplicitTLS verifies the connection-mode selection logic.
+// Port 465 and TLSMode "implicit" both trigger implicit-TLS (SMTPS); an
+// explicit TLSMode always overrides port-based detection.
+func TestUseImplicitTLS(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.SMTPConfig
+		want bool
+	}{
+		{"port 465 auto", config.SMTPConfig{Port: 465}, true},
+		{"port 587 auto", config.SMTPConfig{Port: 587}, false},
+		{"port 25 auto", config.SMTPConfig{Port: 25}, false},
+		{"tls=implicit explicit", config.SMTPConfig{Port: 587, TLSMode: "implicit"}, true},
+		{"tls=starttls explicit", config.SMTPConfig{Port: 587, TLSMode: "starttls"}, false},
+		{"tls=none explicit", config.SMTPConfig{Port: 587, TLSMode: "none"}, false},
+		{"port 465 tls=starttls explicit overrides", config.SMTPConfig{Port: 465, TLSMode: "starttls"}, false},
+		{"port 465 tls=implicit redundant", config.SMTPConfig{Port: 465, TLSMode: "implicit"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := useImplicitTLS(tt.cfg)
+			if got != tt.want {
+				t.Errorf("useImplicitTLS(%+v) = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEmail_ImplicitTLS_SMTPSServer starts a local TLS SMTP server and verifies
+// that Email can deliver a message using implicit TLS (SMTPS / port 465).
+// This test exercises the code path that smtp.SendMail cannot handle.
+func TestEmail_ImplicitTLS_SMTPSServer(t *testing.T) {
+	cert := generateTestCert(t)
+	port, serverDone := startMinimalSMTPSServer(t, cert)
+
+	// Override dialTLS to skip certificate verification for the self-signed test cert.
+	origDial := dialTLS
+	dialTLS = func(addr, _ string) (net.Conn, error) {
+		return tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+	}
+	t.Cleanup(func() { dialTLS = origDial })
+
+	da := alarm.DueAlarm{
+		Event: event.Event{Title: "SMTPS Test"},
+		Alarm: model.Alarm{
+			Action:    "EMAIL",
+			Attendees: []model.AlarmAttendee{{Email: "user@example.com"}},
+		},
+	}
+
+	err := Email(da, config.SMTPConfig{
+		Host:    "127.0.0.1",
+		Port:    port,
+		From:    "sender@example.com",
+		TLSMode: "implicit",
+	}, ExecutionPolicy{AllowUnsafeEmailAttendees: true})
+	if err != nil {
+		t.Fatalf("Email (implicit TLS) error: %v", err)
+	}
+
+	select {
+	case serverErr := <-serverDone:
+		if serverErr != nil {
+			t.Fatalf("SMTPS server error: %v", serverErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for SMTPS server to finish")
+	}
+}
+
+// generateTestCert creates a self-signed ECDSA certificate for 127.0.0.1/localhost.
+func generateTestCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privDER}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+// startMinimalSMTPSServer starts a TLS SMTP listener on a random local port.
+// It accepts exactly one connection, runs a minimal SMTP dialog, and signals
+// completion (with any error) on the returned channel.
+func startMinimalSMTPSServer(t *testing.T, cert tls.Certificate) (port int, done <-chan error) {
+	t.Helper()
+	tlsCfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch := make(chan error, 1)
+	go func() {
+		defer ln.Close()
+		conn, err := ln.Accept()
+		if err != nil {
+			ch <- err
+			return
+		}
+		defer conn.Close()
+		ch <- runMinimalSMTPDialog(conn)
+	}()
+	return ln.Addr().(*net.TCPAddr).Port, ch
+}
+
+// runMinimalSMTPDialog handles one SMTP session: greeting → EHLO → MAIL FROM →
+// RCPT TO(s) → DATA → body → QUIT. No AUTH is required.
+func runMinimalSMTPDialog(conn net.Conn) error {
+	rdr := bufio.NewReader(conn)
+
+	send := func(line string) error {
+		_, err := fmt.Fprintf(conn, "%s\r\n", line)
+		return err
+	}
+	recv := func() (string, error) {
+		line, err := rdr.ReadString('\n')
+		return strings.TrimRight(line, "\r\n"), err
+	}
+
+	if err := send("220 localhost ESMTP test"); err != nil {
+		return err
+	}
+
+	// EHLO / HELO
+	line, err := recv()
+	if err != nil {
+		return err
+	}
+	upper := strings.ToUpper(line)
+	if !strings.HasPrefix(upper, "EHLO") && !strings.HasPrefix(upper, "HELO") {
+		return fmt.Errorf("expected EHLO/HELO, got %q", line)
+	}
+	if err := send("250 OK"); err != nil {
+		return err
+	}
+
+	// MAIL FROM
+	line, err = recv()
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(strings.ToUpper(line), "MAIL FROM:") {
+		return fmt.Errorf("expected MAIL FROM, got %q", line)
+	}
+	if err := send("250 OK"); err != nil {
+		return err
+	}
+
+	// One or more RCPT TO, then DATA
+	for {
+		line, err = recv()
+		if err != nil {
+			return err
+		}
+		up := strings.ToUpper(line)
+		if strings.HasPrefix(up, "RCPT TO:") {
+			if err := send("250 OK"); err != nil {
+				return err
+			}
+		} else if up == "DATA" {
+			break
+		} else {
+			return fmt.Errorf("expected RCPT TO or DATA, got %q", line)
+		}
+	}
+
+	if err := send("354 Start mail input; end with <CRLF>.<CRLF>"); err != nil {
+		return err
+	}
+
+	// Read body until lone "."
+	for {
+		line, err = recv()
+		if err != nil {
+			return err
+		}
+		if line == "." {
+			break
+		}
+	}
+	if err := send("250 OK"); err != nil {
+		return err
+	}
+
+	// QUIT
+	line, err = recv()
+	if err != nil {
+		return err
+	}
+	if strings.ToUpper(line) != "QUIT" {
+		return fmt.Errorf("expected QUIT, got %q", line)
+	}
+	return send("221 Bye")
 }


### PR DESCRIPTION
Fixes #370

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8