### PR TITLE
fix(auth): normalize missing credential to keyring.ErrNotFound in PlaintextFileStore

### DIFF
--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -140,6 +140,9 @@ func (s *PlaintextFileStore) Get(accountID int64) (Credential, error) {
 	path := s.path(accountID)
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Credential{}, errCredentialNotFound
+		}
 		return Credential{}, fmt.Errorf("read credential: %w", err)
 	}
 	var cred Credential

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -97,6 +97,14 @@ func TestPlaintextFileStore_GetMissing(t *testing.T) {
 	}
 }
 
+func TestPlaintextFileStore_GetMissingReturnsErrNotFound(t *testing.T) {
+	store := &PlaintextFileStore{dir: t.TempDir()}
+	_, err := store.Get(999)
+	if !errors.Is(err, errCredentialNotFound) {
+		t.Errorf("Get for non-existent account should satisfy errors.Is(err, errCredentialNotFound), got %v", err)
+	}
+}
+
 func TestPlaintextFileStore_DeleteMissing(t *testing.T) {
 	store := &PlaintextFileStore{dir: t.TempDir()}
 	// Deleting a non-existent credential should not error
@@ -268,7 +276,7 @@ func TestNewCredentialStore_MigratesLegacyPlaintextCredentials(t *testing.T) {
 		t.Fatalf("Get returned %+v", got)
 	}
 
-	if _, err := legacyStore.Get(99); !errors.Is(err, os.ErrNotExist) {
+	if _, err := legacyStore.Get(99); !errors.Is(err, errCredentialNotFound) {
 		t.Fatalf("legacy credential should be removed after migration, got %v", err)
 	}
 	if len(backing) == 0 {


### PR DESCRIPTION
Fixes #371

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8