### PR TITLE
fix(calendar): gate credential deletion on account deletion in Disconnect and DeleteWithRemoteCleanup

### DIFF
--- a/internal/calendar/remote.go
+++ b/internal/calendar/remote.go
@@ -173,6 +173,7 @@ func (s *Service) Disconnect(ctx context.Context, cal Calendar, credStore auth.C
 		return fmt.Errorf("unlink calendar: %w", err)
 	}
 
+	var deleteCredential bool
 	if strings.HasPrefix(account.Name, hiddenAccountPrefix) {
 		linked, err := qtx.ListCalendarsByAccount(ctx, &account.ID)
 		if err != nil {
@@ -184,13 +185,14 @@ func (s *Service) Disconnect(ctx context.Context, cal Calendar, credStore auth.C
 				_ = tx.Rollback()
 				return fmt.Errorf("delete hidden account: %w", err)
 			}
+			deleteCredential = true
 		}
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit remote calendar disconnect: %w", err)
 	}
 
-	if credStore != nil && strings.HasPrefix(account.Name, hiddenAccountPrefix) {
+	if credStore != nil && deleteCredential {
 		_ = credStore.Delete(account.ID)
 	}
 	return nil
@@ -264,6 +266,7 @@ func (s *Service) DeleteWithRemoteCleanup(ctx context.Context, id, newDefaultID 
 		}
 	}
 
+	var deleteCredential bool
 	if hasAccount && hiddenAccount {
 		linked, err := qtx.ListCalendarsByAccount(ctx, &account.ID)
 		if err != nil {
@@ -273,6 +276,7 @@ func (s *Service) DeleteWithRemoteCleanup(ctx context.Context, id, newDefaultID 
 			if err := qtx.DeleteAccount(ctx, account.ID); err != nil {
 				return fmt.Errorf("delete hidden account: %w", err)
 			}
+			deleteCredential = true
 		}
 	}
 
@@ -280,7 +284,7 @@ func (s *Service) DeleteWithRemoteCleanup(ctx context.Context, id, newDefaultID 
 		return err
 	}
 
-	if hasAccount && hiddenAccount && credStore != nil {
+	if deleteCredential && credStore != nil {
 		_ = credStore.Delete(account.ID)
 	}
 	return nil

--- a/internal/calendar/remote_test.go
+++ b/internal/calendar/remote_test.go
@@ -312,3 +312,127 @@ func TestConnect_NoRemoteColor_LeavesLocalColor(t *testing.T) {
 		t.Errorf("RemoteColor = %q, want empty when fetch yielded nothing", got.RemoteColor)
 	}
 }
+
+// TestDisconnect_HiddenAccountWithMultipleCalendars_PreservesCredential verifies
+// that disconnecting one calendar from a shared hidden account does not delete
+// the stored credential when the account still has other calendars linked.
+func TestDisconnect_HiddenAccountWithMultipleCalendars_PreservesCredential(t *testing.T) {
+	svc, q, _ := newTestServiceWithDB(t)
+	ctx := context.Background()
+
+	// Create a second calendar.
+	cal2, err := q.CreateCalendar(ctx, storage.CreateCalendarParams{
+		Name:  "Work",
+		Color: "#0000ff",
+	})
+	if err != nil {
+		t.Fatalf("CreateCalendar: %v", err)
+	}
+
+	// Create a hidden account shared by both calendars.
+	account, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      hiddenAccountPrefix + "shared",
+		ServerUrl: "https://example.com",
+		AuthType:  "basic",
+		Username:  "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	// Link both calendars to the same hidden account.
+	for _, calID := range []int64{1, cal2.ID} {
+		id := calID
+		if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+			ID:        id,
+			AccountID: &account.ID,
+			RemoteUrl: storage.StringToNullable("https://example.com/dav/"),
+		}); err != nil {
+			t.Fatalf("LinkCalendarToAccount(%d): %v", id, err)
+		}
+	}
+
+	// Seed the credential.
+	store := &memCredStore{}
+	if err := store.Set(auth.Credential{AccountID: account.ID, Username: "user", Password: "secret"}); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+
+	// Disconnect calendar 1 only. The account still has calendar 2 linked so
+	// the account row is not deleted, and the credential must survive.
+	cal1, err := svc.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("Get cal1: %v", err)
+	}
+	if err := svc.Disconnect(ctx, cal1, store); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+
+	got, err := store.Get(account.ID)
+	if err != nil {
+		t.Fatalf("Get credential after Disconnect: %v", err)
+	}
+	if got.Password != "secret" {
+		t.Errorf("Disconnect: credential wrongly deleted when account survived; password = %q, want %q", got.Password, "secret")
+	}
+}
+
+// TestDeleteWithRemoteCleanup_HiddenAccountWithMultipleCalendars_PreservesCredential
+// verifies that deleting a calendar whose hidden account still serves another
+// calendar does not delete the stored credential.
+func TestDeleteWithRemoteCleanup_HiddenAccountWithMultipleCalendars_PreservesCredential(t *testing.T) {
+	svc, q, _ := newTestServiceWithDB(t)
+	ctx := context.Background()
+
+	// Create a second calendar.
+	cal2, err := q.CreateCalendar(ctx, storage.CreateCalendarParams{
+		Name:  "Work",
+		Color: "#0000ff",
+	})
+	if err != nil {
+		t.Fatalf("CreateCalendar: %v", err)
+	}
+
+	// Create a hidden account shared by both calendars.
+	account, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      hiddenAccountPrefix + "shared",
+		ServerUrl: "https://example.com",
+		AuthType:  "basic",
+		Username:  "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+
+	// Link both calendars to the same hidden account.
+	for _, calID := range []int64{1, cal2.ID} {
+		id := calID
+		if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+			ID:        id,
+			AccountID: &account.ID,
+			RemoteUrl: storage.StringToNullable("https://example.com/dav/"),
+		}); err != nil {
+			t.Fatalf("LinkCalendarToAccount(%d): %v", id, err)
+		}
+	}
+
+	// Seed the credential.
+	store := &memCredStore{}
+	if err := store.Set(auth.Credential{AccountID: account.ID, Username: "user", Password: "secret"}); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+
+	// Delete cal2 (non-default). The account still has calendar 1 linked so
+	// the account row is not deleted, and the credential must survive.
+	if err := svc.DeleteWithRemoteCleanup(ctx, cal2.ID, 0, store); err != nil {
+		t.Fatalf("DeleteWithRemoteCleanup: %v", err)
+	}
+
+	got, err := store.Get(account.ID)
+	if err != nil {
+		t.Fatalf("Get credential after DeleteWithRemoteCleanup: %v", err)
+	}
+	if got.Password != "secret" {
+		t.Errorf("DeleteWithRemoteCleanup: credential wrongly deleted when account survived; password = %q, want %q", got.Password, "secret")
+	}
+}


### PR DESCRIPTION
Fixes #373

Reproducing test added first (TDD), then the fix, followed by a self code-review and simplify pass. See commit body for root-cause details.

Assisted-by: Claude:claude-opus-4-8