### PR TITLE
fix(tui): repair ends-date picker button hit-test after #343/#344 merge

### DIFF
--- a/internal/tui/recurrence_editor.go
+++ b/internal/tui/recurrence_editor.go
@@ -471,6 +471,7 @@ func (m RecurrenceEditorModel) HandleEndsDateMouse(msg tea.MouseClickMsg, picker
 	const buttonRowRY = 8
 	if ry == buttonRowRY {
 		mmX := msg.X - ox - 2
+		innerW := pickerBoxW - 4
 		bs := DefaultButtonStyles()
 		cancelW := lipgloss.Width(bs.Normal.Render("Cancel", false))
 		okW := lipgloss.Width(bs.Normal.Render("Ok", false))

--- a/internal/tui/recurrence_editor_test.go
+++ b/internal/tui/recurrence_editor_test.go
@@ -135,7 +135,7 @@ func TestRecurrenceEditor_EndsDatePickerButtonRowMouseClickable(t *testing.T) {
 	btnY := gridY + buttonRowRY // 25
 
 	// Compute button x positions to match EndsDatePickerView rendering.
-	innerW := pickerBoxW - 6 // 34
+	innerW := pickerBoxW - 4 // 36, matching EndsDatePickerView's boxW-4
 	bs := DefaultButtonStyles()
 	cancelW := lipgloss.Width(bs.Normal.Render("Cancel", false))
 	okW := lipgloss.Width(bs.Normal.Render("Ok", false))


### PR DESCRIPTION
Integration repair for a semantic merge conflict between #343 and #344 (git auto-merged textually but #343 removed the `innerW` that #344's button-row block referenced). Restores `innerW` matching `EndsDatePickerView` and corrects an off-by-2 test constant. Build, vet, and full test suite green.

Assisted-by: Claude:claude-opus-4-8