### PR TITLE
fix(tui): clear all promote fields in calendar-promote OOB branch (#407)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2892,6 +2892,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.Choice < 0 || msg.Choice >= len(m.pendingCalendarPromoteCands) {
 				m.pendingCalendarDelete = 0
 				m.pendingCalendarDeleteName = ""
+				m.pendingCalendarPromote = 0
+				m.pendingCalendarPromoteName = ""
 				m.pendingCalendarPromoteCands = nil
 				return m, nil
 			}

--- a/internal/tui/app_scope_cancel_test.go
+++ b/internal/tui/app_scope_cancel_test.go
@@ -69,3 +69,30 @@ func TestChoiceDialogCancel_NoSpuriousReopenOnNextUpdate(t *testing.T) {
 	require.False(t, reopened,
 		"spurious EventViewRequestedMsg must not be dispatched after scope-dialog cancel")
 }
+
+// Regression (#407): the defensive out-of-bounds branch of the
+// calendar-promote choice handler must clear all four promote fields, just
+// like the cancel path. Otherwise a stale pendingCalendarPromoteName leaks
+// into the next calendar-delete confirm text.
+func TestChoiceDialogPromoteOOB_ClearsAllPendingFields(t *testing.T) {
+	m := Model{
+		pendingScopeKind:            pendingScopeCalendarPromote,
+		pendingCalendarDelete:       7,
+		pendingCalendarDeleteName:   "Work",
+		pendingCalendarPromote:      9,
+		pendingCalendarPromoteName:  "Home",
+		pendingCalendarPromoteCands: nil, // empty: any non-negative Choice is OOB
+	}
+
+	// Choice 0 with no candidates triggers the defensive OOB branch.
+	updated, _ := m.Update(ChoiceDialogResultMsg{Choice: 0})
+	m = updated.(Model)
+
+	require.Equal(t, int64(0), m.pendingCalendarDelete)
+	require.Equal(t, "", m.pendingCalendarDeleteName)
+	require.Equal(t, int64(0), m.pendingCalendarPromote,
+		"OOB branch must clear pendingCalendarPromote")
+	require.Equal(t, "", m.pendingCalendarPromoteName,
+		"OOB branch must clear pendingCalendarPromoteName")
+	require.Nil(t, m.pendingCalendarPromoteCands)
+}


### PR DESCRIPTION
## Root cause

In the `ChoiceDialogResultMsg` handler (`internal/tui/app.go`), the
`pendingScopeCalendarPromote` branch has a defensive out-of-bounds guard
(`msg.Choice < 0 || msg.Choice >= len(m.pendingCalendarPromoteCands)`).
That guard cleared only three of the four promote fields, leaving
`pendingCalendarPromote` and `pendingCalendarPromoteName` stale.

A stale `pendingCalendarPromoteName` leaks into the next calendar-delete
confirm dialog text, which appends `"<name>" will become the default.`
when the field is non-empty (app.go:2643-2644).

The cancel path (`msg.Choice < 0`) already clears all four fields; the OOB
branch now matches it.

This branch is currently unreachable via normal UI (ChoiceDialogModel only
emits valid indices or -1), so this is a latent defensive fix.

## Fix

Also zero `pendingCalendarPromote` and `pendingCalendarPromoteName` in the
OOB branch.

## Test

Added `TestChoiceDialogPromoteOOB_ClearsAllPendingFields` in
`internal/tui/app_scope_cancel_test.go`. It seeds all four promote fields
with stale values and an empty candidate slice, drives the OOB branch with
`Choice: 0`, and asserts all four fields are cleared. Fails before the fix
(pendingCalendarPromote stays 9), passes after.

`go test ./internal/... -count=1` all green; `go build ./...` and
`go vet` clean.

Closes #407
