### PR TITLE
fix(tui): keep scroll position when form focus reaches the button row (#408)

### DIFF
--- a/internal/tui/calendar_dialog.go
+++ b/internal/tui/calendar_dialog.go
@@ -904,6 +904,11 @@ func (m *CalendarDialogModel) keepFocusedFieldVisible() {
 		return
 	}
 	line := m.form.FocusedLine()
+	if line < 0 {
+		// Focus is on the button row, not a body field; leave the
+		// scroll position where the last field left it.
+		return
+	}
 	if line < m.body.YOffset() {
 		m.body.ScrollUp(m.body.YOffset() - line)
 		return

--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -867,6 +867,11 @@ func (m *EventFormModel) keepFocusedFieldVisible() {
 		return
 	}
 	line := m.form.FocusedLine()
+	if line < 0 {
+		// Focus is on the button row, not a body field; leave the
+		// scroll position where the last field left it.
+		return
+	}
 	if line < m.body.YOffset() {
 		m.body.ScrollUp(m.body.YOffset() - line)
 		return

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -2061,9 +2061,15 @@ func (f Form) ButtonRowView() string {
 	return f.buttonRow()
 }
 
-// FocusedLine returns the first rendered body line for the focused item.
-// It is used by scrollable dialogs to keep the active field visible.
+// FocusedLine returns the first rendered body line for the focused item,
+// or -1 when focus is on an action button (Submit/Cancel/etc.) rather than
+// a body field. It is used by scrollable dialogs to keep the active field
+// visible; callers must leave the scroll position untouched for buttons,
+// otherwise reaching the button row would yank the body back to line 0.
 func (f Form) FocusedLine() int {
+	if f.focused >= len(f.items) {
+		return -1
+	}
 	parts := f.fieldParts()
 	line := 0
 	for i, part := range parts {
@@ -2072,7 +2078,7 @@ func (f Form) FocusedLine() int {
 		}
 		line += max(lipgloss.Height(part), 1)
 	}
-	return 0
+	return -1
 }
 
 func (f Form) View() string {

--- a/internal/tui/form_test.go
+++ b/internal/tui/form_test.go
@@ -356,6 +356,29 @@ func TestForm_FocusCycling(t *testing.T) {
 	assert.Equal(t, 0, form.Focused(), "wraps to first field")
 }
 
+func TestForm_FocusedLine(t *testing.T) {
+	form := newTestForm(
+		FormItem{Label: "First", Field: NewTextField("first")},
+		FormItem{Label: "Second", Field: NewTextField("second")},
+	)
+
+	// Focus on a field returns that field's first body line.
+	assert.Equal(t, 0, form.FocusedLine(), "first field")
+	formPressTab(&form)
+	assert.Greater(t, form.FocusedLine(), 0, "second field is below the first")
+
+	// Focus on the Submit/Cancel button row is not a body field, so
+	// FocusedLine must not point back into the body (regression #408:
+	// returning 0 scrolled the body to the top when Tab reached the buttons).
+	formPressTab(&form)
+	assert.Equal(t, form.submitIndex(), form.Focused(), "submit button")
+	assert.Less(t, form.FocusedLine(), 0, "submit button is not a body field")
+
+	formPressTab(&form)
+	assert.Equal(t, form.cancelIndex(), form.Focused(), "cancel button")
+	assert.Less(t, form.FocusedLine(), 0, "cancel button is not a body field")
+}
+
 func TestForm_ShiftTabCycling(t *testing.T) {
 	form := newTestForm(
 		FormItem{Label: "First", Field: NewTextField("first")},


### PR DESCRIPTION
## Root cause

`Form.FocusedLine()` walks the body field parts and matches each index
against `f.focused`. Once focus advances past the last field to the
Submit/Cancel button row, `f.focused >= len(items)`, no part matches,
and the function fell through to `return 0`. The scrollable-dialog
helper `keepFocusedFieldVisible` then read `line (0) < body.YOffset()`
and scrolled the body all the way back to the top — so every Tab that
reached the button row yanked the form away from where the user was.

## Fix

- `FocusedLine()` now returns `-1` when focus is on an action button
  (any index `>= len(f.items)`, which covers leading buttons, Submit,
  trailing buttons, and Cancel) instead of a misleading `0`.
- Both callers (`EventFormModel` and `CalendarDialogModel`
  `keepFocusedFieldVisible`) return early on the `-1` sentinel, leaving
  the scroll position exactly where the last focused field left it.

## Test

Added `TestForm_FocusedLine` in `internal/tui/form_test.go`: asserts
field focus yields ascending body lines and that Submit/Cancel focus
yields a negative (non-body) line. It fails on master (returned 0) and
passes with the fix.

`go build ./...`, `go vet ./internal/tui/`, and
`go test ./internal/... -count=1` all pass.

Closes #408
