### PR TITLE
fix(tui): apply TextField input filter to bracketed paste (#411)

### DIFF
--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -119,8 +119,16 @@ func (f *TextField) Update(msg tea.Msg) tea.Cmd {
 		return nil
 	}
 	if f.filter != nil {
-		if msg, ok := msg.(tea.KeyPressMsg); ok {
-			if k := msg.Key(); k.Text != "" && !f.filter(k) {
+		switch m := msg.(type) {
+		case tea.KeyPressMsg:
+			if k := m.Key(); k.Text != "" && !f.filter(k) {
+				return nil
+			}
+		case tea.PasteMsg:
+			// A bracketed paste bypasses the per-keystroke path, so run its
+			// content through the same filter (issue #411). The filter
+			// inspects only the key's Text, so a synthetic key suffices.
+			if !f.filter(tea.Key{Text: m.Content}) {
 				return nil
 			}
 		}

--- a/internal/tui/form_test.go
+++ b/internal/tui/form_test.go
@@ -62,6 +62,44 @@ func TestFilterDigits_MultiRuneText(t *testing.T) {
 	}
 }
 
+func TestTextField_PasteIsFiltered(t *testing.T) {
+	// A bracketed paste arrives as tea.PasteMsg, not tea.KeyPressMsg. The
+	// filter must apply to it too, otherwise pasted text bypasses the filter
+	// entirely (issue #411).
+	tests := []struct {
+		content string
+		wantVal string
+		desc    string
+	}{
+		{"123", "123", "all-digit paste accepted"},
+		{"12ab", "", "paste with letters rejected wholesale"},
+		{"xyz", "", "non-digit paste rejected"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := NewTextField("n")
+			f.SetDigitsOnly()
+			f.Focus()
+			f.Update(tea.PasteMsg{Content: tc.content})
+			assert.Equal(t, tc.wantVal, f.Value(), tc.desc)
+		})
+	}
+}
+
+func TestHexColorField_PasteIsFiltered(t *testing.T) {
+	// The hex-color field must reject pasted non-hex strings, not just
+	// rejected keystrokes (issue #411).
+	f := NewHexColorField("#rrggbb", lipgloss.Color("8"))
+	f.Focus()
+
+	f.Update(tea.PasteMsg{Content: "xyz"})
+	assert.Equal(t, "", f.Value(), "non-hex paste rejected")
+
+	f.Update(tea.PasteMsg{Content: "#aabbcc"})
+	assert.Equal(t, "#aabbcc", f.Value(), "valid hex paste accepted")
+}
+
 func TestTextField_CustomFilter(t *testing.T) {
 	f := NewTextField("hex")
 	f.SetFilter(func(k tea.Key) bool {


### PR DESCRIPTION
## Root cause

`TextField.Update` only ran the input filter against `tea.KeyPressMsg`. A
`tea.PasteMsg` (bracketed paste) bypassed the filter and was forwarded
verbatim to the underlying `textinput`, so the hex-color field (and any
`SetDigitsOnly`/`SetFilter` field) accepted arbitrary pasted strings (e.g.
`xyz`, `##`) until `Validate()` rejected them at submit. The filter's
purpose was defeated for paste.

## Fix

Handle `tea.PasteMsg` in `TextField.Update`: run the pasted content through
the existing filter via a synthetic `tea.Key{Text: m.Content}` (the filter
inspects only `Key.Text`), rejecting the whole paste if any rune fails. The
hex filter closure reads the current cursor position and value, so the `#`
placement rule still applies to pastes.

## Tests

Added to `internal/tui/form_test.go` (table-driven, matching existing style):
- `TestTextField_PasteIsFiltered` — digits-only field accepts `123`, rejects
  `12ab` and `xyz` pastes wholesale.
- `TestHexColorField_PasteIsFiltered` — rejects `xyz`, accepts `#aabbcc`.

Both failed before the fix and pass after. `go build ./...`, `go vet`, and
`go test ./internal/... -count=1` all pass.

Closes #411