### PR TITLE
fix(notify): drop redundant os.Stat in resolveLocalAudioPath (#424)

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -113,12 +113,9 @@ func resolveLocalAudioPath(uri string, policy ExecutionPolicy) string {
 	if !filepath.IsAbs(path) {
 		return ""
 	}
-	if _, err := os.Stat(path); err != nil {
-		return "" // File doesn't exist.
-	}
 	info, err := os.Stat(path)
 	if err != nil || !info.Mode().IsRegular() {
-		return ""
+		return "" // File doesn't exist or isn't a regular file.
 	}
 	if !isLikelyAudioFile(path) {
 		return ""


### PR DESCRIPTION
## Root cause

`resolveLocalAudioPath` (`internal/notify/notify.go`) called `os.Stat`
twice on the same path. The first call only checked existence — but the
second call already returns an error for a missing path *and* checks
`Mode().IsRegular()`. The first stat was therefore redundant: an extra
syscall per audio alarm and a tiny TOCTOU window for no behavioral gain.

## Fix

Collapse the two stats into one:

```go
info, err := os.Stat(path)
if err != nil || !info.Mode().IsRegular() {
    return "" // File doesn't exist or isn't a regular file.
}
```

Behavior is identical — a missing path, a directory, and a non-regular
file are all still rejected.

## Test

No new failing test is possible because this is a non-behavioral
refactor (one fewer syscall, same outcomes). The existing table-driven
`TestResolveLocalAudioPath_RequiresExplicitUnsafeOptIn` already covers
every relevant outcome — missing path, directory rejected, non-audio
rejected, and valid regular files accepted — and continues to pass,
guarding the behavior the fix preserves.

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/...` all
pass.

Closes #424