### PR TITLE
fix(auth): keep legacy credential read when migration write fails (#423)

### DIFF
--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -242,8 +242,13 @@ func (s *migratingCredentialStore) Get(accountID int64) (Credential, error) {
 	if legacyErr != nil {
 		return Credential{}, err
 	}
+	// Migrate into the primary store best-effort. A transient write failure
+	// (e.g. the keyring is momentarily unavailable) must not turn a successful
+	// legacy read into an error — that would lock the user out of sync for the
+	// whole process lifetime. On failure, return the legacy credential and keep
+	// the legacy copy so a later read can retry the migration.
 	if setErr := s.primary.Set(legacyCred); setErr != nil {
-		return Credential{}, setErr
+		return legacyCred, nil
 	}
 	// Migration succeeded: the caller now has the credential and the primary
 	// store owns it. Cleaning up the legacy copy is best-effort — a failure

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -421,6 +421,51 @@ func TestMigratingCredentialStore_GetIgnoresLegacyCleanupError(t *testing.T) {
 	}
 }
 
+// TestMigratingCredentialStore_GetReturnsLegacyWhenMigrationWriteFails
+// reproduces issue #423: when the primary keyring is transiently
+// unavailable for writes, the migration's primary.Set fails. Get must
+// still return the legacy credential (a successful read) rather than
+// turning the read into an error and locking the user out of sync for
+// the whole process lifetime.
+func TestMigratingCredentialStore_GetReturnsLegacyWhenMigrationWriteFails(t *testing.T) {
+	legacy := &PlaintextFileStore{dir: t.TempDir(), warn: io.Discard}
+
+	legacyCred := Credential{
+		AccountID: 42,
+		Username:  "legacy",
+		Password:  "plaintext-secret",
+	}
+	if err := legacy.Set(legacyCred); err != nil {
+		t.Fatalf("legacy Set: %v", err)
+	}
+
+	// Keyring reads miss (no migrated copy yet) and keyring writes fail,
+	// simulating a transient backend that can be read-probed but not written.
+	backing := map[string]string{}
+	overrideKeyringForTest(t, true, backing)
+	keyringSetFn = func(service, user, value string) error {
+		return errors.New("keyring temporarily unavailable")
+	}
+
+	store := &migratingCredentialStore{
+		primary: &KeyringStore{},
+		legacy:  legacy,
+	}
+
+	got, err := store.Get(42)
+	if err != nil {
+		t.Fatalf("Get should return the legacy credential when migration write fails, got %v", err)
+	}
+	if got.Username != "legacy" || got.Password != "plaintext-secret" {
+		t.Fatalf("Get returned %+v, want the legacy credential", got)
+	}
+	// The migration write failed, so the legacy copy must survive for a
+	// later retry rather than being deleted.
+	if _, err := legacy.Get(42); err != nil {
+		t.Fatalf("legacy credential should survive a failed migration write, got %v", err)
+	}
+}
+
 func TestPlaintextFileStore_WarningsRouteToInjectedWriter(t *testing.T) {
 	var buf strings.Builder
 	store := &PlaintextFileStore{dir: t.TempDir(), warn: &buf}


### PR DESCRIPTION
## Root cause

`migratingCredentialStore.Get` (`internal/auth/credential.go`) lazily migrates a
legacy plaintext credential into the primary store via `primary.Set`. On a
`Set` failure it returned the set error, turning a *successful legacy read*
into an error. A transient keyring write failure (backend momentarily
unavailable) thus fails the read. Because store selection is memoized with
`sync.Once`, the migrating store remains active and the user loses sync access
for the entire process lifetime — even though the credential is perfectly
readable from the legacy store.

This also contradicted the function's own adjacent comment, which states a
post-migration failure "must not turn a successful read into an error" (that
philosophy was only applied to the `legacy.Delete` cleanup, not the
`primary.Set` write).

## Fix

Make the migration write best-effort: on `primary.Set` failure, return
`legacyCred, nil` and leave the legacy copy in place so a later read can retry
the migration. The successful-migration path (delete legacy copy, return
credential) is unchanged.

## Test

Added `TestMigratingCredentialStore_GetReturnsLegacyWhenMigrationWriteFails` in
`internal/auth/credential_test.go`: a legacy plaintext credential exists,
keyring reads miss and keyring writes fail. Asserts `Get` returns the legacy
credential with no error and that the legacy copy survives for a later retry.
Fails before the fix (`got write credential to keyring: ...`), passes after.

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/... -count=1` all
pass.

Closes #423
