### PR TITLE
fix(sync): record sync health on early loadCalendarClient failure (#416)

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -186,18 +186,26 @@ func (e *Engine) loadCalendarClient(ctx context.Context, calendarID int64) (stor
 
 // SyncCalendar runs a full sync cycle for one calendar.
 func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy ConflictStrategy) (result *SyncResult, err error) {
+	// Register the health-update defer before loading the client so that an
+	// early return from loadCalendarClient (missing credentials, no linked
+	// account, empty RemoteUrl) still records the failed attempt — otherwise
+	// LastSyncError stays stale and the ambient ⚠ glyph never lights up for a
+	// permanently failing calendar (issue #416).
+	attemptedAt := time.Now().UTC().Format(time.RFC3339)
+	defer func() {
+		if updateErr := e.updateSyncHealth(ctx, calendarID, attemptedAt, result, err); updateErr != nil {
+			e.logger.Warn("update sync health failed", "calendar_id", calendarID, "error", updateErr)
+			if result != nil {
+				result.Errors = append(result.Errors, fmt.Errorf("update sync health: %w", updateErr))
+			}
+		}
+	}()
+
 	cal, account, client, remoteURL, err := e.loadCalendarClient(ctx, calendarID)
 	if err != nil {
 		return nil, err
 	}
 	result = &SyncResult{CalendarID: cal.ID}
-	attemptedAt := time.Now().UTC().Format(time.RFC3339)
-	defer func() {
-		if updateErr := e.updateSyncHealth(ctx, cal.ID, attemptedAt, result, err); updateErr != nil {
-			e.logger.Warn("update sync health failed", "calendar_id", cal.ID, "error", updateErr)
-			result.Errors = append(result.Errors, fmt.Errorf("update sync health: %w", updateErr))
-		}
-	}()
 
 	e.logger.Info("sync started", "calendar_id", calendarID, "remote_url", remoteURL)
 

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -968,6 +968,43 @@ func TestEnginePullIncompletePullMarksCalendarUnhealthy(t *testing.T) {
 	}
 }
 
+// TestEngineSyncCalendarRecordsHealthOnEarlyClientFailure is the regression
+// test for issue #416: when loadCalendarClient returns early (missing
+// credentials, no linked account, empty RemoteUrl) the updateSyncHealth defer
+// used to be registered after that call, so it never ran. LastSyncAttemptedAt /
+// LastSyncError stayed stale and the ambient ⚠ sidebar glyph (which keys on a
+// non-empty LastSyncError) stayed dark while the calendar was permanently
+// failing — notably OAuth calendars with revoked credentials.
+func TestEngineSyncCalendarRecordsHealthOnEarlyClientFailure(t *testing.T) {
+	t.Parallel()
+
+	engine, _, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	// The default calendar has no linked account, so loadCalendarClient
+	// returns early before any sync phase runs.
+	if _, err := engine.SyncCalendar(ctx, calendarID, ConflictServerWins); err == nil {
+		t.Fatal("SyncCalendar: want error from loadCalendarClient, got nil")
+	}
+
+	calRow, err := q.GetCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if got := storage.NullableToString(calRow.LastSyncError); got == "" {
+		t.Fatal("LastSyncError empty: an unsyncable calendar still shows healthy")
+	}
+	if got := storage.NullableToString(calRow.LastSyncAttemptedAt); got == "" {
+		t.Fatal("LastSyncAttemptedAt empty: the failed sync attempt was not recorded")
+	}
+}
+
 // TestEnginePushSerializesConcurrentNewResourceCreate is the regression test
 // for issue #225: two concurrent push runs for the same calendar (e.g. an
 // opportunistic save-time PushCalendar racing a periodic SyncCalendar) must not


### PR DESCRIPTION
## Root cause

`SyncCalendar` (`internal/sync/engine.go`) registered its `updateSyncHealth`
defer *after* calling `loadCalendarClient`. Any early return from that helper
(expired/missing credentials, no linked account, empty `RemoteUrl`) exited
before the defer was registered, so `UpdateCalendarSyncHealth` never ran.
`LastSyncAttemptedAt` / `LastSyncError` stayed stale and the ambient ⚠ sidebar
glyph (which keys on a non-empty `LastSyncError`) stayed dark while the calendar
was permanently failing — notably OAuth calendars with revoked credentials.

## Fix

Register the health-update defer *before* calling `loadCalendarClient`
(`calendarID` is already known, and equals `cal.ID`). The defer now also guards
`result == nil` before appending its own update error, since `result` is only
set after the client loads successfully. `updateSyncHealth` itself is safe with
a nil `result` on the early path because `runErr` is non-nil there, so it never
dereferences `result`.

## Test

Added `TestEngineSyncCalendarRecordsHealthOnEarlyClientFailure` in
`internal/sync/engine_test.go`: it runs `SyncCalendar` against the default
unlinked calendar (so `loadCalendarClient` returns early) and asserts that
`LastSyncError` and `LastSyncAttemptedAt` are recorded. The test fails before
the fix (`LastSyncError empty`) and passes after.

Full `go build ./...`, `go vet`, and `go test ./internal/... -count=1` pass.

Closes #416
