### PR TITLE
fix(ical): avoid nested VCALENDAR when merging a component-less stream (#422)

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -576,19 +576,25 @@ func MergeCalendars(a, b []byte) []byte {
 	}
 
 	// Remove header from b: find the earliest component marker regardless of
-	// type, so that a stream mixing VEVENT/VTODO/VJOURNAL does not lose the
-	// components that appear before the first marker of a later-searched type.
+	// type, so that a stream mixing VEVENT/VTODO/VJOURNAL/VFREEBUSY does not
+	// lose the components that appear before the first marker of a
+	// later-searched type. VFREEBUSY is included so a free/busy-only stream is
+	// still recognized; otherwise its BEGIN:VCALENDAR header would be appended
+	// verbatim, nesting a second VCALENDAR.
 	firstComp := -1
-	for _, marker := range []string{"BEGIN:VEVENT", "BEGIN:VTODO", "BEGIN:VJOURNAL"} {
+	for _, marker := range []string{"BEGIN:VEVENT", "BEGIN:VTODO", "BEGIN:VJOURNAL", "BEGIN:VFREEBUSY"} {
 		if idx := strings.Index(bStr, marker); idx >= 0 {
 			if firstComp < 0 || idx < firstComp {
 				firstComp = idx
 			}
 		}
 	}
-	if firstComp >= 0 {
-		bStr = bStr[firstComp:]
+	if firstComp < 0 {
+		// b has no components to contribute; keep only the (already extracted)
+		// VTIMEZONE blocks and avoid appending b's VCALENDAR header verbatim.
+		return []byte(aStr + extraTZ + "END:VCALENDAR\r\n")
 	}
+	bStr = bStr[firstComp:]
 
 	// Remove trailing END:VCALENDAR from b, then re-add it
 	if idx := strings.LastIndex(bStr, "END:VCALENDAR"); idx >= 0 {

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -796,6 +796,52 @@ func TestMergeCalendars_MixedSecondStream_JournalBeforeTodo(t *testing.T) {
 	}
 }
 
+// TestMergeCalendars_FreeBusyOnlySecondStream covers issue #422: when the
+// second stream carries a VFREEBUSY component but no VEVENT/VTODO/VJOURNAL, the
+// component-marker search must still find it so b's BEGIN:VCALENDAR header is
+// stripped. Otherwise b is appended verbatim, nesting a second VCALENDAR.
+func TestMergeCalendars_FreeBusyOnlySecondStream(t *testing.T) {
+	t.Parallel()
+	a := []byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:e1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n")
+	b := []byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+		"BEGIN:VFREEBUSY\r\nUID:fb1\r\nEND:VFREEBUSY\r\n" +
+		"END:VCALENDAR\r\n")
+
+	merged := string(MergeCalendars(a, b))
+	if !strings.Contains(merged, "UID:e1") {
+		t.Error("UID:e1 from first calendar is missing")
+	}
+	if !strings.Contains(merged, "BEGIN:VFREEBUSY") {
+		t.Error("VFREEBUSY from second calendar was dropped")
+	}
+	if strings.Count(merged, "BEGIN:VCALENDAR") != 1 {
+		t.Errorf("expected 1 VCALENDAR header, got %d", strings.Count(merged, "BEGIN:VCALENDAR"))
+	}
+	if strings.Count(merged, "END:VCALENDAR") != 1 {
+		t.Errorf("expected 1 END:VCALENDAR, got %d", strings.Count(merged, "END:VCALENDAR"))
+	}
+}
+
+// TestMergeCalendars_NoComponentsSecondStream covers issue #422: a second
+// stream with no components at all must not contribute a nested VCALENDAR
+// header to the merged output.
+func TestMergeCalendars_NoComponentsSecondStream(t *testing.T) {
+	t.Parallel()
+	a := []byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:e1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n")
+	b := []byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n")
+
+	merged := string(MergeCalendars(a, b))
+	if !strings.Contains(merged, "UID:e1") {
+		t.Error("UID:e1 from first calendar is missing")
+	}
+	if strings.Count(merged, "BEGIN:VCALENDAR") != 1 {
+		t.Errorf("expected 1 VCALENDAR header, got %d", strings.Count(merged, "BEGIN:VCALENDAR"))
+	}
+	if strings.Count(merged, "END:VCALENDAR") != 1 {
+		t.Errorf("expected 1 END:VCALENDAR, got %d", strings.Count(merged, "END:VCALENDAR"))
+	}
+}
+
 func TestExport_MasterWithOverride(t *testing.T) {
 	t.Parallel()
 	events := []event.Event{


### PR DESCRIPTION
## Root cause

`MergeCalendars` (internal/ical/export.go) strips stream `b`'s `BEGIN:VCALENDAR` header by locating the earliest component marker, but the search list only contained `BEGIN:VEVENT`, `BEGIN:VTODO`, and `BEGIN:VJOURNAL`. When `b` had none of these — e.g. a VFREEBUSY-only calendar or an empty one — `firstComp` stayed `-1`, the `if firstComp >= 0` strip was skipped, and `b`'s full `BEGIN:VCALENDAR ... VERSION:2.0` header was appended verbatim, nesting a second VCALENDAR inside the merged output (malformed iCal).

## Fix

- Add `BEGIN:VFREEBUSY` to the marker search so free/busy-only streams are recognized and their header stripped.
- When no component marker is found, return early with `aStr + extraTZ + "END:VCALENDAR\r\n"` rather than appending `b`'s raw header. `extraTZ` already holds any new VTIMEZONE blocks extracted from `b`, so timezone data is still preserved; only the redundant/empty header is dropped.

## Tests

Added two table-style cases in internal/ical/export_test.go (both failed before the fix with `expected 1 VCALENDAR header, got 2`):

- `TestMergeCalendars_FreeBusyOnlySecondStream` — VFREEBUSY-only `b`: VFREEBUSY survives, exactly one VCALENDAR header/footer.
- `TestMergeCalendars_NoComponentsSecondStream` — empty `b`: first calendar intact, exactly one VCALENDAR header/footer.

All existing merge tests, `go build ./...`, `go vet`, and `go test ./internal/...` pass.

Closes #422
