### PR TITLE
fix(tui): let q close read-only/choice overlays instead of quitting (#406)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1347,9 +1347,10 @@ func (m Model) openQuitConfirm() Model {
 // interceptGlobalKeys routes the quit guard (q / ctrl+c) and help (?) ahead
 // of any open dialog so they work from anywhere. A second ctrl+c while the
 // quit confirm is showing forces the exit. ctrl+c is truly global (it isn't
-// a character anyone types into a field); q and ? are suppressed while a
-// text-entry surface owns input (palette search, event form, calendar form)
-// so users can type those characters normally. The quit confirm additionally
+// a character anyone types into a field); ? is suppressed while a text-entry
+// surface owns input (palette search, event form, calendar form) so users can
+// type it normally, and q is suppressed while any overlay is open so the
+// overlay's own close binding runs instead. The quit confirm additionally
 // blocks ?, and the help dialog handles its own close keys.
 func (m Model) interceptGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 	inQuitConfirm := m.confirmOpen && m.pendingQuit
@@ -1368,7 +1369,11 @@ func (m Model) interceptGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 		return m.openQuitConfirm(), nil, true
 	}
 	textEntryActive := m.paletteOpen || m.formOpen || m.calendarDialogOpen || m.oauthFlowOpen
-	if key.Matches(msg, m.keys.Quit) && !m.confirmOpen && !textEntryActive {
+	// q opens the quit confirm only from the bare grid. Any open overlay —
+	// text-entry (palette, form) or read-only/choice (event view, list,
+	// choice, calendar list, trash, help) — owns q so its own `q`-to-close
+	// binding runs instead of the global quit guard (issue #406).
+	if key.Matches(msg, m.keys.Quit) && !m.anyOverlayOpen() {
 		return m.openQuitConfirm(), nil, true
 	}
 	if key.Matches(msg, m.keys.Help) && !inQuitConfirm && !m.helpDialogOpen && !textEntryActive {

--- a/internal/tui/quit_confirm_test.go
+++ b/internal/tui/quit_confirm_test.go
@@ -65,3 +65,50 @@ func TestCtrlCClearsPurgePendingState(t *testing.T) {
 		t.Fatalf("abandoned purge pending state not cleared: entries=%d title=%q", len(next.pendingPurgeEntries), next.pendingPurgeTitle)
 	}
 }
+
+// TestQuitKeyDeferredToOpenOverlay reproduces issue #406: pressing `q` while a
+// read-only/choice overlay owns input must NOT route to the quit confirm. The
+// global intercept should leave the keystroke unhandled so the overlay's own
+// `q`-to-close binding runs.
+func TestQuitKeyDeferredToOpenOverlay(t *testing.T) {
+	qKey := tea.KeyPressMsg{Code: 'q', Text: "q"}
+
+	setters := map[string]func(*Model){
+		"viewDialogOpen":         func(m *Model) { m.viewDialogOpen = true },
+		"dialogOpen":             func(m *Model) { m.dialogOpen = true },
+		"choiceOpen":             func(m *Model) { m.choiceOpen = true },
+		"calendarListDialogOpen": func(m *Model) { m.calendarListDialogOpen = true },
+		"trashOpen":              func(m *Model) { m.trashOpen = true },
+		"helpDialogOpen":         func(m *Model) { m.helpDialogOpen = true },
+	}
+
+	for name, set := range setters {
+		t.Run(name, func(t *testing.T) {
+			m := Model{keys: defaultAppKeys()}
+			set(&m)
+
+			next, _, handled := m.interceptGlobalKeys(qKey)
+			if handled {
+				t.Fatalf("q was intercepted while %s is open; the overlay should own q (issue #406)", name)
+			}
+			if next.pendingQuit || next.confirmOpen {
+				t.Fatalf("q opened the quit confirm while %s is open: pendingQuit=%v confirmOpen=%v", name, next.pendingQuit, next.confirmOpen)
+			}
+		})
+	}
+}
+
+// TestQuitKeyStillQuitsFromMainGrid guards the happy path: with no overlay
+// open, `q` must still route to the quit confirm.
+func TestQuitKeyStillQuitsFromMainGrid(t *testing.T) {
+	qKey := tea.KeyPressMsg{Code: 'q', Text: "q"}
+
+	m := Model{keys: defaultAppKeys()}
+	next, _, handled := m.interceptGlobalKeys(qKey)
+	if !handled {
+		t.Fatalf("q not handled from the main grid; expected the quit confirm to open")
+	}
+	if !next.pendingQuit || !next.confirmOpen {
+		t.Fatalf("q should open the quit confirm from the main grid: pendingQuit=%v confirmOpen=%v", next.pendingQuit, next.confirmOpen)
+	}
+}


### PR DESCRIPTION
## Root cause

`interceptGlobalKeys` (internal/tui/app.go) gated the `q` quit guard on
`!m.confirmOpen && !textEntryActive`, where `textEntryActive` only
covered `paletteOpen`, `formOpen`, `calendarDialogOpen`, and
`oauthFlowOpen`. The read-only/choice overlays — `viewDialogOpen`,
`dialogOpen`, `choiceOpen`, `calendarListDialogOpen`, `trashOpen`, and
`helpDialogOpen` — were omitted, so pressing `q` to dismiss any of them
routed to `openQuitConfirm()` before the overlay's own `q`-to-close
binding could run. The most disruptive case was abandoning a
recurring-edit scope choice mid-workflow, and it broke the "esc · q —
close (read-only dialogs)" promise in the help text.

## Fix

Gate the quit guard on `!m.anyOverlayOpen()` instead. That helper
already enumerates every overlay (and includes `confirmOpen`, so the
prior behavior for destructive confirms and the quit confirm itself is
preserved). `q` now opens the quit confirm only from the bare grid; with
any overlay open the keystroke falls through to that overlay's `Update`,
where its `esc/q` close binding handles it.

The `?` (help) and `D` (trash) bindings still use `textEntryActive`,
unchanged — this change is scoped to `q`.

## Test

Added to `internal/tui/quit_confirm_test.go`:
- `TestQuitKeyDeferredToOpenOverlay` — table-driven across all six
  previously-omitted overlay flags; asserts `q` is left unhandled and
  does not open the quit confirm. Fails on master for the right reason.
- `TestQuitKeyStillQuitsFromMainGrid` — guards the happy path: `q` still
  opens the quit confirm from the bare grid.

`go build ./...`, `go test ./internal/... -count=1`, `gofmt`, and
`go vet ./internal/tui/` all pass.

Closes #406
