### PR TITLE
fix(event): propagate non-ErrNoRows master-lookup error on override delete (#412)

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -572,6 +573,14 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		qtx := s.q.WithTx(tx)
 
 		master, err := qtx.GetEventByUID(ctx, evt.UID)
+		// A genuine lookup error (e.g. SQLITE_BUSY) must not collapse into the
+		// "no master" path: that would soft-delete the override while skipping
+		// its EXDATE/provenance bookkeeping, resurrecting the occurrence via
+		// series expansion (issue #412). Only a missing master (ErrNoRows)
+		// legitimately skips the bookkeeping.
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("get master: %w", err)
+		}
 		if err == nil {
 			existing := ParseTimeList(storage.NullableToString(master.Exdates))
 			recIDTime, parseErr := timeutil.ParseRecurrenceID(evt.RecurrenceID)

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -740,3 +740,62 @@ func TestSoftDelete_RestoreSurfacesTombstoneClearError(t *testing.T) {
 		t.Fatal("RestoreByID returned nil, want error when tombstone clear fails")
 	}
 }
+
+// TestSoftDelete_OverrideMasterLookupError is the regression test for issue
+// #412: deleting an override must not collapse a genuine DB error from the
+// master lookup into the "no master" path. On a non-ErrNoRows error the old
+// code soft-deleted the override while silently skipping the EXDATE and
+// provenance bookkeeping, resurrecting the occurrence via series expansion and
+// leaving it unrestorable via trash. Same failure mode as #290, fixed there in
+// the todo and journal services but never in the event service.
+func TestSoftDelete_OverrideMasterLookupError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "weekly-uid",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Review (moved)",
+		StartTime:    time.Date(2026, 4, 15, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 15, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Force the master lookup (GetEventByUID) to fail with a genuine, non-
+	// ErrNoRows error by writing non-numeric text into the master's integer
+	// sequence column so its row scan fails. The override row that the initial
+	// Get(id) loads is untouched, and SoftDeleteEvent never scans, so the buggy
+	// path would still soft-delete the override and return nil.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET sequence = 'corrupt' WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("corrupt master sequence: %v", err)
+	}
+
+	if err := svc.Delete(ctx, override.ID); err == nil {
+		t.Fatal("Delete should propagate a non-ErrNoRows master-lookup error, got nil")
+	}
+
+	// Repair the master so reads work, then confirm the override is still
+	// live: the transaction must have rolled back.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET sequence = 0 WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("repair master sequence: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("override should still be live after failed delete: %v", err)
+	}
+}


### PR DESCRIPTION
## Root cause

In `internal/event/service.go`, the override branch of `Delete` looked up the
master via `qtx.GetEventByUID(...)` and gated the EXDATE update +
`RecordEventExdateDelete` provenance write on `if err == nil`. Any non-`ErrNoRows`
lookup error (e.g. `SQLITE_BUSY`, or a corrupt master row) was silently swallowed
into the "no master" path: the bookkeeping was skipped, but `SoftDeleteEvent` still
ran and the transaction committed. The deleted instance reappeared on the next
series expansion and was unrestorable via trash (no provenance record).

This was the same bug as #290, which was fixed in `todo/service.go` and
`journal/service.go` but never in the event service.

## Fix

Add the two-stage guard before the EXDATE block, matching the todo/journal
services:

```go
if err != nil && !errors.Is(err, sql.ErrNoRows) {
    return fmt.Errorf("get master: %w", err)
}
if err == nil { ... }
```

Now a genuine error rolls the transaction back (override stays live); only a
truly missing master (`ErrNoRows`) skips the bookkeeping as before.

## Test

Added `TestSoftDelete_OverrideMasterLookupError` in
`internal/event/soft_delete_test.go`. It creates a recurring master + override,
corrupts the master's integer `sequence` column so the master row scan fails with
a non-`ErrNoRows` error, then asserts `Delete(override)` returns an error and the
override remains live (transaction rolled back). The test fails on the old code
(`Delete` returned nil) and passes with the fix.

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/... -count=1` all pass.

Closes #412
