### PR TITLE
fix(tui): keep FocusedLine in sync with item index after a field error (#409)

### DIFF
--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -2066,11 +2066,20 @@ func (f Form) ButtonRowView() string {
 func (f Form) FocusedLine() int {
 	parts := f.fieldParts()
 	line := 0
-	for i, part := range parts {
-		if i == f.focused {
+	part := 0
+	// fieldParts emits one part per item, except the errored field which
+	// emits a second part for its error line. Walk items (not parts) so the
+	// returned offset tracks f.focused, which is an item index.
+	for item := 0; item < len(f.items) && part < len(parts); item++ {
+		if item == f.focused {
 			return line
 		}
-		line += max(lipgloss.Height(part), 1)
+		line += max(lipgloss.Height(parts[part]), 1)
+		part++
+		if f.error != "" && item == f.errorField && part < len(parts) {
+			line += max(lipgloss.Height(parts[part]), 1)
+			part++
+		}
 	}
 	return 0
 }

--- a/internal/tui/form_test.go
+++ b/internal/tui/form_test.go
@@ -620,6 +620,32 @@ func TestForm_ValidationFocusesFirstError(t *testing.T) {
 	assert.Equal(t, "Second is required", form.Error())
 }
 
+func TestForm_FocusedLineAccountsForErrorLine(t *testing.T) {
+	// With LabelTop each field row is two lines tall; a validation error
+	// inserts an extra one-line part after its field's row. FocusedLine must
+	// count items (not parts) so the error line shifts later fields down by
+	// exactly one rather than letting the part index run ahead of the item
+	// index.
+	newForm := func() Form {
+		return newTestForm(
+			FormItem{Label: "First", Field: NewTextField("first")},
+			FormItem{Label: "Second", Field: NewTextField("second")},
+			FormItem{Label: "Third", Field: NewTextField("third")},
+		)
+	}
+
+	noError := newForm()
+	noError.focused = 2
+	assert.Equal(t, 4, noError.FocusedLine(),
+		"two field rows of height 2 precede the third field")
+
+	withError := newForm()
+	withError.SetError(0, "bad value")
+	withError.focused = 2
+	assert.Equal(t, 5, withError.FocusedLine(),
+		"the error line below the first field shifts the third field down one")
+}
+
 func TestForm_OnRebuildCalledOnKeyPress(t *testing.T) {
 	form := newTestForm(
 		FormItem{Label: "Field", Field: NewTextField("val")},


### PR DESCRIPTION
## Root cause

`Form.FocusedLine()` (used by `keepFocusedFieldVisible` in the scrollable
calendar/event dialogs) walked the slice returned by `fieldParts()` and
compared the *part* index against `f.focused`. But `f.focused` is an *item*
index. A field with a validation error emits **two** parts (its row plus a
separate error line), while every other item emits one. So after an errored
field the part index ran one ahead of the item index, and `FocusedLine`
returned an offset one line short — `keepFocusedFieldVisible` then scrolled
the focused field one line below the viewport, exposing the separator instead.

## Fix

Walk items rather than parts, consuming the errored field's extra error part
so the accumulated line offset stays aligned with `f.focused`.

## Test

Added `TestForm_FocusedLineAccountsForErrorLine` in
`internal/tui/form_test.go`: three LabelTop fields (each row height 2). With
no error, `FocusedLine()` for the third field is 4; with an error on the
first field, it must be 5 (the extra error line shifts later fields down one).
Failed before the fix (got 3), passes after.

## Verification

- `go build ./...`, `go vet ./internal/tui/`, `gofmt` clean
- `go test ./internal/... -count=1` all pass

Closes #409
