### PR TITLE
fix(event): guard RDATE-only recurring masters against orphaning overrides on Delete (#415)

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -528,8 +528,9 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 	}
 	evt := FromStorage(r)
 
-	// If this is a recurring master, check for overrides.
-	if evt.RecurrenceRule != "" && evt.RecurrenceID == "" {
+	// If this is a recurring master, check for overrides. RDATE-only masters
+	// (no RRULE) are recurring too, so guard on either rule or RDATEs (#415).
+	if (evt.RecurrenceRule != "" || evt.RDates != "") && evt.RecurrenceID == "" {
 		overrides, err := s.q.ListOverridesByUID(ctx, evt.UID)
 		if err != nil {
 			return fmt.Errorf("check overrides: %w", err)

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -510,6 +510,34 @@ func TestDelete_MasterWithOverridesRefused(t *testing.T) {
 	}
 }
 
+// TestDelete_RDateMasterWithOverridesRefused covers an RDATE-only recurring
+// master (no RRULE). Its overrides must still block single-row deletion;
+// otherwise the master is soft-deleted and the override rows are orphaned
+// (issue #415).
+func TestDelete_RDateMasterWithOverridesRefused(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "del-rdate-master", CalendarID: 1, Title: "RDATE series",
+		StartTime: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RDates:    "2026-04-08T10:00:00Z",
+	})
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "del-rdate-master", CalendarID: 1, Title: "RDATE series (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: "2026-04-08T10:00:00Z",
+	})
+
+	master, _ := svc.GetByUID(ctx, "del-rdate-master")
+	err := svc.Delete(ctx, master.ID)
+	if !errors.Is(err, ErrHasOverrides) {
+		t.Fatalf("Delete RDATE master with overrides: got %v, want ErrHasOverrides", err)
+	}
+}
+
 func TestDelete_MasterNoOverridesSucceeds(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -543,7 +543,9 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		return err
 	}
 
-	if td.RecurrenceRule != "" && td.RecurrenceID == "" {
+	// RDATE-only masters (no RRULE) are recurring too, so guard on either rule
+	// or RDATEs; otherwise their overrides would be orphaned (#415).
+	if (td.RecurrenceRule != "" || td.RDates != "") && td.RecurrenceID == "" {
 		overrides, err := s.q.ListTodoOverridesByUID(ctx, td.UID)
 		if err != nil {
 			return fmt.Errorf("check overrides: %w", err)

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -389,6 +389,32 @@ func TestDelete_MasterWithOverridesRefused(t *testing.T) {
 	}
 }
 
+// TestDelete_RDateMasterWithOverridesRefused covers an RDATE-only recurring
+// master (no RRULE). Its overrides must still block single-row deletion;
+// otherwise the master is soft-deleted and the override rows are orphaned
+// (issue #415).
+func TestDelete_RDateMasterWithOverridesRefused(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "del-rdate-master", CalendarID: 1, Summary: "RDATE series",
+		DueDate: time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RDates:  "2026-04-08T23:59:59Z",
+	})
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "del-rdate-master", CalendarID: 1, Summary: "RDATE series (moved)",
+		DueDate:      time.Date(2026, 4, 8, 23, 59, 59, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceID: "2026-04-08T23:59:59Z",
+	})
+
+	master, _ := svc.GetByUID(ctx, "del-rdate-master")
+	err := svc.Delete(ctx, master.ID)
+	if !errors.Is(err, ErrHasOverrides) {
+		t.Fatalf("Delete RDATE master with overrides: got %v, want ErrHasOverrides", err)
+	}
+}
+
 func TestDelete_MasterNoOverridesSucceeds(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Root cause

`event.Service.Delete` and `todo.Service.Delete` guard against single-row
deletion of a recurring master that still has override instances, returning
`ErrHasOverrides` to push callers toward `DeleteSeries`. The guard only fired
when `RecurrenceRule != ""`. RDATE-only recurring masters carry no RRULE, so
the guard was skipped: `Delete` soft-deleted only the master and left the
override rows (same UID, non-empty `recurrence_id`) live with no master —
violating the "every override has a live master" invariant. The orphans never
surface in expansion but accumulate.

## Fix

Extend the guard in both services to fire when `RecurrenceRule != "" ||
RDates != ""` (still scoped to masters via `RecurrenceID == ""`). RDATE-only
masters with overrides are now rejected with `ErrHasOverrides`.

## Tests

Added `TestDelete_RDateMasterWithOverridesRefused` to both
`internal/event/service_test.go` and `internal/todo/service_test.go`. Each
creates an RDATE-only master plus an override, then asserts `Delete` on the
master returns `ErrHasOverrides`. Both tests fail before the fix (Delete
returns nil) and pass after.

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/... -count=1` all
pass.

Closes #415
