### PR TITLE
fix(notify): declare UTF-8 Content-Type on outgoing alarm email (#427)

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -259,12 +259,7 @@ func Email(da alarm.DueAlarm, smtpCfg config.SMTPConfig, policy ExecutionPolicy)
 		return fmt.Errorf("no valid attendees for EMAIL alarm")
 	}
 
-	msg := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n%s\r\n",
-		textsafe.Display(smtpCfg.From),
-		strings.Join(to, ", "),
-		textsafe.Display(title),
-		textsafe.Display(body),
-	)
+	msg := buildEmailMessage(smtpCfg.From, to, title, body)
 
 	addr := fmt.Sprintf("%s:%d", smtpCfg.Host, smtpCfg.Port)
 
@@ -274,9 +269,24 @@ func Email(da alarm.DueAlarm, smtpCfg config.SMTPConfig, policy ExecutionPolicy)
 	}
 
 	if useImplicitTLS(smtpCfg) {
-		return sendMailImplicitTLS(addr, smtpCfg.Host, auth, smtpCfg.From, to, []byte(msg))
+		return sendMailImplicitTLS(addr, smtpCfg.Host, auth, smtpCfg.From, to, msg)
 	}
-	return smtp.SendMail(addr, auth, smtpCfg.From, to, []byte(msg))
+	return smtp.SendMail(addr, auth, smtpCfg.From, to, msg)
+}
+
+// buildEmailMessage assembles an RFC 5322 message with MIME headers declaring a
+// UTF-8 text/plain body. The Content-Type/charset header is required so strict
+// mail clients render non-ASCII titles and bodies as UTF-8 rather than defaulting
+// to US-ASCII (which produces mojibake).
+func buildEmailMessage(from string, to []string, subject, body string) []byte {
+	msg := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n"+
+		"MIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n%s\r\n",
+		textsafe.Display(from),
+		strings.Join(to, ", "),
+		textsafe.Display(subject),
+		textsafe.Display(body),
+	)
+	return []byte(msg)
 }
 
 func isLikelyAudioFile(path string) bool {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -402,6 +402,55 @@ func TestEmail_ImplicitTLS_SMTPSServer(t *testing.T) {
 	}
 }
 
+func TestBuildEmailMessage_MIMEHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		from    string
+		to      []string
+		subject string
+		body    string
+	}{
+		{
+			name:    "ascii",
+			from:    "sender@example.com",
+			to:      []string{"user@example.com"},
+			subject: "Reminder",
+			body:    "Meeting at noon",
+		},
+		{
+			name:    "non-ascii",
+			from:    "sender@example.com",
+			to:      []string{"a@example.com", "b@example.com"},
+			subject: "Reunião com café",
+			body:    "Não esqueça do açúcar — naïve façade ☕",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := string(buildEmailMessage(tt.from, tt.to, tt.subject, tt.body))
+
+			head, rest, found := strings.Cut(msg, "\r\n\r\n")
+			if !found {
+				t.Fatalf("message has no header/body separator:\n%q", msg)
+			}
+
+			if !strings.Contains(head, "MIME-Version: 1.0") {
+				t.Errorf("message headers missing MIME-Version:\n%q", head)
+			}
+			if !strings.Contains(head, "Content-Type: text/plain; charset=utf-8") {
+				t.Errorf("message headers missing UTF-8 Content-Type:\n%q", head)
+			}
+			if !strings.Contains(head, "Subject: "+tt.subject) {
+				t.Errorf("message headers missing Subject %q:\n%q", tt.subject, head)
+			}
+			if !strings.Contains(rest, tt.body) {
+				t.Errorf("message body = %q, want it to contain %q", rest, tt.body)
+			}
+		})
+	}
+}
+
 // generateTestCert creates a self-signed ECDSA certificate for 127.0.0.1/localhost.
 func generateTestCert(t *testing.T) tls.Certificate {
 	t.Helper()


### PR DESCRIPTION
## Root cause

`notify.Email` assembled the SMTP message with only `From`/`To`/`Subject`
headers and no MIME metadata. Since `textsafe.Display` preserves non-ASCII
runes, Unicode event titles/descriptions were emitted as raw UTF-8 bytes in
the body. Strict mail clients treat an undeclared body as US-ASCII and render
those bytes as mojibake.

## Fix

Extracted message construction into a `buildEmailMessage` helper and added the
two missing headers:

```
MIME-Version: 1.0
Content-Type: text/plain; charset=utf-8
```

Behaviour is otherwise unchanged: `textsafe.Display` still sanitizes
from/subject/body (which also guards against header injection).

## Test

Added `TestBuildEmailMessage_MIMEHeaders` (table-driven, ASCII + non-ASCII
cases) asserting the assembled message carries `MIME-Version: 1.0`,
`Content-Type: text/plain; charset=utf-8`, the Subject, and preserves the body
before/after the header separator.

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/... -count=1` all pass.

Closes #427
