### PR TITLE
fix(ical): emit floating RECURRENCE-ID without Z suffix (#420)

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -111,7 +111,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 
 		// RECURRENCE-ID
 		if e.RecurrenceID != "" {
-			emitRecurrenceID(vevent.Props, e.RecurrenceID, e.AllDay)
+			emitRecurrenceID(vevent.Props, e.RecurrenceID, e.AllDay, e.Timezone == "FLOATING")
 		}
 
 		if e.Geo != "" {
@@ -453,7 +453,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			if anchor == "" {
 				anchor = t.DueDate
 			}
-			emitRecurrenceID(vtodo.Props, t.RecurrenceID, timeutil.IsDateOnly(anchor))
+			emitRecurrenceID(vtodo.Props, t.RecurrenceID, timeutil.IsDateOnly(anchor), t.Timezone == "FLOATING")
 		}
 
 		if t.Geo != "" {
@@ -650,18 +650,25 @@ func emitDateListOnComponent(comp *ical.Component, propName, dates string) {
 }
 
 // emitRecurrenceID writes RECURRENCE-ID onto props. recurrenceID is the stored
-// RFC 3339 string. Per RFC 5545 the RECURRENCE-ID value type must match the
-// master's DTSTART: when the component is all-day it is emitted as VALUE=DATE
-// (YYYYMMDD), otherwise as a UTC DATE-TIME. A type mismatch prevents CalDAV
-// servers from binding the override to its master.
-func emitRecurrenceID(props ical.Props, recurrenceID string, allDay bool) {
+// RFC 3339 string. Per RFC 5545 §3.8.4.4 the RECURRENCE-ID value type must
+// match the master's DTSTART: when the component is all-day it is emitted as
+// VALUE=DATE (YYYYMMDD); when floating (no timezone) it is emitted as a
+// floating DATE-TIME (no Z, no TZID); otherwise as a UTC DATE-TIME. A type
+// mismatch prevents CalDAV servers from binding the override to its master.
+func emitRecurrenceID(props ical.Props, recurrenceID string, allDay, floating bool) {
 	t, err := time.Parse(time.RFC3339, recurrenceID)
 	if err != nil {
 		return
 	}
-	if allDay {
+	switch {
+	case allDay:
 		props.SetDate(ical.PropRecurrenceID, t.UTC())
-	} else {
+	case floating:
+		props.Set(&ical.Prop{
+			Name:  ical.PropRecurrenceID,
+			Value: t.UTC().Format("20060102T150405"),
+		})
+	default:
 		props.SetDateTime(ical.PropRecurrenceID, t.UTC())
 	}
 }
@@ -1078,7 +1085,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 		if j.RecurrenceID != "" {
 			// A VJOURNAL is all-day when its DTSTART is a date-only value;
 			// the RECURRENCE-ID type must match.
-			emitRecurrenceID(vjournal.Props, j.RecurrenceID, timeutil.IsDateOnly(j.StartDate))
+			emitRecurrenceID(vjournal.Props, j.RecurrenceID, timeutil.IsDateOnly(j.StartDate), j.Timezone == "FLOATING")
 		}
 
 		if j.DtStamp != "" {

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -993,6 +993,41 @@ func TestExport_TimedOverrideRecurrenceIDIsDateTime(t *testing.T) {
 	}
 }
 
+func TestExport_FloatingOverrideRecurrenceIDIsFloating(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{
+		{
+			UID:          "floating-recurring",
+			Title:        "Workout (moved)",
+			StartTime:    time.Date(2026, 4, 13, 14, 0, 0, 0, time.UTC),
+			EndTime:      time.Date(2026, 4, 13, 15, 0, 0, 0, time.UTC),
+			Timezone:     "FLOATING",
+			Status:       "CONFIRMED",
+			RecurrenceID: "2026-04-13T09:00:00Z",
+		},
+	}
+	data, err := ExportEvents(events, "Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := recurrenceIDLine(string(data))
+	if line == "" {
+		t.Fatal("missing RECURRENCE-ID")
+	}
+	if strings.Contains(line, "VALUE=DATE") {
+		t.Errorf("floating override RECURRENCE-ID must not carry VALUE=DATE, got %q", line)
+	}
+	if strings.Contains(line, "TZID") {
+		t.Errorf("floating override RECURRENCE-ID must not carry TZID, got %q", line)
+	}
+	if v := recurrenceIDValue(line); strings.HasSuffix(v, "Z") {
+		t.Errorf("floating override RECURRENCE-ID must not carry a Z suffix (must match floating DTSTART), got %q", line)
+	}
+	if !strings.Contains(recurrenceIDValue(line), "T") {
+		t.Errorf("floating override RECURRENCE-ID must keep its time component, got %q", line)
+	}
+}
+
 func TestExport_AllDayTodoOverrideRecurrenceIDIsDate(t *testing.T) {
 	t.Parallel()
 	todos := []todo.Todo{


### PR DESCRIPTION
## Root cause

`emitRecurrenceID` (`internal/ical/export.go`) only knew whether a
component was all-day. For any non-all-day component it emitted
`RECURRENCE-ID` as a UTC `DATE-TIME` via `SetDateTime(t.UTC())`, producing
a `...Z` value. But for **floating** components (`Timezone == "FLOATING"`)
`DTSTART` is emitted floating (no `Z`, no `TZID`). The resulting
`RECURRENCE-ID` was a value-type mismatch with the master's `DTSTART`,
violating RFC 5545 §3.8.4.4. CalDAV servers that bind overrides to masters
by `RECURRENCE-ID` value could reject the PUT or fail to bind the override.

## Fix

Added a `floating bool` parameter to `emitRecurrenceID`. When floating and
not all-day, it emits the wall-clock `DATE-TIME` (`20060102T150405`, no
`Z`, no `TZID`) — matching how floating `DTSTART` is emitted. All-day and
zoned/UTC paths are unchanged. The three call sites (`ExportEvents`,
`ExportTodos`, `ExportJournals`) pass `<comp>.Timezone == "FLOATING"`.

## Test

Added `TestExport_FloatingOverrideRecurrenceIDIsFloating` in
`internal/ical/export_test.go`: a floating timed override must export a
`RECURRENCE-ID` with no `VALUE=DATE`, no `TZID`, no `Z` suffix, and a kept
time component. It failed before the fix
(`got "RECURRENCE-ID:20260413T090000Z"`) and passes after.

Verified: `go build ./...`, `go vet ./internal/ical/`, and
`go test ./internal/... -count=1` all pass.

Closes #420
