### PR TITLE
fix(todo): mark Complete dirty via dirtyExec so it joins WithTx (#425)

### DIFF
--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -470,7 +470,7 @@ func (s *Service) Complete(ctx context.Context, id int64) (Todo, error) {
 		return Todo{}, err
 	}
 	t := fromStorage(r)
-	_ = storage.MarkResourceDirty(ctx, s.db, t.CalendarID, t.UID, "todo")
+	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), t.CalendarID, t.UID, "todo")
 	return t, nil
 }
 

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -128,6 +128,58 @@ func TestTodoService_Complete_MarksResourceDirty(t *testing.T) {
 	}
 }
 
+// TestTodoService_Complete_MarksResourceDirtyUnderTx asserts that when Complete
+// runs on a WithTx-bound service, the dirty mark joins the outer transaction and
+// survives the commit. Before the fix Complete marked dirty on s.db rather than
+// s.dirtyExec(): a second connection (or the single :memory: pool connection,
+// already held by the outer tx) could never take the write lock the outer tx
+// holds, so MarkResourceDirty's discarded error meant the completion silently
+// never synced.
+func TestTodoService_Complete_MarksResourceDirtyUnderTx(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	testutil.LinkCalendarToAccount(t, svc.db)
+
+	td := createTodo(t, svc)
+
+	// Creation dirties the row; clear it so the test isolates Complete.
+	if err := svc.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
+		Etag: "", CalendarID: td.CalendarID, Uid: td.UID,
+	}); err != nil {
+		t.Fatalf("ClearSyncResourceDirty: %v", err)
+	}
+	if dirty, _ := svc.q.ListDirtySyncResources(ctx, td.CalendarID); len(dirty) != 0 {
+		t.Fatalf("precondition: expected 0 dirty resources, got %d", len(dirty))
+	}
+
+	// Bound the Complete call so the buggy path (which blocks on the pool
+	// connection held by the outer tx) fails fast instead of deadlocking.
+	callCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	tx, err := svc.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := svc.WithTx(tx).Complete(callCtx, td.ID); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	dirty, err := svc.q.ListDirtySyncResources(ctx, td.CalendarID)
+	if err != nil {
+		t.Fatalf("ListDirtySyncResources: %v", err)
+	}
+	if len(dirty) != 1 || dirty[0].Uid != td.UID {
+		t.Fatalf("Complete under tx did not mark resource dirty: got %d dirty resources", len(dirty))
+	}
+}
+
 func TestTodoService_ListAll(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Root cause

`Service.Complete` (`internal/todo/service.go:473`) marked the resource dirty
with `storage.MarkResourceDirty(ctx, s.db, ...)` instead of `s.dirtyExec()`.
Every other dirty-mark in the file routes through `dirtyExec()`, which returns
the active outer transaction when the service is `WithTx`-bound.

When `Complete` runs under `WithTx`, `CompleteTodo` executes on the outer
transaction (via `s.q`) while the dirty write went to `s.db`. That second write
can never acquire the write lock the outer tx holds:

- file-backed pool: the extra connection hits `SQLITE_BUSY` after the busy
  timeout;
- single-connection `:memory:` pool: it blocks on the connection the tx already
  checked out.

Because the result was discarded (`_ =`), the completion was silently never
marked dirty and would never sync.

## Fix

Use `s.dirtyExec()` so the mark joins the active transaction, matching every
other dirty-mark in the file. One-line change.

## Test

Added `TestTodoService_Complete_MarksResourceDirtyUnderTx` in
`internal/todo/service_test.go`: links calendar 1 to an account, clears the
creation dirty mark, then runs `Complete` on a `WithTx`-bound service, commits,
and asserts exactly one dirty `sync_resource` for the todo's UID. The call is
wrapped in a 3s timeout so the buggy path fails fast instead of deadlocking on
the held pool connection.

- Before fix: FAIL (`got 0 dirty resources`).
- After fix: PASS.

Full `go build ./...`, `go vet`, and `go test ./internal/... -count=1` all pass.

Closes #425