### PR TITLE
fix(caldav): keep weak ETag quotes so a strong "W/" opaque value is not suppressed (#418)

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -534,21 +534,31 @@ func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
 	return 0, false
 }
 
-// normalizeETag strips surrounding whitespace and the quotes from an ETag,
-// preserving the weak "W/" marker (RFC 7232 §2.3) so callers can tell a weak
-// validator apart from a strong one. Weak tags are kept as "W/<opaque>", strong
-// tags as "<opaque>". Comparisons elsewhere are opaque equality, which stays
-// consistent because both sides flow through this function.
+// normalizeETag strips surrounding whitespace and the outer quotes from an
+// ETag, preserving the weak "W/" marker (RFC 7232 §2.3) so callers can tell a
+// weak validator apart from a strong one. Weak tags are kept quoted as
+// `W/"<opaque>"`, strong tags as bare `<opaque>`. Retaining the quotes on weak
+// tags keeps the representation unambiguous: a strong validator whose opaque
+// value happens to start with "W/" (e.g. `"W/abc"` normalizing to `W/abc`)
+// would otherwise be indistinguishable from a weak `W/"abc"`. Because the weak
+// marker is the literal "W/" *before* the opening quote, it is detected before
+// the quotes are stripped. Comparisons elsewhere are opaque equality, which
+// stays consistent because both sides flow through this function, and the
+// function is idempotent so a stored normalized value re-normalizes to itself.
 func normalizeETag(etag string) string {
 	etag = strings.TrimSpace(etag)
 	weak := false
 	if rest, ok := strings.CutPrefix(etag, "W/"); ok {
-		weak = true
-		etag = strings.TrimSpace(rest)
+		// A lenient tolerance for "W/ " (marker followed by space) matches some
+		// servers; only treat it as weak when an opening quote follows.
+		if trimmed := strings.TrimSpace(rest); strings.HasPrefix(trimmed, `"`) {
+			weak = true
+			etag = trimmed
+		}
 	}
 	etag = strings.Trim(etag, `"`)
 	if weak && etag != "" {
-		return "W/" + etag
+		return `W/"` + etag + `"`
 	}
 	return etag
 }
@@ -561,7 +571,10 @@ func normalizeETag(etag string) string {
 // the sync-token/ctag pull comparison instead.
 func formatIfMatch(etag string) string {
 	etag = normalizeETag(etag)
-	if etag == "" || strings.HasPrefix(etag, "W/") {
+	// A weak validator normalizes to `W/"<opaque>"`; the `W/"` prefix (marker
+	// plus opening quote) distinguishes it from a strong opaque value that
+	// merely begins with "W/".
+	if etag == "" || strings.HasPrefix(etag, `W/"`) {
 		return ""
 	}
 	return `"` + etag + `"`

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -101,8 +101,15 @@ func TestNormalizeAndFormatIfMatch(t *testing.T) {
 		{"strong_spaced", ` "abc" `, "abc", `"abc"`},
 		// Weak validators must keep their W/ marker through normalization and
 		// must NOT be asserted as strong validators in If-Match (RFC 7232 §3.1).
-		{"weak", `W/"abc"`, `W/abc`, ""},
-		{"weak_spaced", `W/ "abc"`, `W/abc`, ""},
+		{"weak", `W/"abc"`, `W/"abc"`, ""},
+		{"weak_spaced", `W/ "abc"`, `W/"abc"`, ""},
+		// A strong validator whose opaque value merely starts with "W/" must not
+		// be misread as weak: the weak marker is "W/" before the opening quote.
+		{"strong_w_prefix", `"W/abc"`, `W/abc`, `"W/abc"`},
+		// The normalized strong form re-enters normalizeETag/formatIfMatch (the
+		// stored ETag is the normalized value), so the classification must be
+		// idempotent and keep emitting an If-Match.
+		{"strong_w_prefix_normalized", `W/abc`, `W/abc`, `"W/abc"`},
 		{"empty", "", "", ""},
 	}
 
@@ -145,8 +152,8 @@ func TestClientPutResourceWeakETagOmitsIfMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutResource: %v", err)
 	}
-	if etag != `W/etag-after` {
-		t.Fatalf("etag = %q, want %q", etag, `W/etag-after`)
+	if etag != `W/"etag-after"` {
+		t.Fatalf("etag = %q, want %q", etag, `W/"etag-after"`)
 	}
 }
 


### PR DESCRIPTION
## Root cause

`normalizeETag` (`internal/caldav/client.go`) stripped the surrounding quotes from an ETag and then used a bare `W/` prefix to mark weak validators, storing weak tags as `W/<opaque>`. This collides with a *strong* validator whose opaque value happens to start with `W/`:

- A strong ETag received as `"W/abc"` does not begin with `W/` (it begins with `"`), so it was correctly treated as strong — but it normalized to `W/abc`, indistinguishable from a genuine weak `W/"abc"`.
- The normalized value is what gets stored and later fed back into `formatIfMatch` (e.g. `sync/engine.go` passes the stored `res.Etag` to `PutResource`/`DeleteResource`). `formatIfMatch` re-classified `W/abc` as weak via `strings.HasPrefix(etag, "W/")` and returned `""`, suppressing the `If-Match` header.

The result: the next PUT/DELETE went out unconditionally, so a concurrent remote edit could be silently overwritten — a RFC 7232 §3.1 violation. Latent in practice (no mainstream server emits such ETags), severity low.

The issue's suggested one-line fix (check `W/"` before stripping quotes) is necessary but not sufficient on its own, because the round-trip through the stored normalized value still left strong-opaque-`W/abc` and weak-`abc` mapping to the same string `W/abc`.

## Fix

- `normalizeETag` now detects the weak marker as the literal `W/` *before* the opening quote, and keeps weak tags **quoted** as `W/"<opaque>"`. This makes the normalized representation unambiguous (a strong opaque `W/abc` cannot collide with a weak `W/"abc"`) and idempotent, so a stored normalized value re-normalizes to itself.
- `formatIfMatch` keys off the `W/"` prefix instead of bare `W/`.

Strong tags still normalize to bare `<opaque>`; weak/strong opaque-equality comparisons elsewhere stay consistent because both sides flow through `normalizeETag`.

## Tests

`TestNormalizeAndFormatIfMatch` gains two cases that fail before the fix:
- `strong_w_prefix`: `"W/abc"` → norm `W/abc`, If-Match `"W/abc"` (no longer suppressed).
- `strong_w_prefix_normalized`: re-feeding the normalized `W/abc` still yields If-Match `"W/abc"` (idempotent round-trip).

Existing weak cases updated to the new unambiguous normalized form `W/"abc"` (incl. `TestClientPutResourceWeakETagOmitsIfMatch`, which still confirms weak validators emit no `If-Match`).

`go build ./...`, `go vet`, and `go test ./internal/... -count=1` all pass.

Closes #418
