### PR TITLE
fix(calendar): defer tx.Rollback in Connect transaction branches (#426)

### DIFF
--- a/internal/calendar/remote.go
+++ b/internal/calendar/remote.go
@@ -57,6 +57,7 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 			if err != nil {
 				return fmt.Errorf("begin tx: %w", err)
 			}
+			defer tx.Rollback()
 			qtx := s.q.WithTx(tx)
 			if err := qtx.UpdateAccount(ctx, storage.UpdateAccountParams{
 				ID:        existing.ID,
@@ -65,7 +66,6 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 				AuthType:  link.AuthType,
 				Username:  link.Username,
 			}); err != nil {
-				_ = tx.Rollback()
 				return fmt.Errorf("update hidden account: %w", err)
 			}
 			if err := qtx.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
@@ -73,7 +73,6 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 				AccountID: &existing.ID,
 				RemoteUrl: storage.StringToNullable(link.RemoteURL),
 			}); err != nil {
-				_ = tx.Rollback()
 				return fmt.Errorf("link calendar: %w", err)
 			}
 			// Intentionally skip seeding RemoteColor on re-link: the calendar
@@ -89,7 +88,6 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 			// the DB writes succeed, mirroring the new-account path below.
 			prevCred, prevErr := credStore.Get(existing.ID)
 			if err := credStore.Set(cred); err != nil {
-				_ = tx.Rollback()
 				return fmt.Errorf("store credentials: %w", err)
 			}
 			if err := tx.Commit(); err != nil {
@@ -108,6 +106,7 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
+	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
 	account, err := qtx.CreateAccount(ctx, storage.CreateAccountParams{
 		Name:      hiddenAccountName(cal.ID),
@@ -116,7 +115,6 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 		Username:  link.Username,
 	})
 	if err != nil {
-		_ = tx.Rollback()
 		return fmt.Errorf("create hidden account: %w", err)
 	}
 	if err := qtx.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
@@ -124,7 +122,6 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 		AccountID: &account.ID,
 		RemoteUrl: storage.StringToNullable(link.RemoteURL),
 	}); err != nil {
-		_ = tx.Rollback()
 		return fmt.Errorf("link calendar: %w", err)
 	}
 	if link.RemoteColor != "" {
@@ -133,14 +130,12 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 			Color:       link.RemoteColor,
 			RemoteColor: storage.StringToNullable(link.RemoteColor),
 		}); err != nil {
-			_ = tx.Rollback()
 			return fmt.Errorf("seed remote calendar color: %w", err)
 		}
 	}
 
 	cred.AccountID = account.ID
 	if err := credStore.Set(cred); err != nil {
-		_ = tx.Rollback()
 		return fmt.Errorf("store credentials: %w", err)
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/calendar/remote_test.go
+++ b/internal/calendar/remote_test.go
@@ -5,11 +5,20 @@ import (
 	"database/sql"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
+
+// panicCredStore panics from Set to simulate a panic raised inside Connect
+// after BeginTx but before Commit.
+type panicCredStore struct{}
+
+func (panicCredStore) Get(int64) (auth.Credential, error) { return auth.Credential{}, nil }
+func (panicCredStore) Set(auth.Credential) error          { panic("simulated credential-store panic") }
+func (panicCredStore) Delete(int64) error                 { return nil }
 
 // failGetAccountDB wraps a DBTX and turns the GetAccount read into a
 // non-ErrNoRows failure (a "no such column" scan error), simulating a
@@ -277,6 +286,45 @@ func TestConnect_RelinkPropagatesTransientGetAccountError(t *testing.T) {
 	}
 	if len(store.creds) != 1 {
 		t.Errorf("credential count = %d, want 1: a transient read error must not orphan the old credential behind a new one", len(store.creds))
+	}
+}
+
+// TestConnect_PanicDoesNotLeakTransaction verifies that a panic raised between
+// BeginTx and Commit in Connect does not leak the transaction. The in-memory
+// test pool is pinned to a single connection (storage.Open sets
+// SetMaxOpenConns(1) for ":memory:"), so a leaked transaction never returns its
+// connection to the pool and the next query blocks until its context expires.
+// A deferred rollback releases the connection, so the follow-up read returns
+// promptly.
+func TestConnect_PanicDoesNotLeakTransaction(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	cal, err := svc.Get(ctx, 1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	link := RemoteLink{
+		RemoteURL:     "https://example.com/dav/calendars/work/",
+		Username:      "user",
+		AuthType:      "basic",
+		AllowInsecure: false,
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("Connect: expected the credential-store panic to propagate, got none")
+			}
+		}()
+		_ = svc.Connect(ctx, cal, link, auth.Credential{Username: "user"}, panicCredStore{})
+	}()
+
+	deadline, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if _, err := svc.Get(deadline, 1); err != nil {
+		t.Fatalf("read after panicked Connect failed (transaction leaked, connection not released): %v", err)
 	}
 }
 


### PR DESCRIPTION
## Root cause

Both transaction blocks in `calendar.Service.Connect` (`internal/calendar/remote.go`, the re-link path and the new-account path) relied on explicit `_ = tx.Rollback()` calls scattered across each error branch, rather than a single `defer tx.Rollback()` like every other transactional method in the file (`Disconnect`, `DeleteWithRemoteCleanup`). Any future error path added before the explicit rollback — or a panic raised between `BeginTx` and `Commit` — leaks the transaction. The connection (and SQLite's WAL write slot) is never released, which in a long-running TUI can wedge subsequent writes.

## Fix

Add `defer tx.Rollback()` immediately after each `BeginTx` and drop the now-redundant explicit `_ = tx.Rollback()` calls. A committed transaction makes the deferred rollback a harmless no-op (`sql.ErrTxDone`), exactly matching the existing `DeleteWithRemoteCleanup` pattern in the same file. Behavior on all existing error paths is unchanged; the change only adds rollback coverage for panics and any future early returns.

## Test

Added `TestConnect_PanicDoesNotLeakTransaction` in `internal/calendar/remote_test.go`. It injects a credential store whose `Set` panics mid-transaction (after `BeginTx`, before `Commit`). Because the in-memory test pool is pinned to a single connection (`storage.Open` sets `SetMaxOpenConns(1)` for `:memory:`), a leaked transaction never returns its connection to the pool, so the follow-up read blocks until its context deadline.

- Before the fix: the test fails with `context deadline exceeded` (connection leaked).
- After the fix: the deferred rollback releases the connection and the read returns promptly.

Full `go test ./internal/... -count=1`, `go build ./...`, `go vet`, and `gofmt` all pass.

Closes #426