### PR TITLE
fix(tui): revert recurrence ends-date picker on Cancel/Esc (#410)

### DIFF
--- a/internal/tui/recurrence_editor.go
+++ b/internal/tui/recurrence_editor.go
@@ -50,6 +50,12 @@ type RecurrenceEditorModel struct {
 
 	endsDate       time.Time
 	endsDatePicker bool
+	// endsDateRevert holds the committed ends date captured when the picker
+	// opens, so Cancel/Esc can discard in-picker navigation (issue #410).
+	endsDateRevert time.Time
+	// endsDateBtnFocus tracks keyboard focus inside the picker:
+	// -1 grid, 0 Cancel, 1 Ok. Tab cycles grid -> Cancel -> Ok -> grid.
+	endsDateBtnFocus int
 
 	form      Form
 	fieldKeys []string
@@ -354,10 +360,28 @@ func (m *RecurrenceEditorModel) tryOpenOverlay() tea.Cmd {
 		return nil
 	}
 	if m.fieldKeys[idx] == recFieldEnds && m.currentEnds() == endsOnDate {
-		m.endsDatePicker = true
+		m.openEndsDatePicker()
 		return noopCmd
 	}
 	return nil
+}
+
+// openEndsDatePicker opens the ends-date picker, staging the current ends date
+// so Cancel/Esc can revert any in-picker navigation, and focusing the grid.
+func (m *RecurrenceEditorModel) openEndsDatePicker() {
+	m.endsDateRevert = m.endsDate
+	m.endsDateBtnFocus = -1
+	m.endsDatePicker = true
+}
+
+// cancelEndsDatePicker discards in-picker navigation, restoring the ends date
+// captured when the picker opened, and closes the overlay.
+func (m RecurrenceEditorModel) cancelEndsDatePicker() RecurrenceEditorModel {
+	m.endsDate = m.endsDateRevert
+	m.endsDatePicker = false
+	m.updatePreview()
+	m.syncFromForm()
+	return m
 }
 
 // Update handles all messages for the recurrence editor.
@@ -416,7 +440,7 @@ func (m RecurrenceEditorModel) Update(msg tea.Msg) (RecurrenceEditorModel, tea.C
 			m.fieldKeys[idx] == recFieldEnds &&
 			m.currentEnds() == endsOnDate &&
 			target == fieldTarget(idx) {
-			m.endsDatePicker = true
+			m.openEndsDatePicker()
 		}
 		return m, cmd
 	}
@@ -428,6 +452,36 @@ func (m RecurrenceEditorModel) Update(msg tea.Msg) (RecurrenceEditorModel, tea.C
 }
 
 func (m RecurrenceEditorModel) handleEndsDateKey(msg tea.KeyPressMsg) RecurrenceEditorModel {
+	switch msg.String() {
+	case "esc", "q":
+		return m.cancelEndsDatePicker()
+	case "tab":
+		// grid (-1) -> Cancel (0) -> Ok (1) -> grid (-1)
+		m.endsDateBtnFocus++
+		if m.endsDateBtnFocus > 1 {
+			m.endsDateBtnFocus = -1
+		}
+		return m
+	case "shift+tab":
+		// grid (-1) -> Ok (1) -> Cancel (0) -> grid (-1)
+		m.endsDateBtnFocus--
+		if m.endsDateBtnFocus < -1 {
+			m.endsDateBtnFocus = 1
+		}
+		return m
+	case "enter", "space":
+		if m.endsDateBtnFocus == 0 { // Cancel
+			return m.cancelEndsDatePicker()
+		}
+		// Ok (1) or grid (-1): commit the navigated date.
+		m.endsDatePicker = false
+		return m
+	}
+
+	// Arrow / month / today navigation only applies while the grid is focused.
+	if m.endsDateBtnFocus != -1 {
+		return m
+	}
 	switch msg.String() {
 	case "left", "h":
 		m.endsDate = m.endsDate.AddDate(0, 0, -1)
@@ -443,8 +497,6 @@ func (m RecurrenceEditorModel) handleEndsDateKey(msg tea.KeyPressMsg) Recurrence
 		m.endsDate = addMonthClamped(m.endsDate, 1)
 	case "t":
 		m.endsDate = time.Now()
-	case "enter", "space", "esc", "q":
-		m.endsDatePicker = false
 	}
 	m.updatePreview()
 	m.syncFromForm()
@@ -478,7 +530,7 @@ func (m RecurrenceEditorModel) HandleEndsDateMouse(msg tea.MouseClickMsg, picker
 		btnPad := max(innerW-cancelW-1-okW, 0)
 		switch {
 		case mmX >= btnPad && mmX < btnPad+cancelW:
-			m.endsDatePicker = false
+			return m.cancelEndsDatePicker()
 		case mmX >= btnPad+cancelW+1 && mmX < btnPad+cancelW+1+okW:
 			m.endsDatePicker = false
 		}
@@ -656,8 +708,8 @@ func (m RecurrenceEditorModel) EndsDatePickerView() string {
 	sepStyle := lipgloss.NewStyle().Foreground(m.theme.Border)
 	resultLines = append(resultLines, sepStyle.Render(strings.Repeat("─", innerW)))
 	bs := DefaultButtonStyles()
-	cancelBtn := bs.Normal.Render("Cancel", false)
-	okBtn := bs.Normal.Render("Ok", false)
+	cancelBtn := bs.Normal.Render("Cancel", m.endsDateBtnFocus == 0)
+	okBtn := bs.Normal.Render("Ok", m.endsDateBtnFocus == 1)
 	buttonRow := cancelBtn + " " + okBtn
 	btnPad := max(innerW-lipgloss.Width(buttonRow), 0)
 	resultLines = append(resultLines, strings.Repeat(" ", btnPad)+buttonRow)

--- a/internal/tui/recurrence_ends_revert_test.go
+++ b/internal/tui/recurrence_ends_revert_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openRecurrenceEndsPicker drives the real open flow so the picker is opened
+// the same way a user does: select "On <date>", focus the Ends field, press
+// enter. This ensures any staging/revert state is initialised exactly as in
+// production.
+func openRecurrenceEndsPicker(t *testing.T, start time.Time) RecurrenceEditorModel {
+	t.Helper()
+	m := NewRecurrenceEditorModel(start, 120, 40, Theme{})
+	m.endsField.SetSelected(int(endsOnDate))
+	m.syncFromForm()
+
+	endsIdx := -1
+	for i, item := range m.form.items {
+		if item.Label == "Ends" {
+			endsIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, endsIdx, "Ends field must exist")
+	m.form.focused = endsIdx
+
+	m, _ = m.Update(keyPressMsg("enter"))
+	require.True(t, m.endsDatePicker, "enter on Ends=ondate must open the picker")
+	return m
+}
+
+// TestRecurrenceEditor_EscRevertsNavigatedEndsDate is the TDD regression test
+// for issue #410: arrow-key navigation in the ends-date picker mutated the
+// committed date with no staging, so pressing Esc committed the navigated date
+// instead of reverting to the original.
+func TestRecurrenceEditor_EscRevertsNavigatedEndsDate(t *testing.T) {
+	start := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	m := openRecurrenceEndsPicker(t, start)
+
+	original := m.endsDate
+
+	// Navigate away from the original date.
+	m, _ = m.Update(keyPressMsg("right"))
+	m, _ = m.Update(keyPressMsg("down"))
+	require.NotEqual(t, original, m.endsDate, "navigation should move the displayed date")
+
+	// Esc must revert and close.
+	m, _ = m.Update(keyPressMsg("esc"))
+	assert.False(t, m.endsDatePicker, "esc must close the picker")
+	assert.Equal(t, original, m.endsDate,
+		"esc must revert the ends date, not commit the navigated value")
+}
+
+// TestRecurrenceEditor_MouseCancelRevertsNavigatedEndsDate verifies that
+// clicking Cancel after navigating discards the navigation.
+func TestRecurrenceEditor_MouseCancelRevertsNavigatedEndsDate(t *testing.T) {
+	const screenW, screenH = 120, 40
+	start := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	m := openRecurrenceEndsPicker(t, start)
+
+	original := m.endsDate
+
+	m, _ = m.Update(keyPressMsg("right"))
+	require.NotEqual(t, original, m.endsDate)
+
+	pickerBoxW, _ := m.EndsDatePickerBoxSize()
+	ox := (screenW - pickerBoxW) / 2
+	oy := (screenH - 14) / 2
+	gridY := oy + 4
+	const buttonRowRY = 8
+	btnY := gridY + buttonRowRY
+
+	innerW := pickerBoxW - 4
+	bs := DefaultButtonStyles()
+	cancelW := lipgloss.Width(bs.Normal.Render("Cancel", false))
+	btnPad := max(innerW-(cancelW+1+lipgloss.Width(bs.Normal.Render("Ok", false))), 0)
+	cancelX := ox + 2 + btnPad
+
+	m, _ = m.Update(tea.MouseClickMsg(tea.Mouse{X: cancelX, Y: btnY, Button: tea.MouseLeft}))
+	assert.False(t, m.endsDatePicker, "clicking Cancel must close the picker")
+	assert.Equal(t, original, m.endsDate, "clicking Cancel must revert the navigated date")
+}
+
+// TestRecurrenceEditor_OkCommitsNavigatedEndsDate verifies the positive path:
+// tabbing to Ok and confirming commits the navigated date.
+func TestRecurrenceEditor_OkCommitsNavigatedEndsDate(t *testing.T) {
+	start := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	m := openRecurrenceEndsPicker(t, start)
+
+	original := m.endsDate
+
+	m, _ = m.Update(keyPressMsg("right"))
+	navigated := m.endsDate
+	require.NotEqual(t, original, navigated)
+
+	// Tab: grid -> Cancel -> Ok, then confirm.
+	m, _ = m.Update(keyPressMsg("tab"))
+	m, _ = m.Update(keyPressMsg("tab"))
+	m, _ = m.Update(keyPressMsg("enter"))
+
+	assert.False(t, m.endsDatePicker, "Ok must close the picker")
+	assert.Equal(t, navigated, m.endsDate, "Ok must commit the navigated date")
+}


### PR DESCRIPTION
## Root cause

`handleEndsDateKey` / `HandleEndsDateMouse` in `internal/tui/recurrence_editor.go`
navigated the ends-date picker by mutating `m.endsDate` in place with no
staging copy. Cancel (mouse) and `esc`/`q`/`enter`/`space` (keyboard) all
just set `endsDatePicker = false`, so there was no revert path: a user who
navigated with arrows then pressed Esc or clicked Cancel committed the
navigated date instead of restoring the original. This was inconsistent with
`EventFormModel`'s picker, which only commits on Ok.

## Fix

- Capture the committed date in a new `endsDateRevert` field when the picker
  opens (`openEndsDatePicker`), and restore it on Cancel/Esc via
  `cancelEndsDatePicker`. Ok (or a grid Enter / day click) commits.
- Add `endsDateBtnFocus` (-1 grid, 0 Cancel, 1 Ok) so `Tab`/`Shift+Tab` cycle
  grid -> Cancel -> Ok like the event-form picker; the focused button is
  highlighted in the overlay and arrow navigation is gated to grid focus.
- Both picker-open sites now route through `openEndsDatePicker` so the revert
  state is always initialised.

## Test

`internal/tui/recurrence_ends_revert_test.go` (table of focused cases):

- `TestRecurrenceEditor_EscRevertsNavigatedEndsDate` — navigate then Esc must
  restore the original date (failed before the fix: kept Aug 1 instead of
  reverting to Jul 24).
- `TestRecurrenceEditor_MouseCancelRevertsNavigatedEndsDate` — clicking Cancel
  reverts.
- `TestRecurrenceEditor_OkCommitsNavigatedEndsDate` — Tab to Ok + Enter commits
  the navigated date (positive path).

All three drive the real open flow via `Update`. `go test ./internal/... -count=1`
passes; `go build ./...`, `gofmt`, and `go vet` are clean.

Closes #410
