### PR TITLE
fix(cmd): normalize event search --from/--to date bounds (#428)

### DIFF
--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -394,7 +394,7 @@ Use --from and --to to narrow the search window when you already know
 roughly when the event occurred.`,
 		Example: `  chroncal event search standup
   chroncal event search deploy --calendar Work --status CONFIRMED
-  chroncal event search conference --from 2026-04-01T00:00:00Z --to 2026-05-01T00:00:00Z
+  chroncal event search conference --from 2026-04-01 --to 2026-05-01
   chroncal event search standup --compact`,
 		Args: exactOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -413,11 +413,32 @@ roughly when the event occurred.`,
 				}
 			}
 
+			// Parse the YYYY-MM-DD --from/--to flags into RFC3339 UTC bounds
+			// before populating SearchParams. Search compares these strings
+			// lexicographically against UTC-stored start times, so feeding the
+			// raw "2026-04-30" through would make "2026-04-30T09:00:00Z" sort
+			// after the bound (since 'T' > '0') and silently drop every event
+			// on the end day (issue #428). parseExportDateBounds (not
+			// parseDateRange) treats each bound independently so a one-sided
+			// window stays open on the other side, and its half-open --to
+			// includes the entire end day.
+			fromT, toT, err := parseExportDateBounds(fromStr, toStr)
+			if err != nil {
+				return err
+			}
+			var from, to string
+			if !fromT.IsZero() {
+				from = fromT.UTC().Format(time.RFC3339)
+			}
+			if !toT.IsZero() {
+				to = toT.UTC().Format(time.RFC3339)
+			}
+
 			events, err := a.Events.Search(ctx, event.SearchParams{
 				Query:      args[0],
 				CalendarID: calID,
-				From:       fromStr,
-				To:         toStr,
+				From:       from,
+				To:         to,
 				Status:     status,
 			})
 			if err != nil {
@@ -451,8 +472,8 @@ roughly when the event occurred.`,
 		},
 	}
 	cmd.Flags().StringVar(&calendarName, "calendar", "", "filter by calendar name")
-	cmd.Flags().StringVar(&fromStr, "from", "", "start date filter (RFC3339)")
-	cmd.Flags().StringVar(&toStr, "to", "", "end date filter (RFC3339)")
+	cmd.Flags().StringVar(&fromStr, "from", "", "start date filter (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&toStr, "to", "", "end date filter (YYYY-MM-DD, inclusive)")
 	cmd.Flags().StringVar(&status, "status", "", "status filter (TENTATIVE, CONFIRMED, CANCELLED)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "one line per event (DATE  TIME  TITLE); same shape as event list --compact")
 	return cmd

--- a/cmd/chroncal/event_cli_test.go
+++ b/cmd/chroncal/event_cli_test.go
@@ -214,6 +214,73 @@ func TestEventJSONTimestampsAreUTC(t *testing.T) {
 	}
 }
 
+// TestEventSearchDateBoundsIncludeEndDay locks in the fix for issue #428:
+// `event search --from/--to` accept the same YYYY-MM-DD bounds as event
+// list and the half-open --to bound includes the entire end day. Before
+// the fix the raw "2026-04-30" string was compared lexicographically
+// against the RFC3339-stored start time ("2026-04-30T09:00:00Z"), so the
+// 'T' > '0' ordering silently excluded every event on the final day.
+func TestEventSearchDateBoundsIncludeEndDay(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Quarterly Review",
+		"--calendar", "Work",
+		"--date", "2026-04-30",
+		"--time", "09:00",
+		"--duration", "30m",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t,
+		"event", "search", "Quarterly",
+		"--from", "2026-04-01",
+		"--to", "2026-04-30",
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("event search: %v", err)
+	}
+
+	var events []struct {
+		Title string `json:"title"`
+	}
+	if jerr := json.Unmarshal([]byte(stdout), &events); jerr != nil {
+		t.Fatalf("decode %q: %v", stdout, jerr)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1 (event on the --to end day must be included)", len(events))
+	}
+	if events[0].Title != "Quarterly Review" {
+		t.Fatalf("title = %q, want %q", events[0].Title, "Quarterly Review")
+	}
+}
+
+// TestEventSearchInvalidDateBound locks in that unparseable --from/--to
+// values are rejected with a clean error instead of being passed through
+// verbatim into the lexicographic comparison (issue #428).
+func TestEventSearchInvalidDateBound(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	_, _, err := runChroncalCommand(t, "event", "search", "anything", "--to", "not-a-date")
+	if err == nil {
+		t.Fatal("event search --to not-a-date should fail")
+	}
+	if !strings.Contains(err.Error(), "--to") {
+		t.Fatalf("error = %q, want it to mention the --to flag", err.Error())
+	}
+}
+
 func TestNotFoundErrorJSONHasNoWrapPrefix(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 


### PR DESCRIPTION
## Root cause

`event search --from/--to` were passed verbatim into `event.SearchParams`
(`From string // RFC3339`), where the FTS query compares them
lexicographically against the RFC3339 UTC-stored `start_time`. A user
typing the documented `event list` format `--to 2026-04-30` got
`"2026-04-30T09:00:00Z" <= "2026-04-30"` == false (since `'T' > '0'`),
silently excluding every event on the final day. `event list` normalizes
its bounds via the date-parse helpers; `event search` did not. The flag
help also claimed RFC3339 while `list` documents YYYY-MM-DD.

## Fix

Run `--from/--to` through `parseExportDateBounds` (the same helper the
export command uses for the identical lexicographic-comparison concern,
issue #305/#358) before populating `SearchParams`, then format the
parsed times as RFC3339 UTC strings. `parseExportDateBounds` treats each
bound independently (a one-sided window stays open on the other side —
the right semantic for a retrospective search, unlike `parseDateRange`'s
today/+30d defaults) and its `--to` is half-open so the entire end day is
included. Unparseable input now returns a clean `--<flag>: invalid date`
error instead of silently passing through. Flag help and examples updated
to YYYY-MM-DD.

## Tests

Added to `cmd/chroncal/event_cli_test.go`:
- `TestEventSearchDateBoundsIncludeEndDay` — event at 09:00 on 2026-04-30
  is found by `event search --to 2026-04-30` (failed before the fix:
  0 results).
- `TestEventSearchInvalidDateBound` — `--to not-a-date` is rejected with
  an error naming the flag.

`go build ./...`, `go vet`, `go test ./internal/... -count=1`, and
`go test ./cmd/chroncal/ -count=1` all pass.

Closes #428
