### PR TITLE
fix(ical): emit floating EXDATE/RDATE without Z to preserve occurrence exclusion (#421)

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -104,10 +104,10 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 		}
 
 		// EXDATE
-		emitDateListOnComponent(vevent.Component, ical.PropExceptionDates, e.ExDates)
+		emitDateListOnComponent(vevent.Component, ical.PropExceptionDates, e.ExDates, e.Timezone)
 
 		// RDATE
-		emitDateListOnComponent(vevent.Component, ical.PropRecurrenceDates, e.RDates)
+		emitDateListOnComponent(vevent.Component, ical.PropRecurrenceDates, e.RDates, e.Timezone)
 
 		// RECURRENCE-ID
 		if e.RecurrenceID != "" {
@@ -443,8 +443,8 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 		}
 
 		// Dates
-		emitDateListOnComponent(vtodo, ical.PropExceptionDates, t.ExDates)
-		emitDateListOnComponent(vtodo, ical.PropRecurrenceDates, t.RDates)
+		emitDateListOnComponent(vtodo, ical.PropExceptionDates, t.ExDates, t.Timezone)
+		emitDateListOnComponent(vtodo, ical.PropRecurrenceDates, t.RDates, t.Timezone)
 
 		if t.RecurrenceID != "" {
 			// A VTODO is all-day when its recurrence anchor (DTSTART, else DUE)
@@ -627,7 +627,7 @@ func extractVTIMEZONEBlocks(s string) []string {
 	return blocks
 }
 
-func emitDateListOnComponent(comp *ical.Component, propName, dates string) {
+func emitDateListOnComponent(comp *ical.Component, propName, dates, timezone string) {
 	if dates == "" {
 		return
 	}
@@ -643,7 +643,15 @@ func emitDateListOnComponent(comp *ical.Component, propName, dates string) {
 		}
 		if t, err := time.Parse(time.RFC3339, ds); err == nil {
 			prop := &ical.Prop{Name: propName, Params: make(ical.Params)}
-			prop.SetDateTime(t.UTC())
+			if timezone == "FLOATING" {
+				// Floating components store wall-clock numbers; emit
+				// EXDATE/RDATE as floating (no Z) so the value type matches
+				// DTSTART. A trailing Z is a value-type mismatch that stops
+				// servers from suppressing the excluded occurrence (#421).
+				prop.Value = t.UTC().Format("20060102T150405")
+			} else {
+				prop.SetDateTime(t.UTC())
+			}
 			comp.Props.Add(prop)
 		}
 	}
@@ -1072,8 +1080,8 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 		}
 
 		// Dates
-		emitDateListOnComponent(vjournal, ical.PropExceptionDates, j.ExDates)
-		emitDateListOnComponent(vjournal, ical.PropRecurrenceDates, j.RDates)
+		emitDateListOnComponent(vjournal, ical.PropExceptionDates, j.ExDates, j.Timezone)
+		emitDateListOnComponent(vjournal, ical.PropRecurrenceDates, j.RDates, j.Timezone)
 
 		if j.RecurrenceID != "" {
 			// A VJOURNAL is all-day when its DTSTART is a date-only value;

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -208,6 +208,48 @@ func TestExport_MultipleExdatesRdates(t *testing.T) {
 	}
 }
 
+// Regression test for issue #421: a floating recurring component (no TZID,
+// no Z on DTSTART) must emit EXDATE/RDATE as floating values too. Emitting
+// them with a trailing Z creates a value-type mismatch against DTSTART, so
+// CalDAV servers that match EXDATE against RRULE occurrences by exact string
+// fail to suppress the excluded occurrence and a deleted instance reappears.
+func TestExport_FloatingExdatesRdatesNoZ(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{{
+		UID:            "floating-exdate",
+		Title:          "Recurring Floating",
+		StartTime:      time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 13, 0, 0, 0, time.UTC),
+		Timezone:       "FLOATING",
+		RecurrenceRule: "FREQ=WEEKLY",
+		Status:         "CONFIRMED",
+		Transp:         "OPAQUE",
+		ExDates:        "2026-04-15T12:00:00Z",
+		RDates:         "2026-05-06T12:00:00Z",
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}}
+
+	data, err := ExportEvents(events, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	ics := string(data)
+
+	if !strings.Contains(ics, "EXDATE:20260415T120000") {
+		t.Errorf("expected floating EXDATE 20260415T120000, got:\n%s", ics)
+	}
+	if !strings.Contains(ics, "RDATE:20260506T120000") {
+		t.Errorf("expected floating RDATE 20260506T120000, got:\n%s", ics)
+	}
+	if strings.Contains(ics, "20260415T120000Z") {
+		t.Errorf("EXDATE must not carry a trailing Z for a floating component:\n%s", ics)
+	}
+	if strings.Contains(ics, "20260506T120000Z") {
+		t.Errorf("RDATE must not carry a trailing Z for a floating component:\n%s", ics)
+	}
+}
+
 func TestExport_CategoriesNotEscaped(t *testing.T) {
 	t.Parallel()
 	events := []event.Event{{

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/recurrence"
 )
 
@@ -236,6 +237,51 @@ END:VCALENDAR`
 	}
 	if e.RDates != "2026-04-22T13:00:00Z" {
 		t.Fatalf("RDates = %q, want 2026-04-22T13:00:00Z", e.RDates)
+	}
+}
+
+// Regression test for issue #421: a floating recurring event (DTSTART with
+// no TZID and no Z) whose EXDATE/RDATE are also floating must round-trip back
+// out as floating values. UTC-converting them on export breaks occurrence
+// exclusion on servers that match EXDATE against RRULE occurrences by string.
+func TestImport_EventFloatingEXDATERoundTrip(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:floating-exdate-rdate
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T120000
+DTEND:20260401T130000
+RRULE:FREQ=WEEKLY;COUNT=6
+EXDATE:20260415T120000
+RDATE:20260506T120000
+SUMMARY:Floating recurrence dates
+END:VEVENT
+END:VCALENDAR`
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	e := result.Events[0]
+	if e.Timezone != "FLOATING" {
+		t.Fatalf("Timezone = %q, want FLOATING", e.Timezone)
+	}
+
+	data, err := ExportEvents([]event.Event{e}, "")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "EXDATE:20260415T120000") || strings.Contains(out, "20260415T120000Z") {
+		t.Errorf("EXDATE should round-trip as floating, got:\n%s", out)
+	}
+	if !strings.Contains(out, "RDATE:20260506T120000") || strings.Contains(out, "20260506T120000Z") {
+		t.Errorf("RDATE should round-trip as floating, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Root cause

Floating recurring components (DTSTART with no TZID and no `Z`) store their EXDATE/RDATE
values as wall-clock numbers in the DB (e.g. `2026-04-15T12:00:00Z`, numbers preserved).
On export, `emitDateListOnComponent` always re-emitted via `prop.SetDateTime(t.UTC())`,
appending a trailing `Z`. Against a floating DTSTART that is a value-type mismatch, so
CalDAV servers that match EXDATE to RRULE occurrences by exact string fail to suppress the
excluded occurrence and a deleted instance reappears.

(Import already preserves the wall-clock numbers for floating values — `time.Parse` reads
them as UTC and the format is a numeric no-op — so the defect was purely on the export side.)

## Fix

`internal/ical/export.go`: thread the component's `Timezone` into
`emitDateListOnComponent`. When it is `FLOATING`, emit the stored wall-clock value with
`Format("20060102T150405")` (no `Z`), matching how DTSTART is emitted via `setPropFloating`.
UTC and TZID components keep their existing UTC emission. Applied to all three callers —
events, todos, and journals.

Date-only (`VALUE=DATE`) values are handled by the earlier branch and are unaffected.

## Tests

- `TestExport_FloatingExdatesRdatesNoZ` (export_test.go): a FLOATING event with
  ExDates/RDates exports `EXDATE:20260415T120000` / `RDATE:20260506T120000` with no `Z`.
- `TestImport_EventFloatingEXDATERoundTrip` (import_test.go): imports a floating recurring
  event with floating EXDATE/RDATE, confirms Timezone=FLOATING, and re-exports as floating.

Both fail before the fix and pass after. Full `go test ./internal/... -count=1`,
`go build ./...`, `go vet`, and `gofmt` all pass.

Closes #421
