### PR TITLE
fix(event): don't synthesize UNTIL on RDATE-only masters (#414)

### DIFF
--- a/internal/event/rdate_only_truncate_test.go
+++ b/internal/event/rdate_only_truncate_test.go
@@ -1,0 +1,96 @@
+package event
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newRDateOnlyMaster creates a recurring master that has no RRULE and relies
+// purely on RDATEs (RFC 5545 §3.8.5.2). Its StartTime is the DTSTART
+// occurrence; rdates lists the remaining occurrences.
+func newRDateOnlyMaster(t *testing.T, svc *Service, uid string, rdates []time.Time) Event {
+	t.Helper()
+	parts := make([]string, len(rdates))
+	for i, d := range rdates {
+		parts[i] = d.UTC().Format(time.RFC3339)
+	}
+	master, err := svc.UpsertByUID(context.Background(), UpsertParams{
+		UID:        uid,
+		CalendarID: 1,
+		Title:      "Irregular Meeting",
+		StartTime:  time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		// No RecurrenceRule: pure RDATE recurrence.
+		RDates: strings.Join(parts, ","),
+	})
+	if err != nil {
+		t.Fatalf("upsert RDATE-only master: %v", err)
+	}
+	return master
+}
+
+// TestSetRRuleUntil_EmptyRule guards against the malformed ";UNTIL=..." token
+// produced when an empty rule is passed through the part filter (issue #414).
+// An empty input must never grow a leading ";" separator.
+func TestSetRRuleUntil_EmptyRule(t *testing.T) {
+	got := setRRuleUntil("", time.Date(2026, 1, 1, 23, 59, 59, 0, time.UTC), false)
+	if strings.HasPrefix(got, ";") {
+		t.Fatalf("setRRuleUntil(\"\") = %q, must not start with a bare \";\" separator", got)
+	}
+}
+
+// TestDeleteFromInstance_RDateOnlyMasterNotCorrupted reproduces issue #414: a
+// "this and following" delete on an RDATE-only master used to write a synthetic
+// ";UNTIL=..." RRULE that fails to parse, collapsing the whole series. The
+// master's recurrence_rule must stay empty so expansion keeps working.
+func TestDeleteFromInstance_RDateOnlyMasterNotCorrupted(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	rdate1 := time.Date(2026, 4, 15, 9, 0, 0, 0, time.UTC)
+	rdate2 := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	master := newRDateOnlyMaster(t, svc, "rdate-only-del", []time.Time{rdate1, rdate2})
+
+	if err := svc.DeleteFromInstance(ctx, master.UID, rdate2); err != nil {
+		t.Fatalf("DeleteFromInstance: %v", err)
+	}
+
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("GetByUID after delete: %v", err)
+	}
+	if got.RecurrenceRule != "" {
+		t.Errorf("master RecurrenceRule = %q, want empty (RDATE-only master must not gain a synthetic RRULE)", got.RecurrenceRule)
+	}
+}
+
+// TestUpdateFromInstance_RDateOnlyMasterNotCorrupted mirrors the delete case for
+// the split/"edit this and following" path through updateFromInstanceTx.
+func TestUpdateFromInstance_RDateOnlyMasterNotCorrupted(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	rdate1 := time.Date(2026, 4, 15, 9, 0, 0, 0, time.UTC)
+	rdate2 := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	master := newRDateOnlyMaster(t, svc, "rdate-only-upd", []time.Time{rdate1, rdate2})
+
+	_, err := svc.UpdateFromInstance(ctx, master.UID, rdate2, UpdateParams{
+		CalendarID: master.CalendarID,
+		Title:      "Irregular Meeting (changed)",
+		StartTime:  rdate2,
+		EndTime:    rdate2.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("UpdateFromInstance: %v", err)
+	}
+
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("GetByUID after update: %v", err)
+	}
+	if got.RecurrenceRule != "" {
+		t.Errorf("master RecurrenceRule = %q, want empty (RDATE-only master must not gain a synthetic RRULE)", got.RecurrenceRule)
+	}
+}

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -752,15 +752,21 @@ func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTi
 		return "", fmt.Errorf("get master: %w", err)
 	}
 
+	// An RDATE-only master (no RRULE) has no recurrence rule to truncate.
+	// Synthesizing an "UNTIL=..." here would be an invalid bare RRULE that fails
+	// to parse, collapsing the whole series to its DTSTART (issue #414). Leave
+	// the rule NULL; the future-override soft-delete and truncation record below
+	// still apply.
 	prevRRule := storage.NullableToString(master.RecurrenceRule)
-	until := instanceTime.UTC().Add(-time.Second)
-	rule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
-
-	if err := qtx.UpdateEventRecurrenceRule(ctx, storage.UpdateEventRecurrenceRuleParams{
-		RecurrenceRule: storage.StringToNullable(rule),
-		ID:             master.ID,
-	}); err != nil {
-		return "", fmt.Errorf("update rrule: %w", err)
+	if prevRRule != "" {
+		until := instanceTime.UTC().Add(-time.Second)
+		rule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
+		if err := qtx.UpdateEventRecurrenceRule(ctx, storage.UpdateEventRecurrenceRuleParams{
+			RecurrenceRule: storage.StringToNullable(rule),
+			ID:             master.ID,
+		}); err != nil {
+			return "", fmt.Errorf("update rrule: %w", err)
+		}
 	}
 
 	cutoff := instanceTime.UTC().Format(time.RFC3339)
@@ -1045,15 +1051,19 @@ func updateFromInstanceTx(ctx context.Context, qtx *storage.Queries, uid string,
 		return Event{}, 0, fmt.Errorf("get master: %w", err)
 	}
 
+	// An RDATE-only master (no RRULE) has no recurrence rule to truncate;
+	// synthesizing an "UNTIL=..." would corrupt it into an unparseable RRULE
+	// (issue #414). Leave the rule NULL when there is nothing to truncate.
 	prevRRule := storage.NullableToString(master.RecurrenceRule)
-	until := instanceTime.UTC().Add(-time.Second)
-	truncatedRule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
-
-	if err := qtx.UpdateEventRecurrenceRule(ctx, storage.UpdateEventRecurrenceRuleParams{
-		RecurrenceRule: storage.StringToNullable(truncatedRule),
-		ID:             master.ID,
-	}); err != nil {
-		return Event{}, 0, fmt.Errorf("truncate master rrule: %w", err)
+	if prevRRule != "" {
+		until := instanceTime.UTC().Add(-time.Second)
+		truncatedRule := setRRuleUntil(prevRRule, until, master.AllDay == 1)
+		if err := qtx.UpdateEventRecurrenceRule(ctx, storage.UpdateEventRecurrenceRuleParams{
+			RecurrenceRule: storage.StringToNullable(truncatedRule),
+			ID:             master.ID,
+		}); err != nil {
+			return Event{}, 0, fmt.Errorf("truncate master rrule: %w", err)
+		}
 	}
 
 	cutoff := instanceTime.UTC().Format(time.RFC3339)
@@ -1120,6 +1130,12 @@ func setRRuleUntil(rule string, until time.Time, allDay bool) string {
 	parts := strings.Split(rule, ";")
 	out := parts[:0]
 	for _, p := range parts {
+		// strings.Split("", ";") yields [""]; that empty element must not
+		// survive, or it would join into a leading ";" separator and a bogus
+		// ";UNTIL=..." RRULE (issue #414).
+		if p == "" {
+			continue
+		}
 		if !strings.HasPrefix(strings.ToUpper(p), "UNTIL=") && !strings.HasPrefix(strings.ToUpper(p), "COUNT=") {
 			out = append(out, p)
 		}


### PR DESCRIPTION
## Root cause

`setRRuleUntil(prevRRule, ...)` is called from `deleteFromInstance` and
`updateFromInstanceTx` with `prevRRule = NullableToString(master.RecurrenceRule)`.
For an RDATE-only master (`recurrence_rule` is NULL → `""`),
`strings.Split("", ";")` yields `[""]`. The empty element survived the
filter loop and joined into the result `";UNTIL=20260101T235959Z"` — an
invalid RRULE. Stored on the master, it then fails `rrule.StrToRRuleSet`, so
`ExpandEvent` falls back to `singleEventInstance` and the entire series
disappears. Reachable today via the TUI "This and following" path on an
RDATE-only event (exposed by the #362 RDATE-only expansion work).

## Fix

- Guard `deleteFromInstance` and `updateFromInstanceTx`: only rewrite the
  recurrence rule when the master actually has one (`prevRRule != ""`). An
  RDATE-only master keeps its NULL rule and stays expandable. The
  future-override soft-delete and truncation record still run as before.
- Harden `setRRuleUntil` to skip empty parts (`if p == "" { continue }`) so a
  stray separator can never produce a malformed token.

Minimal and scoped: no schema or query changes.

## Tests

`internal/event/rdate_only_truncate_test.go`:
- `TestSetRRuleUntil_EmptyRule` — an empty rule must not grow a leading `;`.
- `TestDeleteFromInstance_RDateOnlyMasterNotCorrupted` — after a "this and
  following" delete, the RDATE-only master's `recurrence_rule` stays empty
  (previously `";UNTIL=..."`).
- `TestUpdateFromInstance_RDateOnlyMasterNotCorrupted` — same for the
  split/edit path.

All three failed before the fix (`recurrence_rule = ";UNTIL=20260422T085959Z"`)
and pass after. Full `go build ./...`, `go vet`, and `go test ./internal/...`
green.

Closes #414
