### PR TITLE
fix(cmd): emit alarm missed JSON as a flat array (#433)

### DIFF
--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -916,10 +916,30 @@ system was not running when they became due.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, map[string]any{
-					"events": missedEvents,
-					"todos":  missedTodos,
-				})
+				// Flat array with a "type" discriminator, matching the
+				// shape of "alarm list"/"alarm check" so the
+				// `... -o json | jq '.[]'` idiom works across all alarm
+				// subcommands (issue #433).
+				items := make([]map[string]any, 0, len(missedEvents)+len(missedTodos))
+				for _, m := range missedEvents {
+					items = append(items, map[string]any{
+						"type":       "event",
+						"alarm_id":   m.AlarmID,
+						"title":      m.EventTitle,
+						"trigger_at": m.TriggerAt.UTC().Format(time.RFC3339),
+						"age":        m.Age,
+					})
+				}
+				for _, m := range missedTodos {
+					items = append(items, map[string]any{
+						"type":       "todo",
+						"alarm_id":   m.AlarmID,
+						"title":      m.TodoSummary,
+						"trigger_at": m.TriggerAt.UTC().Format(time.RFC3339),
+						"age":        m.Age,
+					})
+				}
+				return printOutput(w, items)
 			}
 
 			if len(missedEvents) == 0 && len(missedTodos) == 0 {

--- a/cmd/chroncal/alarm_missed_test.go
+++ b/cmd/chroncal/alarm_missed_test.go
@@ -1,8 +1,18 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/config"
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/todo"
+	"github.com/spf13/cobra"
 )
 
 // TestAlarmMissed_RejectsNonPositiveDays guards against issue #140: a
@@ -29,5 +39,99 @@ func TestAlarmMissed_RejectsNonPositiveDays(t *testing.T) {
 				t.Fatalf("--days %s: code = %q, want invalid_input", days, ce.Code)
 			}
 		})
+	}
+}
+
+// TestAlarmMissed_JSONIsFlatArray is the regression test for issue #433:
+// "alarm missed -o json" emitted a map {"events":[...],"todos":[...]} while
+// the sibling "alarm list"/"alarm check" commands emit a flat array. Scripts
+// using the `... -o json | jq '.[]'` idiom broke on the inconsistent shape.
+// The output must be a flat array of items, each carrying a "type" discriminator.
+func TestAlarmMissed_JSONIsFlatArray(t *testing.T) {
+	a := newAlarmTestApp(t)
+	ctx := t.Context()
+
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	// Event 3 days ago with a 15-min-before alarm: trigger is well past the
+	// 24h stale threshold and never fired, so it counts as missed.
+	start := time.Now().Add(-72 * time.Hour)
+	evt, err := a.Events.Create(ctx, event.CreateParams{
+		CalendarID: cal.ID,
+		Title:      "Missed Meeting",
+		StartTime:  start,
+		EndTime:    start.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	if err := a.Events.ReplaceAlarms(ctx, evt.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"},
+	}); err != nil {
+		t.Fatalf("replace event alarms: %v", err)
+	}
+
+	// Todo 3 days ago with a missed alarm too.
+	due := time.Now().Add(-72 * time.Hour)
+	td, err := a.Todos.Create(ctx, todo.CreateParams{
+		CalendarID: cal.ID,
+		Summary:    "Missed Task",
+		DueDate:    due.UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create todo: %v", err)
+	}
+	if err := a.Todos.ReplaceAlarms(ctx, td.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"},
+	}); err != nil {
+		t.Fatalf("replace todo alarms: %v", err)
+	}
+
+	prevFmt := outputFmt
+	outputFmt = "json"
+	t.Cleanup(func() { outputFmt = prevFmt })
+
+	root := &cobra.Command{
+		Use: "chroncal-test",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			var loadErr error
+			cfg, loadErr = config.Load()
+			return loadErr
+		},
+	}
+	missed := alarmMissedCmd()
+	root.AddCommand(missed)
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"missed", "--days", "7"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("alarm missed: %v", err)
+	}
+
+	// The wire shape must be a flat JSON array, not an object. A map shape
+	// fails to unmarshal into a slice, which is exactly what scripts hit.
+	var items []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		t.Fatalf("alarm missed JSON is not a flat array: %v\noutput:\n%s", err, out.String())
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2 (one event, one todo):\n%s", len(items), out.String())
+	}
+
+	types := map[string]int{}
+	for _, it := range items {
+		typ, _ := it["type"].(string)
+		types[typ]++
+	}
+	if types["event"] != 1 || types["todo"] != 1 {
+		t.Fatalf("type discriminators = %v, want one event and one todo:\n%s", types, out.String())
+	}
+
+	if strings.Contains(out.String(), `"events"`) || strings.Contains(out.String(), `"todos"`) {
+		t.Fatalf("output still uses map shape with events/todos keys:\n%s", out.String())
 	}
 }


### PR DESCRIPTION
## Root cause

`alarmMissedCmd` in `cmd/chroncal/alarm.go` emitted JSON with `--output json`
as a **map**: `{"events":[...],"todos":[...]}`. The sibling `alarm check` and
`alarm list` commands emit **flat JSON arrays**. Scripts that consume alarm
output with the idiom `... -o json | jq '.[]'` broke on `alarm missed` because
`.[]` over an object yields the two inner arrays, not the alarm items.

## Fix

Emit a flat array of items, each carrying a `"type": "event"|"todo"`
discriminator, mirroring the `alarm list` shape. Each item exposes
`type`, `alarm_id`, `title`, `trigger_at` (RFC 3339 UTC), and `age`.

## Test

Added `TestAlarmMissed_JSONIsFlatArray` in
`cmd/chroncal/alarm_missed_test.go`. It seeds one missed event alarm and one
missed todo alarm, runs `alarm missed --days 7 -o json`, and asserts the output
unmarshals into a `[]map[string]any` of length 2 with one `event` and one `todo`
discriminator, and that the old `"events"`/`"todos"` map keys are gone. The test
fails against the pre-fix code (`cannot unmarshal object into Go value of type
[]map[string]interface {}`) and passes after the fix.

Full `go test ./internal/... ./cmd/chroncal/` passes; `go build ./...`,
`gofmt`, and `go vet` are clean.

Closes #433
