### PR TITLE
fix(cmd): preserve calendar auth type when updating remote URL without --auth (#430)

### DIFF
--- a/cmd/chroncal/calendar.go
+++ b/cmd/chroncal/calendar.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -312,16 +313,34 @@ Only the flags you pass are changed.`,
 			defer a.Close()
 			ctx := context.Background()
 
-			if err := validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID, allowInsecure, disconnectRemote); err != nil {
-				return err
-			}
-
 			cals, err := a.Calendars.List(ctx)
 			if err != nil {
 				return fmt.Errorf("list calendars: %w", err)
 			}
 			existing, err := findCalendarByRef(cals, args[0])
 			if err != nil {
+				return err
+			}
+
+			// Preserve the existing remote auth type when re-pointing
+			// --remote-url at an already linked calendar without --auth.
+			// Defaulting to "basic" here would prompt for a password and
+			// overwrite a stored bearer/OAuth token (issue #430).
+			if !disconnectRemote && strings.TrimSpace(remoteURL) != "" &&
+				!cmd.Flags().Changed("auth") && existing.AccountID != 0 {
+				account, err := a.Queries.GetAccount(ctx, existing.AccountID)
+				// A missing account row means the link is orphaned; let
+				// Connect recreate it from the flag default rather than
+				// failing the update. Any other read error is propagated.
+				if err != nil && !errors.Is(err, sql.ErrNoRows) {
+					return fmt.Errorf("get account: %w", err)
+				}
+				if err == nil {
+					authType = account.AuthType
+				}
+			}
+
+			if err := validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID, allowInsecure, disconnectRemote); err != nil {
 				return err
 			}
 

--- a/cmd/chroncal/calendar_cli_test.go
+++ b/cmd/chroncal/calendar_cli_test.go
@@ -123,6 +123,29 @@ func TestCalendarUpdateCanConnectRemoteCalendar(t *testing.T) {
 	assertConnectedCalendarAndAccount(t, dbPath, "Work", "https://cal.example.com/dav/calendars/work/", "https://cal.example.com/dav", "bearer", "alice")
 }
 
+// TestCalendarUpdatePreservesAuthTypeWhenReconnectingWithoutAuthFlag is the
+// regression guard for issue #430: re-pointing --remote-url at an already
+// linked calendar without passing --auth must keep the stored auth type
+// (here "bearer") instead of resetting it to the "basic" flag default, which
+// would prompt for a password and clobber the existing bearer/OAuth token.
+func TestCalendarUpdatePreservesAuthTypeWhenReconnectingWithoutAuthFlag(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "test-token")
+
+	createLinkedCalendarForTest(t, dbPath)
+
+	_, _, err := runChroncalCommand(t,
+		"calendar", "update", "Work",
+		"--remote-url", "https://cal.example.com/dav/calendars/renamed/",
+		"--username", "alice",
+	)
+	if err != nil {
+		t.Fatalf("calendar update with new remote URL: %v", err)
+	}
+
+	assertConnectedCalendarAndAccount(t, dbPath, "Work", "https://cal.example.com/dav/calendars/renamed/", "https://cal.example.com/dav", "bearer", "alice")
+}
+
 func TestCalendarUpdateCanDisconnectRemoteCalendar(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 


### PR DESCRIPTION
## Root cause

`calendar update` registers `--auth` with default `"basic"`. Re-pointing an
already linked calendar's `--remote-url` without passing `--auth` sent
`authType="basic"` to `connectCalendarRemote` → `calendar.Connect`, which
prompted for a password and overwrote the stored credential. An OAuth2 or
bearer calendar therefore had its access/refresh tokens silently replaced by
basic auth, breaking future syncs (`cmd/chroncal/calendar.go:388`,
`internal/calendar/remote.go` `Connect` `UpdateAccount`).

## Fix

In `calendarUpdateCmd`, when `--auth` was not explicitly set
(`cmd.Flags().Changed("auth")` is false) and we are reconnecting an already
linked calendar (`existing.AccountID != 0`, `--remote-url` given, not
`--disconnect-remote`), load the stored account and preserve its `AuthType`
instead of defaulting to basic. Flag validation was moved to after the auth
type is resolved so it validates the effective value. An orphaned link
(`sql.ErrNoRows`) falls back to the flag default so `Connect` can recreate
the account; any other read error is propagated.

The change is scoped to the connect path: disconnect and first-time link
(AccountID == 0) behavior is unchanged.

## Test

`TestCalendarUpdatePreservesAuthTypeWhenReconnectingWithoutAuthFlag` creates a
calendar linked with `bearer` auth, runs `calendar update Work --remote-url
<new> --username alice` (no `--auth`), and asserts the account still has
`bearer` auth and the new remote URL. Before the fix it failed with
`read password: inappropriate ioctl for device` (the basic-auth password
prompt); after the fix it passes.

All `cmd/chroncal` and `internal/...` tests pass; `go build ./...`, `gofmt`,
and `go vet` are clean.

Closes #430
