### PR TITLE
fix(cmd): default all-day→timed event update to 1h span (#431)

### DIFF
--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1131,7 +1131,14 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				}
 				p.EndTime = p.StartTime.Add(dur)
 			case cmd.Flags().Changed("date") || cmd.Flags().Changed("time"):
-				p.EndTime = p.StartTime.Add(existing.EndTime.Sub(existing.StartTime))
+				if existing.AllDay && !p.AllDay {
+					// All-day → timed conversion with no explicit span:
+					// default to 1h like `event add`, not the 24h (or
+					// multi-day) all-day duration.
+					p.EndTime = p.StartTime.Add(time.Hour)
+				} else {
+					p.EndTime = p.StartTime.Add(existing.EndTime.Sub(existing.StartTime))
+				}
 			}
 
 			// Parse EXDATE/RDATE after date/time resolution so date-only

--- a/cmd/chroncal/event_cli_test.go
+++ b/cmd/chroncal/event_cli_test.go
@@ -281,6 +281,66 @@ func TestEventSearchInvalidDateBound(t *testing.T) {
 	}
 }
 
+func TestEventUpdateAllDayToTimedDefaultsToOneHour(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	// All-day event (no --time) spans 24h internally.
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Holiday",
+		"--calendar", "Work",
+		"--date", "2026-04-21",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	// Convert to a timed event with only --time, no --duration/--end-time.
+	if _, _, err := runChroncalCommand(t,
+		"event", "update", "1",
+		"--time", "09:00",
+	); err != nil {
+		t.Fatalf("event update: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t,
+		"event", "list",
+		"--from", "2026-04-21",
+		"--to", "2026-04-21",
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("event list --output json: %v", err)
+	}
+
+	var events []struct {
+		StartTime string `json:"start_time"`
+		EndTime   string `json:"end_time"`
+		AllDay    bool   `json:"all_day"`
+	}
+	if jerr := json.Unmarshal([]byte(stdout), &events); jerr != nil {
+		t.Fatalf("decode %q: %v", stdout, jerr)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	e := events[0]
+	if e.AllDay {
+		t.Fatalf("event still all-day after --time conversion; all_day = true")
+	}
+	if e.StartTime != "2026-04-21T09:00:00Z" {
+		t.Fatalf("start_time = %q, want %q", e.StartTime, "2026-04-21T09:00:00Z")
+	}
+	// Converting an all-day event to timed with no explicit span should
+	// default to a 1h duration (like `event add`), not preserve the 24h
+	// all-day span.
+	if e.EndTime != "2026-04-21T10:00:00Z" {
+		t.Fatalf("end_time = %q, want %q (1h default, not 24h all-day span)", e.EndTime, "2026-04-21T10:00:00Z")
+	}
+}
+
 func TestNotFoundErrorJSONHasNoWrapPrefix(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 


### PR DESCRIPTION
## Root cause
`eventUpdateCmd` (`cmd/chroncal/event.go`) converts an all-day event to timed when `--time HH:MM` is passed (it sets `p.AllDay = false`). With no `--duration`/`--end-time`, the date/time-changed branch fell through to:

```go
p.EndTime = p.StartTime.Add(existing.EndTime.Sub(existing.StartTime))
```

For an all-day event that span is 24h (multi-day all-day events scale worse), so the converted timed event ended up at least 24 hours long.

## Fix
Detect the all-day→timed transition (`existing.AllDay && !p.AllDay`) in that branch and default to a 1h span, matching `event add`'s default for timed events. All other paths (all-day→all-day, timed→timed date shift) are unchanged.

## Test
Added `TestEventUpdateAllDayToTimedDefaultsToOneHour` in `cmd/chroncal/event_cli_test.go`: creates an all-day event, runs `event update --time 09:00`, and asserts via JSON output that the result is timed (`all_day=false`), starts at 09:00, and ends at 10:00 (1h) — not 24h later. It failed before the fix (end_time was the next day) and passes after.

`go build ./...`, `go vet`, `go test ./internal/... ./cmd/chroncal/` all pass.

Closes #431
