### PR TITLE
fix(cmd): apply ical export --from/--to to todos and journals (#429)

### DIFF
--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -338,6 +338,21 @@ to stdout.`,
 			if !toT.IsZero() {
 				toTime = toT.UTC().Format(time.RFC3339)
 			}
+			// Todos and journals store DUE / DTSTART as date-only
+			// ("YYYY-MM-DD") for all-day items, so use date-only bounds
+			// (matching ListTodosFiltered / ListJournalsFiltered) instead of
+			// the RFC3339 bounds used for events. A datetime bound would
+			// lexically exclude a date-only value on the lower boundary.
+			// Format the local wall-clock date the user typed (the bounds were
+			// parsed at local midnight); don't convert to UTC, which would shift
+			// the date by a day west of UTC and skew the filter.
+			var fromDate, toDate string
+			if !fromT.IsZero() {
+				fromDate = fromT.Format("2006-01-02")
+			}
+			if !toT.IsZero() {
+				toDate = toT.Format("2006-01-02")
+			}
 
 			// Load events
 			var events []event.Event
@@ -387,6 +402,8 @@ to stdout.`,
 			if includeTodos {
 				todos, err = a.Todos.ExportFiltered(ctx, todo.ExportParams{
 					CalendarID: calID,
+					From:       fromDate,
+					To:         toDate,
 					Category:   category,
 					Status:     status,
 				})
@@ -403,6 +420,8 @@ to stdout.`,
 			if includeJournals {
 				journals, err = a.Journals.ExportFiltered(ctx, journal.ExportParams{
 					CalendarID: calID,
+					From:       fromDate,
+					To:         toDate,
 					Category:   category,
 					Status:     status,
 				})

--- a/internal/journal/search_test.go
+++ b/internal/journal/search_test.go
@@ -74,3 +74,54 @@ func TestJournalService_Search(t *testing.T) {
 		})
 	}
 }
+
+// TestJournalService_ExportFiltered_DateRange covers issue #429: export
+// --from/--to must actually restrict journals by start date instead of being a
+// silent no-op.
+func TestJournalService_ExportFiltered_DateRange(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+	calID := testCalendar(t, q)
+
+	mustCreateJournal(t, svc, ctx, CreateParams{
+		CalendarID: calID,
+		Summary:    "January entry",
+		StartDate:  "2026-01-15",
+	})
+	mustCreateJournal(t, svc, ctx, CreateParams{
+		CalendarID: calID,
+		Summary:    "June entry",
+		StartDate:  "2026-06-15",
+	})
+	mustCreateJournal(t, svc, ctx, CreateParams{
+		CalendarID: calID,
+		Summary:    "No start date",
+	})
+
+	tests := []struct {
+		name    string
+		params  ExportParams
+		wantLen int
+	}{
+		{"no range exports all", ExportParams{}, 3},
+		{"from bound only", ExportParams{From: "2026-03-01"}, 2}, // June + dateless
+		{"to bound only", ExportParams{To: "2026-03-01"}, 2},     // January + dateless
+		{"narrow window around June", ExportParams{From: "2026-06-01", To: "2026-07-01"}, 2},
+		{"window excludes both dated journals", ExportParams{From: "2026-03-01", To: "2026-04-01"}, 1}, // dateless only
+		{"lower boundary is inclusive", ExportParams{From: "2026-06-15", To: "2026-07-01"}, 2},
+		{"upper boundary is exclusive", ExportParams{From: "2026-01-01", To: "2026-06-15"}, 2}, // January + dateless
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := svc.ExportFiltered(ctx, tt.params)
+			if err != nil {
+				t.Fatalf("export: %v", err)
+			}
+			if len(results) != tt.wantLen {
+				t.Errorf("got %d results, want %d", len(results), tt.wantLen)
+			}
+		})
+	}
+}

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -23,6 +23,8 @@ type SearchParams struct {
 
 type ExportParams struct {
 	CalendarID int64  // 0 = all
+	From       string // date-only ("YYYY-MM-DD") or empty
+	To         string // date-only ("YYYY-MM-DD") or empty
 	Category   string // empty = all
 	Status     string // empty = all
 }
@@ -167,6 +169,8 @@ func (s *Service) Search(ctx context.Context, p SearchParams) ([]Journal, error)
 func (s *Service) ExportFiltered(ctx context.Context, p ExportParams) ([]Journal, error) {
 	rows, err := s.q.ListJournalsForExport(ctx, storage.ListJournalsForExportParams{
 		CalendarID:   p.CalendarID,
+		FromDate:     p.From,
+		ToDate:       p.To,
 		Category:     p.Category,
 		FilterStatus: p.Status,
 	})

--- a/internal/storage/journals_dynamic.go
+++ b/internal/storage/journals_dynamic.go
@@ -67,6 +67,8 @@ type ListJournalsForExportParams struct {
 	CalendarID     int64
 	Category       string
 	FilterStatus   string
+	FromDate       string
+	ToDate         string
 	IncludeDeleted bool
 	DeletedOnly    bool
 }
@@ -82,6 +84,14 @@ func (q *Queries) ListJournalsForExport(ctx context.Context, arg ListJournalsFor
 	}
 	if arg.FilterStatus != "" {
 		w.add("status = ?", arg.FilterStatus)
+	}
+	// Match the half-open [from, to) date semantics used by
+	// ListJournalsFiltered; dateless journals pass the filter (NULL stays in).
+	if arg.FromDate != "" {
+		w.add("(start_date IS NULL OR start_date >= ?)", arg.FromDate)
+	}
+	if arg.ToDate != "" {
+		w.add("(start_date IS NULL OR start_date < ?)", arg.ToDate)
 	}
 	where, args := w.build()
 	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")

--- a/internal/storage/todos_dynamic.go
+++ b/internal/storage/todos_dynamic.go
@@ -68,6 +68,8 @@ type ListTodosForExportParams struct {
 	Category        string
 	FilterStatus    string
 	CompletedFilter int64
+	FromDate        string
+	ToDate          string
 	IncludeDeleted  bool
 	DeletedOnly     bool
 }
@@ -88,6 +90,14 @@ func (q *Queries) ListTodosForExport(ctx context.Context, arg ListTodosForExport
 		w.add("completed_at IS NOT NULL")
 	} else if arg.CompletedFilter == 2 {
 		w.add("completed_at IS NULL")
+	}
+	// Match the half-open [from, to) date semantics used by
+	// ListTodosFiltered; dateless todos pass the filter (NULL stays in).
+	if arg.FromDate != "" {
+		w.add("(due_date IS NULL OR due_date >= ?)", arg.FromDate)
+	}
+	if arg.ToDate != "" {
+		w.add("(due_date IS NULL OR due_date < ?)", arg.ToDate)
 	}
 	where, args := w.build()
 	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")

--- a/internal/todo/search_test.go
+++ b/internal/todo/search_test.go
@@ -153,3 +153,53 @@ func TestService_ExportFiltered(t *testing.T) {
 		})
 	}
 }
+
+// TestService_ExportFiltered_DateRange covers issue #429: export --from/--to
+// must actually restrict todos by due date instead of being a silent no-op.
+func TestService_ExportFiltered_DateRange(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+	calID := testCalendar(t, q)
+
+	mustCreateTodo(t, svc, ctx, CreateParams{
+		CalendarID: calID,
+		Summary:    "January task",
+		DueDate:    "2026-01-15",
+	})
+	mustCreateTodo(t, svc, ctx, CreateParams{
+		CalendarID: calID,
+		Summary:    "June task",
+		DueDate:    "2026-06-15",
+	})
+	mustCreateTodo(t, svc, ctx, CreateParams{
+		CalendarID: calID,
+		Summary:    "No due date",
+	})
+
+	tests := []struct {
+		name    string
+		params  ExportParams
+		wantLen int
+	}{
+		{"no range exports all", ExportParams{}, 3},
+		{"from bound only", ExportParams{From: "2026-03-01"}, 2}, // June + dateless
+		{"to bound only", ExportParams{To: "2026-03-01"}, 2},     // January + dateless
+		{"narrow window around June", ExportParams{From: "2026-06-01", To: "2026-07-01"}, 2},
+		{"window excludes both dated todos", ExportParams{From: "2026-03-01", To: "2026-04-01"}, 1}, // dateless only
+		{"lower boundary is inclusive", ExportParams{From: "2026-06-15", To: "2026-07-01"}, 2},
+		{"upper boundary is exclusive", ExportParams{From: "2026-01-01", To: "2026-06-15"}, 2}, // January + dateless
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := svc.ExportFiltered(ctx, tt.params)
+			if err != nil {
+				t.Fatalf("export: %v", err)
+			}
+			if len(results) != tt.wantLen {
+				t.Errorf("got %d results, want %d", len(results), tt.wantLen)
+			}
+		})
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -24,6 +24,8 @@ type SearchParams struct {
 
 type ExportParams struct {
 	CalendarID int64  // 0 = all
+	From       string // date-only ("YYYY-MM-DD") or empty
+	To         string // date-only ("YYYY-MM-DD") or empty
 	Category   string // empty = all
 	Status     string // empty = all
 	Completed  int    // 0 = all, 1 = completed, 2 = incomplete
@@ -237,6 +239,8 @@ func (s *Service) Search(ctx context.Context, p SearchParams) ([]Todo, error) {
 func (s *Service) ExportFiltered(ctx context.Context, p ExportParams) ([]Todo, error) {
 	rows, err := s.q.ListTodosForExport(ctx, storage.ListTodosForExportParams{
 		CalendarID:      p.CalendarID,
+		FromDate:        p.From,
+		ToDate:          p.To,
 		Category:        p.Category,
 		FilterStatus:    p.Status,
 		CompletedFilter: int64(p.Completed),


### PR DESCRIPTION
## Problem

`chroncal ical export --from ... --to ...` silently ignored the date
window for `--todos` and `--journals`. The CLI computed the bounds and
passed them only to `event.ExportParams`; `todo.ExportParams` and
`journal.ExportParams` had no `From`/`To` fields, so every todo/journal
was exported regardless of date — a silent filter no-op (#429).

## Root cause

`todo.ExportParams` / `journal.ExportParams` lacked `From`/`To`, and the
underlying dynamic queries `ListTodosForExport` / `ListJournalsForExport`
had no date predicate, so the date flags never reached SQL for those
kinds.

## Fix

- Add `From`/`To` (date-only) to `todo.ExportParams` and
  `journal.ExportParams` and thread them into `ExportFiltered`.
- Add `FromDate`/`ToDate` to the storage export params and apply the same
  half-open `[from, to)` predicate already used by `ListTodosFiltered` /
  `ListJournalsFiltered` (`due_date` / `start_date`), keeping dateless
  rows in the result as those list filters do.
- Wire date-only bounds from `cmd/chroncal/ical.go`. Todos/journals store
  DUE/DTSTART as date-only for all-day items, so a date-only bound is used
  (a datetime bound would lexically exclude a date-only value on the lower
  boundary). Bounds are formatted in local wall-clock time, not UTC, to
  avoid a day-shift west of UTC — matching the existing list-filter
  convention.

## Tests

Added table-driven `TestService_ExportFiltered_DateRange` (todo) and
`TestJournalService_ExportFiltered_DateRange` (journal) covering: no
range (all), from-only, to-only, narrow window, an excluding window,
inclusive lower boundary, and exclusive upper boundary. Confirmed they
fail against the unwired code ("got 3, want 2") and pass with the fix.

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/... ./cmd/...`
all pass.

Closes #429
