### PR TITLE
fix(sync): rev-guard dirty clear on accept-server import (#417)

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -512,12 +512,11 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 							result.conflicts++
 							continue
 						}
-						// Clear dirty and update ETag to accept server version
-						if err := e.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
-							CalendarID: calendarID,
-							Uid:        res.Uid,
-							Etag:       serverRes.ETag,
-						}); err != nil {
+						// Clear dirty and update ETag to accept server version.
+						// Guard the clear on the post-import rev so a local edit
+						// landing between the import and here is not silently
+						// dropped (lost update). See issues #92 and #417.
+						if err := e.clearDirtyAfterImport(ctx, calendarID, res.Uid, serverRes.ETag); err != nil {
 							e.logger.Error("clear dirty after conflict", "uid", res.Uid, "error", err)
 						}
 					}
@@ -620,6 +619,41 @@ func (e *Engine) putAlreadyLanded(ctx context.Context, client *caldav.Client, pa
 		return "", false
 	}
 	return serverRes.ETag, true
+}
+
+// afterImportRevCapture, when non-nil, runs inside clearDirtyAfterImport between
+// reading the post-import rev and the conditional clear. It is nil in production
+// and exists only so tests can simulate a concurrent local edit landing in that
+// window to exercise the rev guard. See issue #417.
+var afterImportRevCapture func()
+
+// clearDirtyAfterImport adopts the server ETag and clears the dirty flag for a
+// resource whose local row we just overwrote with the server's version
+// (accept-server conflict resolution or a pull), but only when no local edit has
+// landed since the import. importICal/persistImported route through the
+// event/todo/journal services, which flip dirty=1 and bump rev via
+// MarkResourceDirty as a side effect; we read that post-import rev and feed it to
+// FinalizePushedResource so the clear becomes a no-op when a concurrent user edit
+// bumped rev again before we got here. An unconditional clear would wipe that
+// edit's dirty flag and silently drop it — the same lost-update race
+// FinalizePushedResource guards on the push path. See issues #92 and #417.
+func (e *Engine) clearDirtyAfterImport(ctx context.Context, calendarID int64, uid, etag string) error {
+	res, err := e.q.GetSyncResource(ctx, storage.GetSyncResourceParams{
+		CalendarID: calendarID,
+		Uid:        uid,
+	})
+	if err != nil {
+		return err
+	}
+	if afterImportRevCapture != nil {
+		afterImportRevCapture()
+	}
+	return e.q.FinalizePushedResource(ctx, storage.FinalizePushedResourceParams{
+		CalendarID: calendarID,
+		Uid:        uid,
+		Etag:       etag,
+		Rev:        res.Rev,
+	})
 }
 
 type pullResult struct {
@@ -821,13 +855,11 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 		}
 		// persistImported flips dirty=1 via the Replace* services'
 		// MarkResourceDirty side effect, and UpsertSyncResource's MAX
-		// clause preserves it. Force dirty=0 — the server's version is
-		// now authoritative. See applySyncCollection for the full note.
-		if err := e.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
-			CalendarID: calendarID,
-			Uid:        uid,
-			Etag:       res.ETag,
-		}); err != nil {
+		// clause preserves it. Clear dirty — the server's version is now
+		// authoritative — but guard the clear on the post-import rev so a
+		// concurrent local edit is not silently dropped (issue #417). See
+		// applySyncCollection for the full note.
+		if err := e.clearDirtyAfterImport(ctx, calendarID, uid, res.ETag); err != nil {
 			e.logger.Warn("clear post-import dirty", "uid", uid, "error", err)
 		}
 
@@ -1122,13 +1154,11 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 			// sync-driven imports). UpsertSyncResource's `dirty = MAX(...)`
 			// clause then preserves that 1, so without an explicit clear here
 			// every pull re-dirties everything it just absorbed and the next
-			// push round-trips it back to the server. Force dirty=0 since the
-			// server's version is now authoritative locally.
-			if err := e.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
-				CalendarID: calendarID,
-				Uid:        uid,
-				Etag:       res.ETag,
-			}); err != nil {
+			// push round-trips it back to the server. Clear dirty since the
+			// server's version is now authoritative locally, but guard the
+			// clear on the post-import rev so a concurrent local edit is not
+			// silently dropped (issue #417).
+			if err := e.clearDirtyAfterImport(ctx, calendarID, uid, res.ETag); err != nil {
 				e.logger.Warn("clear post-import dirty", "uid", uid, "error", err)
 			}
 			result.pulled++

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -3210,3 +3210,139 @@ func TestOwnerDispatchRejectsUnknownTypeUniformly(t *testing.T) {
 		t.Fatalf("exportResource err = %v, want errUnknownOwnerType", err)
 	}
 }
+
+// linkCalendarToTestAccount links the first seeded calendar to a fresh account
+// so service-layer mutations (and the simulated concurrent edit below) flip the
+// dirty flag via MarkResourceDirty. Returns the calendar ID.
+func linkCalendarToTestAccount(t *testing.T, ctx context.Context, q *storage.Queries) int64 {
+	t.Helper()
+	account, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      "test",
+		ServerUrl: "https://example.com",
+		AuthType:  "basic",
+		Username:  "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+	remoteCalURL := "https://example.com/cal"
+	if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		ID:        calendarID,
+		AccountID: &account.ID,
+		RemoteUrl: &remoteCalURL,
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+	return calendarID
+}
+
+// serverWinsConflictClient returns a CalDAV client whose PUT 412s and whose GET
+// returns the server's version of uid (SUMMARY "Server version", ETag
+// "etag-server"), driving the ConflictServerWins accept-server path.
+func serverWinsConflictClient(t *testing.T, uid string) *caldav.Client {
+	t.Helper()
+	path := "/calendar/" + uid + ".ics"
+	return newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodPut:
+			return &http.Response{
+				StatusCode: http.StatusPreconditionFailed,
+				Status:     "412 Precondition Failed",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("precondition failed")),
+				Request:    r,
+			}, nil
+		case http.MethodGet:
+			if r.URL.Path != path {
+				t.Fatalf("GET path = %s, want %s", r.URL.Path, path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/calendar; charset=utf-8"},
+					"Etag":         []string{`"etag-server"`},
+				},
+				Body: io.NopCloser(strings.NewReader("BEGIN:VCALENDAR\r\n" +
+					"VERSION:2.0\r\n" +
+					"PRODID:-//chroncal//tests//EN\r\n" +
+					"BEGIN:VEVENT\r\n" +
+					"UID:" + uid + "\r\n" +
+					"DTSTAMP:20260403T120000Z\r\n" +
+					"DTSTART:20260403T120000Z\r\n" +
+					"DTEND:20260403T130000Z\r\n" +
+					"SUMMARY:Server version\r\n" +
+					"END:VEVENT\r\n" +
+					"END:VCALENDAR\r\n")),
+				Request: r,
+			}, nil
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+}
+
+// TestEnginePushServerWinsPreservesConcurrentEdit reproduces issue #417: a local
+// edit landing in the window between the accept-server import and the dirty
+// clear must not be silently dropped. The afterImportRevCapture hook simulates
+// that edit; the rev-guarded clear must leave the resource dirty so the next
+// push sends it. With the previous unconditional clear this test fails because
+// the edit's dirty flag is wiped. Serial (no t.Parallel) because it mutates the
+// package-level hook.
+func TestEnginePushServerWinsPreservesConcurrentEdit(t *testing.T) {
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+	calendarID := linkCalendarToTestAccount(t, ctx, q)
+
+	insertTestEvent(t, db, calendarID, "srv-wins-race")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "srv-wins-race",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/srv-wins-race.ics",
+		Etag:         `"etag-before"`,
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	// Simulate a concurrent local edit landing after the import recorded the
+	// server version but before the dirty flag is cleared: it bumps rev and
+	// re-marks the resource dirty, exactly as a real service-layer mutation would.
+	var fired int
+	afterImportRevCapture = func() {
+		fired++
+		if err := storage.MarkResourceDirty(ctx, db, calendarID, "srv-wins-race", "event"); err != nil {
+			t.Errorf("simulate concurrent edit: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterImportRevCapture = nil })
+
+	client := serverWinsConflictClient(t, "srv-wins-race")
+	if _, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("afterImportRevCapture fired %d times, want 1", fired)
+	}
+
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: calendarID, Uid: "srv-wins-race"})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Dirty != 1 {
+		t.Fatalf("dirty = %d, want 1 (concurrent edit must not be dropped, #417)", res.Dirty)
+	}
+	// The ETag still advances to the server's version so the next push's If-Match
+	// matches the server, mirroring FinalizePushedResource on the push path.
+	if res.Etag != "etag-server" {
+		t.Fatalf("etag = %q, want %q", res.Etag, "etag-server")
+	}
+}


### PR DESCRIPTION
## Root cause

On a 412 with `ConflictServerWins`, `push` ran `importICal` (which routes
through the event/todo/journal services and so flips `dirty=1` and bumps
`rev` via `MarkResourceDirty`), then called `ClearSyncResourceDirty`
**unconditionally**. A concurrent local edit landing between the import
commit and the clear bumps `rev` and re-marks the resource dirty; the
unconditional clear then wiped that flag without a `rev` check — the edit
was silently dropped and never pushed. This is the lost-update race that
`FinalizePushedResource`'s `CASE WHEN rev = ?` guard (#92) prevents on the
push path, but the accept-server resolution skipped it.

The same unconditional-clear-after-import pattern existed in both pull
import paths (`pullFullSnapshot` and `applySyncCollection`), which share
the identical window — the three locations called out in #417
(`engine.go:509`, `:826`, `:1127`).

## Fix

Added `clearDirtyAfterImport`, which reads the post-import `rev` and feeds
it to the existing `FinalizePushedResource` query so the clear becomes a
no-op when `rev` advanced again after the import (i.e. a concurrent edit
landed). The ETag still advances to the server's version so the next
push's `If-Match` matches the server. Wired into all three call sites.

The two other `ClearSyncResourceDirty` calls in `push` (non-organizer
skip, missing-local-row) are deliberate "stop retrying" drops with no
import behind them — left unconditional.

## Test

`TestEnginePushServerWinsPreservesConcurrentEdit` drives the full
`push(ConflictServerWins)` path and, via a nil-in-production hook
(`afterImportRevCapture`, mirroring the repo's `newRemoteObjectName`
override pattern), injects a concurrent local edit in the window between
the rev capture and the clear. It asserts the resource stays `dirty=1`
(edit preserved) while the server ETag is still adopted. Verified it
**fails** against the old unconditional clear (`dirty = 0, want 1`) and
passes with the fix. The existing
`TestEnginePushServerWinsAdoptsServerVersion` continues to cover the
no-concurrent-edit happy path (dirty cleared, server data imported).

`go build ./...`, `go vet`, and `go test ./internal/... -count=1` all pass.

## Note / follow-up

`internal/sync/service.go` `ResolveConflict` (manual `sync resolve <id>
server`) shares the same import-then-unconditional-clear shape but was not
listed in #417; left untouched to keep this change scoped. Worth a
follow-up if desired.

Closes #417
