### PR TITLE
fix(caldav): omit If-Match on DELETE for weak ETags

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -245,8 +245,8 @@ func (c *Client) DeleteResource(ctx context.Context, path, etag string) error {
 	if err != nil {
 		return fmt.Errorf("new DELETE request: %w", err)
 	}
-	if etag != "" {
-		req.Header.Set("If-Match", formatIfMatch(etag))
+	if ifMatch := formatIfMatch(etag); ifMatch != "" {
+		req.Header.Set("If-Match", ifMatch)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -235,6 +235,35 @@ func TestClientDeleteResourceSendsIfMatch(t *testing.T) {
 	}
 }
 
+func TestClientDeleteResourceWeakETagOmitsIfMatch(t *testing.T) {
+	t.Parallel()
+
+	// A weak validator cannot be used with the strong If-Match comparison
+	// (RFC 7232 §3.1), so DeleteResource must fall back to an unconditional
+	// DELETE rather than emitting an empty/malformed If-Match header.
+	client, err := NewClient(putTestHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", req.Method)
+		}
+		if vals, ok := req.Header["If-Match"]; ok {
+			t.Fatalf("If-Match present for weak ETag: %q, want header absent", vals)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Status:     "204 No Content",
+			Body:       io.NopCloser(http.NoBody),
+			Request:    req,
+		}, nil
+	}}, "https://example.com")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := client.DeleteResource(context.Background(), "/cal/test.ics", `W/"etag-weak"`); err != nil {
+		t.Fatalf("DeleteResource: %v", err)
+	}
+}
+
 func TestClientDeleteResourceConflict(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Bug
`DeleteResource` gated the conditional precondition on `if etag != ""` and
then set `If-Match` to `formatIfMatch(etag)` unconditionally. `normalizeETag`
deliberately preserves weak validators as `W/"<opaque>"`, and `formatIfMatch`
returns `""` for them because RFC 7232 §3.1 forbids weak tags with the strong
If-Match comparison. So for a stored weak ETag, `etag != ""` was true but the
formatted value was empty, producing a malformed empty `If-Match:` request
header.

Servers respond either:
- **400** — `processTombstones` appends an error and re-issues the DELETE on
  every sync, forever; or
- **412** — `caldav.IsConflict` routes it through the tombstone-conflict
  branch, which drops the tombstone but KEEPS the `sync_resource`, so the next
  pull re-imports and silently resurrects a user-deleted event.

Weak ETags are reachable: some servers (e.g. Apache mod_dav-derived) serve
weak `getetag`, and `processTombstones` passes the stored normalized ETag
straight into `DeleteResource`.

## Fix
Mirror `PutResource` (client.go:211): compute `ifMatch := formatIfMatch(etag)`
and set the header only when it is non-empty. A weak ETag now falls back to an
unconditional DELETE instead of emitting an invalid precondition; conflict
detection still relies on the sync-token/ctag pull comparison in that case.

## Test
Added `TestClientDeleteResourceWeakETagOmitsIfMatch`, which asserts that a
`W/"..."` ETag produces a DELETE with no `If-Match` header. It fails on the
old code (header present as `""`) and passes with the fix. Existing
strong-ETag tests (`SendsIfMatch`, `Conflict`) still pass.

Closes #465
