### PR TITLE
fix(journal): guard RDATE-only master override check in Delete

### DIFF
--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -413,7 +413,9 @@ func (s *Service) Delete(ctx context.Context, id int64) error {
 		return err
 	}
 
-	if j.RecurrenceRule != "" && j.RecurrenceID == "" {
+	// If this is a recurring master, check for overrides. RDATE-only masters
+	// (no RRULE) are recurring too, so guard on either rule or RDATEs (#471).
+	if (j.RecurrenceRule != "" || j.RDates != "") && j.RecurrenceID == "" {
 		overrides, err := s.q.ListJournalOverridesByUID(ctx, j.UID)
 		if err != nil {
 			return fmt.Errorf("check overrides: %w", err)

--- a/internal/journal/service_test.go
+++ b/internal/journal/service_test.go
@@ -2,7 +2,9 @@ package journal
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
@@ -112,6 +114,54 @@ func TestJournalService_Delete(t *testing.T) {
 	_, err := svc.Get(ctx, created.ID)
 	if err == nil {
 		t.Error("Get after Delete expected error")
+	}
+}
+
+func TestJournalDelete_MasterWithOverridesRefused(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "del-master", CalendarID: 1, Summary: "Weekly Notes",
+		StartDate:      time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceRule: "FREQ=WEEKLY",
+	})
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "del-master", CalendarID: 1, Summary: "Weekly Notes (moved)",
+		StartDate:    time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceID: "2026-04-08T00:00:00Z",
+	})
+
+	master, _ := svc.GetByUID(ctx, "del-master")
+	err := svc.Delete(ctx, master.ID)
+	if !errors.Is(err, ErrHasOverrides) {
+		t.Fatalf("Delete master with overrides: got %v, want ErrHasOverrides", err)
+	}
+}
+
+// TestJournalDelete_RDateMasterWithOverridesRefused covers an RDATE-only
+// recurring master (no RRULE). Its overrides must still block single-row
+// deletion; otherwise the master is soft-deleted and the override rows are
+// orphaned (issue #471, matching the #415 fix for events and todos).
+func TestJournalDelete_RDateMasterWithOverridesRefused(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "del-rdate-master", CalendarID: 1, Summary: "RDATE series",
+		StartDate: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		RDates:    "2026-04-08T00:00:00Z",
+	})
+	svc.UpsertByUID(ctx, UpsertParams{
+		UID: "del-rdate-master", CalendarID: 1, Summary: "RDATE series (moved)",
+		StartDate:    time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		RecurrenceID: "2026-04-08T00:00:00Z",
+	})
+
+	master, _ := svc.GetByUID(ctx, "del-rdate-master")
+	err := svc.Delete(ctx, master.ID)
+	if !errors.Is(err, ErrHasOverrides) {
+		t.Fatalf("Delete RDATE master with overrides: got %v, want ErrHasOverrides", err)
 	}
 }
 


### PR DESCRIPTION
## Bug

`journal.Service.Delete` gated the override-presence check only on
`j.RecurrenceRule != ""`. An RDATE-only recurring master (occurrences
defined purely via RDATEs, no RRULE) with override rows (same UID,
non-empty `recurrence_id`) was therefore not recognized as recurring.
The override check was skipped, and since the master's `RecurrenceID == ""`,
`Delete` fell into the standalone branch and soft-deleted only the master
row plus a tombstone. The override rows stayed live but lost their
anchoring master, leaving orphaned overrides that recurrence expansion
cannot resolve and that round-trip incorrectly.

This is the same data-integrity bug the #415 fix already prevents for
`event.Service.Delete` and `todo.Service.Delete`; it was never applied to
journals.

## Fix

Change the guard to `(j.RecurrenceRule != "" || j.RDates != "") && j.RecurrenceID == ""`,
matching the event/todo `Delete` guards, so RDATE-only recurring masters
with overrides are rejected with `ErrHasOverrides` and routed through
`DeleteSeries`.

## Test

Added `TestJournalDelete_RDateMasterWithOverridesRefused` (RDATE-only
master with an override must be refused) plus
`TestJournalDelete_MasterWithOverridesRefused` (the existing RRULE case,
for parity with the event/todo suites). The RDATE-only test fails on
master with `got <nil>, want ErrHasOverrides` and passes with the fix.

Closes #471
