### PR TITLE
fix(event): normalize date-range query bounds to UTC (#464)

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -217,8 +217,8 @@ func (s *Service) CountByCalendar(ctx context.Context, calendarID int64) (int64,
 
 func (s *Service) ListByDateRange(ctx context.Context, from, to time.Time) ([]Event, error) {
 	rows, err := s.q.ListEventsByDateRange(ctx, storage.ListEventsByDateRangeParams{
-		StartTime: to.Format(time.RFC3339),   // start_time < to
-		EndTime:   from.Format(time.RFC3339), // end_time > from
+		StartTime: to.UTC().Format(time.RFC3339),   // start_time < to
+		EndTime:   from.UTC().Format(time.RFC3339), // end_time > from
 	})
 	if err != nil {
 		return nil, err
@@ -231,8 +231,8 @@ func (s *Service) ListByDateRange(ctx context.Context, from, to time.Time) ([]Ev
 func (s *Service) ListByCalendarAndDateRange(ctx context.Context, calID int64, from, to time.Time) ([]Event, error) {
 	rows, err := s.q.ListEventsByCalendarAndDateRange(ctx, storage.ListEventsByCalendarAndDateRangeParams{
 		CalendarID: calID,
-		StartTime:  to.Format(time.RFC3339),   // start_time < to
-		EndTime:    from.Format(time.RFC3339), // end_time > from
+		StartTime:  to.UTC().Format(time.RFC3339),   // start_time < to
+		EndTime:    from.UTC().Format(time.RFC3339), // end_time > from
 	})
 	if err != nil {
 		return nil, err

--- a/internal/event/utc_normalization_test.go
+++ b/internal/event/utc_normalization_test.go
@@ -128,6 +128,41 @@ func TestCreate_AllDayPinsToUTCMidnight(t *testing.T) {
 	}
 }
 
+// TestListByDateRange_NormalizesBoundsToUTC reproduces issue #464 for the
+// read side: when a caller passes window bounds carrying a non-UTC offset,
+// ListByDateRange must normalize them to UTC before the lexical comparison
+// against the UTC-stored ("Z") start/end strings. Otherwise the offset left in
+// the formatted bound skews the comparison near window edges.
+//
+// Event: 01:00-02:00 UTC on Apr 1. Window in UTC-3 is [00:00, +1d) local =
+// [03:00Z, next-day 03:00Z). The event ends at 02:00Z, before the window
+// starts, so it must NOT appear. With the unnormalized bound, end_time > from
+// becomes "2026-04-01T02:00:00Z" > "2026-04-01T00:00:00-03:00", which is
+// lexically true, and the event wrongly surfaces.
+func TestListByDateRange_NormalizesBoundsToUTC(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, CreateParams{
+		CalendarID: 1,
+		Title:      "Early Event",
+		StartTime:  time.Date(2026, 4, 1, 1, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 2, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	loc := time.FixedZone("-03", -3*60*60)
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, loc) // 03:00Z
+	to := time.Date(2026, 4, 2, 0, 0, 0, 0, loc)   // next-day 03:00Z
+
+	if got := occursOn(t, svc, created.ID, from, to); got != 0 {
+		t.Errorf("event ending before the window appears %d times, want 0", got)
+	}
+}
+
 // TestUpdate_NormalizesToUTC confirms the edit path enforces the same
 // invariant: re-saving with offset-bearing times stores them in UTC.
 func TestUpdate_NormalizesToUTC(t *testing.T) {

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -411,8 +411,8 @@ func (s *Service) ListExpandedEvents(ctx context.Context, from, to time.Time, op
 	}
 	// Non-recurring events in date range.
 	rangeRows, err := s.q.ListEventsByDateRange(ctx, storage.ListEventsByDateRangeParams{
-		StartTime: to.Format(time.RFC3339),   // start_time < to
-		EndTime:   from.Format(time.RFC3339), // end_time > from
+		StartTime: to.UTC().Format(time.RFC3339),   // start_time < to
+		EndTime:   from.UTC().Format(time.RFC3339), // end_time > from
 	})
 	if err != nil {
 		return nil, err
@@ -681,8 +681,8 @@ func (s *Service) expandRecurringRows(ctx context.Context, rows []storage.Event,
 // StartTime/EndTime adjusted to the instance time and are sorted by StartTime.
 func (s *Service) ListExpandedByDateRange(ctx context.Context, from, to time.Time) ([]event.Event, error) {
 	rangeRows, err := s.q.ListEventsByDateRange(ctx, storage.ListEventsByDateRangeParams{
-		StartTime: to.Format(time.RFC3339),   // start_time < to
-		EndTime:   from.Format(time.RFC3339), // end_time > from
+		StartTime: to.UTC().Format(time.RFC3339),   // start_time < to
+		EndTime:   from.UTC().Format(time.RFC3339), // end_time > from
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Bug

`ListByDateRange`, `ListByCalendarAndDateRange` (`internal/event/service.go`), `ListExpandedEvents` and `ListExpandedByDateRange` (`internal/recurrence/service.go`) formatted their date-range query bounds with `to.Format(time.RFC3339)` / `from.Format(time.RFC3339)`, leaving any non-UTC offset in the formatted string.

Those bounds are compared **lexically** against the UTC-stored (`Z`) `start_time` / `end_time` strings in the backing SQL (`start_time < ? AND end_time > ?`). When a caller passes a local-zoned `time.Time`, the offset left in the string breaks the comparison near window edges — exactly the defect `rangeBoundUTC` (`recurrence/service.go`) was added to fix for issue #305, but only the export/filtered path used that helper.

The alarm checker is a real local-zone caller: it builds its window from `time.Now()` (host-local) and passes it straight into `ListExpandedEvents`. Today this is masked by the generous +/-48h padding, but the missing `.UTC()` would skew any local-zoned caller of these public service-API methods, silently violating the documented UTC-bound invariant.

## Fix

Format all four bounds with `.UTC()` before comparison (`to.UTC().Format(time.RFC3339)` / `from.UTC().Format(time.RFC3339)`), so the lexical comparison is correct regardless of the caller's zone and consistent with the #305 fix.

## Test

Added `TestListByDateRange_NormalizesBoundsToUTC` in `internal/event/utc_normalization_test.go`. It stores an event at `01:00-02:00Z` and queries a `UTC-3` window `[00:00, +1d)` local (= `[03:00Z, …)`); the event ends before the window starts and must not appear. The test fails before the fix (event wrongly surfaces because `"…T02:00:00Z" > "…T00:00:00-03:00"` is lexically true) and passes after.

`go build ./...`, `go vet`, `gofmt`, and `golangci-lint` are clean; `internal/event`, `internal/recurrence`, and `internal/alarm` test packages pass.

Closes #464
