### PR TITLE
fix(cmd): resolve service install sync interval at run time (#462)

### DIFF
--- a/cmd/chroncal/service.go
+++ b/cmd/chroncal/service.go
@@ -140,8 +140,9 @@ func serviceInstallCmd() *cobra.Command {
 schedule.
 
 The installed service runs "chroncal service run", which checks alarms every
-minute and also runs sync work when the configured sync interval is due. By
-		default, service install configures sync every 15 minutes.`,
+minute and also runs sync work when the configured sync interval is due.
+Without --sync-interval, the [sync] interval from your config is used, falling
+back to every 15 minutes when it is unset.`,
 		Example: `  chroncal service install
   chroncal service install --sync-interval ""
   chroncal service install --sync-interval 15m`,
@@ -151,7 +152,7 @@ minute and also runs sync work when the configured sync interval is due. By
 			if err != nil {
 				return err
 			}
-			effectiveSyncInterval := syncInterval
+			effectiveSyncInterval := serviceInstallSyncInterval(cmd)
 			// The values below are interpolated into service definitions
 			// (unit file, plist, batch wrapper). Reject anything that
 			// doesn't parse rather than escaping per-format: a config value
@@ -201,16 +202,29 @@ minute and also runs sync work when the configured sync interval is due. By
 			}
 		},
 	}
-	cmd.Flags().StringVar(&syncInterval, "sync-interval", serviceInstallDefaultSyncInterval(), "how often service run should run sync work (for example 15m); empty disables sync")
+	cmd.Flags().StringVar(&syncInterval, "sync-interval", "15m", "how often service run should run sync work (for example 15m); empty disables sync")
 	bindAlarmExecutionPolicyFlags(cmd, &flagPolicy)
 	return cmd
 }
 
-func serviceInstallDefaultSyncInterval() string {
+// serviceInstallSyncInterval resolves the sync interval baked into the
+// installed service definition. An explicit --sync-interval flag always wins
+// (including an explicit empty value, which disables sync). Otherwise the
+// configured [sync] interval is used, falling back to the static flag default
+// ("15m") when config leaves it unset.
+//
+// This must be resolved here, at RunE time, rather than as the flag default:
+// the command tree is built during package init() — before
+// rootCmd.PersistentPreRunE runs config.Load() — so cfg is still the zero
+// value when a computed flag default would be evaluated (issue #462).
+func serviceInstallSyncInterval(cmd *cobra.Command) string {
+	if cmd.Flags().Changed("sync-interval") {
+		return cmd.Flag("sync-interval").Value.String()
+	}
 	if cfg.Sync.Interval != "" {
 		return cfg.Sync.Interval
 	}
-	return "15m"
+	return cmd.Flag("sync-interval").Value.String()
 }
 
 func systemdUserDir() (string, error) {

--- a/cmd/chroncal/service_test.go
+++ b/cmd/chroncal/service_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/douglasdemoura/chroncal/internal/config"
 )
 
@@ -79,18 +81,76 @@ func TestServiceInstallDefaultsSyncIntervalTo15Minutes(t *testing.T) {
 	}
 }
 
-func TestServiceInstallUsesConfiguredSyncIntervalDefault(t *testing.T) {
+// registeredServiceInstallCmd returns the install subcommand as it was wired
+// into rootCmd at package init(), i.e. the production code path — not a fresh
+// serviceInstallCmd() built after cfg has been populated.
+func registeredServiceInstallCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() != "service" {
+			continue
+		}
+		for _, sub := range cmd.Commands() {
+			if sub.Name() == "install" {
+				return sub
+			}
+		}
+	}
+	t.Fatal("service install command not registered on rootCmd")
+	return nil
+}
+
+// TestServiceInstallRespectsConfiguredSyncIntervalAtRunTime exercises the
+// init-time-registered command (as production does) to prove the configured
+// [sync] interval is honored even though the flag tree is built before
+// config.Load() runs. Regression test for issue #462.
+func TestServiceInstallRespectsConfiguredSyncIntervalAtRunTime(t *testing.T) {
+	oldCfg := cfg
+	t.Cleanup(func() { cfg = oldCfg })
+	cfg = config.Config{Sync: config.SyncConfig{Interval: "30m"}}
+
+	install := registeredServiceInstallCmd(t)
+	if got := serviceInstallSyncInterval(install); got != "30m" {
+		t.Fatalf("effective sync interval = %q, want 30m (config must win when --sync-interval unset)", got)
+	}
+}
+
+func TestServiceInstallSyncIntervalFlagOverridesConfig(t *testing.T) {
 	oldCfg := cfg
 	t.Cleanup(func() { cfg = oldCfg })
 	cfg = config.Config{Sync: config.SyncConfig{Interval: "30m"}}
 
 	cmd := serviceInstallCmd()
-	flag := cmd.Flags().Lookup("sync-interval")
-	if flag == nil {
-		t.Fatal("service install missing sync-interval flag")
+	if err := cmd.Flags().Set("sync-interval", "5m"); err != nil {
+		t.Fatalf("set sync-interval: %v", err)
 	}
-	if got := flag.DefValue; got != "30m" {
-		t.Fatalf("sync-interval default = %q, want 30m", got)
+	if got := serviceInstallSyncInterval(cmd); got != "5m" {
+		t.Fatalf("effective sync interval = %q, want 5m (explicit flag must win)", got)
+	}
+}
+
+func TestServiceInstallSyncIntervalFlagCanDisableSync(t *testing.T) {
+	oldCfg := cfg
+	t.Cleanup(func() { cfg = oldCfg })
+	cfg = config.Config{Sync: config.SyncConfig{Interval: "30m"}}
+
+	cmd := serviceInstallCmd()
+	if err := cmd.Flags().Set("sync-interval", ""); err != nil {
+		t.Fatalf("set sync-interval: %v", err)
+	}
+	if got := serviceInstallSyncInterval(cmd); got != "" {
+		t.Fatalf("effective sync interval = %q, want empty (explicit --sync-interval \"\" disables sync)", got)
+	}
+}
+
+func TestServiceInstallSyncIntervalFallsBackToStaticDefault(t *testing.T) {
+	oldCfg := cfg
+	t.Cleanup(func() { cfg = oldCfg })
+	cfg = config.Config{}
+
+	cmd := serviceInstallCmd()
+	if got := serviceInstallSyncInterval(cmd); got != "15m" {
+		t.Fatalf("effective sync interval = %q, want 15m (static default with empty config)", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The command tree is built during package `init()` (`main.go init()` → `serviceCmd()` → `AddCommand(serviceInstallCmd())`), but the global `cfg` is only populated later in `rootCmd.PersistentPreRunE` via `config.Load()`. The `--sync-interval` flag default was computed eagerly at flag-registration time:

```go
cmd.Flags().StringVar(&syncInterval, "sync-interval", serviceInstallDefaultSyncInterval(), ...)
```

`serviceInstallDefaultSyncInterval()` read `cfg.Sync.Interval`, but at `init()` time `cfg` is the zero value, so it always returned the static `"15m"`. cobra evaluates a `StringVar` default once, at registration — it is never recomputed at execute time. Result: a user's `config.toml` `[sync] interval = "30m"` was silently ignored, and `chroncal service install` (without `--sync-interval`) always baked `CHRONCAL_SYNC_INTERVAL=15m` into the unit/plist/wrapper.

## Fix

Keep a static `"15m"` flag default and resolve the configured value at `RunE` time via a new `serviceInstallSyncInterval(cmd)` helper:

- explicit `--sync-interval` (including `""` to disable sync) wins,
- otherwise `cfg.Sync.Interval` (now populated, since `PersistentPreRunE` has run),
- otherwise the static `"15m"` default.

## Tests

The old `TestServiceInstallUsesConfiguredSyncIntervalDefault` built a fresh `serviceInstallCmd()` *after* setting `cfg`, so it evaluated the default post-config and gave false confidence. It is replaced with `TestServiceInstallRespectsConfiguredSyncIntervalAtRunTime`, which exercises the actual init-time `rootCmd`-registered install command — mirroring production wiring. Confirmed to fail with `effective sync interval = "15m", want 30m` against the buggy code path, and pass with the fix. Added coverage for flag-override, explicit-empty (disable), and static-default fallback.

`go build ./...`, `go vet`, `gofmt`, `golangci-lint`, and the full `cmd/chroncal` test package all pass.

Closes #462
