### PR TITLE
fix(ical): emit VALARM ATTACH for EMAIL alarms on export

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -747,8 +747,10 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 		valarm.Props.Add(p)
 	}
 
-	// ATTACH (sound for AUDIO alarms only): inline BASE64 blob or URI.
-	if alarm.Action == "AUDIO" && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
+	// ATTACH: a sound for AUDIO alarms or a document for EMAIL alarms
+	// (RFC 5545 §3.6.6). Emitted as an inline BASE64 blob or a URI. DISPLAY
+	// alarms carry no ATTACH, so only re-emit for the two actions that do.
+	if (alarm.Action == "AUDIO" || alarm.Action == "EMAIL") && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
 		p := &ical.Prop{Name: ical.PropAttach, Params: make(ical.Params)}
 		if len(alarm.AttachBinary) > 0 {
 			p.Value = base64.StdEncoding.EncodeToString(alarm.AttachBinary)

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -1810,6 +1810,69 @@ func TestRoundtrip_AlarmAttachBinary(t *testing.T) {
 	}
 }
 
+func TestRoundtrip_AlarmAttachEMAIL(t *testing.T) {
+	t.Parallel()
+	// EMAIL alarms may carry one or more ATTACH attachments (RFC 5545 §3.6.6).
+	// An imported EMAIL attachment must not be silently dropped on export
+	// (issue #468).
+	original := event.Event{
+		UID:       "roundtrip-alarm-attach-email",
+		Title:     "Event with Email Alarm Attachment",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		Alarms: []model.Alarm{
+			{
+				Action:        "EMAIL",
+				TriggerValue:  "-PT1H",
+				Summary:       "Heads up",
+				Description:   "Meeting soon",
+				AttachURI:     "http://example.com/files/agenda.pdf",
+				AttachFmtType: "application/pdf",
+				Attendees: []model.AlarmAttendee{
+					{Email: "user@example.com"},
+				},
+			},
+		},
+		CreatedAt: time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC),
+	}
+
+	data, err := ExportEvents([]event.Event{original}, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	ics := string(data)
+	if !strings.Contains(ics, "ATTACH") {
+		t.Errorf("exported ICS missing ATTACH for EMAIL alarm:\n%s", ics)
+	}
+	if !strings.Contains(ics, "FMTTYPE=application/pdf") {
+		t.Errorf("exported ICS missing FMTTYPE:\n%s", ics)
+	}
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("reimported %d events, want 1", len(result.Events))
+	}
+
+	got := result.Events[0]
+	if len(got.Alarms) != 1 {
+		t.Fatalf("Alarms: got %d, want 1", len(got.Alarms))
+	}
+	alarm := got.Alarms[0]
+	if alarm.AttachURI != "http://example.com/files/agenda.pdf" {
+		t.Errorf("AttachURI: got %q, want %q", alarm.AttachURI, "http://example.com/files/agenda.pdf")
+	}
+	if alarm.AttachFmtType != "application/pdf" {
+		t.Errorf("AttachFmtType: got %q, want %q", alarm.AttachFmtType, "application/pdf")
+	}
+}
+
 func TestRoundtrip_EventDuration(t *testing.T) {
 	t.Parallel()
 	original := event.Event{


### PR DESCRIPTION
## Bug

`parseAlarm` (import.go) reads `ATTACH` for any VALARM action into the
single-valued `alarm.AttachURI` / `alarm.AttachBinary` fields, but
`buildValarm` (export.go) only re-emitted `ATTACH` when
`alarm.Action == "AUDIO"`. RFC 5545 §3.6.6 also permits `ATTACH` on
`EMAIL` alarms (a document attachment), so an imported EMAIL alarm
attachment was silently dropped on export — a round-trip data loss.
`DISPLAY` alarms legitimately carry no `ATTACH`, so dropping there is
correct.

## Fix

Gate the export `ATTACH` emission on `Action == "AUDIO" || Action ==
"EMAIL"` instead of `AUDIO` only. Minimal, single-condition change in
`buildValarm`; `DISPLAY` remains excluded.

## Test

Added `TestRoundtrip_AlarmAttachEMAIL` in
`internal/ical/roundtrip_test.go`: exports an event with an EMAIL alarm
carrying an `ATTACH` URI + `FMTTYPE`, asserts the exported ICS contains
`ATTACH`/`FMTTYPE`, then re-imports and verifies the attachment URI and
fmttype survive. The test fails before the fix (ATTACH missing from
export) and passes after.

## Notes / follow-ups

The single-valued attachment field still collapses multiple EMAIL
attachments to one on import (`comp.Props.Get` returns only the first
`ATTACH`). Modeling multiple alarm attachments is out of scope for this
minimal round-trip fix and remains a possible future enhancement.

Closes #468
