### PR TITLE
fix(notify): MIME-encode non-ASCII email Subject header

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -273,14 +273,17 @@ func Email(da alarm.DueAlarm, smtpCfg config.SMTPConfig, policy ExecutionPolicy)
 
 // buildEmailMessage assembles an RFC 5322 message with MIME headers declaring a
 // UTF-8 text/plain body. The Content-Type/charset header is required so strict
-// mail clients render non-ASCII titles and bodies as UTF-8 rather than defaulting
-// to US-ASCII (which produces mojibake).
+// mail clients render the non-ASCII body as UTF-8 rather than defaulting to
+// US-ASCII (which produces mojibake). That body charset declaration does not
+// cover header fields, though: RFC 5322 restricts header field bodies to ASCII,
+// so a non-ASCII Subject must be wrapped in an RFC 2047 encoded-word
+// (mime.QEncoding.Encode is a no-op for plain-ASCII subjects).
 func buildEmailMessage(from string, to []string, subject, body string) []byte {
 	msg := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n"+
 		"MIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n%s\r\n",
 		textsafe.Display(from),
 		strings.Join(to, ", "),
-		textsafe.Display(subject),
+		mime.QEncoding.Encode("utf-8", textsafe.Display(subject)),
 		textsafe.Display(body),
 	)
 	return []byte(msg)

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"mime"
 	"net"
 	"os"
 	"path/filepath"
@@ -441,14 +442,69 @@ func TestBuildEmailMessage_MIMEHeaders(t *testing.T) {
 			if !strings.Contains(head, "Content-Type: text/plain; charset=utf-8") {
 				t.Errorf("message headers missing UTF-8 Content-Type:\n%q", head)
 			}
-			if !strings.Contains(head, "Subject: "+tt.subject) {
-				t.Errorf("message headers missing Subject %q:\n%q", tt.subject, head)
+			// The Subject header may be RFC 2047 encoded; decode before comparing.
+			if got := decodeSubjectHeader(t, head); got != tt.subject {
+				t.Errorf("decoded Subject = %q, want %q", got, tt.subject)
 			}
 			if !strings.Contains(rest, tt.body) {
 				t.Errorf("message body = %q, want it to contain %q", rest, tt.body)
 			}
 		})
 	}
+}
+
+// TestBuildEmailMessage_SubjectHeaderEncoding asserts the Subject header is
+// RFC 2047 encoded for non-ASCII titles: the raw header line must stay ASCII so
+// non-SMTPUTF8 servers/clients render it correctly, and decoding it must yield
+// the original subject.
+func TestBuildEmailMessage_SubjectHeaderEncoding(t *testing.T) {
+	subject := "Reunião com café ☕"
+	msg := string(buildEmailMessage("sender@example.com", []string{"user@example.com"}, subject, "body"))
+
+	head, _, found := strings.Cut(msg, "\r\n\r\n")
+	if !found {
+		t.Fatalf("message has no header/body separator:\n%q", msg)
+	}
+
+	var subjectLine string
+	for _, line := range strings.Split(head, "\r\n") {
+		if v, ok := strings.CutPrefix(line, "Subject: "); ok {
+			subjectLine = v
+			break
+		}
+	}
+	if subjectLine == "" {
+		t.Fatalf("no Subject header found:\n%q", head)
+	}
+
+	// The raw Subject header must be pure ASCII (RFC 5322 / 2047).
+	for _, r := range subjectLine {
+		if r > 127 {
+			t.Fatalf("Subject header contains non-ASCII rune %q: %q", r, subjectLine)
+		}
+	}
+
+	// And it must decode back to the original subject.
+	if got := decodeSubjectHeader(t, head); got != subject {
+		t.Errorf("decoded Subject = %q, want %q", got, subject)
+	}
+}
+
+// decodeSubjectHeader extracts the Subject header from a message header block
+// and returns its RFC 2047-decoded value.
+func decodeSubjectHeader(t *testing.T, head string) string {
+	t.Helper()
+	for _, line := range strings.Split(head, "\r\n") {
+		if v, ok := strings.CutPrefix(line, "Subject: "); ok {
+			decoded, err := new(mime.WordDecoder).DecodeHeader(v)
+			if err != nil {
+				t.Fatalf("decoding Subject header %q: %v", v, err)
+			}
+			return decoded
+		}
+	}
+	t.Fatalf("no Subject header found:\n%q", head)
+	return ""
 }
 
 // generateTestCert creates a self-signed ECDSA certificate for 127.0.0.1/localhost.


### PR DESCRIPTION
## Bug
`buildEmailMessage` (internal/notify/notify.go) wrote `Subject: <subject>` with the raw subject string. `textsafe.Display` deliberately preserves non-ASCII runes, so an event/todo title like "Café meeting" produced a Subject header containing raw UTF-8 bytes.

RFC 5322 restricts header field bodies to ASCII; non-ASCII text must use RFC 2047 encoded-words. The `Content-Type: text/plain; charset=utf-8` declaration only governs the body, not header fields, so SMTP servers/clients without UTF-8-header assumptions (no SMTPUTF8 negotiation happens here) render such subjects as mojibake.

## Fix
Wrap the subject in an RFC 2047 encoded-word via `mime.QEncoding.Encode("utf-8", ...)` before composing the header. This is a no-op for plain-ASCII subjects, so existing behavior is unchanged for ASCII titles. The `mime` package was already imported.

## Test
- New `TestBuildEmailMessage_SubjectHeaderEncoding`: asserts the raw Subject header line stays pure ASCII and decodes back to the original subject via `mime.WordDecoder`. Fails on the pre-fix code (raw `ã` byte in the header), passes after.
- Updated `TestBuildEmailMessage_MIMEHeaders` to decode the Subject header before comparing (shared `decodeSubjectHeader` helper).

## Scope note
The From display name is technically subject to the same RFC 2047 rule, but `smtpCfg.From` is also used verbatim as the SMTP envelope sender (MAIL FROM), so it is a bare address in practice; naive Q-encoding of a full `Name <addr>` string would corrupt the address syntax. Left out of scope to keep the fix minimal and correct.

Closes #472
