### PR TITLE
fix(tui): bound date-picker grid hit-test below the day rows

### DIFF
--- a/internal/tui/date_picker_deadspace_test.go
+++ b/internal/tui/date_picker_deadspace_test.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestHandleDatePickerMouse_DeadSpaceBelowGridIgnored is a regression test for
+// issue #469. The mini-month grid renders day rows at content rows 2..7
+// (miniMonthGridRows=6). Below it the overlay draws blank/checkbox/status/
+// separator/button rows. A left-half click on a dead-space row that is neither
+// the checkbox row nor the button row (e.g. row 8, the blank line) must not
+// commit the selection or pin a range endpoint.
+func TestHandleDatePickerMouse_DeadSpaceBelowGridIgnored(t *testing.T) {
+	const screenW, screenH = 120, 40
+	day := time.Date(2026, 7, 5, 0, 0, 0, 0, time.Local)
+
+	t.Run("non-range does not commit/close", func(t *testing.T) {
+		m, _ := NewEventFormModel(day, map[int64]CalendarInfo{1: {}}, NewTheme(true))
+		m = m.SetSize(screenW, screenH)
+		m.openDatePicker()
+
+		// Content row mmY=8 (blank line directly below the grid), left half.
+		boxW, boxH := m.DatePickerBoxSize()
+		ox := (screenW - boxW) / 2
+		oy := (screenH - boxH) / 2
+		msg := tea.MouseClickMsg(tea.Mouse{X: ox + 2, Y: oy + 2 + 8, Button: tea.MouseLeft})
+
+		got, _ := m.handleDatePickerMouse(msg)
+		if !got.datePickerOpen {
+			t.Error("dead-space click below grid must not commit/close the picker")
+		}
+	})
+
+	t.Run("range mode does not pin endpoint", func(t *testing.T) {
+		m, _ := NewEventFormModel(day, map[int64]CalendarInfo{1: {}}, NewTheme(true))
+		m = m.SetSize(screenW, screenH)
+		m.openDatePicker()
+		m.toggleRangeMode() // pins start, arms end pin
+
+		boxW, boxH := m.DatePickerBoxSize()
+		ox := (screenW - boxW) / 2
+		oy := (screenH - boxH) / 2
+		msg := tea.MouseClickMsg(tea.Mouse{X: ox + 2, Y: oy + 2 + 8, Button: tea.MouseLeft})
+
+		got, _ := m.handleDatePickerMouse(msg)
+		if !got.rangeEnd.IsZero() {
+			t.Errorf("dead-space click must not pin a range endpoint; rangeEnd = %v", got.rangeEnd)
+		}
+	})
+}
+
+// TestHandleEndsDatePickerMouse_DeadSpaceBelowGridIgnored covers the sibling
+// ends-date picker handler for issue #469.
+func TestHandleEndsDatePickerMouse_DeadSpaceBelowGridIgnored(t *testing.T) {
+	const screenW, screenH = 120, 40
+	start := time.Date(2026, 4, 24, 0, 0, 0, 0, time.Local)
+	m, _ := NewEventFormModel(start, map[int64]CalendarInfo{1: {}}, NewTheme(true))
+	m = m.SetSize(screenW, screenH)
+	m.openEndsDatePicker()
+	original := m.endsDate
+
+	// Content row mmY=8 (blank line below the grid in the ends-date layout).
+	boxW, boxH := m.DatePickerBoxSize()
+	ox := (screenW - boxW) / 2
+	oy := (screenH - boxH) / 2
+	msg := tea.MouseClickMsg(tea.Mouse{X: ox + 2, Y: oy + 2 + 8, Button: tea.MouseLeft})
+
+	got, _ := m.handleEndsDatePickerMouse(msg)
+	if !got.endsDatePicker {
+		t.Error("dead-space click below grid must not commit/close the ends-date picker")
+	}
+	if !got.endsDate.Equal(original) {
+		t.Errorf("dead-space click must not change endsDate; got %v want %v", got.endsDate, original)
+	}
+}

--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -1274,8 +1274,12 @@ func (m EventFormModel) handleDatePickerMouse(msg tea.MouseClickMsg) (EventFormM
 		return m, nil
 	}
 
-	// Calendar grid hit-testing.
-	if mmX >= miniMonthHeaderWidth {
+	// Calendar grid hit-testing. Day rows occupy content rows 2..7 (header
+	// row 0, weekday row 1, then miniMonthGridRows day rows). Reject the X
+	// overflow and any row below the grid so clicks in the dead space
+	// (blank/status/separator) do not fall through and commit/pin a date.
+	// Row 0 (chevrons) is intentionally kept so mouse month nav still works.
+	if mmX >= miniMonthHeaderWidth || mmY >= 2+miniMonthGridRows {
 		return m, nil
 	}
 
@@ -1340,8 +1344,12 @@ func (m EventFormModel) handleEndsDatePickerMouse(msg tea.MouseClickMsg) (EventF
 		return m, nil
 	}
 
-	// Calendar grid hit-testing.
-	if mmX >= miniMonthHeaderWidth {
+	// Calendar grid hit-testing. Day rows occupy content rows 2..7 (header
+	// row 0, weekday row 1, then miniMonthGridRows day rows). Reject the X
+	// overflow and any row below the grid so clicks in the dead space
+	// (blank/separator) do not fall through and commit a date.
+	// Row 0 (chevrons) is intentionally kept so mouse month nav still works.
+	if mmX >= miniMonthHeaderWidth || mmY >= 2+miniMonthGridRows {
 		return m, nil
 	}
 


### PR DESCRIPTION
## Bug

`handleDatePickerMouse` and `handleEndsDatePickerMouse` (`internal/tui/event_form.go`) only bounded the date-picker calendar grid hit-test on the X axis (`mmX >= miniMonthHeaderWidth`) and a lower Y bound (`mmY >= 2`). They never checked an upper Y bound.

The mini-month renders 8 fixed content lines (header row 0, weekday row 1, then `miniMonthGridRows=6` day rows = rows 2..7). Below it the overlay draws blank / Multi-day checkbox / status / blank / separator / button rows. A left-half click (`mmX < 20`) on a dead-space row that is neither the checkbox row (9) nor the button row (13 event / 10 ends) — event-picker rows 8/10/11/12 or ends-picker row 8 — fell through to the grid branch.

`MiniMonthModel.HandleClick` maps those out-of-grid rows to a day outside `displayMonth` and returns the cursor unchanged, so `monthChanged` is false and `mmY >= 2` holds. The handler then ran `commitDatePickerSelection()` (closing the picker and committing the current cursor) or, in range mode, `pinRangeEndpoint(cursor)` — pinning a range endpoint from a click on empty space.

The sibling `recurrence_editor.go` handler gets this right with `ry >= 6`, confirming the missing bound here was an oversight.

## Fix

Add an upper Y bound to both handlers' grid branch: `mmY >= 2+miniMonthGridRows`. Clicks on rows below the day grid are now rejected before reaching `HandleClick`/commit. Row 0 (chevrons) is intentionally kept inside the branch so mouse-driven month navigation still works.

## Test

`internal/tui/date_picker_deadspace_test.go` adds regression coverage:
- event picker, non-range: a dead-space click (content row 8) must not close/commit the picker
- event picker, range mode: a dead-space click must not pin a range endpoint
- ends picker: a dead-space click must not close the picker or change `endsDate`

All three fail on master for the stated reason and pass with the fix. Full `internal/tui` test suite passes; `gofmt`/`go vet` clean.

Closes #469
