### PR TITLE
fix(cmd): merge attendee/organizer on partial update instead of wiping

### DIFF
--- a/cmd/chroncal/attendee_merge_cli_test.go
+++ b/cmd/chroncal/attendee_merge_cli_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+// findAttendee returns the attendee with the given email, or false.
+func findAttendee(atts []model.Attendee, email string) (model.Attendee, bool) {
+	for _, a := range atts {
+		if a.Email == email {
+			return a, true
+		}
+	}
+	return model.Attendee{}, false
+}
+
+// organizerEmail returns the email of the single organizer row, or "" if none.
+func organizerEmail(atts []model.Attendee) string {
+	for _, a := range atts {
+		if a.Organizer {
+			return a.Email
+		}
+	}
+	return ""
+}
+
+// TestEventUpdateOrganizerPreservesAttendees verifies that updating only the
+// organizer does not wipe existing (non-organizer) attendee rows, and that
+// updating only attendees does not drop the existing organizer (issue #461).
+func TestEventUpdateOrganizerPreservesAttendees(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Standup",
+		"--calendar", "Work",
+		"--date", "2026-04-21",
+		"--attendee", "Alice <alice@example.com>",
+		"--organizer", "Bob <bob@example.com>",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	// Update only the organizer; attendees must be preserved.
+	if _, _, err := runChroncalCommand(t,
+		"event", "update", "1",
+		"--organizer", "Carol <carol@example.com>",
+	); err != nil {
+		t.Fatalf("event update --organizer: %v", err)
+	}
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+	ctx := context.Background()
+
+	atts, err := a.Events.ListAttendees(ctx, 1)
+	if err != nil {
+		t.Fatalf("ListAttendees: %v", err)
+	}
+	if _, ok := findAttendee(atts, "alice@example.com"); !ok {
+		t.Fatalf("attendee alice@example.com was deleted by --organizer-only update; attendees=%+v", atts)
+	}
+	if got := organizerEmail(atts); got != "carol@example.com" {
+		t.Fatalf("organizer = %q, want carol@example.com", got)
+	}
+
+	// Update only the attendee; organizer must be preserved.
+	if _, _, err := runChroncalCommand(t,
+		"event", "update", "1",
+		"--attendee", "Dave <dave@example.com>",
+	); err != nil {
+		t.Fatalf("event update --attendee: %v", err)
+	}
+
+	atts, err = a.Events.ListAttendees(ctx, 1)
+	if err != nil {
+		t.Fatalf("ListAttendees: %v", err)
+	}
+	if got := organizerEmail(atts); got != "carol@example.com" {
+		t.Fatalf("organizer = %q dropped by --attendee-only update; want carol@example.com; attendees=%+v", got, atts)
+	}
+	if _, ok := findAttendee(atts, "dave@example.com"); !ok {
+		t.Fatalf("attendee dave@example.com not set; attendees=%+v", atts)
+	}
+}
+
+// TestTodoUpdateOrganizerPreservesAttendees mirrors the event check for todos.
+func TestTodoUpdateOrganizerPreservesAttendees(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"todo", "add", "Review PR",
+		"--calendar", "Work",
+		"--attendee", "Alice <alice@example.com>",
+		"--organizer", "Bob <bob@example.com>",
+	); err != nil {
+		t.Fatalf("todo add: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"todo", "update", "1",
+		"--organizer", "Carol <carol@example.com>",
+	); err != nil {
+		t.Fatalf("todo update --organizer: %v", err)
+	}
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+
+	atts, err := a.Todos.ListAttendees(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ListAttendees: %v", err)
+	}
+	if _, ok := findAttendee(atts, "alice@example.com"); !ok {
+		t.Fatalf("attendee alice@example.com was deleted by --organizer-only update; attendees=%+v", atts)
+	}
+	if got := organizerEmail(atts); got != "carol@example.com" {
+		t.Fatalf("organizer = %q, want carol@example.com", got)
+	}
+}
+
+// TestJournalUpdateAttendeePreservesOrganizer mirrors the check for journals.
+func TestJournalUpdateAttendeePreservesOrganizer(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"journal", "add", "Sprint notes",
+		"--calendar", "Work",
+		"--date", "2026-04-01",
+		"--attendee", "Alice <alice@example.com>",
+		"--organizer", "Bob <bob@example.com>",
+	); err != nil {
+		t.Fatalf("journal add: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"journal", "update", "1",
+		"--attendee", "Dave <dave@example.com>",
+	); err != nil {
+		t.Fatalf("journal update --attendee: %v", err)
+	}
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+
+	atts, err := a.Journals.ListAttendees(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ListAttendees: %v", err)
+	}
+	if got := organizerEmail(atts); got != "bob@example.com" {
+		t.Fatalf("organizer = %q dropped by --attendee-only update; want bob@example.com; attendees=%+v", got, atts)
+	}
+	if _, ok := findAttendee(atts, "dave@example.com"); !ok {
+		t.Fatalf("attendee dave@example.com not set; attendees=%+v", atts)
+	}
+}

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1211,10 +1211,13 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 			}
 
 			if cmd.Flags().Changed("attendee") || cmd.Flags().Changed("organizer") {
-				attendees := parseAttendeeFlags(attendeeFlags)
-				if cmd.Flags().Changed("organizer") && organizer != "" {
-					attendees = append(attendees, parseOrganizerFlag(organizer))
+				existingAtt, err := a.Events.ListAttendees(ctx, e.ID)
+				if err != nil {
+					return fmt.Errorf("load attendees: %w", err)
 				}
+				attendees := mergeAttendeeUpdate(existingAtt,
+					cmd.Flags().Changed("attendee"), parseAttendeeFlags(attendeeFlags),
+					cmd.Flags().Changed("organizer"), organizer)
 				if err := a.Events.ReplaceAttendees(ctx, e.ID, attendees); err != nil {
 					return fmt.Errorf("update attendees: %w", err)
 				}
@@ -1502,6 +1505,39 @@ func parseAttendeeFlags(flags []string) []model.Attendee {
 			Role:       "REQ-PARTICIPANT",
 			RSVPStatus: "NEEDS-ACTION",
 		})
+	}
+	return out
+}
+
+// mergeAttendeeUpdate computes the attendee set to persist on a partial update.
+//
+// Organizer and attendees share one storage table, but ReplaceAttendees is a
+// full replace. Building the slice from only the flags that were passed wipes
+// the other kind of row (issue #461). So each --flag replaces only its own kind
+// of row: when --attendee is absent, the existing non-organizer attendees are
+// preserved; when --organizer is absent, the existing organizer is preserved.
+// Passing both flags is a full replace; passing --organizer "" clears it.
+func mergeAttendeeUpdate(existing []model.Attendee, attendeeChanged bool, newAttendees []model.Attendee, organizerChanged bool, organizer string) []model.Attendee {
+	out := make([]model.Attendee, 0, len(existing)+len(newAttendees)+1)
+	if attendeeChanged {
+		out = append(out, newAttendees...)
+	} else {
+		for _, a := range existing {
+			if !a.Organizer {
+				out = append(out, a)
+			}
+		}
+	}
+	if organizerChanged {
+		if organizer != "" {
+			out = append(out, parseOrganizerFlag(organizer))
+		}
+	} else {
+		for _, a := range existing {
+			if a.Organizer {
+				out = append(out, a)
+			}
+		}
 	}
 	return out
 }

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -543,10 +543,13 @@ Repeatable flags (--attendee, --comment, --contact, --attach,
 				}
 			}
 			if cmd.Flags().Changed("attendee") || cmd.Flags().Changed("organizer") {
-				attendees := parseAttendeeFlags(attendeeFlags)
-				if organizer != "" {
-					attendees = append(attendees, parseOrganizerFlag(organizer))
+				existingAtt, err := a.Journals.ListAttendees(ctx, j.ID)
+				if err != nil {
+					return fmt.Errorf("load attendees: %w", err)
 				}
+				attendees := mergeAttendeeUpdate(existingAtt,
+					cmd.Flags().Changed("attendee"), parseAttendeeFlags(attendeeFlags),
+					cmd.Flags().Changed("organizer"), organizer)
 				if err := a.Journals.ReplaceAttendees(ctx, j.ID, attendees); err != nil {
 					return fmt.Errorf("update attendees: %w", err)
 				}

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -807,10 +807,13 @@ a --progress value other than 100.`,
 				}
 			}
 			if cmd.Flags().Changed("attendee") || cmd.Flags().Changed("organizer") {
-				attendees := parseAttendeeFlags(attendeeFlags)
-				if organizer != "" {
-					attendees = append(attendees, parseOrganizerFlag(organizer))
+				existingAtt, err := a.Todos.ListAttendees(ctx, t.ID)
+				if err != nil {
+					return fmt.Errorf("load attendees: %w", err)
 				}
+				attendees := mergeAttendeeUpdate(existingAtt,
+					cmd.Flags().Changed("attendee"), parseAttendeeFlags(attendeeFlags),
+					cmd.Flags().Changed("organizer"), organizer)
 				if err := a.Todos.ReplaceAttendees(ctx, t.ID, attendees); err != nil {
 					return fmt.Errorf("update attendees: %w", err)
 				}


### PR DESCRIPTION
## Problem

Organizer and attendees share one storage table, and `ReplaceAttendees`
is a full replace (`replaceAttendeesTx` deletes every attendee row before
re-inserting). The `update` commands rebuilt the attendee slice from only
the flags actually passed, never loading/merging existing rows. Result:
silent data loss on a routine partial edit.

- `chroncal event update 42 --organizer "Bob <bob@x>"` (no `--attendee`)
  wiped every real attendee row, leaving only the organizer.
- `chroncal event update 42 --attendee a@x` (no `--organizer`) dropped the
  existing organizer row.

The same pattern affected `todo update` and `journal update` (which also
used a looser `if organizer != ""` guard with the same effect).

## Fix

Before calling `ReplaceAttendees`, load the existing attendee set and
merge via a new shared `mergeAttendeeUpdate` helper:

- `--attendee` replaces only the non-organizer rows; if absent, existing
  attendees are preserved.
- `--organizer` replaces only the organizer row; if absent, the existing
  organizer is preserved.
- Passing both flags is still a full replace; passing `--organizer ""`
  explicitly clears the organizer.

## Test

`cmd/chroncal/attendee_merge_cli_test.go` drives the real CLI commands and
asserts against the persisted attendee rows:

- event: `--organizer`-only preserves attendees + swaps organizer, then
  `--attendee`-only preserves the organizer.
- todo: `--organizer`-only preserves attendees.
- journal: `--attendee`-only preserves the organizer.

All three fail on `master` and pass with this change. Existing
`cmd/chroncal`, `internal/event`, `internal/todo`, `internal/journal`
tests still pass; `gofmt`, `go vet`, `golangci-lint` clean.

Closes #461
