### PR TITLE
fix(tui): open overlays on mouse click for all opener fields

### DIFF
--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -981,9 +981,14 @@ func (m EventFormModel) Update(msg tea.Msg) (EventFormModel, tea.Cmd) {
 			target := mouseResolve(mc.X-ox, mc.Y-oy)
 			var cmd tea.Cmd
 			m.form, cmd = m.form.Update(MouseEvent{IsClick: true, Target: target})
-			// Click on DatePickerField opens the date picker overlay.
-			if idx := m.form.Focused(); idx < len(m.fieldKeys) && m.fieldKeys[idx] == efKeyDate {
-				m.openDatePicker()
+			// A click landing on the focused field's row opens its overlay,
+			// mirroring the Enter path (tryOpenOverlay) so mouse and keyboard
+			// behave identically for every opener field (Date, Timezone,
+			// custom Repeat, on-date Ends, Alarms).
+			if target == fieldTarget(m.form.Focused()) {
+				if c := m.tryOpenOverlay(); c != nil {
+					return m, c
+				}
 			}
 			return m, cmd
 		}

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -373,6 +373,78 @@ func TestEventForm_EnterOnDateOpensDatePicker(t *testing.T) {
 	assert.False(t, m.timezonePickerOpen)
 }
 
+// fieldIndexByLabel returns the form item index for the field with the given
+// inline label, or -1 if none matches.
+func fieldIndexByLabel(m EventFormModel, label string) int {
+	for i, item := range m.form.items {
+		if item.Label == label {
+			return i
+		}
+	}
+	return -1
+}
+
+// mouseZoneByName returns the recorded clickable zone with the given name.
+func mouseZoneByName(mt *mouseTracker, name string) (mouseZone, bool) {
+	for _, z := range mt.zones {
+		if z.name == name {
+			return z, true
+		}
+	}
+	return mouseZone{}, false
+}
+
+// clickFormField renders the form, locates the clickable zone for the form
+// item at idx, and dispatches a left mouse click at its center through the
+// model's Update — exercising the same coordinate-resolution path as a real
+// mouse click.
+func clickFormField(t *testing.T, m EventFormModel, idx int) EventFormModel {
+	t.Helper()
+	// Focus the target field and scroll it into the body viewport so its
+	// clickable zone is rendered.
+	m.form.focused = idx
+	m.syncBodyViewport(true)
+	_ = m.View() // populates defaultMouseTracker.zones via mouseSweep
+
+	zone, ok := mouseZoneByName(defaultMouseTracker, fieldTarget(idx))
+	require.True(t, ok, "form field %d must register a clickable zone", idx)
+
+	bw, bh := m.BoxSize()
+	ox := (m.width - bw) / 2
+	oy := (m.height - bh) / 2
+	clickX := ox + (zone.startX+zone.endX)/2
+	clickY := oy + zone.startY
+
+	m, _ = m.Update(tea.MouseClickMsg(tea.Mouse{X: clickX, Y: clickY, Button: tea.MouseLeft}))
+	return m
+}
+
+// TestEventForm_MouseClickOpensOverlays is a regression test for issue #470:
+// the mouse-click branch only special-cased the Date field, so clicking the
+// Timezone or Alarms rows merely focused them without opening their overlays.
+// All overlay-opener fields must behave identically under mouse and Enter.
+func TestEventForm_MouseClickOpensOverlays(t *testing.T) {
+	t.Run("timezone", func(t *testing.T) {
+		m, _ := NewEventFormModel(time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), testEventFormCalendars(), Theme{})
+		m = m.SetSize(120, 40)
+		idx := fieldIndexByLabel(m, "Timezone")
+		require.NotEqual(t, -1, idx)
+
+		m = clickFormField(t, m, idx)
+		assert.True(t, m.timezonePickerOpen, "clicking Timezone should open the timezone picker")
+	})
+
+	t.Run("alarms", func(t *testing.T) {
+		m, _ := NewEventFormModel(time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), testEventFormCalendars(), Theme{})
+		m = m.SetSize(120, 40)
+		idx := fieldIndexByLabel(m, "Alarms")
+		require.NotEqual(t, -1, idx)
+
+		m = clickFormField(t, m, idx)
+		assert.True(t, m.alarmEditorOpen, "clicking Alarms should open the alarm editor")
+	})
+}
+
 func TestEventForm_EnterOnAllDayDoesNotOpenTimezonePicker(t *testing.T) {
 	m, _ := NewEventFormModel(time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC), testEventFormCalendars(), Theme{})
 


### PR DESCRIPTION
## Bug

In `EventFormModel.Update`'s left-click branch (`internal/tui/event_form.go`), only the **Date** field was special-cased to open its overlay:

```go
m.form, cmd = m.form.Update(MouseEvent{IsClick: true, Target: target})
if idx := m.form.Focused(); idx < len(m.fieldKeys) && m.fieldKeys[idx] == efKeyDate {
    m.openDatePicker()
}
```

The keyboard (Enter) path instead calls `tryOpenOverlay()`, which opens overlays for `efKeyDate`, `efKeyTimezone`, `efKeyRepeat` (Custom...), `efKeyEnds` (On date), and `efKeyAlarms`. Because `Form.handleClick` only focuses a generic field target and never invokes `onFieldEnter`, a mouse-only user could focus the Timezone, Alarms, custom Repeat, or on-date Ends rows but could **not** open the timezone picker, alarm editor, recurrence editor, or ends-date picker at all.

## Fix

Replace the Date-only special case with a call to `tryOpenOverlay()`, guarded so it only fires when the resolved click `target` equals `fieldTarget(m.form.Focused())` — i.e. the click actually landed on the focused field's row. Mouse and keyboard now open every opener field identically. The guard additionally prevents an off-field click (e.g. empty space) from re-opening the focused field's overlay, which the old unconditional Date check could do.

## Test

Added `TestEventForm_MouseClickOpensOverlays` (Timezone and Alarms subtests). It renders the form, locates each field's registered clickable zone via the mouse tracker, and dispatches a real `tea.MouseClickMsg` at the zone center through `Update` — exercising the full coordinate-resolution path. Both subtests fail on master (overlays never open) and pass with the fix. Full `internal/tui` suite and `go vet` are green.

Closes #470
