### PR TITLE
fix(cmd): report not-found on restore-by-uid no-op

### DIFF
--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -247,6 +247,9 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 
 			// UID path: restore every row sharing the UID.
 			if err := a.Events.RestoreByUID(ctx, ref); err != nil {
+				if errors.Is(err, event.ErrNotDeleted) {
+					return fmt.Errorf("event %q not found (may have been purged)", ref)
+				}
 				return fmt.Errorf("restore event: %w", err)
 			}
 			if outputFmt != "text" {

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -730,6 +730,9 @@ the next sync cycle recreates it remotely.`,
 			}
 
 			if err := a.Journals.RestoreByUID(ctx, ref); err != nil {
+				if errors.Is(err, journal.ErrNotDeleted) {
+					return fmt.Errorf("journal %q not found (may have been purged)", ref)
+				}
 				return fmt.Errorf("restore journal: %w", err)
 			}
 			if outputFmt != "text" {

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -1054,6 +1054,9 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			}
 
 			if err := a.Todos.RestoreByUID(ctx, ref); err != nil {
+				if errors.Is(err, todo.ErrNotDeleted) {
+					return fmt.Errorf("todo %q not found (may have been purged)", ref)
+				}
 				return fmt.Errorf("restore todo: %w", err)
 			}
 			if outputFmt != "text" {

--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -127,7 +127,7 @@ UPDATE events SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? AND deleted_at IS NOT NULL;
 
--- name: RestoreEventsByUID :exec
+-- name: RestoreEventsByUID :execrows
 UPDATE events SET
     deleted_at = NULL,
     sequence = sequence + 1,

--- a/db/queries/journals.sql
+++ b/db/queries/journals.sql
@@ -118,7 +118,7 @@ UPDATE journals SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? AND deleted_at IS NOT NULL;
 
--- name: RestoreJournalsByUID :exec
+-- name: RestoreJournalsByUID :execrows
 UPDATE journals SET
     deleted_at = NULL,
     sequence = sequence + 1,

--- a/db/queries/todos.sql
+++ b/db/queries/todos.sql
@@ -133,7 +133,7 @@ UPDATE todos SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? AND deleted_at IS NOT NULL;
 
--- name: RestoreTodosByUID :exec
+-- name: RestoreTodosByUID :execrows
 UPDATE todos SET
     deleted_at = NULL,
     sequence = sequence + 1,

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -164,14 +164,21 @@ func (s *Service) RestoreUndo(ctx context.Context, meta UndoMeta) error {
 }
 
 // RestoreByUID un-hides every soft-deleted row with the given UID (master and
-// overrides). Used by the CLI `events restore <uid>` path.
+// overrides). Used by the CLI `events restore <uid>` path. Returns
+// ErrNotDeleted when the UID matches no soft-deleted rows (it is live, or
+// unknown, or already purged) so callers can report "not found" instead of a
+// misleading success.
 func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	master, err := s.q.GetEventByUIDIncludingDeleted(ctx, uid)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get master: %w", err)
 	}
-	if err := s.restoreEventsByUIDClearingExdates(ctx, uid); err != nil {
-		return err
+	n, restoreErr := s.restoreEventsByUIDClearingExdates(ctx, uid)
+	if restoreErr != nil {
+		return restoreErr
+	}
+	if n == 0 {
+		return ErrNotDeleted
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
@@ -261,7 +268,8 @@ func (s *Service) restoreSingle(ctx context.Context, uid, recurrenceID string) e
 		if errors.Is(err, sql.ErrNoRows) {
 			// Might be an override-only delete where the master UID has no
 			// master row; fall back to UID-wide restore.
-			return s.restoreEventsByUIDClearingExdates(ctx, uid)
+			_, err := s.restoreEventsByUIDClearingExdates(ctx, uid)
+			return err
 		}
 		return err
 	}
@@ -275,7 +283,8 @@ func (s *Service) restoreSingle(ctx context.Context, uid, recurrenceID string) e
 		// Master is live; an override was probably the thing deleted.
 		// Fall back to RestoreByUID which un-hides any deleted overrides
 		// sharing this UID.
-		return s.restoreEventsByUIDClearingExdates(ctx, uid)
+		_, err := s.restoreEventsByUIDClearingExdates(ctx, uid)
+		return err
 	}
 	if err := s.q.RestoreEvent(ctx, r.ID); err != nil {
 		return err
@@ -289,7 +298,7 @@ func (s *Service) restoreSeries(ctx context.Context, uid string) error {
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
-	if err := s.restoreEventsByUIDClearingExdates(ctx, uid); err != nil {
+	if _, err := s.restoreEventsByUIDClearingExdates(ctx, uid); err != nil {
 		return err
 	}
 	if err == nil {
@@ -342,27 +351,35 @@ func (s *Service) restoreEXDATEOnly(ctx context.Context, uid, recurrenceID strin
 	return s.reconcileSyncAfterRestore(ctx, calendarID, uid)
 }
 
-func (s *Service) restoreEventsByUIDClearingExdates(ctx context.Context, uid string) error {
+// restoreEventsByUIDClearingExdates un-hides every soft-deleted row for uid and
+// clears the master EXDATE for each override that was soft-deleted, all in one
+// transaction. Returns the number of rows un-hidden so callers can distinguish
+// a real restore from a no-op (live/unknown UID).
+func (s *Service) restoreEventsByUIDClearingExdates(ctx context.Context, uid string) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return 0, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
 
 	recurrenceIDs, err := qtx.ListDeletedOverrideRecurrenceIDs(ctx, uid)
 	if err != nil {
-		return fmt.Errorf("list deleted override recurrence ids: %w", err)
+		return 0, fmt.Errorf("list deleted override recurrence ids: %w", err)
 	}
-	if err := qtx.RestoreEventsByUID(ctx, uid); err != nil {
-		return fmt.Errorf("restore by uid: %w", err)
+	n, err := qtx.RestoreEventsByUID(ctx, uid)
+	if err != nil {
+		return 0, fmt.Errorf("restore by uid: %w", err)
 	}
 	for _, recurrenceID := range recurrenceIDs {
 		if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
-			return err
+			return 0, err
 		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // clearMasterEXDATE reverses the EXDATE an instance-delete added for
@@ -434,7 +451,7 @@ func (s *Service) restoreFromInstance(ctx context.Context, meta UndoMeta) error 
 	// Un-hide every soft-deleted row with this UID (the master was not
 	// soft-deleted by DeleteFromInstance, only overrides were — but this is
 	// idempotent).
-	if err := qtx.RestoreEventsByUID(ctx, meta.UID); err != nil {
+	if _, err := qtx.RestoreEventsByUID(ctx, meta.UID); err != nil {
 		return fmt.Errorf("restore overrides: %w", err)
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -104,6 +104,23 @@ func TestSoftDelete_Series(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_RestoreByUIDNotDeleted verifies RestoreByUID reports
+// ErrNotDeleted when nothing was actually restored — a live UID and an
+// unknown UID both match zero soft-deleted rows. Without this the CLI
+// silently prints "Restored event(s) ..." even though no row changed.
+func TestSoftDelete_RestoreByUIDNotDeleted(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	e := createEvent(t, svc) // live, never deleted
+
+	if err := svc.RestoreByUID(ctx, e.UID); !errors.Is(err, ErrNotDeleted) {
+		t.Fatalf("RestoreByUID(live uid) = %v, want ErrNotDeleted", err)
+	}
+	if err := svc.RestoreByUID(ctx, "no-such-uid"); !errors.Is(err, ErrNotDeleted) {
+		t.Fatalf("RestoreByUID(missing uid) = %v, want ErrNotDeleted", err)
+	}
+}
+
 func TestSoftDelete_RestoreOverrideByIDClearsMasterEXDATE(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/internal/journal/soft_delete.go
+++ b/internal/journal/soft_delete.go
@@ -107,14 +107,20 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 // master would keep excluding those slots while also carrying the now-live
 // overrides, which round-trips to iCal as a self-contradicting series
 // (EXDATE + override for the same occurrence). Used by the CLI
-// `journals restore <uid>` path. Mirrors event.RestoreByUID.
+// `journals restore <uid>` path. Mirrors event.RestoreByUID. Returns
+// ErrNotDeleted when the UID matches no soft-deleted rows so callers can
+// report "not found" instead of a misleading success.
 func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	master, err := s.q.GetJournalByUIDIncludingDeleted(ctx, uid)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get master: %w", err)
 	}
-	if err := s.restoreByUIDClearingExdates(ctx, uid); err != nil {
-		return err
+	n, restoreErr := s.restoreByUIDClearingExdates(ctx, uid)
+	if restoreErr != nil {
+		return restoreErr
+	}
+	if n == 0 {
+		return ErrNotDeleted
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
@@ -124,30 +130,35 @@ func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 
 // restoreByUIDClearingExdates un-hides every soft-deleted row for uid and
 // clears the master EXDATE for each override that was soft-deleted, all in
-// one transaction. The recurrence IDs are read before the restore because
-// afterwards the rows are live and no longer match the deleted-overrides
-// query.
-func (s *Service) restoreByUIDClearingExdates(ctx context.Context, uid string) error {
+// one transaction. Returns the number of rows un-hidden so callers can
+// distinguish a real restore from a no-op (live/unknown UID). The recurrence
+// IDs are read before the restore because afterwards the rows are live and no
+// longer match the deleted-overrides query.
+func (s *Service) restoreByUIDClearingExdates(ctx context.Context, uid string) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return 0, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
 
 	recurrenceIDs, err := qtx.ListDeletedJournalOverrideRecurrenceIDs(ctx, uid)
 	if err != nil {
-		return fmt.Errorf("list deleted override recurrence ids: %w", err)
+		return 0, fmt.Errorf("list deleted override recurrence ids: %w", err)
 	}
-	if err := qtx.RestoreJournalsByUID(ctx, uid); err != nil {
-		return fmt.Errorf("restore by uid: %w", err)
+	n, err := qtx.RestoreJournalsByUID(ctx, uid)
+	if err != nil {
+		return 0, fmt.Errorf("restore by uid: %w", err)
 	}
 	for _, recurrenceID := range recurrenceIDs {
 		if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
-			return err
+			return 0, err
 		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // ListDeleted returns soft-deleted journals for a calendar, newest-first.

--- a/internal/journal/soft_delete_test.go
+++ b/internal/journal/soft_delete_test.go
@@ -92,6 +92,22 @@ func TestSoftDelete_Standalone(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_RestoreByUIDNotDeleted verifies RestoreByUID reports
+// ErrNotDeleted when nothing was actually restored — a live UID and an
+// unknown UID both match zero soft-deleted rows.
+func TestSoftDelete_RestoreByUIDNotDeleted(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	j := createJournal(t, svc) // live, never deleted
+
+	if err := svc.RestoreByUID(ctx, j.UID); !errors.Is(err, ErrNotDeleted) {
+		t.Fatalf("RestoreByUID(live uid) = %v, want ErrNotDeleted", err)
+	}
+	if err := svc.RestoreByUID(ctx, "no-such-uid"); !errors.Is(err, ErrNotDeleted) {
+		t.Fatalf("RestoreByUID(missing uid) = %v, want ErrNotDeleted", err)
+	}
+}
+
 // TestSoftDelete_Series verifies DeleteSeries soft-deletes master + overrides
 // and RestoreByUID un-hides them all.
 func TestSoftDelete_Series(t *testing.T) {

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -730,7 +730,7 @@ func (q *Queries) RestoreEventByUIDAndRecurrenceID(ctx context.Context, arg Rest
 	return err
 }
 
-const restoreEventsByUID = `-- name: RestoreEventsByUID :exec
+const restoreEventsByUID = `-- name: RestoreEventsByUID :execrows
 UPDATE events SET
     deleted_at = NULL,
     sequence = sequence + 1,
@@ -738,9 +738,12 @@ UPDATE events SET
 WHERE uid = ? AND deleted_at IS NOT NULL
 `
 
-func (q *Queries) RestoreEventsByUID(ctx context.Context, uid string) error {
-	_, err := q.db.ExecContext(ctx, restoreEventsByUID, uid)
-	return err
+func (q *Queries) RestoreEventsByUID(ctx context.Context, uid string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, restoreEventsByUID, uid)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const restoreOverridesAtOrAfter = `-- name: RestoreOverridesAtOrAfter :exec

--- a/internal/storage/journals.sql.go
+++ b/internal/storage/journals.sql.go
@@ -757,7 +757,7 @@ func (q *Queries) RestoreJournal(ctx context.Context, id int64) error {
 	return err
 }
 
-const restoreJournalsByUID = `-- name: RestoreJournalsByUID :exec
+const restoreJournalsByUID = `-- name: RestoreJournalsByUID :execrows
 UPDATE journals SET
     deleted_at = NULL,
     sequence = sequence + 1,
@@ -765,9 +765,12 @@ UPDATE journals SET
 WHERE uid = ? AND deleted_at IS NOT NULL
 `
 
-func (q *Queries) RestoreJournalsByUID(ctx context.Context, uid string) error {
-	_, err := q.db.ExecContext(ctx, restoreJournalsByUID, uid)
-	return err
+func (q *Queries) RestoreJournalsByUID(ctx context.Context, uid string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, restoreJournalsByUID, uid)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const softDeleteJournal = `-- name: SoftDeleteJournal :exec

--- a/internal/storage/todos.sql.go
+++ b/internal/storage/todos.sql.go
@@ -921,7 +921,7 @@ func (q *Queries) RestoreTodo(ctx context.Context, id int64) error {
 	return err
 }
 
-const restoreTodosByUID = `-- name: RestoreTodosByUID :exec
+const restoreTodosByUID = `-- name: RestoreTodosByUID :execrows
 UPDATE todos SET
     deleted_at = NULL,
     sequence = sequence + 1,
@@ -929,9 +929,12 @@ UPDATE todos SET
 WHERE uid = ? AND deleted_at IS NOT NULL
 `
 
-func (q *Queries) RestoreTodosByUID(ctx context.Context, uid string) error {
-	_, err := q.db.ExecContext(ctx, restoreTodosByUID, uid)
-	return err
+func (q *Queries) RestoreTodosByUID(ctx context.Context, uid string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, restoreTodosByUID, uid)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const softDeleteTodo = `-- name: SoftDeleteTodo :exec

--- a/internal/todo/soft_delete.go
+++ b/internal/todo/soft_delete.go
@@ -113,14 +113,20 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 // cleanup the master would keep excluding those slots while also carrying
 // the now-live overrides, which round-trips to iCal as a self-contradicting
 // series (EXDATE + override for the same occurrence). Used by the CLI
-// `todos restore <uid>` path. Mirrors event.RestoreByUID.
+// `todos restore <uid>` path. Mirrors event.RestoreByUID. Returns
+// ErrNotDeleted when the UID matches no soft-deleted rows so callers can
+// report "not found" instead of a misleading success.
 func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	master, err := s.q.GetTodoByUIDIncludingDeleted(ctx, uid)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get master: %w", err)
 	}
-	if err := s.restoreByUIDClearingExdates(ctx, uid); err != nil {
-		return err
+	n, restoreErr := s.restoreByUIDClearingExdates(ctx, uid)
+	if restoreErr != nil {
+		return restoreErr
+	}
+	if n == 0 {
+		return ErrNotDeleted
 	}
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
@@ -130,30 +136,35 @@ func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 
 // restoreByUIDClearingExdates un-hides every soft-deleted row for uid and
 // clears the master EXDATE for each override that was soft-deleted, all in
-// one transaction. The recurrence IDs are read before the restore because
-// afterwards the rows are live and no longer match the deleted-overrides
-// query.
-func (s *Service) restoreByUIDClearingExdates(ctx context.Context, uid string) error {
+// one transaction. Returns the number of rows un-hidden so callers can
+// distinguish a real restore from a no-op (live/unknown UID). The recurrence
+// IDs are read before the restore because afterwards the rows are live and no
+// longer match the deleted-overrides query.
+func (s *Service) restoreByUIDClearingExdates(ctx context.Context, uid string) (int64, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return 0, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
 
 	recurrenceIDs, err := qtx.ListDeletedTodoOverrideRecurrenceIDs(ctx, uid)
 	if err != nil {
-		return fmt.Errorf("list deleted override recurrence ids: %w", err)
+		return 0, fmt.Errorf("list deleted override recurrence ids: %w", err)
 	}
-	if err := qtx.RestoreTodosByUID(ctx, uid); err != nil {
-		return fmt.Errorf("restore by uid: %w", err)
+	n, err := qtx.RestoreTodosByUID(ctx, uid)
+	if err != nil {
+		return 0, fmt.Errorf("restore by uid: %w", err)
 	}
 	for _, recurrenceID := range recurrenceIDs {
 		if err := clearMasterEXDATE(ctx, qtx, uid, recurrenceID); err != nil {
-			return err
+			return 0, err
 		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // ListDeleted returns soft-deleted todos for a calendar, newest-first.

--- a/internal/todo/soft_delete_test.go
+++ b/internal/todo/soft_delete_test.go
@@ -92,6 +92,22 @@ func TestSoftDelete_Standalone(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_RestoreByUIDNotDeleted verifies RestoreByUID reports
+// ErrNotDeleted when nothing was actually restored — a live UID and an
+// unknown UID both match zero soft-deleted rows.
+func TestSoftDelete_RestoreByUIDNotDeleted(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	td := createTodo(t, svc) // live, never deleted
+
+	if err := svc.RestoreByUID(ctx, td.UID); !errors.Is(err, ErrNotDeleted) {
+		t.Fatalf("RestoreByUID(live uid) = %v, want ErrNotDeleted", err)
+	}
+	if err := svc.RestoreByUID(ctx, "no-such-uid"); !errors.Is(err, ErrNotDeleted) {
+		t.Fatalf("RestoreByUID(missing uid) = %v, want ErrNotDeleted", err)
+	}
+}
+
 // TestSoftDelete_Series verifies DeleteSeries soft-deletes master + overrides
 // and RestoreByUID un-hides them all.
 func TestSoftDelete_Series(t *testing.T) {


### PR DESCRIPTION
## Problem

`chroncal {event,todo,journal} restore <uid>` printed a success message
— e.g. `Restored event(s) with uid "X".` — even when the UID matched **no
soft-deleted rows** (the entry was live, unknown, or already purged).

The issue (#432) framed this as the CLI "silently wrapping `ErrNotDeleted`",
but `RestoreByUID` never actually returned that error: the underlying
`RestoreXByUID` query was an `:exec` statement scoped to
`deleted_at IS NOT NULL`, so a live/missing UID matched zero rows and
returned `nil`. The CLI then reported a misleading success. This also
contradicts the documented contract in AGENTS.md ("Returns ErrNotDeleted
when the row is live or missing") and is inconsistent with the numeric-ID
branch, which already reports `not found (may have been purged)`.

## Fix

- Switch `RestoreEventsByUID` / `RestoreTodosByUID` / `RestoreJournalsByUID`
  from `:exec` to `:execrows` (regenerated via `make generate`; no hand-edits
  to `*.sql.go`).
- Thread the affected-row count through each domain's
  `restore…ByUIDClearingExdates` helper, and have `RestoreByUID` return
  `ErrNotDeleted` when zero rows were un-hidden.
- The CLI UID branch now maps `ErrNotDeleted` to a friendly
  `<kind> %q not found (may have been purged)` message, mirroring the ID
  branch.

Counting rows actually affected (rather than inspecting the master's
`deleted_at`) correctly handles override-only deletes where the master is
live but only overrides are soft-deleted.

## Tests

Added `TestSoftDelete_RestoreByUIDNotDeleted` to the event, todo, and
journal packages, asserting `RestoreByUID` returns `ErrNotDeleted` for both
a live UID and an unknown UID. Confirmed the event test fails before the fix
(`= <nil>, want ErrNotDeleted`) and passes after. Full event/todo/journal/
trash/storage/cmd suites pass; `go vet` and `golangci-lint` clean.

Closes #432
