### PR TITLE
fix(event): trim post-cutoff RDATEs on series truncation (#463)

### DIFF
--- a/db/migrations/039_event_truncate_removed_rdates.sql
+++ b/db/migrations/039_event_truncate_removed_rdates.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Record the master RDATEs a "this and following" truncation dropped, so
+-- restore re-adds exactly those (issue #463). rrule-go expands RDATEs
+-- independently of the RRULE's UNTIL bound, so truncation must trim post-cutoff
+-- RDATEs too — and remember them to make the delete reversible. Comma-separated
+-- RFC 3339 (or date-only) values; '' means the truncation dropped no RDATEs.
+-- NULL marks pre-#463 log rows that recorded no RDATE provenance.
+ALTER TABLE event_truncate_deletes ADD COLUMN removed_rdates TEXT;
+
+-- +goose Down
+ALTER TABLE event_truncate_deletes DROP COLUMN removed_rdates;

--- a/db/queries/event_truncate_deletes.sql
+++ b/db/queries/event_truncate_deletes.sql
@@ -1,10 +1,10 @@
 -- name: RecordEventTruncateDelete :exec
 -- Idempotent: truncating the same cutoff twice keeps one log row. Stores
--- only the FIRST previous_rrule and hidden_overrides seen so re-truncating
--- doesn't overwrite the original pre-truncation state with an already-
--- truncated rule or an empty override set.
-INSERT INTO event_truncate_deletes (calendar_id, uid, cutoff_time, previous_rrule, hidden_overrides)
-VALUES (?, ?, ?, ?, ?)
+-- only the FIRST previous_rrule, hidden_overrides, and removed_rdates seen so
+-- re-truncating doesn't overwrite the original pre-truncation state with an
+-- already-truncated rule or an empty override/rdate set.
+INSERT INTO event_truncate_deletes (calendar_id, uid, cutoff_time, previous_rrule, hidden_overrides, removed_rdates)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT(uid, cutoff_time) DO UPDATE SET
     deleted_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now');
 

--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -92,6 +92,9 @@ RETURNING *;
 -- name: UpdateEventExdates :exec
 UPDATE events SET exdates = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?;
 
+-- name: UpdateEventRdates :exec
+UPDATE events SET rdates = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?;
+
 -- name: UpdateEventRecurrenceRule :exec
 UPDATE events SET recurrence_rule = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?;
 

--- a/internal/event/rdate_only_truncate_test.go
+++ b/internal/event/rdate_only_truncate_test.go
@@ -66,6 +66,119 @@ func TestDeleteFromInstance_RDateOnlyMasterNotCorrupted(t *testing.T) {
 	}
 }
 
+// TestDeleteFromInstance_TrimsRDatesPastCutoff reproduces issue #463: a "this
+// and following" delete must drop the master's RDATEs at/after the cutoff,
+// otherwise the deleted occurrences reappear on the next expansion (rrule-go
+// expands RDATEs independently of the RRULE's UNTIL bound).
+func TestDeleteFromInstance_TrimsRDatesPastCutoff(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	rdate1 := time.Date(2026, 4, 15, 9, 0, 0, 0, time.UTC)
+	rdate2 := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	master := newRDateOnlyMaster(t, svc, "rdate-only-trim", []time.Time{rdate1, rdate2})
+
+	if err := svc.DeleteFromInstance(ctx, master.UID, rdate2); err != nil {
+		t.Fatalf("DeleteFromInstance: %v", err)
+	}
+
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("GetByUID after delete: %v", err)
+	}
+	rdates := got.ParseRDates()
+	for _, rd := range rdates {
+		if !rd.Before(rdate2) {
+			t.Errorf("RDATE %s survived truncation at cutoff %s; deleted occurrence will reappear", rd.Format(time.RFC3339), rdate2.Format(time.RFC3339))
+		}
+	}
+	if len(rdates) != 1 || !rdates[0].Equal(rdate1) {
+		t.Errorf("RDates = %v, want only the pre-cutoff occurrence %s", rdates, rdate1.Format(time.RFC3339))
+	}
+}
+
+// TestUpdateFromInstance_TrimsRDatesPastCutoff mirrors the trim assertion for
+// the split/"edit this and following" path (issue #463). Surviving post-cutoff
+// RDATEs would duplicate the brand-new split series.
+func TestUpdateFromInstance_TrimsRDatesPastCutoff(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	rdate1 := time.Date(2026, 4, 15, 9, 0, 0, 0, time.UTC)
+	rdate2 := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	master := newRDateOnlyMaster(t, svc, "rdate-only-split-trim", []time.Time{rdate1, rdate2})
+
+	if _, err := svc.UpdateFromInstance(ctx, master.UID, rdate2, UpdateParams{
+		CalendarID: master.CalendarID,
+		Title:      "Irregular Meeting (changed)",
+		StartTime:  rdate2,
+		EndTime:    rdate2.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("UpdateFromInstance: %v", err)
+	}
+
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("GetByUID after update: %v", err)
+	}
+	rdates := got.ParseRDates()
+	if len(rdates) != 1 || !rdates[0].Equal(rdate1) {
+		t.Errorf("old master RDates = %v, want only the pre-cutoff occurrence %s", rdates, rdate1.Format(time.RFC3339))
+	}
+}
+
+// TestRestoreTruncation_ReAddsRDates verifies the trim is reversible: restoring
+// a "this and following" delete from the trash must put the dropped RDATEs back
+// on the master (issue #463), mirroring the RRULE/override restore.
+func TestRestoreTruncation_ReAddsRDates(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	rdate1 := time.Date(2026, 4, 15, 9, 0, 0, 0, time.UTC)
+	rdate2 := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	master := newRDateOnlyMaster(t, svc, "rdate-only-restore", []time.Time{rdate1, rdate2})
+
+	if err := svc.DeleteFromInstance(ctx, master.UID, rdate2); err != nil {
+		t.Fatalf("DeleteFromInstance: %v", err)
+	}
+
+	entries, err := svc.ListTrash(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("ListTrash: %v", err)
+	}
+	var trunc *TrashEntry
+	for i := range entries {
+		if entries[i].Kind == TrashKindTruncation {
+			trunc = &entries[i]
+			break
+		}
+	}
+	if trunc == nil {
+		t.Fatal("no truncation trash entry found")
+	}
+	if err := svc.RestoreTrash(ctx, *trunc); err != nil {
+		t.Fatalf("RestoreTrash: %v", err)
+	}
+
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("GetByUID after restore: %v", err)
+	}
+	rdates := got.ParseRDates()
+	if len(rdates) != 2 {
+		t.Fatalf("RDates = %v, want both occurrences restored", rdates)
+	}
+	foundR2 := false
+	for _, rd := range rdates {
+		if rd.Equal(rdate2) {
+			foundR2 = true
+		}
+	}
+	if !foundR2 {
+		t.Errorf("restored RDates = %v, missing dropped occurrence %s", rdates, rdate2.Format(time.RFC3339))
+	}
+}
+
 // TestUpdateFromInstance_RDateOnlyMasterNotCorrupted mirrors the delete case for
 // the split/"edit this and following" path through updateFromInstanceTx.
 func TestUpdateFromInstance_RDateOnlyMasterNotCorrupted(t *testing.T) {

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -706,12 +706,28 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 	return err
 }
 
-// softDeleteOverridesAndRecordTruncation hides every live override at/after
-// cutoff and records the truncation so the trash view can restore it. It
-// captures the recurrence_ids it hides BEFORE soft-deleting them, so restore
-// re-shows exactly those overrides and never resurrects one the user deleted
-// independently (issue #287). Pairs with restoreTruncatedOverrides.
-func softDeleteOverridesAndRecordTruncation(ctx context.Context, qtx *storage.Queries, calendarID int64, uid, cutoff, prevRRule string) error {
+// softDeleteOverridesAndRecordTruncation trims the master's post-cutoff RDATEs,
+// hides every live override at/after cutoff, and records the truncation so the
+// trash view can restore it. It captures the recurrence_ids it hides and the
+// RDATEs it drops BEFORE removing them, so restore re-shows exactly those
+// overrides and re-adds exactly those RDATEs — never resurrecting an override
+// the user deleted independently (issue #287) and never leaving a post-cutoff
+// RDATE behind to reappear on the next expansion (issue #463, since rrule-go
+// expands RDATEs independently of the RRULE's UNTIL bound). Pairs with
+// restoreTruncatedOverrides / restoreTruncatedRDates.
+//
+// prevRRule is the master's pre-truncation RRULE; the caller passes it because
+// it has already overwritten the master's recurrence_rule in the DB by the time
+// this runs.
+func softDeleteOverridesAndRecordTruncation(ctx context.Context, qtx *storage.Queries, master storage.Event, instanceTime time.Time, prevRRule string) error {
+	uid := master.Uid
+	cutoff := instanceTime.UTC().Format(time.RFC3339)
+
+	removedRDates, err := trimMasterRDatesAtOrAfter(ctx, qtx, master, instanceTime)
+	if err != nil {
+		return err
+	}
+
 	hidden, err := qtx.ListLiveOverrideRecurrenceIDsAtOrAfter(ctx, storage.ListLiveOverrideRecurrenceIDsAtOrAfterParams{
 		Uid:          uid,
 		RecurrenceID: cutoff,
@@ -729,15 +745,46 @@ func softDeleteOverridesAndRecordTruncation(ctx context.Context, qtx *storage.Qu
 	}
 
 	if err := qtx.RecordEventTruncateDelete(ctx, storage.RecordEventTruncateDeleteParams{
-		CalendarID:      calendarID,
+		CalendarID:      master.CalendarID,
 		Uid:             uid,
 		CutoffTime:      cutoff,
 		PreviousRrule:   prevRRule,
 		HiddenOverrides: &hiddenList,
+		RemovedRdates:   &removedRDates,
 	}); err != nil {
 		return fmt.Errorf("record truncate: %w", err)
 	}
 	return nil
+}
+
+// trimMasterRDatesAtOrAfter rewrites the master's rdates column to keep only the
+// occurrences strictly before instanceTime, and returns the dropped ones
+// serialized for the truncation log. It only issues an UPDATE when something
+// changes, so a master with no post-cutoff RDATEs is left untouched.
+func trimMasterRDatesAtOrAfter(ctx context.Context, qtx *storage.Queries, master storage.Event, instanceTime time.Time) (string, error) {
+	rdates := ParseTimeList(storage.NullableToString(master.Rdates))
+	if len(rdates) == 0 {
+		return "", nil
+	}
+	kept := make([]time.Time, 0, len(rdates))
+	var removed []time.Time
+	for _, rd := range rdates {
+		if rd.Before(instanceTime) {
+			kept = append(kept, rd)
+		} else {
+			removed = append(removed, rd)
+		}
+	}
+	if len(removed) == 0 {
+		return "", nil
+	}
+	if err := qtx.UpdateEventRdates(ctx, storage.UpdateEventRdatesParams{
+		Rdates: storage.StringToNullable(SerializeTimeList(kept)),
+		ID:     master.ID,
+	}); err != nil {
+		return "", fmt.Errorf("trim rdates: %w", err)
+	}
+	return SerializeTimeList(removed), nil
 }
 
 // deleteFromInstance performs the truncation and returns the master's
@@ -779,8 +826,7 @@ func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTi
 		}
 	}
 
-	cutoff := instanceTime.UTC().Format(time.RFC3339)
-	if err := softDeleteOverridesAndRecordTruncation(ctx, qtx, master.CalendarID, uid, cutoff, prevRRule); err != nil {
+	if err := softDeleteOverridesAndRecordTruncation(ctx, qtx, master, instanceTime, prevRRule); err != nil {
 		return "", err
 	}
 
@@ -1076,8 +1122,7 @@ func updateFromInstanceTx(ctx context.Context, qtx *storage.Queries, uid string,
 		}
 	}
 
-	cutoff := instanceTime.UTC().Format(time.RFC3339)
-	if err := softDeleteOverridesAndRecordTruncation(ctx, qtx, master.CalendarID, uid, cutoff, prevRRule); err != nil {
+	if err := softDeleteOverridesAndRecordTruncation(ctx, qtx, master, instanceTime, prevRRule); err != nil {
 		return Event{}, 0, err
 	}
 

--- a/internal/event/trash.go
+++ b/internal/event/trash.go
@@ -298,9 +298,9 @@ func (s *Service) restoreInstanceByLogID(ctx context.Context, logID int64) error
 }
 
 // restoreTruncationByLogID rewrites the master's RRULE back to the
-// pre-truncation value and un-hides every override soft-deleted at/after
-// the cutoff, then drops the log row. The master is marked dirty so the
-// next push propagates the restored RRULE.
+// pre-truncation value, re-adds the RDATEs the truncation trimmed, and un-hides
+// every override soft-deleted at/after the cutoff, then drops the log row. The
+// master is marked dirty so the next push propagates the restored series.
 func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) error {
 	log, err := s.q.GetEventTruncateDelete(ctx, logID)
 	if err != nil {
@@ -334,6 +334,9 @@ func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) err
 	}); err != nil {
 		return fmt.Errorf("restore rrule: %w", err)
 	}
+	if err := restoreTruncatedRDates(ctx, qtx, master, log); err != nil {
+		return fmt.Errorf("restore rdates: %w", err)
+	}
 	if err := restoreTruncatedOverrides(ctx, qtx, log); err != nil {
 		return fmt.Errorf("restore overrides: %w", err)
 	}
@@ -344,6 +347,22 @@ func (s *Service) restoreTruncationByLogID(ctx context.Context, logID int64) err
 		return fmt.Errorf("mark resource dirty: %w", err)
 	}
 	return tx.Commit()
+}
+
+// restoreTruncatedRDates re-adds to the master the RDATEs a truncation trimmed.
+// removed_rdates is non-NULL only for #463-era log rows; pre-#463 rows store
+// NULL (the truncation left RDATEs untouched) and an empty string means the
+// truncation dropped none, so both no-op. The kept RDATEs (already on the
+// master after a concurrent edit) are merged with the recorded removed ones.
+func restoreTruncatedRDates(ctx context.Context, qtx *storage.Queries, master storage.Event, log storage.EventTruncateDelete) error {
+	if log.RemovedRdates == nil || *log.RemovedRdates == "" {
+		return nil
+	}
+	merged := append(ParseTimeList(storage.NullableToString(master.Rdates)), ParseTimeList(*log.RemovedRdates)...)
+	return qtx.UpdateEventRdates(ctx, storage.UpdateEventRdatesParams{
+		Rdates: storage.StringToNullable(SerializeTimeList(merged)),
+		ID:     master.ID,
+	})
 }
 
 // restoreTruncatedOverrides un-hides the overrides a truncation soft-deleted.

--- a/internal/storage/event_truncate_deletes.sql.go
+++ b/internal/storage/event_truncate_deletes.sql.go
@@ -19,7 +19,7 @@ func (q *Queries) DeleteEventTruncateDelete(ctx context.Context, id int64) error
 }
 
 const getEventTruncateDelete = `-- name: GetEventTruncateDelete :one
-SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at, hidden_overrides FROM event_truncate_deletes WHERE id = ?
+SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at, hidden_overrides, removed_rdates FROM event_truncate_deletes WHERE id = ?
 `
 
 func (q *Queries) GetEventTruncateDelete(ctx context.Context, id int64) (EventTruncateDelete, error) {
@@ -33,12 +33,13 @@ func (q *Queries) GetEventTruncateDelete(ctx context.Context, id int64) (EventTr
 		&i.PreviousRrule,
 		&i.DeletedAt,
 		&i.HiddenOverrides,
+		&i.RemovedRdates,
 	)
 	return i, err
 }
 
 const listEventTruncateDeletesByCalendar = `-- name: ListEventTruncateDeletesByCalendar :many
-SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at, hidden_overrides FROM event_truncate_deletes
+SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at, hidden_overrides, removed_rdates FROM event_truncate_deletes
 WHERE calendar_id = ?
 ORDER BY deleted_at DESC
 `
@@ -60,6 +61,7 @@ func (q *Queries) ListEventTruncateDeletesByCalendar(ctx context.Context, calend
 			&i.PreviousRrule,
 			&i.DeletedAt,
 			&i.HiddenOverrides,
+			&i.RemovedRdates,
 		); err != nil {
 			return nil, err
 		}
@@ -87,8 +89,8 @@ func (q *Queries) PurgeOldEventTruncateDeletes(ctx context.Context, deletedAt st
 }
 
 const recordEventTruncateDelete = `-- name: RecordEventTruncateDelete :exec
-INSERT INTO event_truncate_deletes (calendar_id, uid, cutoff_time, previous_rrule, hidden_overrides)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO event_truncate_deletes (calendar_id, uid, cutoff_time, previous_rrule, hidden_overrides, removed_rdates)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT(uid, cutoff_time) DO UPDATE SET
     deleted_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 `
@@ -99,12 +101,13 @@ type RecordEventTruncateDeleteParams struct {
 	CutoffTime      string
 	PreviousRrule   string
 	HiddenOverrides *string
+	RemovedRdates   *string
 }
 
 // Idempotent: truncating the same cutoff twice keeps one log row. Stores
-// only the FIRST previous_rrule and hidden_overrides seen so re-truncating
-// doesn't overwrite the original pre-truncation state with an already-
-// truncated rule or an empty override set.
+// only the FIRST previous_rrule, hidden_overrides, and removed_rdates seen so
+// re-truncating doesn't overwrite the original pre-truncation state with an
+// already-truncated rule or an empty override/rdate set.
 func (q *Queries) RecordEventTruncateDelete(ctx context.Context, arg RecordEventTruncateDeleteParams) error {
 	_, err := q.db.ExecContext(ctx, recordEventTruncateDelete,
 		arg.CalendarID,
@@ -112,6 +115,7 @@ func (q *Queries) RecordEventTruncateDelete(ctx context.Context, arg RecordEvent
 		arg.CutoffTime,
 		arg.PreviousRrule,
 		arg.HiddenOverrides,
+		arg.RemovedRdates,
 	)
 	return err
 }

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -915,6 +915,20 @@ func (q *Queries) UpdateEventExdates(ctx context.Context, arg UpdateEventExdates
 	return err
 }
 
+const updateEventRdates = `-- name: UpdateEventRdates :exec
+UPDATE events SET rdates = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?
+`
+
+type UpdateEventRdatesParams struct {
+	Rdates *string
+	ID     int64
+}
+
+func (q *Queries) UpdateEventRdates(ctx context.Context, arg UpdateEventRdatesParams) error {
+	_, err := q.db.ExecContext(ctx, updateEventRdates, arg.Rdates, arg.ID)
+	return err
+}
+
 const updateEventRecurrenceRule = `-- name: UpdateEventRecurrenceRule :exec
 UPDATE events SET recurrence_rule = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?
 `

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -172,6 +172,7 @@ type EventTruncateDelete struct {
 	PreviousRrule   string
 	DeletedAt       string
 	HiddenOverrides *string
+	RemovedRdates   *string
 }
 
 type EventsFt struct {


### PR DESCRIPTION
## Bug

"This and following" deletes (`DeleteFromInstance`) and edits
(`UpdateFromInstance`) truncate a recurring series by setting `UNTIL` on the
master RRULE and soft-deleting overrides at/after the cutoff — but they never
touched the master's `rdates` column. rrule-go expands RDATEs independently of
the RRULE's `UNTIL` bound, so any explicit RDATE at/after the cutoff survived
truncation:

- For an RDATE-only master (no RRULE, where #414 deliberately leaves the rule
  NULL) or a combined RRULE+RDATE master, the removed occurrences reappeared on
  the next expansion.
- For the split path, the old master's surviving post-cutoff RDATEs also
  duplicated the brand-new split series.

## Fix

Both truncation paths now filter the master's RDATEs, dropping every entry
at/after the cutoff, and record the dropped values in a new
`event_truncate_deletes.removed_rdates` column (migration 039). Restoring the
truncation from the trash re-adds exactly those RDATEs, mirroring how the
RRULE's `UNTIL` and the soft-deleted overrides are already captured and
reversed. The trim only issues an UPDATE when something actually changes, and
the record is idempotent (re-truncating keeps the first `removed_rdates`).

- `softDeleteOverridesAndRecordTruncation` now takes the master row + instance
  time, trims RDATEs via the new `trimMasterRDatesAtOrAfter` helper, and stores
  `removed_rdates`.
- `restoreTruncationByLogID` calls the new `restoreTruncatedRDates`, which
  no-ops for pre-#463 (NULL) log rows and for truncations that dropped no
  RDATEs.

## Tests

Added to `internal/event/rdate_only_truncate_test.go`:

- `TestDeleteFromInstance_TrimsRDatesPastCutoff` — reproduces the leak; fails
  on master, passes with the fix.
- `TestUpdateFromInstance_TrimsRDatesPastCutoff` — same for the split path.
- `TestRestoreTruncation_ReAddsRDates` — verifies the trim is reversible.

All event/recurrence/trash/storage/sync/cmd package tests pass; `go vet` and
`golangci-lint` are clean on touched packages.

Closes #463
