### PR TITLE
fix(ical): emit VTIMEZONE transition DTSTART in TZOFFSETFROM

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -820,8 +820,11 @@ func buildVTimezone(tzID string) (*ical.Component, error) {
 	addSubComp := func(compName, tzName string, offset, fromOffset int, dtstart time.Time, rrule string) {
 		comp := ical.NewComponent(compName)
 
+		// dtstart is the transition wall-clock already expressed in
+		// TZOFFSETFROM (RFC 5545 Section 3.6.5), carried in a UTC-located
+		// time.Time, so format its fields verbatim.
 		p := &ical.Prop{Name: ical.PropDateTimeStart}
-		p.Value = dtstart.In(loc).Format("20060102T150405")
+		p.Value = dtstart.Format("20060102T150405")
 		comp.Props.Set(p)
 
 		p = &ical.Prop{Name: "TZOFFSETFROM"}
@@ -852,41 +855,51 @@ func buildVTimezone(tzID string) (*ical.Component, error) {
 	if len(transitions) == 0 {
 		// No DST — single STANDARD component
 		addSubComp("STANDARD", janName, janOffset, janOffset,
-			time.Date(refYear, 1, 1, 0, 0, 0, 0, loc), "")
+			time.Date(refYear, 1, 1, 0, 0, 0, 0, time.UTC), "")
 	} else {
 		for _, tr := range transitions {
-			// The transition was detected between month M-1 and M, but the
-			// exact day could be anywhere in the prior month. Search backward.
-			dtstart := findTransitionDay(loc, refYear, tr.month, tr.fromOffset)
+			// The transition was detected between month M-1 and M; find the
+			// exact instant it occurs, then express its wall-clock in
+			// TZOFFSETFROM (RFC 5545 Section 3.6.5). For US Eastern this
+			// yields the canonical 02:00 DTSTART rather than the
+			// post-transition 03:00 wall-clock.
+			instant := findTransitionInstant(loc, refYear, tr.month, tr.fromOffset)
+			fromWall := instant.UTC().Add(time.Duration(tr.fromOffset) * time.Second)
 			compName := "STANDARD"
 			if tr.offset > tr.fromOffset {
 				compName = "DAYLIGHT"
 			}
-			addSubComp(compName, tr.name, tr.offset, tr.fromOffset, dtstart,
-				transitionRRULE(dtstart))
+			addSubComp(compName, tr.name, tr.offset, tr.fromOffset, fromWall,
+				transitionRRULE(fromWall))
 		}
 	}
 
 	return vtz, nil
 }
 
-// findTransitionDay finds the exact day when the UTC offset changes to a new
-// value, searching backward from the start of the detected month into the
-// previous month where the transition actually occurs.
-func findTransitionDay(loc *time.Location, year int, detectedMonth time.Month, prevOffset int) time.Time {
-	// Search from the previous month's first day through the detected month
-	searchStart := time.Date(year, detectedMonth-1, 1, 3, 0, 0, 0, loc)
+// findTransitionInstant finds the exact instant when the UTC offset changes
+// away from prevOffset, binary-searching to one-second precision. The bounds
+// are noon on the first of the previous and detected months — the same instants
+// buildVTimezone samples to detect the transition, so offset(lo) == prevOffset
+// and offset(hi) != prevOffset are guaranteed and the transition is always
+// bracketed regardless of the local hour at which it occurs. The returned
+// instant is the first second carrying the new offset, i.e. the precise
+// transition moment.
+func findTransitionInstant(loc *time.Location, year int, detectedMonth time.Month, prevOffset int) time.Time {
+	lo := time.Date(year, detectedMonth-1, 1, 12, 0, 0, 0, loc)
 	if detectedMonth == time.January {
-		searchStart = time.Date(year-1, time.December, 1, 3, 0, 0, 0, loc)
+		lo = time.Date(year-1, time.December, 1, 12, 0, 0, 0, loc)
 	}
-	searchEnd := time.Date(year, detectedMonth, 1, 3, 0, 0, 0, loc)
-	for d := searchStart; !d.After(searchEnd); d = d.AddDate(0, 0, 1) {
-		_, offset := d.Zone()
-		if offset != prevOffset {
-			return d
+	hi := time.Date(year, detectedMonth, 1, 12, 0, 0, 0, loc)
+	for hi.Sub(lo) > time.Second {
+		mid := lo.Add(hi.Sub(lo) / 2)
+		if _, offset := mid.Zone(); offset == prevOffset {
+			lo = mid
+		} else {
+			hi = mid
 		}
 	}
-	return searchEnd
+	return hi
 }
 
 // transitionRRULE builds a yearly RFC 5545 recurrence rule describing when a

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -399,6 +399,47 @@ func TestExport_VTimezoneRecurringTransitions(t *testing.T) {
 	}
 }
 
+func TestExport_VTimezoneTransitionDTSTART(t *testing.T) {
+	t.Parallel()
+	// RFC 5545 Section 3.6.5: a sub-component's DTSTART is the transition
+	// wall-clock expressed in TZOFFSETFROM. US Eastern transitions occur at
+	// 02:00 local, so both DAYLIGHT and STANDARD DTSTARTs must read T020000
+	// (matching IANA-published VTIMEZONE), not the post-transition T030000.
+	events := []event.Event{{
+		UID:       "vtz-transition",
+		Title:     "Eastern Event",
+		StartTime: time.Date(2026, 7, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 7, 1, 15, 0, 0, 0, time.UTC),
+		Timezone:  "America/New_York",
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}}
+
+	data, _ := ExportEvents(events, "")
+	ics := string(data)
+
+	start := strings.Index(ics, "BEGIN:VTIMEZONE")
+	end := strings.Index(ics, "END:VTIMEZONE")
+	if start < 0 || end < 0 {
+		t.Fatalf("missing VTIMEZONE block:\n%s", ics)
+	}
+	vtz := ics[start:end]
+
+	// Both US Eastern transitions occur at 02:00 local; IANA-published
+	// VTIMEZONE emits DTSTART:...T020000 for each.
+	if got := strings.Count(vtz, "T020000"); got != 2 {
+		t.Errorf("expected two T020000 transition DTSTARTs, got %d:\n%s", got, vtz)
+	}
+	if want := []string{"20260308T020000", "20261101T020000"}; !strings.Contains(vtz, want[0]) || !strings.Contains(vtz, want[1]) {
+		t.Errorf("VTIMEZONE missing canonical transition DTSTARTs %v:\n%s", want, vtz)
+	}
+	if strings.Contains(vtz, "T030000") {
+		t.Errorf("VTIMEZONE DTSTART must not be the post-transition 03:00 wall-clock (T030000):\n%s", vtz)
+	}
+}
+
 func TestExport_VTimezoneNoDST(t *testing.T) {
 	t.Parallel()
 	// Asia/Kolkata does not observe DST


### PR DESCRIPTION
## Bug

`buildVTimezone()` (`internal/ical/export.go`) probed candidate DST
transition days at a fixed local hour of **03:00** and then formatted that
sampled instant's wall clock as the VTIMEZONE sub-component `DTSTART`.
Because 03:00 is already past the typical 02:00 transition, the sampled wall
clock lands in the **post-transition (TO)** offset. For `America/New_York`
this emitted:

```
DTSTART:20260308T030000   (DAYLIGHT)
DTSTART:20261101T030000   (STANDARD)
```

RFC 5545 §3.6.5 requires the transition wall clock expressed in
`TZOFFSETFROM` — i.e. `...T020000` for US Eastern, matching the
IANA-published VTIMEZONE. With the wrong `DTSTART` plus `TZOFFSETFROM`, a
consumer that relies on the embedded VTIMEZONE (no local tzdata for the
TZID) computes the transition instant ~1 hour late, mis-resolving the offset
during the ~1-hour transition window on the two transition days each year.
Zones transitioning after 03:00 local were also detected a day late.

## Fix

- Replace `findTransitionDay` with `findTransitionInstant`, which binary
  searches to **one-second precision**. Bounds are noon-of-month on the
  first of the previous and detected months — the exact instants
  `buildVTimezone` already samples to detect the transition — so
  `offset(lo) == prevOffset` and `offset(hi) != prevOffset` are guaranteed
  and the transition is bracketed regardless of the local hour it occurs
  (this also fixes the after-03:00 day-late detection).
- Express the `DTSTART` wall clock in `TZOFFSETFROM` by applying the
  from-offset to the precise instant, and derive the transition `RRULE` from
  that same from-offset wall clock so the weekday/day are read consistently.

## Test

`TestExport_VTimezoneTransitionDTSTART` exports an `America/New_York` event
and asserts both transition `DTSTART`s are the canonical `...T020000`, with
no post-transition `T030000`. Fails before the fix, passes after.

Also manually verified against IANA-published VTIMEZONE for
`America/New_York`, `Europe/London`, `Australia/Sydney` and
`Pacific/Chatham` (e.g. Chatham → `T034500` / `T024500`). Full `go test ./...`
passes; `gofmt`, `go vet`, and `golangci-lint` are clean on the touched
package.

Closes #467
