### PR TITLE
test(lint): fix noctx and ST1018 lint failures in tests

### DIFF
--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"bufio"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -371,7 +372,8 @@ func TestEmail_ImplicitTLS_SMTPSServer(t *testing.T) {
 	// Override dialTLS to skip certificate verification for the self-signed test cert.
 	origDial := dialTLS
 	dialTLS = func(addr, _ string) (net.Conn, error) {
-		return tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+		dialer := tls.Dialer{Config: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+		return dialer.DialContext(context.Background(), "tcp", addr)
 	}
 	t.Cleanup(func() { dialTLS = origDial })
 

--- a/internal/textsafe/textsafe_test.go
+++ b/internal/textsafe/textsafe_test.go
@@ -55,33 +55,33 @@ func TestDisplayStripsBidiFormatControls(t *testing.T) {
 		want string
 	}{
 		// U+202E RIGHT-TO-LEFT OVERRIDE — canonical Trojan Source char.
-		{"RLO stripped", "hello‮world", "helloworld"},
+		{"RLO stripped", "hello\u202eworld", "helloworld"},
 		// U+202A LEFT-TO-RIGHT EMBEDDING.
-		{"LRE stripped", "‪hello‬", "hello"},
+		{"LRE stripped", "\u202ahello\u202c", "hello"},
 		// U+202B RIGHT-TO-LEFT EMBEDDING.
-		{"RLE stripped", "‫hello‬", "hello"},
+		{"RLE stripped", "\u202bhello\u202c", "hello"},
 		// U+202D LEFT-TO-RIGHT OVERRIDE.
-		{"LRO stripped", "‭hello", "hello"},
+		{"LRO stripped", "\u202dhello", "hello"},
 		// U+202C POP DIRECTIONAL FORMATTING (closes embeddings/overrides).
-		{"PDF stripped", "ab‬cd", "abcd"},
+		{"PDF stripped", "ab\u202ccd", "abcd"},
 		// U+200E LEFT-TO-RIGHT MARK.
-		{"LRM stripped", "a‎b", "ab"},
+		{"LRM stripped", "a\u200eb", "ab"},
 		// U+200F RIGHT-TO-LEFT MARK.
-		{"RLM stripped", "a‏b", "ab"},
+		{"RLM stripped", "a\u200fb", "ab"},
 		// U+200B ZERO WIDTH SPACE.
-		{"ZWSP stripped", "a​b", "ab"},
+		{"ZWSP stripped", "a\u200bb", "ab"},
 		// U+FEFF BOM / ZERO WIDTH NO-BREAK SPACE.
 		{"BOM stripped", "\uFEFFfoo", "foo"},
 		// U+2066 LEFT-TO-RIGHT ISOLATE / U+2069 POP DIRECTIONAL ISOLATE.
-		{"LRI and PDI stripped", "⁦hello⁩", "hello"},
+		{"LRI and PDI stripped", "\u2066hello\u2069", "hello"},
 		// U+2067 RIGHT-TO-LEFT ISOLATE.
-		{"RLI stripped", "⁧hello⁩", "hello"},
+		{"RLI stripped", "\u2067hello\u2069", "hello"},
 		// U+2068 FIRST STRONG ISOLATE.
-		{"FSI stripped", "⁨hello⁩", "hello"},
+		{"FSI stripped", "\u2068hello\u2069", "hello"},
 		// U+2069 POP DIRECTIONAL ISOLATE standalone.
-		{"PDI stripped", "a⁩b", "ab"},
+		{"PDI stripped", "a\u2069b", "ab"},
 		// Combination that would spoof a filename extension in terminals.
-		{"trojan-source filename spoof", "evil‮⁦gnp.exe", "evilgnp.exe"},
+		{"trojan-source filename spoof", "evil\u202e\u2066gnp.exe", "evilgnp.exe"},
 		// Legitimate accented/non-ASCII text must not be touched.
 		{"plain text preserved", "Meeting with Ángela at café", "Meeting with Ángela at café"},
 	}


### PR DESCRIPTION
## Problem

The required **Lint** CI job (golangci-lint, CI-pinned v2.11.4) is red on `master`, forcing admin-bypass merges. Two checks fire in test files:

- `internal/notify/notify_test.go:373` — `crypto/tls.Dial must not be called. use (*crypto/tls.Dialer).DialContext (noctx)`. The line carried `//nolint:gosec`, but the firing linter is **noctx**, so the suppression did not apply.
- `internal/textsafe/textsafe_test.go` — `ST1018: string literal contains the Unicode format character ...` for the raw bidi/Trojan-Source control characters embedded throughout the test table (U+202E and friends).

## Fix

- **notify_test.go** — replace the context-less `tls.Dial("tcp", addr, cfg)` in the SMTPS test's `dialTLS` override with a context-aware `(&tls.Dialer{Config: cfg}).DialContext(context.Background(), "tcp", addr)`. The `//nolint:gosec` is retained on the `tls.Config` literal for the intentional `InsecureSkipVerify` against the self-signed test cert. Added the `context` import.
- **textsafe_test.go** — replace every embedded raw bidi control rune in the test cases with its `\uXXXX` escape sequence. The test's intent (verifying `Display` strips bidi/Trojan-Source format characters, CVE-2021-42574) is unchanged, and the human-readable `U+XXXX` describing comments are kept.

Verified with the CI-pinned golangci-lint v2.11.4: both packages now report `0 issues`. `go build ./...` and `go test ./internal/notify/... ./internal/textsafe/...` pass; `gofmt`/`go vet` clean.

## Note — out of scope

A full-repo `golangci-lint run ./...` (v2.11.4) surfaces **two additional, unrelated** failures that are NOT part of this issue and post-date it:

- `internal/auth/credential.go:251` — `nilerr` (a false positive: the code intentionally returns the legacy credential with `nil` when the best-effort migration write fails; introduced by commit `2afaf1b5`, ~2h after this issue's reference commit `332ce63`). Likely warrants a documented `//nolint:nilerr`.
- `internal/tui/event_dialog.go:375` — `unparam` (`setZone` always receives `zoneRSVP`).

These touch unrelated (and security-sensitive) logic, so they're left for separate fixes to keep this PR tight. CI will need those addressed too before the Lint job is fully green.

Closes #473
