### PR TITLE
fix(sync): rev-guard manual ResolveConflict server-pick dirty clear

### DIFF
--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -129,6 +129,13 @@ func (s *Service) ListConflicts(ctx context.Context) ([]Conflict, error) {
 	return out, nil
 }
 
+// resolveConflictAfterRevCapture, when non-nil, runs inside ResolveConflict's
+// accept-server path between reading the post-import rev and the rev-guarded
+// dirty clear. It is nil in production and exists only so tests can simulate a
+// concurrent local edit landing in that window to exercise the guard. See the
+// engine's afterImportRevCapture and issue #466.
+var resolveConflictAfterRevCapture func()
+
 // ResolveConflict resolves a conflict by picking local or server version.
 func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick string) error {
 	if pick != "server" && pick != "local" {
@@ -140,6 +147,10 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 		return fmt.Errorf("get conflict: %w", err)
 	}
 
+	// serverRev captures the sync_resources rev right after the accept-server
+	// import so the dirty clear below can be made conditional on it (see the
+	// "server" case in the transaction). Unused for the "local" pick.
+	var serverRev int64
 	if pick == "server" {
 		// Accept the server version: import the recorded server iCal into the
 		// local row so it reflects the server state. Without the import the
@@ -163,6 +174,23 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 			// branch exists to prevent. Refuse instead of resolving falsely.
 			return fmt.Errorf("server version has no importable data for %q", conflict.Uid)
 		}
+		// Capture the post-import rev so the dirty clear can be rev-guarded like
+		// the auto accept-server paths (engine.clearDirtyAfterImport). importICal
+		// bumps rev and re-sets dirty=1 via MarkResourceDirty; a concurrent local
+		// edit landing after this read bumps rev again, and the conditional clear
+		// below then leaves dirty=1 so the edit is still pushed instead of being
+		// silently dropped — the lost-update race of issues #92/#417/#466.
+		res, err := s.q.GetSyncResource(ctx, storage.GetSyncResourceParams{
+			CalendarID: conflict.CalendarID,
+			Uid:        conflict.Uid,
+		})
+		if err != nil {
+			return fmt.Errorf("get sync resource: %w", err)
+		}
+		serverRev = res.Rev
+		if resolveConflictAfterRevCapture != nil {
+			resolveConflictAfterRevCapture()
+		}
 	}
 
 	// Wrap the dirty/etag mutation and the conflict deletion in one transaction
@@ -178,12 +206,18 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 
 	switch pick {
 	case "server":
-		// Clear the pending local push and adopt the server ETag now that the
-		// local row reflects the server version.
-		if err := qtx.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
+		// Adopt the server ETag and clear the pending local push now that the
+		// local row reflects the server version — but only when no local edit
+		// has landed since serverRev was captured. FinalizePushedResource always
+		// advances the ETag yet clears dirty only on rev == serverRev, so a
+		// concurrent edit (which bumped rev) keeps dirty=1 and survives to the
+		// next push. The unconditional ClearSyncResourceDirty used here before
+		// wiped that edit — issues #92/#417/#466.
+		if err := qtx.FinalizePushedResource(ctx, storage.FinalizePushedResourceParams{
 			CalendarID: conflict.CalendarID,
 			Uid:        conflict.Uid,
 			Etag:       conflict.ServerEtag,
+			Rev:        serverRev,
 		}); err != nil {
 			return fmt.Errorf("clear dirty: %w", err)
 		}

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -292,6 +292,108 @@ func TestService_ResolveConflict_Server(t *testing.T) {
 	}
 }
 
+// TestService_ResolveConflict_ServerPreservesConcurrentEdit is the regression
+// test for issue #466 (a reopening of #417 on the manual path): a local edit
+// landing in the window between the accept-server import and the dirty clear
+// must not be silently dropped. The resolveConflictAfterRevCapture hook
+// simulates that edit; the rev-guarded clear must leave the resource dirty so
+// the next push sends it. With the previous unconditional ClearSyncResourceDirty
+// this test fails because the edit's dirty flag is wiped. Serial (no t.Parallel)
+// because it mutates the package-level hook.
+func TestService_ResolveConflict_ServerPreservesConcurrentEdit(t *testing.T) {
+	svc, db, q := newTestServiceWithDB(t)
+	ctx := context.Background()
+
+	// Link the calendar to an account so MarkResourceDirty (which no-ops on
+	// local-only calendars) actually writes — the hook below relies on it to
+	// bump rev and simulate the concurrent edit.
+	testutil.LinkCalendarToAccount(t, db)
+
+	cals, _ := q.ListCalendars(ctx)
+	calID := cals[0].ID
+
+	const uid = "resolve-server-race"
+	events := event.NewService(db, q)
+
+	if _, err := events.UpsertByUID(ctx, event.UpsertParams{
+		UID:        uid,
+		CalendarID: calID,
+		Title:      "Local Title",
+		StartTime:  time.Date(2026, 4, 3, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 3, 11, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("seed local event: %v", err)
+	}
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calID,
+		Uid:          uid,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/resolve-server-race.ics",
+		Etag:         "etag-before",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	serverIcal := "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//chroncal//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:" + uid + "\r\n" +
+		"DTSTART:20260403T120000Z\r\n" +
+		"DTEND:20260403T130000Z\r\n" +
+		"SUMMARY:Server Title\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	if err := q.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
+		CalendarID: calID,
+		OwnerType:  "event",
+		OwnerID:    1,
+		Uid:        uid,
+		LocalIcal:  "local",
+		ServerIcal: serverIcal,
+		ServerEtag: "etag-456",
+	}); err != nil {
+		t.Fatalf("CreateSyncConflict: %v", err)
+	}
+
+	// Simulate a concurrent local edit landing after the import recorded the
+	// server version but before the dirty flag is cleared: it bumps rev and
+	// re-marks the resource dirty, exactly as a real service-layer mutation would.
+	var fired int
+	resolveConflictAfterRevCapture = func() {
+		fired++
+		if err := storage.MarkResourceDirty(ctx, db, calID, uid, "event"); err != nil {
+			t.Errorf("simulate concurrent edit: %v", err)
+		}
+	}
+	t.Cleanup(func() { resolveConflictAfterRevCapture = nil })
+
+	conflicts, _ := q.ListSyncConflicts(ctx)
+	if err := svc.ResolveConflict(ctx, conflicts[0].ID, "server"); err != nil {
+		t.Fatalf("ResolveConflict server: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("resolveConflictAfterRevCapture fired %d times, want 1", fired)
+	}
+
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: calID, Uid: uid})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Dirty != 1 {
+		t.Fatalf("Dirty = %d, want 1 (concurrent edit must not be dropped, #466)", res.Dirty)
+	}
+	// The ETag still advances to the server's version so the next push's If-Match
+	// matches the server, mirroring FinalizePushedResource on the push path.
+	if res.Etag != "etag-456" {
+		t.Fatalf("Etag = %q, want %q", res.Etag, "etag-456")
+	}
+}
+
 // TestService_ResolveConflict_ServerDoesNotResurrectDeleted is the regression
 // test for issue #89 (gap #2): accepting the server version of a conflict must
 // NOT un-delete a row the user has locally soft-deleted and tombstoned for


### PR DESCRIPTION
## Problem

The manual conflict-resolution path `ResolveConflict(ctx, id, "server")`
(`internal/sync/service.go`) accepted the server version by running
`importICal` — which bumps `rev` and re-sets `dirty=1` via
`MarkResourceDirty` — and then cleared dirty **unconditionally** with
`ClearSyncResourceDirty`.

A concurrent local edit landing in the window between `importICal`
returning and the clear (another CLI invocation, or a TUI save-time
mutation, on a separate connection) bumps `rev`/`dirty=1`, but the
unconditional clear then wipes `dirty` back to 0. The edit is never
pushed and is overwritten by the server on the next pull.

This is exactly the lost-update race that `FinalizePushedResource`'s
`CASE WHEN rev = ?` guard (issues #92 / #417) prevents, and which every
auto accept-server path already uses via `engine.clearDirtyAfterImport`
(engine.go:527 ConflictServerWins, 870 / 1169 pulls). The manual path
was the lone hole.

## Fix

Capture the post-import `sync_resources.rev` and clear dirty via
`FinalizePushedResource` instead of the unconditional
`ClearSyncResourceDirty`. The ETag still always advances to the server's
version (so the next push's `If-Match` matches), but `dirty` is cleared
only when `rev` is unchanged — a concurrent edit that bumped `rev` keeps
`dirty=1` and survives to the next push.

The clear stays inside the same transaction as `DeleteSyncConflict`, so
resolution remains atomic (issue #89 gap #3). The rev is captured outside
that transaction (via an auto-commit read) to avoid holding the single
SQLite connection while the guard window is open.

## Test

Adds `TestService_ResolveConflict_ServerPreservesConcurrentEdit`, which
uses a test-only hook (`resolveConflictAfterRevCapture`) to simulate a
concurrent local edit landing in the guarded window, mirroring the
engine's existing `TestEnginePushServerWinsPreservesConcurrentEdit`. It
asserts `dirty` stays 1 and the ETag advances. Verified the test fails
against the old unconditional clear (`Dirty = 0, want 1`) and passes
with the fix. Full `internal/sync` suite, `go build ./...`, `go vet`, and
`golangci-lint` are green.

Closes #466
