### PR TITLE
fix(alarm): anchor RELATED=END todo alarms at per-occurrence DUE

### DIFF
--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -229,14 +229,26 @@ func computeTodoTriggerTimeForInstance(inst recurrence.ExpandedTodo, alarm model
 		return time.Time{}, fmt.Errorf("todo instance has no anchor time")
 	}
 
-	// For RELATED=END, anchor at the todo's end: DUE if present, else
-	// START+DURATION. A VTODO with DTSTART+DUE but no explicit DURATION has an
-	// empty Duration field, so resolving via DUE first is required — otherwise
-	// the trigger fires (DUE−DTSTART) too early (issue #367).
+	// For RELATED=END, anchor at the occurrence's end. ExpandTodo leaves the
+	// embedded Todo's DueDate/StartDate as the master's (first-occurrence)
+	// values and only advances InstanceTime, so the end must be derived from
+	// InstanceTime — not read from the stored DueDate, which would pin every
+	// occurrence to the master's DUE (issue #489).
+	//
+	// InstanceTime is the occurrence's START when DTSTART is present, else its
+	// DUE. So: with DTSTART+DUE, shift the DUE−START span onto InstanceTime
+	// (issue #367: a VTODO with DTSTART+DUE has an empty Duration field, so the
+	// span must come from the dates); DUE-only occurrences are already anchored
+	// at DUE; otherwise fall back to START+DURATION.
 	if alarm.Related == "END" {
-		if due := inst.ParseDueDate(); !due.IsZero() {
-			base = due
-		} else if inst.Duration != "" {
+		start := inst.ParseStartDate()
+		due := inst.ParseDueDate()
+		switch {
+		case !start.IsZero() && !due.IsZero():
+			base = inst.InstanceTime.Add(due.Sub(start))
+		case !due.IsZero():
+			base = inst.InstanceTime
+		case inst.Duration != "":
 			base = duration.Add(base, inst.Duration)
 		}
 	}

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -57,6 +57,79 @@ func TestComputeTodoTrigger_RelatedEnd_DtStartPlusDue(t *testing.T) {
 	}
 }
 
+// TestComputeTodoTrigger_RelatedEnd_RecurringInstance guards issue #489: a
+// recurring VTODO with a RELATED=END alarm must anchor the trigger at each
+// occurrence's own DUE, not at the master's first-occurrence DUE. ExpandTodo
+// leaves the embedded Todo unshifted (only InstanceTime moves per occurrence),
+// so deriving END from the stored DueDate field would land occurrence N>1 in
+// the past, where it gets dropped as stale.
+func TestComputeTodoTrigger_RelatedEnd_RecurringInstance(t *testing.T) {
+	// Master: START 2026-04-01 09:00, DUE 2026-04-01 17:00 (8h span).
+	masterStart := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	masterDue := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+
+	// Occurrence 2 (one week later): InstanceTime is the occurrence's START.
+	occStart := masterStart.AddDate(0, 0, 7)
+
+	inst := recurrence.ExpandedTodo{
+		Todo: todo.Todo{
+			StartDate:      masterStart.Format(time.RFC3339),
+			DueDate:        masterDue.Format(time.RFC3339), // unshifted master DUE
+			RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+		},
+		InstanceTime: occStart, // anchor = this occurrence's START
+	}
+
+	alarm := model.Alarm{
+		Action:       "DISPLAY",
+		TriggerValue: "-PT30M", // 30 min before END
+		Related:      "END",
+	}
+
+	got, err := computeTodoTriggerTimeForInstance(inst, alarm)
+	if err != nil {
+		t.Fatalf("computeTodoTriggerTimeForInstance: %v", err)
+	}
+
+	// END of occurrence 2 = occStart + 8h = 2026-04-08 17:00; trigger at 16:30.
+	want := occStart.Add(masterDue.Sub(masterStart)).Add(-30 * time.Minute)
+	if !got.Equal(want) {
+		t.Errorf("RELATED=END on recurring occurrence: got %v, want %v (END must anchor at this occurrence's DUE, not the master's)", got, want)
+	}
+}
+
+// TestComputeTodoTrigger_RelatedEnd_RecurringDueOnly is the DUE-only variant of
+// issue #489: with no DTSTART, the occurrence's InstanceTime is already the
+// occurrence's DUE, so END must anchor directly on InstanceTime.
+func TestComputeTodoTrigger_RelatedEnd_RecurringDueOnly(t *testing.T) {
+	masterDue := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	occDue := masterDue.AddDate(0, 0, 7) // occurrence 2 DUE
+
+	inst := recurrence.ExpandedTodo{
+		Todo: todo.Todo{
+			DueDate:        masterDue.Format(time.RFC3339), // unshifted master DUE
+			RecurrenceRule: "FREQ=WEEKLY;COUNT=3",
+		},
+		InstanceTime: occDue, // anchor = this occurrence's DUE
+	}
+
+	alarm := model.Alarm{
+		Action:       "DISPLAY",
+		TriggerValue: "-PT30M",
+		Related:      "END",
+	}
+
+	got, err := computeTodoTriggerTimeForInstance(inst, alarm)
+	if err != nil {
+		t.Fatalf("computeTodoTriggerTimeForInstance: %v", err)
+	}
+
+	want := occDue.Add(-30 * time.Minute)
+	if !got.Equal(want) {
+		t.Errorf("RELATED=END DUE-only recurring occurrence: got %v, want %v", got, want)
+	}
+}
+
 func TestCheckTodoAlarms_DueAlarm(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 


### PR DESCRIPTION
## Bug

For a recurring `VTODO` with a `RELATED=END` `VALARM`, every occurrence's alarm
trigger was computed from the **master's first-occurrence DUE** instead of the
**per-occurrence DUE**.

`alarm.CheckTodos` expands recurring todos via `recurrence.ExpandTodo`, which
(unlike the listing path's `expandRecurringTodoRows`) leaves the embedded
`Todo` unshifted and only advances `InstanceTime` per occurrence. The
`RELATED=END` branch in `computeTodoTriggerTimeForInstance` read the stored
`DueDate` directly via `inst.ParseDueDate()`, so it always saw the master's
first DUE. For occurrence N>1 the trigger landed in the past and was dropped as
stale (`StaleThreshold`), so `RELATED=END` alarms never fired after the first
occurrence (and fired at the wrong time even for the second).

The event path already does this correctly via `InstanceTime.Add(Span())`; the
todo path was the only one reading a stored (unshifted) date field.

## Fix

Derive the occurrence's end from `InstanceTime` instead of the stored field:

- DTSTART + DUE present: shift the DUE−START span onto `InstanceTime`.
- DUE-only: `InstanceTime` is already the occurrence's DUE.
- Otherwise: fall back to START + DURATION.

This preserves the issue #367 behavior (DTSTART+DUE with empty `Duration` must
anchor at DUE) while making every occurrence anchor at its own DUE.

## Test

Added two failing-then-passing unit tests in
`internal/alarm/todo_service_test.go`:

- `TestComputeTodoTrigger_RelatedEnd_RecurringInstance` — DTSTART+DUE recurring
  todo, asserts occurrence 2's END trigger lands one week out, not at the
  master DUE.
- `TestComputeTodoTrigger_RelatedEnd_RecurringDueOnly` — DUE-only recurring
  todo, asserts the END trigger anchors on `InstanceTime`.

Both failed before the fix (anchoring at 2026-04-01 instead of 2026-04-08) and
pass after. Full `go test ./...` is green.

Closes #489
