### PR TITLE
fix(ical): emit TZID on EXDATE/RDATE for zoned recurring events

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -655,6 +655,15 @@ func emitDateListOnComponent(comp *ical.Component, propName, dates, timezone str
 				// DTSTART. A trailing Z is a value-type mismatch that stops
 				// servers from suppressing the excluded occurrence (#421).
 				prop.Value = t.UTC().Format("20060102T150405")
+			} else if loc, lerr := time.LoadLocation(timezone); timezone != "" && lerr == nil {
+				// Zoned components emit DTSTART in local wall-clock with a
+				// TZID, so EXDATE/RDATE must match: same TZID, same zone-local
+				// wall clock. A bare UTC value drops the TZID and is a
+				// value-type mismatch that stops servers expanding the RRULE
+				// in the DTSTART zone (e.g. Google) from suppressing the
+				// excluded occurrence (#492), mirroring setEventTimes.
+				prop.Params.Set(ical.ParamTimezoneID, timezone)
+				prop.Value = t.In(loc).Format("20060102T150405")
 			} else {
 				prop.SetDateTime(t.UTC())
 			}

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -250,6 +250,50 @@ func TestExport_FloatingExdatesRdatesNoZ(t *testing.T) {
 	}
 }
 
+// Regression test for issue #492: a zoned recurring component emits DTSTART
+// with a TZID in local wall-clock, so its EXDATE/RDATE must carry the same
+// TZID and wall-clock value. Emitting them as bare UTC (...Z) drops the TZID
+// and creates a value-type mismatch against DTSTART, so servers that expand
+// the RRULE in the DTSTART zone (e.g. Google) fail to suppress the excluded
+// occurrence and a deleted instance reappears.
+func TestExport_ZonedExdatesRdatesCarryTZID(t *testing.T) {
+	t.Parallel()
+	// DTSTART 2026-04-01T09:00 America/New_York == 13:00Z (EDT, UTC-4).
+	events := []event.Event{{
+		UID:            "zoned-exdate",
+		Title:          "Recurring Zoned",
+		StartTime:      time.Date(2026, 4, 1, 13, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		Timezone:       "America/New_York",
+		RecurrenceRule: "FREQ=WEEKLY",
+		Status:         "CONFIRMED",
+		Transp:         "OPAQUE",
+		ExDates:        "2026-04-08T13:00:00Z",
+		RDates:         "2026-05-06T13:00:00Z",
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}}
+
+	data, err := ExportEvents(events, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	ics := string(data)
+
+	if !strings.Contains(ics, "EXDATE;TZID=America/New_York:20260408T090000") {
+		t.Errorf("expected EXDATE;TZID=America/New_York:20260408T090000, got:\n%s", ics)
+	}
+	if !strings.Contains(ics, "RDATE;TZID=America/New_York:20260506T090000") {
+		t.Errorf("expected RDATE;TZID=America/New_York:20260506T090000, got:\n%s", ics)
+	}
+	if strings.Contains(ics, "EXDATE:20260408T130000Z") {
+		t.Errorf("EXDATE must not be emitted as bare UTC for a zoned component:\n%s", ics)
+	}
+	if strings.Contains(ics, "RDATE:20260506T130000Z") {
+		t.Errorf("RDATE must not be emitted as bare UTC for a zoned component:\n%s", ics)
+	}
+}
+
 func TestExport_CategoriesNotEscaped(t *testing.T) {
 	t.Parallel()
 	events := []event.Event{{


### PR DESCRIPTION
## Summary

For a zoned (non-floating, non-all-day) recurring component, `DTSTART` is
exported in local wall-clock with a `TZID`, but `EXDATE`/`RDATE` for the same
component were emitted as bare UTC (`...Z`), dropping the `TZID`. Servers that
expand the RRULE in the DTSTART zone (e.g. Google) match `EXDATE` by
zone+wall-clock and ignore a bare UTC value, so the excluded occurrence
silently reappears. This is the same value-type mismatch already fixed for
FLOATING times in #421, left unfixed for the zoned case.

## Fix

In `emitDateListOnComponent` (`internal/ical/export.go`), the `else` branch now
emits zoned `EXDATE`/`RDATE` with the same `TZID` param and zone-local wall
clock as `DTSTART` (mirroring `setEventTimes`), falling back to the UTC path
only when the component has no IANA zone or `LoadLocation` fails. The helper is
shared by events, todos, and journals, so all three are fixed in one place.

## Test

Added `TestExport_ZonedExdatesRdatesCarryTZID` (`internal/ical/export_test.go`):
an `America/New_York` weekly event with an EXDATE/RDATE must export
`EXDATE;TZID=America/New_York:20260408T090000` (local wall clock), not a bare
`...130000Z`. Confirmed it fails before the fix and passes after. `go build
./...`, `go vet`, `golangci-lint`, and the full `go test ./...` suite are green.

Closes #492
