### PR TITLE
fix(lint): clear unparam and nilerr Lint CI blockers (#500, #501)

### DIFF
--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -248,7 +248,7 @@ func (s *migratingCredentialStore) Get(accountID int64) (Credential, error) {
 	// whole process lifetime. On failure, return the legacy credential and keep
 	// the legacy copy so a later read can retry the migration.
 	if setErr := s.primary.Set(legacyCred); setErr != nil {
-		return legacyCred, nil
+		return legacyCred, nil //nolint:nilerr // best-effort migration: a keyring write failure must not fail a successful legacy read (see comment above)
 	}
 	// Migration succeeded: the caller now has the credential and the primary
 	// store owns it. Cleaning up the legacy copy is best-effort — a failure

--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -345,8 +345,8 @@ func (m EventDialogModel) shortHelp() []key.Binding {
 	return []key.Binding{nav, days, sk.Tab, m.keys.Create, m.keys.Delete, sk.Close}
 }
 
-// Focus-zone IDs used by currentZone/setZone. Kept as ints so existing
-// switch-based callers in handleKey stay unchanged.
+// Focus-zone IDs used by currentZone and the tab-order helpers. Kept as
+// ints so existing switch-based callers stay unchanged.
 const (
 	zoneList        = 0
 	zoneRSVP        = 1
@@ -369,21 +369,12 @@ func (m EventDialogModel) currentZone() int {
 	return zoneList
 }
 
-// setZone moves focus to the head of a zone. Used by domain hotkeys (y/m for
-// RSVP, e/d/t for actions) and mouse clicks; Tab uses focusStop below to
-// land on a specific element.
-func (m EventDialogModel) setZone(z int) EventDialogModel {
-	switch z {
-	case zoneList:
-		m.rsvpFocused = false
-		m.shell = m.shell.SetFocusZone(ListZoneList)
-	case zoneRSVP:
-		m.rsvpFocused = true
-		m.shell = m.shell.SetFocusZone(ListZoneCustom)
-	case zoneAction:
-		m.rsvpFocused = false
-		m.shell = m.shell.FocusAction(0)
-	}
+// focusRSVP moves focus to the head of the RSVP button zone. Invoked by the
+// RSVP hotkeys (y/n/m) and by clicking an RSVP button; Tab uses focusStop
+// below to land on a specific element.
+func (m EventDialogModel) focusRSVP() EventDialogModel {
+	m.rsvpFocused = true
+	m.shell = m.shell.SetFocusZone(ListZoneCustom)
 	return m
 }
 
@@ -581,19 +572,19 @@ func (m EventDialogModel) handleKey(msg tea.KeyPressMsg) (EventDialogModel, tea.
 		return m, func() tea.Msg { return EventCreateMsg{Day: day} }
 	case key.Matches(msg, m.keys.RSVPYes):
 		if len(rsvp) > 0 {
-			m = m.setZone(zoneRSVP)
+			m = m.focusRSVP()
 			m.focusedRSVP = 0
 			return m.refresh(), rsvp[0].msg
 		}
 	case key.Matches(msg, m.keys.RSVPNo):
 		if len(rsvp) > 1 {
-			m = m.setZone(zoneRSVP)
+			m = m.focusRSVP()
 			m.focusedRSVP = 1
 			return m.refresh(), rsvp[1].msg
 		}
 	case key.Matches(msg, m.keys.RSVPMaybe):
 		if len(rsvp) > 2 {
-			m = m.setZone(zoneRSVP)
+			m = m.focusRSVP()
 			m.focusedRSVP = 2
 			return m.refresh(), rsvp[2].msg
 		}
@@ -626,7 +617,7 @@ func (m EventDialogModel) handleMouse(msg tea.MouseClickMsg) (EventDialogModel, 
 		return m.refresh(), cmd
 	}
 	if idx, cmd, hit := m.hitRSVPBtn(msg.X, msg.Y); hit {
-		m = m.setZone(zoneRSVP)
+		m = m.focusRSVP()
 		m.focusedRSVP = idx
 		return m.refresh(), cmd
 	}


### PR DESCRIPTION
## Summary

Clears the two `golangci-lint` findings that kept the **Lint** CI job red after #473. Confirmed against the CI-pinned `golangci-lint v2.11.4` (`.github/workflows/ci.yml`): both surface on `master`, and both are gone after this change. Restores a green Lint job.

## Changes

### `internal/tui/event_dialog.go` — `unparam` (#500)
`(EventDialogModel).setZone(z int)` received `zoneRSVP` from all four call sites (`:584`, `:590`, `:596`, `:629`), so the parameter was dead and the `zoneList` / `zoneAction` switch cases were unreachable. Renamed to `focusRSVP()` with no parameter, inlined the RSVP-focus body, and fixed the misleading comments. Behavior is identical — every caller already took the `zoneRSVP` path (`m.rsvpFocused = true; m.shell = m.shell.SetFocusZone(ListZoneCustom)`). The zone-ID constants remain in use by the tab-order helpers.

### `internal/auth/credential.go` — `nilerr` false positive (#501)
`migratingCredentialStore.Get` deliberately returns `legacyCred, nil` after a failed best-effort `primary.Set`: a transient keyring write failure must not turn a successful legacy read into an error (that would lock the user out of sync for the process lifetime; the legacy copy is kept so a later read retries the migration). `Set`/`Delete` on the same type propagate real failures, so the asymmetry is by design. No control-flow change — added a documented `//nolint:nilerr` at the return site.

## Verification
- `go build ./...` — ok
- `go test ./internal/tui/ ./internal/auth/` — pass
- `golangci-lint run ./...` (v2.11.4) — **0 issues** (was 2)
- `gofmt -l` clean, `go vet` clean

Closes #500
Closes #501
