### PR TITLE
fix(ical): preserve multiple VJOURNAL DESCRIPTION properties on round-trip

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -1060,7 +1060,16 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 		vjournal.Props.SetText(ical.PropUID, j.UID)
 		vjournal.Props.SetText(ical.PropSummary, j.Summary)
 
-		if j.Description != "" {
+		// DESCRIPTION. RFC 5545 permits multiple; emit one per element when the
+		// per-property split survived (a fresh import), otherwise fall back to
+		// the single DB-backed Description value.
+		if len(j.Descriptions) > 0 {
+			for _, d := range j.Descriptions {
+				p := &ical.Prop{Name: ical.PropDescription}
+				p.SetText(d)
+				vjournal.Props.Add(p)
+			}
+		} else if j.Description != "" {
 			vjournal.Props.SetText(ical.PropDescription, j.Description)
 		}
 

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -997,7 +997,9 @@ func journalFromVJournal(comp *ical.Component) (journal.Journal, error) {
 
 	summary := propText(props, ical.PropSummary)
 
-	// VJOURNAL can have multiple DESCRIPTION properties; join them.
+	// VJOURNAL can have multiple DESCRIPTION properties (RFC 5545). Keep each
+	// one in the Descriptions slice for round-trip fidelity, and join them into
+	// the single DB-backed Description field used for display and search.
 	var descriptions []string
 	for _, prop := range props.Values(ical.PropDescription) {
 		text, err := prop.Text()
@@ -1081,6 +1083,7 @@ func journalFromVJournal(comp *ical.Component) (journal.Journal, error) {
 		UID:            uid,
 		Summary:        summary,
 		Description:    description,
+		Descriptions:   descriptions,
 		StartDate:      startDate,
 		Status:         strings.ToUpper(status),
 		Class:          strings.ToUpper(class),

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -2327,6 +2327,47 @@ func TestRoundtrip_Journal(t *testing.T) {
 	}
 }
 
+// TestRoundtrip_JournalMultipleDescriptions guards against collapsing a
+// VJOURNAL's multiple DESCRIPTION properties (permitted by RFC 5545) into a
+// single concatenated value (issue #493). N descriptions must survive import ->
+// export as N distinct DESCRIPTION properties, mirroring COMMENT/CONTACT.
+func TestRoundtrip_JournalMultipleDescriptions(t *testing.T) {
+	t.Parallel()
+	const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VJOURNAL
+UID:multi-desc-journal
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T090000Z
+SUMMARY:Multiple Descriptions
+DESCRIPTION:First description block
+DESCRIPTION:Second description block
+END:VJOURNAL
+END:VCALENDAR`
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.Journals) != 1 {
+		t.Fatalf("imported %d journals, want 1", len(result.Journals))
+	}
+	if got := len(result.Journals[0].Descriptions); got != 2 {
+		t.Errorf("Descriptions: got %d, want 2 (%q)", got, result.Journals[0].Descriptions)
+	}
+
+	data, err := ExportJournals(result.Journals, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	count := strings.Count(string(data), "DESCRIPTION:")
+	if count != 2 {
+		t.Errorf("exported DESCRIPTION properties: got %d, want 2\n%s", count, data)
+	}
+}
+
 // TestRoundtrip_CategoryWithEmbeddedComma guards against fragmenting a single
 // CATEGORIES value that legitimately contains a comma (issue #101). A category
 // like "Foo, Bar" must survive import -> store -> export -> import as one value,

--- a/internal/journal/model.go
+++ b/internal/journal/model.go
@@ -29,6 +29,13 @@ type Journal struct {
 	UpdatedAt      time.Time
 	DeletedAt      *time.Time // nil = not soft-deleted; set = soft-deleted at this time
 
+	// Descriptions carries every DESCRIPTION property for iCal round-trip
+	// fidelity. RFC 5545 permits a VJOURNAL to hold multiple DESCRIPTIONs;
+	// the Description field above is the joined, DB-backed value used for
+	// display and search, while this transient slice preserves the original
+	// per-property split on export (mirroring Comments/Contacts).
+	Descriptions []string
+
 	Attendees   []model.Attendee
 	Attachments []model.Attachment
 	Comments    []string


### PR DESCRIPTION
## Summary

A `VJOURNAL` carrying multiple `DESCRIPTION` properties (permitted by RFC 5545)
was collapsed into one on import — joined with `\n\n` into the single
`journal.Journal.Description` string — and re-exported as a single
`DESCRIPTION`. So N descriptions round-tripped as 1 (concatenated).

## Fix

Add a transient `Descriptions []string` field on `journal.Journal`, mirroring
the existing `Comments`/`Contacts` transient slices:

- **Import** populates `Descriptions` with each `DESCRIPTION` value while still
  joining them into the DB-backed `Description` column used for display/search.
- **Export** emits one `DESCRIPTION` per element when the split survived a fresh
  import, and falls back to the single `Description` value for journals loaded
  from the database.

No schema change or migration: `description` remains a single column, so a
save-then-export cycle keeps the prior single-value behavior. True fidelity is
preserved for `ical -> ical` round-trips (the case the issue describes).

### Scope note

Full multi-value DB persistence (a `journal_descriptions` side table like
`journal_comments`/`journal_contacts`) was considered but judged out of scope:
`description` is a primary, FTS-searchable display field, unlike the aux
comment/contact lists, so replacing/supplementing it carries broad risk
disproportionate to a medium-severity round-trip bug. The transient-slice
approach matches how the codebase already models other transient iCal fields.

## Test

Added `TestRoundtrip_JournalMultipleDescriptions` in
`internal/ical/roundtrip_test.go`: a VJOURNAL with two `DESCRIPTION` props
imports to a 2-element `Descriptions` slice and exports back to two
`DESCRIPTION` properties. Confirmed failing before the fix, passing after.

`go build ./...`, `go vet`, `gofmt`, `golangci-lint`, and the full `go test ./...`
suite all pass.

Closes #493
