### PR TITLE
fix(event): route truncation undo through truncate-log reversal (#490, #491)

### DIFF
--- a/db/queries/event_truncate_deletes.sql
+++ b/db/queries/event_truncate_deletes.sql
@@ -16,6 +16,12 @@ ORDER BY deleted_at DESC;
 -- name: GetEventTruncateDelete :one
 SELECT * FROM event_truncate_deletes WHERE id = ?;
 
+-- name: GetEventTruncateDeleteByUIDAndCutoff :one
+-- Looks up the truncation log row by its unique (uid, cutoff_time) key so the
+-- TUI undo path can reverse a "this and following" delete through the same
+-- provenance-aware reversal the trash view uses.
+SELECT * FROM event_truncate_deletes WHERE uid = ? AND cutoff_time = ?;
+
 -- name: DeleteEventTruncateDelete :exec
 DELETE FROM event_truncate_deletes WHERE id = ?;
 

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -47,8 +47,13 @@ type UndoMeta struct {
 	// UndoKindSingle only, when undoing DeleteInstanceWithUndo.
 	RecurrenceID string
 
-	// UndoKindFromInstance only.
+	// UndoKindFromInstance only. MasterRRuleBefore records the pre-truncation
+	// RRULE; CutoffTime is the truncation cutoff, used to find the
+	// event_truncate_deletes log row that Undo reverses (so the RRULE, trimmed
+	// RDATEs, and the exact overrides the truncation hid are all restored).
+	// MasterUpdatedBefore is the stale-master guard baseline.
 	MasterRRuleBefore   string
+	CutoffTime          time.Time
 	MasterUpdatedBefore time.Time
 }
 
@@ -124,6 +129,7 @@ func (s *Service) DeleteFromInstanceWithUndo(ctx context.Context, uid string, in
 		Label:               master.Title,
 		DeletedAt:           time.Now().UTC(),
 		MasterRRuleBefore:   prevRRule,
+		CutoffTime:          instanceTime.UTC(),
 		MasterUpdatedBefore: parseStorageTime(postUpdated),
 	}, nil
 }
@@ -423,6 +429,14 @@ func clearMasterEXDATE(ctx context.Context, qtx *storage.Queries, uid, recurrenc
 	}, recurrenceID)
 }
 
+// restoreFromInstance reverses a "this and following" truncation for the TUI/CLI
+// undo path. It applies the stale-master guard (rejecting Undo if an external
+// edit advanced the master past the truncation), then routes the actual reversal
+// through restoreTruncationByLogID — the same provenance-aware path the trash
+// view uses. That guarantees the RRULE, the trimmed RDATEs (issue #490), and
+// only the overrides the truncation itself hid (issue #491, the #287 class on
+// undo) are all restored, and the truncate-log row is consumed so no phantom
+// "Series tail" trash entry lingers for the now-live series.
 func (s *Service) restoreFromInstance(ctx context.Context, meta UndoMeta) error {
 	master, err := s.q.GetEventByUIDIncludingDeleted(ctx, meta.UID)
 	if err != nil {
@@ -434,33 +448,17 @@ func (s *Service) restoreFromInstance(ctx context.Context, meta UndoMeta) error 
 			meta.MasterUpdatedBefore.Format(time.RFC3339), prevUpdated.Format(time.RFC3339))
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	log, err := s.q.GetEventTruncateDeleteByUIDAndCutoff(ctx, storage.GetEventTruncateDeleteByUIDAndCutoffParams{
+		Uid:        meta.UID,
+		CutoffTime: meta.CutoffTime.UTC().Format(time.RFC3339),
+	})
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotDeleted
+		}
+		return fmt.Errorf("get truncate log: %w", err)
 	}
-	defer tx.Rollback()
-	qtx := s.q.WithTx(tx)
-
-	// Rewrite RRULE back.
-	if err := qtx.UpdateEventRecurrenceRule(ctx, storage.UpdateEventRecurrenceRuleParams{
-		RecurrenceRule: storage.StringToNullable(meta.MasterRRuleBefore),
-		ID:             master.ID,
-	}); err != nil {
-		return fmt.Errorf("restore rrule: %w", err)
-	}
-	// Un-hide every soft-deleted row with this UID (the master was not
-	// soft-deleted by DeleteFromInstance, only overrides were — but this is
-	// idempotent).
-	if _, err := qtx.RestoreEventsByUID(ctx, meta.UID); err != nil {
-		return fmt.Errorf("restore overrides: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	if err := storage.MarkResourceDirty(ctx, s.db, master.CalendarID, meta.UID, "event"); err != nil {
-		return fmt.Errorf("mark resource dirty after restore: %w", err)
-	}
-	return nil
+	return s.restoreTruncationByLogID(ctx, log.ID)
 }
 
 // reconcileSyncAfterRestore mirrors the 3-case state machine from

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -816,3 +816,111 @@ func TestSoftDelete_OverrideMasterLookupError(t *testing.T) {
 		t.Fatalf("override should still be live after failed delete: %v", err)
 	}
 }
+
+// TestSoftDelete_FromInstanceUndo_ReAddsRDates reproduces issue #490: the TUI
+// truncation-undo path (RestoreUndo of an UndoKindFromInstance) must re-add the
+// post-cutoff RDATEs the truncation trimmed, mirroring the trash-restore path
+// (issue #463). Before the fix, RestoreUndo rewrote only the RRULE and silently
+// dropped the trimmed RDATEs.
+func TestSoftDelete_FromInstanceUndo_ReAddsRDates(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	rdate1 := time.Date(2026, 4, 15, 9, 0, 0, 0, time.UTC)
+	rdate2 := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	master := newRDateOnlyMaster(t, svc, "rdate-undo-readds", []time.Time{rdate1, rdate2})
+
+	meta, err := svc.DeleteFromInstanceWithUndo(ctx, master.UID, rdate2)
+	if err != nil {
+		t.Fatalf("DeleteFromInstanceWithUndo: %v", err)
+	}
+
+	// The truncation trimmed the post-cutoff RDATE.
+	trimmed, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("GetByUID after truncate: %v", err)
+	}
+	if got := trimmed.ParseRDates(); len(got) != 1 || !got[0].Equal(rdate1) {
+		t.Fatalf("RDates after truncate = %v, want only %s", got, rdate1.Format(time.RFC3339))
+	}
+
+	// Undo must put the dropped RDATE back.
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+	restored, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("GetByUID after undo: %v", err)
+	}
+	rdates := restored.ParseRDates()
+	foundR2 := false
+	for _, rd := range rdates {
+		if rd.Equal(rdate2) {
+			foundR2 = true
+		}
+	}
+	if len(rdates) != 2 || !foundR2 {
+		t.Fatalf("issue #490: RDates after undo = %v, want both restored (incl. %s)",
+			rdates, rdate2.Format(time.RFC3339))
+	}
+}
+
+// TestSoftDelete_FromInstanceUndo_KeepsIndependentlyDeletedOverride reproduces
+// issue #491 (the #287 class on the undo path): deleting a single override, then
+// truncating "this and following" from an earlier cutoff, then Undo must NOT
+// resurrect the independently-deleted override. Before the fix, RestoreUndo
+// called RestoreEventsByUID, which un-hid every soft-deleted row sharing the UID.
+func TestSoftDelete_FromInstanceUndo_KeepsIndependentlyDeletedOverride(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "standup-undo",
+		CalendarID:     1,
+		Title:          "Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=10",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	// User customizes the Apr 22 instance (creates an override).
+	overrideTime := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Standup (moved)",
+		StartTime:    time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 22, 10, 30, 0, 0, time.UTC),
+		RecurrenceID: overrideTime.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// User deletes that single customized instance on its own.
+	if err := svc.DeleteInstance(ctx, master.UID, overrideTime); err != nil {
+		t.Fatalf("DeleteInstance: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err == nil {
+		t.Fatalf("override should be soft-deleted after DeleteInstance")
+	}
+
+	// Later, user truncates "this and following" from an earlier cutoff (Apr 8).
+	cutoff := time.Date(2026, 4, 8, 9, 0, 0, 0, time.UTC)
+	meta, err := svc.DeleteFromInstanceWithUndo(ctx, master.UID, cutoff)
+	if err != nil {
+		t.Fatalf("DeleteFromInstanceWithUndo: %v", err)
+	}
+
+	// Undo the truncation. This must NOT resurrect the override the user
+	// independently deleted before the truncation.
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+	if _, err := svc.Get(ctx, override.ID); err == nil {
+		t.Fatalf("issue #491: independently-deleted override resurrected by truncation undo")
+	}
+}

--- a/internal/storage/event_truncate_deletes.sql.go
+++ b/internal/storage/event_truncate_deletes.sql.go
@@ -38,6 +38,34 @@ func (q *Queries) GetEventTruncateDelete(ctx context.Context, id int64) (EventTr
 	return i, err
 }
 
+const getEventTruncateDeleteByUIDAndCutoff = `-- name: GetEventTruncateDeleteByUIDAndCutoff :one
+SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at, hidden_overrides, removed_rdates FROM event_truncate_deletes WHERE uid = ? AND cutoff_time = ?
+`
+
+type GetEventTruncateDeleteByUIDAndCutoffParams struct {
+	Uid        string
+	CutoffTime string
+}
+
+// Looks up the truncation log row by its unique (uid, cutoff_time) key so the
+// TUI undo path can reverse a "this and following" delete through the same
+// provenance-aware reversal the trash view uses.
+func (q *Queries) GetEventTruncateDeleteByUIDAndCutoff(ctx context.Context, arg GetEventTruncateDeleteByUIDAndCutoffParams) (EventTruncateDelete, error) {
+	row := q.db.QueryRowContext(ctx, getEventTruncateDeleteByUIDAndCutoff, arg.Uid, arg.CutoffTime)
+	var i EventTruncateDelete
+	err := row.Scan(
+		&i.ID,
+		&i.CalendarID,
+		&i.Uid,
+		&i.CutoffTime,
+		&i.PreviousRrule,
+		&i.DeletedAt,
+		&i.HiddenOverrides,
+		&i.RemovedRdates,
+	)
+	return i, err
+}
+
 const listEventTruncateDeletesByCalendar = `-- name: ListEventTruncateDeletesByCalendar :many
 SELECT id, calendar_id, uid, cutoff_time, previous_rrule, deleted_at, hidden_overrides, removed_rdates FROM event_truncate_deletes
 WHERE calendar_id = ?


### PR DESCRIPTION
## Summary

The TUI/CLI "this and following" undo path (`restoreFromInstance`) was a
less-careful sibling of the trash restore path (`restoreTruncationByLogID`).
It rewrote only the master RRULE and then called `RestoreEventsByUID` — a
UID-wide un-hide with no provenance. Two related bugs fell out of that:

- **#490** — undo silently dropped the post-cutoff RDATEs the truncation
  trimmed. `UndoMeta` never captured them, so they could not be re-added,
  yet Undo reported success.
- **#491** — undo resurrected overrides the user had deleted *independently*
  before truncating (the #287 class, on the undo path), because
  `RestoreEventsByUID` un-hides every soft-deleted row sharing the UID.

Both validated as real: reproduced with two failing tests on the `RestoreUndo`
path before the fix.

## Fix

One durable, consolidating fix for both: route the undo through the existing
`event_truncate_deletes` log via `restoreTruncationByLogID`, which already

- rewrites the master RRULE back,
- re-adds exactly the trimmed RDATEs (`restoreTruncatedRDates`, the #463 fix), and
- un-hides only the overrides the truncation itself hid
  (`restoreTruncatedOverrides`, the #287 fix).

`restoreFromInstance` keeps its stale-master guard, then captures the cutoff in
`UndoMeta` and looks up the log row by its unique `(uid, cutoff_time)` key
(new sqlc query `GetEventTruncateDeleteByUIDAndCutoff`). Consuming the log row
on undo also clears the phantom "Series tail" trash entry that previously
lingered for a now-live series.

## Tests

- `TestSoftDelete_FromInstanceUndo_ReAddsRDates` (#490)
- `TestSoftDelete_FromInstanceUndo_KeepsIndependentlyDeletedOverride` (#491)

Both fail on `master` and pass with this change. `go build ./...`, the full
`go test ./...` suite, `go vet`, and `golangci-lint` (0 issues) all green.

Closes #490
Closes #491
