### PR TITLE
fix(tui): guard disabled-field clicks and key select arrows by index

### DIFF
--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -297,6 +297,19 @@ type SelectField struct {
 	renderLabel func(SelectOption, bool) string
 	highlight   selectHighlight
 	flashID     int // incremented per flash; stale ticks are ignored
+	// arrowIndex keys the prev/next mouse targets by form-field index when
+	// arrowIndexed is set, so clicking an unfocused select's arrow can resolve
+	// to the owning field (issue #498). Nested selects (e.g. the monthly select
+	// inside RecurrenceOnField) leave it unset and keep the generic targets.
+	arrowIndex   int
+	arrowIndexed bool
+}
+
+// SetArrowIndex keys this select's prev/next arrow mouse targets to a form-field
+// index, so a click on an unfocused arrow resolves to the right field.
+func (f *SelectField) SetArrowIndex(i int) {
+	f.arrowIndex = i
+	f.arrowIndexed = true
 }
 
 func NewSelectField(options []SelectOption) *SelectField {
@@ -413,7 +426,13 @@ func (f *SelectField) View() string {
 		next = flash.Render(next)
 	}
 
-	return label + "  " + mouseMark("select:prev", prev) + " " + mouseMark("select:next", next)
+	prevTarget, nextTarget := "select:prev", "select:next"
+	if f.arrowIndexed {
+		prevTarget = fmt.Sprintf("select:prev:%d", f.arrowIndex)
+		nextTarget = fmt.Sprintf("select:next:%d", f.arrowIndex)
+	}
+
+	return label + "  " + mouseMark(prevTarget, prev) + " " + mouseMark(nextTarget, next)
 }
 
 func (f *SelectField) Focus() tea.Cmd {
@@ -1356,6 +1375,9 @@ func (f *TimeRangeField) SetDisabled(v bool)     { f.disabled = v }
 func (f *TimeRangeField) Value() string { return f.start.Value() }
 
 func (f *TimeRangeField) Update(msg tea.Msg) tea.Cmd {
+	if f.disabled {
+		return nil
+	}
 	active := f.start
 	if f.subFocus != 0 {
 		active = f.end
@@ -1402,6 +1424,9 @@ func (f *TimeRangeField) View() string {
 }
 
 func (f *TimeRangeField) Focus() tea.Cmd {
+	if f.disabled {
+		return nil
+	}
 	f.focused = true
 	f.subFocus = 0
 	f.end.Blur()
@@ -1923,6 +1948,12 @@ func (f Form) fieldParts() []string {
 			continue
 		}
 
+		// Key a top-level select's arrow targets by field index so clicking an
+		// unfocused arrow resolves to the owning field (issue #498).
+		if sf, ok := item.Field.(*SelectField); ok {
+			sf.SetArrowIndex(i)
+		}
+
 		field := mouseMark(fieldTarget(i), item.Field.View())
 		hasError := f.error != "" && i == f.errorField
 
@@ -2370,6 +2401,30 @@ func (f Form) handleClick(target string) (Form, tea.Cmd) {
 		return f, nil
 	}
 
+	// Index-keyed select arrows: "select:prev:i" / "select:next:i" focus the
+	// owning field and apply the keypress in one click, even when the select
+	// was unfocused (issue #498).
+	if strings.HasPrefix(target, "select:prev:") || strings.HasPrefix(target, "select:next:") {
+		key := "right"
+		prefix := "select:next:"
+		if strings.HasPrefix(target, "select:prev:") {
+			key = "left"
+			prefix = "select:prev:"
+		}
+		if idx, err := strconv.Atoi(strings.TrimPrefix(target, prefix)); err == nil &&
+			idx >= 0 && idx < len(f.items) {
+			if sf, ok := f.items[idx].Field.(*SelectField); ok {
+				f, _ = f.focusIndex(idx)
+				cmd := sf.Update(keyMsg(key))
+				if f.onRebuild != nil {
+					f.onRebuild(&f)
+				}
+				return f, cmd
+			}
+		}
+		return f, nil
+	}
+
 	// Palette swatch clicks: "palette:N" selects swatch N and focuses the
 	// field. Works for both standalone PaletteField and the composite
 	// ColorField.
@@ -2432,6 +2487,11 @@ func (f Form) handleClick(target string) (Form, tea.Cmd) {
 
 	for i := range f.items {
 		if target == fieldTarget(i) {
+			// Mirror Tab, which skips non-focusable fields: a click must not
+			// focus or edit a disabled field (issue #497).
+			if !f.items[i].Field.IsFocusable() {
+				return f, nil
+			}
 			if cb, ok := f.items[i].Field.(*CheckboxField); ok {
 				cb.Toggle()
 				if f.onRebuild != nil {

--- a/internal/tui/form_click_focus_test.go
+++ b/internal/tui/form_click_focus_test.go
@@ -1,0 +1,85 @@
+package tui
+
+import (
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zoneCenterByName returns the center coordinates of the most recently swept
+// mouse zone with the given name, or ok=false when no such zone exists.
+func zoneCenterByName(name string) (x, y int, ok bool) {
+	for _, z := range defaultMouseTracker.zones {
+		if z.name == name {
+			return (z.startX + z.endX) / 2, (z.startY + z.endY) / 2, true
+		}
+	}
+	return 0, 0, false
+}
+
+// TestForm_ClickDisabledTimeRangeDoesNotFocusOrEdit is a regression test for
+// issue #497: a mouse click on a disabled field must behave like Tab, which
+// skips non-focusable fields. Clicking a disabled (all-day) time-range field
+// previously focused its inner text input and let keystrokes mutate the locked
+// start/end.
+func TestForm_ClickDisabledTimeRangeDoesNotFocusOrEdit(t *testing.T) {
+	tr := NewTimeRangeField(lipgloss.Color("240"))
+	tr.SetStartValue("09:00")
+	tr.SetEndValue("10:00")
+	tr.SetDisabled(true)
+
+	form := newTestForm(
+		FormItem{Label: "Name", Field: NewTextField("name")},
+		FormItem{Label: "Time", Field: tr},
+	)
+	require.Equal(t, 0, form.Focused())
+
+	// Click directly on the disabled time-range field's registered zone.
+	formClickTarget(&form, "field:1")
+	assert.Equal(t, 0, form.Focused(),
+		"clicking a disabled field must not move focus to it")
+
+	// A subsequent keystroke must not edit the locked start/end values.
+	form = updateForm(form, keyPressMsg("9"))
+	assert.Equal(t, "09:00", tr.StartValue(), "disabled start must stay locked")
+	assert.Equal(t, "10:00", tr.EndValue(), "disabled end must stay locked")
+}
+
+// TestForm_ClickUnfocusedSelectArrowFocusesAndAdvances is a regression test for
+// issue #498: clicking the prev/next arrow of an unfocused SelectField was a
+// mouse dead zone. The arrow targets are now keyed by field index, so a single
+// click both focuses the field and applies the keypress.
+func TestForm_ClickUnfocusedSelectArrowFocusesAndAdvances(t *testing.T) {
+	sel := NewSelectField([]SelectOption{
+		{Label: "Alpha", Value: "a"},
+		{Label: "Bravo", Value: "b"},
+		{Label: "Charlie", Value: "c"},
+	})
+
+	form := newTestForm(
+		FormItem{Label: "Name", Field: NewTextField("name")},
+		FormItem{Label: "Choice", Field: sel},
+	)
+	require.Equal(t, 0, form.Focused(), "focus starts on the first field")
+	require.Equal(t, 0, sel.Selected())
+	require.False(t, sel.focused, "the select must be unfocused for this test")
+
+	// Render and sweep so the arrow zones are registered, then resolve the
+	// next arrow's screen position the way a real mouse click would.
+	_ = mouseSweep(form.View())
+	x, y, ok := zoneCenterByName("select:next:1")
+	require.True(t, ok, "the next arrow must render an index-keyed mouse zone")
+
+	target := mouseResolve(x, y)
+	require.Equal(t, "select:next:1", target,
+		"resolving the arrow position must yield the index-keyed target")
+
+	form, _ = form.handleClick(target)
+
+	assert.Equal(t, 1, form.Focused(),
+		"clicking an unfocused select's arrow must focus the field")
+	assert.Equal(t, 1, sel.Selected(),
+		"clicking the next arrow must advance the value in the same click")
+}


### PR DESCRIPTION
## Summary

Two mouse hit-testing bugs in `internal/tui/form.go` `handleClick`, fixed together.

### #497 — clicks focus/edit disabled fields
The `field:i` click branch focused any matching field with no `IsFocusable()` guard, unlike Tab. Clicking a disabled all-day time-range focused its inner text input and let keystrokes mutate the locked start/end. Now the branch returns early when the clicked field is not focusable, mirroring Tab. Added defensive `disabled` guards to `TimeRangeField.Update`/`Focus`.

### #498 — unfocused select arrow is a dead zone
`SelectField` arrows rendered generic `select:prev`/`select:next` targets that `handleClick` resolved only via `focusedSelect` (which requires `.focused`). Clicking an unfocused select's arrow did nothing. Arrow targets are now keyed by field index (`select:prev:i` / `select:next:i`), so a single click focuses the field and applies the keypress. The generic targets remain for the nested monthly select inside `RecurrenceOnField`, still resolved via `focusedSelect`.

## Tests

`internal/tui/form_click_focus_test.go`:
- `TestForm_ClickDisabledTimeRangeDoesNotFocusOrEdit` — a click on a disabled time-range neither focuses it nor edits the locked values.
- `TestForm_ClickUnfocusedSelectArrowFocusesAndAdvances` — clicking an unfocused select's next arrow (resolved through the real sweep/resolve mouse path) focuses the field and advances the value in one click.

Both fail before the fix and pass after. Full `go test ./internal/tui/` passes; `go build ./...`, `gofmt`, and `go vet` are clean.

Closes #497
Closes #498