### PR TITLE
fix(tui): sync dynamic event-form fields and end-date tz on live model

### DIFF
--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -334,9 +334,16 @@ func NewEventFormModel(day time.Time, calendars map[int64]CalendarInfo, theme Th
 }
 
 // multiDayEndDate reports whether the event spans more than one calendar
-// day and, if so, returns the last included day (inclusive, local). For
-// all-day events the stored end is exclusive midnight of the day after
-// the last included day; for timed events the actual end instant is used.
+// day and, if so, returns the last included day (inclusive). For all-day
+// events the stored end is exclusive midnight of the day after the last
+// included day; for timed events the actual end instant is used.
+//
+// Timed events are evaluated in the event's display timezone (the same loc
+// NewEventFormModelForEditInstance uses to anchor m.day and render the Time
+// field), not machine-local. Using machine-local here would disagree with
+// the start day on the last calendar day when ev.Timezone != local and the
+// end instant is near midnight, shifting the saved end forward a day on a
+// no-op edit (issue #499).
 func multiDayEndDate(ev event.Event) (time.Time, bool) {
 	if ev.AllDay {
 		s := ev.StartTime.UTC()
@@ -350,8 +357,14 @@ func multiDayEndDate(ev event.Event) (time.Time, bool) {
 		}
 		return time.Time{}, false
 	}
-	s := ev.StartTime.Local()
-	e := ev.EndTime.Local()
+	displayLoc := time.Local
+	if ev.Timezone != "" {
+		if loc, err := time.LoadLocation(ev.Timezone); err == nil {
+			displayLoc = loc
+		}
+	}
+	s := ev.StartTime.In(displayLoc)
+	e := ev.EndTime.In(displayLoc)
 	startDay := time.Date(s.Year(), s.Month(), s.Day(), 0, 0, 0, 0, s.Location())
 	endDay := time.Date(e.Year(), e.Month(), e.Day(), 0, 0, 0, 0, e.Location())
 	// If the end instant is exactly midnight of the next day, the event
@@ -619,9 +632,11 @@ func (m *EventFormModel) buildDialogAndForm() {
 		}
 		return nil
 	})
-	m.form.OnRebuild(func(f *Form) {
-		m.syncFromForm()
-	})
+	// No OnRebuild closure: it would capture the construction-time value
+	// receiver, so its syncFromForm would mutate a stale copy's form rather
+	// than the live one the app holds (issue #496). EventFormModel.Update
+	// calls m.syncFromForm() on the live receiver after every form.Update
+	// instead, mirroring RecurrenceEditorModel.
 	m.body = viewport.New()
 	m.body.MouseWheelEnabled = true
 }
@@ -742,10 +757,25 @@ func (m *EventFormModel) syncFromForm() {
 		m.ends != prevEnds
 
 	if needRebuild {
+		focused := m.form.Focused()
 		items, keys := m.buildFormItems()
 		m.fieldKeys = keys
 		m.form.RemoveItems(0)
 		m.form.AppendItems(items...)
+		// Re-clamp focus: a rebuild can shrink the form (e.g. Repeat→None
+		// drops the Ends field). The OnRebuild closure used to do this on the
+		// live form; now that Update drives syncFromForm we own it here,
+		// mirroring RecurrenceEditorModel.syncFromForm.
+		if focused >= m.form.totalCount() {
+			focused = m.form.totalCount() - 1
+		}
+		if focused < 0 {
+			focused = 0
+		}
+		m.form.focused = focused
+		if m.form.focused < len(m.form.items) && !m.form.items[m.form.focused].Field.IsFocusable() {
+			m.form, _ = m.form.skipToFocusable(1)
+		}
 	}
 }
 
@@ -981,6 +1011,10 @@ func (m EventFormModel) Update(msg tea.Msg) (EventFormModel, tea.Cmd) {
 			target := mouseResolve(mc.X-ox, mc.Y-oy)
 			var cmd tea.Cmd
 			m.form, cmd = m.form.Update(MouseEvent{IsClick: true, Target: target})
+			// Sync dynamic fields against the live receiver (issue #496):
+			// a click that toggles All-day or changes Repeat/Ends must
+			// rebuild the live form, not a stale construction-time copy.
+			m.syncFromForm()
 			// A click landing on the focused field's row opens its overlay,
 			// mirroring the Enter path (tryOpenOverlay) so mouse and keyboard
 			// behave identically for every opener field (Date, Timezone,
@@ -1003,6 +1037,11 @@ func (m EventFormModel) Update(msg tea.Msg) (EventFormModel, tea.Cmd) {
 
 	var cmd tea.Cmd
 	m.form, cmd = m.form.Update(msg)
+	// Rebuild dynamic fields against the live receiver (issue #496). The
+	// OnRebuild closure could only mutate a stale construction-time copy, so
+	// the live form never gained the Ends selector / Ends-count field and
+	// the All-day toggle never re-disabled the Time field.
+	m.syncFromForm()
 	m.syncBodyViewport(true)
 	return m, cmd
 }

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -568,3 +568,91 @@ func TestEventForm_EditTimedMultiDayMidnightEndPreservesEnd(t *testing.T) {
 	assert.Truef(t, end.Equal(msg.EndTime),
 		"no-op edit shifted end: want %s, got %s", end, msg.EndTime)
 }
+
+// TestEventForm_RepeatChangeAddsEndsFieldToLiveForm guards issue #496: changing
+// Repeat from None to a preset on the LIVE form (via Update, as a real key press
+// would) must rebuild the rendered form so the inline "Ends" selector appears.
+// The old OnRebuild closure ran syncFromForm against a stale value-captured copy,
+// so the live form never grew and form-created recurrences were endless.
+func TestEventForm_RepeatChangeAddsEndsFieldToLiveForm(t *testing.T) {
+	m, _ := NewEventFormModel(time.Date(2026, 7, 5, 0, 0, 0, 0, time.Local),
+		map[int64]CalendarInfo{1: {}}, NewTheme(true))
+
+	repeatIdx := -1
+	for i, item := range m.form.items {
+		if item.Label == "Repeat" {
+			repeatIdx = i
+			break
+		}
+	}
+	if repeatIdx < 0 {
+		t.Fatal("Repeat field not found in form")
+	}
+	m.form.focused = repeatIdx
+
+	before := len(m.form.items)
+
+	// Drive a real "→" key press through the live model, advancing Repeat
+	// from None to the first preset.
+	m, _ = m.Update(keyMsg("right"))
+
+	if m.repeatField.Selected() == 0 {
+		t.Fatal("precondition failed: Repeat selection did not advance off None")
+	}
+
+	after := len(m.form.items)
+	if after <= before {
+		t.Errorf("live form item count did not grow after Repeat change: before=%d after=%d (Ends field never reached live form)", before, after)
+	}
+
+	hasEnds := false
+	for _, item := range m.form.items {
+		if item.Label == "Ends" {
+			hasEnds = true
+			break
+		}
+	}
+	if !hasEnds {
+		t.Error("live form is missing the 'Ends' field after enabling recurrence")
+	}
+}
+
+// TestEventFormForEdit_MultiDayEndUsesDisplayTimezone guards issue #499: the
+// pre-filled multi-day end date must be computed in the event's display
+// timezone (the loc used to anchor m.day), not machine-local. Otherwise an
+// event whose tz != machine-local with an end near midnight gets an off-by-one
+// end day, so a no-op edit shifts the event end forward a day on save.
+func TestEventFormForEdit_MultiDayEndUsesDisplayTimezone(t *testing.T) {
+	// Force machine-local to UTC so the scenario is deterministic regardless
+	// of where the test runs.
+	origLocal := time.Local
+	time.Local = time.UTC
+	defer func() { time.Local = origLocal }()
+
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	// In New York the event spans two calendar days (Jun 13 20:00 → Jun 14
+	// 01:00). In UTC both instants fall on Jun 14, so a machine-local (UTC)
+	// computation would wrongly see a single day.
+	ev := event.Event{
+		ID:         7,
+		CalendarID: 1,
+		Title:      "Overnight",
+		Timezone:   "America/New_York",
+		StartTime:  time.Date(2026, 6, 13, 20, 0, 0, 0, loc),
+		EndTime:    time.Date(2026, 6, 14, 1, 0, 0, 0, loc),
+	}
+
+	m, _ := NewEventFormModelForEdit(ev, map[int64]CalendarInfo{1: {}}, NewTheme(true))
+
+	if !m.rangeHasEnd {
+		t.Fatal("expected multi-day range to be detected in the display timezone")
+	}
+	want := time.Date(2026, 6, 14, 0, 0, 0, 0, loc)
+	if m.rangeEndDate.Year() != want.Year() ||
+		m.rangeEndDate.Month() != want.Month() ||
+		m.rangeEndDate.Day() != want.Day() {
+		t.Errorf("rangeEndDate = %v, want display-tz day %v", m.rangeEndDate, want)
+	}
+}


### PR DESCRIPTION
Fixes two bugs in `internal/tui/event_form.go`, both rooted in the form's value-receiver lifecycle and timezone handling.

## #496 — dynamic recurrence "Ends" fields never reach the live form

`EventFormModel.buildDialogAndForm` registered `form.OnRebuild(func(f *Form){ m.syncFromForm() })`, but the closure captured the **construction-time value receiver**. The app holds and updates a *copy* whose `Form` is a distinct struct, so `RemoveItems`/`AppendItems` mutated the stale copy and never the live form. Result: changing Repeat None→preset never added the inline **Ends** selector (form-created recurrences were endless), and a live All-day toggle never re-disabled the Time field.

**Fix:** drop the `OnRebuild` closure and call `m.syncFromForm()` on the **live** receiver in `EventFormModel.Update` after every `form.Update` (and in the mouse-click branch), mirroring the already-correct `RecurrenceEditorModel`. `syncFromForm` now re-clamps focus on rebuild (the dropped `OnRebuild` path used to do that).

## #499 — multi-day timed end-date computed in machine-local zone

`multiDayEndDate` used `ev.StartTime.Local()`/`ev.EndTime.Local()`, while `NewEventFormModelForEditInstance` re-anchors `m.day` to the event's display tz (the #91 fix). When tz ≠ machine-local and the end is near midnight, the two disagreed on the last calendar day, so a no-op edit shifted the end +1 day on save.

**Fix:** resolve `displayLoc` from `ev.Timezone` (same logic the form uses to anchor `m.day`) and compute the end day with `.In(displayLoc)`.

## Tests

Both added to `internal/tui/event_form_test.go`, confirmed failing before the fix and passing after:
- `TestEventForm_RepeatChangeAddsEndsFieldToLiveForm` — drives a real `→` key press through `Update`; asserts the live form grows and gains the "Ends" item.
- `TestEventFormForEdit_MultiDayEndUsesDisplayTimezone` — `America/New_York` overnight event with machine-local forced to UTC; asserts the prefilled `rangeEndDate` matches the display-tz calendar day (no off-by-one).

`go build ./...`, `go vet`, `gofmt`, and the full test suite pass.

Closes #496
Closes #499
