### PR TITLE
fix(sync): guard accept-server import rev capture and empty server body (#494, #495)

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -514,18 +514,31 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 							result.conflicts++
 							continue
 						}
-						if _, err := e.importICal(ctx, calendarID, buf.String()); err != nil {
+						imported, revs, err := e.importICal(ctx, calendarID, buf.String())
+						if err != nil {
 							e.logger.Error("import server resource failed", "uid", res.Uid, "error", err)
 							result.errors = append(result.errors, fmt.Errorf("import server resource %s: %w", res.Uid, err))
 							result.conflicts++
 							continue
 						}
-						// Clear dirty and update ETag to accept server version.
-						// Guard the clear on the post-import rev so a local edit
-						// landing between the import and here is not silently
-						// dropped (lost update). See issues #92 and #417.
-						if err := e.clearDirtyAfterImport(ctx, calendarID, res.Uid, serverRes.ETag); err != nil {
-							e.logger.Error("clear dirty after conflict", "uid", res.Uid, "error", err)
+						if !imported {
+							// The server's 412 body carried no importable
+							// VEVENT/VTODO/VJOURNAL, so nothing was applied.
+							// Clearing dirty and stamping the server ETag here
+							// would drop the local edit behind a server version we
+							// never adopted. Keep dirty so the next push retries;
+							// the conflict is still counted below. Mirrors the
+							// manual ResolveConflict guard. See issue #495.
+							e.logger.Warn("server resource has no importable data; keeping local dirty", "uid", res.Uid)
+						} else {
+							// Clear dirty and update ETag to accept server version.
+							// Guard the clear on the rev persistImported captured
+							// inside its transaction so a local edit landing after
+							// the import committed is not silently dropped (lost
+							// update). See issues #92, #417 and #494.
+							if err := e.clearDirtyAfterImport(ctx, calendarID, res.Uid, serverRes.ETag, revs[res.Uid]); err != nil {
+								e.logger.Error("clear dirty after conflict", "uid", res.Uid, "error", err)
+							}
 						}
 					}
 				} else {
@@ -629,30 +642,33 @@ func (e *Engine) putAlreadyLanded(ctx context.Context, client *caldav.Client, pa
 	return serverRes.ETag, true
 }
 
-// afterImportRevCapture, when non-nil, runs inside clearDirtyAfterImport between
-// reading the post-import rev and the conditional clear. It is nil in production
-// and exists only so tests can simulate a concurrent local edit landing in that
-// window to exercise the rev guard. See issue #417.
+// afterImportRevCapture, when non-nil, runs inside clearDirtyAfterImport just
+// before the conditional clear. It is nil in production and exists only so tests
+// can simulate a concurrent local edit landing between the import and the clear
+// to exercise the rev guard. See issue #417.
 var afterImportRevCapture func()
+
+// afterImportPersist, when non-nil, runs inside importICal right after
+// persistImported commits and before the caller's clearDirtyAfterImport. It is
+// nil in production and exists only so tests can simulate a concurrent local edit
+// landing in the persist-commit→clear window to exercise the rev guard now that
+// the rev is captured inside the persist transaction. See issue #494.
+var afterImportPersist func()
 
 // clearDirtyAfterImport adopts the server ETag and clears the dirty flag for a
 // resource whose local row we just overwrote with the server's version
 // (accept-server conflict resolution or a pull), but only when no local edit has
 // landed since the import. importICal/persistImported route through the
 // event/todo/journal services, which flip dirty=1 and bump rev via
-// MarkResourceDirty as a side effect; we read that post-import rev and feed it to
-// FinalizePushedResource so the clear becomes a no-op when a concurrent user edit
-// bumped rev again before we got here. An unconditional clear would wipe that
-// edit's dirty flag and silently drop it — the same lost-update race
-// FinalizePushedResource guards on the push path. See issues #92 and #417.
-func (e *Engine) clearDirtyAfterImport(ctx context.Context, calendarID int64, uid, etag string) error {
-	res, err := e.q.GetSyncResource(ctx, storage.GetSyncResourceParams{
-		CalendarID: calendarID,
-		Uid:        uid,
-	})
-	if err != nil {
-		return err
-	}
+// MarkResourceDirty as a side effect; persistImported captures that post-import
+// rev inside the same transaction and the caller feeds it here as rev. Passing it
+// to FinalizePushedResource makes the clear a no-op when a concurrent user edit
+// bumped rev again after the import committed. An unconditional clear would wipe
+// that edit's dirty flag and silently drop it — the same lost-update race
+// FinalizePushedResource guards on the push path. Capturing rev inside the persist
+// transaction (rather than re-reading it after commit) also closes the narrow
+// window between persist-commit and the read. See issues #92, #417 and #494.
+func (e *Engine) clearDirtyAfterImport(ctx context.Context, calendarID int64, uid, etag string, rev int64) error {
 	if afterImportRevCapture != nil {
 		afterImportRevCapture()
 	}
@@ -660,7 +676,7 @@ func (e *Engine) clearDirtyAfterImport(ctx context.Context, calendarID int64, ui
 		CalendarID: calendarID,
 		Uid:        uid,
 		Etag:       etag,
-		Rev:        res.Rev,
+		Rev:        rev,
 	})
 }
 
@@ -841,7 +857,8 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 
 		// Persist imported data to the database
 		ownerType := detectOwnerType(importResult)
-		if persistErr := e.persistImported(ctx, calendarID, importResult); persistErr != nil {
+		revs, persistErr := e.persistImported(ctx, calendarID, importResult)
+		if persistErr != nil {
 			e.logger.Error("persist imported resource", "uid", uid, "path", res.Path, "error", persistErr)
 			continue
 		}
@@ -864,10 +881,11 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 		// persistImported flips dirty=1 via the Replace* services'
 		// MarkResourceDirty side effect, and UpsertSyncResource's MAX
 		// clause preserves it. Clear dirty — the server's version is now
-		// authoritative — but guard the clear on the post-import rev so a
-		// concurrent local edit is not silently dropped (issue #417). See
-		// applySyncCollection for the full note.
-		if err := e.clearDirtyAfterImport(ctx, calendarID, uid, res.ETag); err != nil {
+		// authoritative — but guard the clear on the rev persistImported
+		// captured inside its transaction so a concurrent local edit is not
+		// silently dropped (issues #417 and #494). See applySyncCollection
+		// for the full note.
+		if err := e.clearDirtyAfterImport(ctx, calendarID, uid, res.ETag, revs[uid]); err != nil {
 			e.logger.Warn("clear post-import dirty", "uid", uid, "error", err)
 		}
 
@@ -1133,7 +1151,8 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 				continue
 			}
 			ownerType := detectOwnerType(importResult)
-			if persistErr := e.persistImported(ctx, calendarID, importResult); persistErr != nil {
+			revs, persistErr := e.persistImported(ctx, calendarID, importResult)
+			if persistErr != nil {
 				// A changed body we fetched but couldn't store (transient
 				// SQLite busy/lock, or a malformed component a Replace*
 				// rejects). Leave the sync_resource on its old etag and count
@@ -1164,9 +1183,10 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 			// every pull re-dirties everything it just absorbed and the next
 			// push round-trips it back to the server. Clear dirty since the
 			// server's version is now authoritative locally, but guard the
-			// clear on the post-import rev so a concurrent local edit is not
-			// silently dropped (issue #417).
-			if err := e.clearDirtyAfterImport(ctx, calendarID, uid, res.ETag); err != nil {
+			// clear on the rev persistImported captured inside its transaction
+			// so a concurrent local edit is not silently dropped (issues #417
+			// and #494).
+			if err := e.clearDirtyAfterImport(ctx, calendarID, uid, res.ETag, revs[uid]); err != nil {
 				e.logger.Warn("clear post-import dirty", "uid", uid, "error", err)
 			}
 			result.pulled++
@@ -1555,7 +1575,17 @@ func hydrateJournal(ctx context.Context, e *Engine, j *journal.Journal) {
 
 // persistImported saves parsed iCal data to the local database using the same
 // upsert pattern as the CLI import command.
-func (e *Engine) persistImported(ctx context.Context, calendarID int64, result icalPkg.ImportResult) error {
+//
+// It returns the post-import sync_resources.rev for each persisted UID, read
+// inside the same transaction that bumped it via MarkResourceDirty. Accept-server
+// callers feed that rev to FinalizePushedResource so the dirty clear is guarded
+// on a rev captured atomically with the import, rather than re-read after commit
+// where a concurrent local edit could slip in and have its dirty flag wiped — the
+// lost-update window of issue #494. A UID with no tracking row yet (a first pull)
+// reports rev 0.
+func (e *Engine) persistImported(ctx context.Context, calendarID int64, result icalPkg.ImportResult) (map[string]int64, error) {
+	revs := make(map[string]int64)
+
 	// Store timezones
 	for _, tz := range result.Timezones {
 		if _, err := e.q.UpsertTimezone(ctx, storage.UpsertTimezoneParams{
@@ -1617,9 +1647,14 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			if err := events.ReplaceXProperties(ctx, saved.ID, ev.XProperties); err != nil {
 				return fmt.Errorf("replace xproperties for event %q: %w", ev.UID, err)
 			}
+			rev, err := captureImportRev(ctx, e.q.WithTx(tx), calendarID, ev.UID)
+			if err != nil {
+				return fmt.Errorf("capture rev for event %q: %w", ev.UID, err)
+			}
+			revs[ev.UID] = rev
 			return nil
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -1668,9 +1703,14 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			if err := todos.ReplaceXProperties(ctx, saved.ID, t.XProperties); err != nil {
 				return fmt.Errorf("replace xproperties for todo %q: %w", t.UID, err)
 			}
+			rev, err := captureImportRev(ctx, e.q.WithTx(tx), calendarID, t.UID)
+			if err != nil {
+				return fmt.Errorf("capture rev for todo %q: %w", t.UID, err)
+			}
+			revs[t.UID] = rev
 			return nil
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -1711,13 +1751,36 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			if err := journals.ReplaceXProperties(ctx, saved.ID, j.XProperties); err != nil {
 				return fmt.Errorf("replace xproperties for journal %q: %w", j.UID, err)
 			}
+			rev, err := captureImportRev(ctx, e.q.WithTx(tx), calendarID, j.UID)
+			if err != nil {
+				return fmt.Errorf("capture rev for journal %q: %w", j.UID, err)
+			}
+			revs[j.UID] = rev
 			return nil
 		}); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return revs, nil
+}
+
+// captureImportRev reads the sync_resources.rev for uid using qtx (a Queries
+// bound to the import's transaction), so the value reflects the rev as bumped by
+// this import and nothing committed after it. A UID with no tracking row yet (a
+// first pull, before UpsertSyncResource creates it) reports rev 0. See #494.
+func captureImportRev(ctx context.Context, qtx *storage.Queries, calendarID int64, uid string) (int64, error) {
+	res, err := qtx.GetSyncResource(ctx, storage.GetSyncResourceParams{
+		CalendarID: calendarID,
+		Uid:        uid,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return res.Rev, nil
 }
 
 // inTx runs fn inside a single transaction, committing on success and rolling
@@ -1746,10 +1809,10 @@ func (e *Engine) inTx(ctx context.Context, fn func(*sql.Tx) error) error {
 // input, so callers that must not accept the server version without applying it
 // (e.g. clearing the dirty flag) check imported to avoid silently stamping the
 // server ETag onto an unchanged local row.
-func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) (imported bool, err error) {
+func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) (imported bool, revs map[string]int64, err error) {
 	importResult, err := icalPkg.ImportFile(strings.NewReader(data))
 	if err != nil {
-		return false, fmt.Errorf("import ical: %w", err)
+		return false, nil, fmt.Errorf("import ical: %w", err)
 	}
 	// imported reflects whether the SERVER payload carried any component. It is
 	// computed before tombstone filtering so the empty-iCal guard in callers
@@ -1766,12 +1829,16 @@ func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) 
 	// ConflictServerWins — consistent with it. Issue #89 gap #2.
 	importResult, err = e.dropTombstonedFromImport(ctx, calendarID, importResult)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
-	if err := e.persistImported(ctx, calendarID, importResult); err != nil {
-		return false, err
+	revs, err = e.persistImported(ctx, calendarID, importResult)
+	if err != nil {
+		return false, nil, err
 	}
-	return imported, nil
+	if afterImportPersist != nil {
+		afterImportPersist()
+	}
+	return imported, revs, nil
 }
 
 // dropTombstonedFromImport removes events/todos/journals whose UID is

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -689,7 +689,7 @@ func TestEnginePersistImportedKeepsDirtyOnChildReplaceError(t *testing.T) {
 		}},
 	}
 
-	if err := engine.persistImported(ctx, calendarID, result); err == nil {
+	if _, err := engine.persistImported(ctx, calendarID, result); err == nil {
 		t.Fatal("persistImported returned nil, want child-replace error to propagate")
 	}
 
@@ -3052,7 +3052,7 @@ END:VCALENDAR
 	if err != nil {
 		t.Fatalf("ImportFile (with alarm): %v", err)
 	}
-	if err := engine.persistImported(ctx, calendarID, withAlarmResult); err != nil {
+	if _, err := engine.persistImported(ctx, calendarID, withAlarmResult); err != nil {
 		t.Fatalf("persistImported (with alarm): %v", err)
 	}
 
@@ -3086,7 +3086,7 @@ END:VCALENDAR
 	if err != nil {
 		t.Fatalf("ImportFile (no alarm): %v", err)
 	}
-	if err := engine.persistImported(ctx, calendarID, noAlarmResult); err != nil {
+	if _, err := engine.persistImported(ctx, calendarID, noAlarmResult); err != nil {
 		t.Fatalf("persistImported (no alarm): %v", err)
 	}
 
@@ -3254,7 +3254,7 @@ func TestPersistImportedRollsBackOnReplaceFailure(t *testing.T) {
 		t.Fatalf("drop event_comments: %v", err)
 	}
 
-	if err := engine.persistImported(ctx, calendarID, result); err == nil {
+	if _, err := engine.persistImported(ctx, calendarID, result); err == nil {
 		t.Fatal("expected persistImported to fail when a Replace step errors")
 	}
 
@@ -3464,5 +3464,165 @@ func TestEnginePushServerWinsPreservesConcurrentEdit(t *testing.T) {
 	// matches the server, mirroring FinalizePushedResource on the push path.
 	if res.Etag != "etag-server" {
 		t.Fatalf("etag = %q, want %q", res.Etag, "etag-server")
+	}
+}
+
+// TestEnginePushServerWinsPreservesConcurrentEditAfterPersist reproduces issue
+// #494: a local edit that commits between the accept-server import's persist
+// commit and the dirty clear must not be silently dropped. The afterImportPersist
+// hook fires in that window — after persistImported committed, before
+// clearDirtyAfterImport — and bumps rev + re-marks dirty exactly as a real
+// service-layer mutation would. Because persistImported now captures the
+// post-import rev inside its own transaction (rather than re-reading it after
+// commit, where this edit's bump would be read and matched), the rev-guarded
+// clear leaves the resource dirty. With the old after-commit re-read this test
+// fails: the clear reads the edit's bumped rev and wipes dirty. Serial (no
+// t.Parallel) because it mutates the package-level hook.
+func TestEnginePushServerWinsPreservesConcurrentEditAfterPersist(t *testing.T) {
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+	calendarID := linkCalendarToTestAccount(t, ctx, q)
+
+	insertTestEvent(t, db, calendarID, "srv-wins-persist-race")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "srv-wins-persist-race",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/srv-wins-persist-race.ics",
+		Etag:         `"etag-before"`,
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	// Simulate a concurrent local edit landing after the import committed but
+	// before the dirty clear. persistImported already released its connection,
+	// so this auto-commit write is safe under SetMaxOpenConns(1).
+	var fired int
+	afterImportPersist = func() {
+		fired++
+		if err := storage.MarkResourceDirty(ctx, db, calendarID, "srv-wins-persist-race", "event"); err != nil {
+			t.Errorf("simulate concurrent edit: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterImportPersist = nil })
+
+	client := serverWinsConflictClient(t, "srv-wins-persist-race")
+	if _, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("afterImportPersist fired %d times, want 1", fired)
+	}
+
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: calendarID, Uid: "srv-wins-persist-race"})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Dirty != 1 {
+		t.Fatalf("dirty = %d, want 1 (concurrent edit must not be dropped, #494)", res.Dirty)
+	}
+	// The ETag still advances to the server's version, mirroring
+	// FinalizePushedResource on the push path.
+	if res.Etag != "etag-server" {
+		t.Fatalf("etag = %q, want %q", res.Etag, "etag-server")
+	}
+}
+
+// emptyServerWinsConflictClient is like serverWinsConflictClient but its GET
+// returns a VCALENDAR carrying only a VTIMEZONE — a non-empty body the encoder
+// accepts, yet with no importable VEVENT/VTODO/VJOURNAL, simulating a 412'd
+// resource whose server body has nothing to apply (issue #495).
+func emptyServerWinsConflictClient(t *testing.T, uid string) *caldav.Client {
+	t.Helper()
+	path := "/calendar/" + uid + ".ics"
+	return newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodPut:
+			return &http.Response{
+				StatusCode: http.StatusPreconditionFailed,
+				Status:     "412 Precondition Failed",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("precondition failed")),
+				Request:    r,
+			}, nil
+		case http.MethodGet:
+			if r.URL.Path != path {
+				t.Fatalf("GET path = %s, want %s", r.URL.Path, path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/calendar; charset=utf-8"},
+					"Etag":         []string{`"etag-server"`},
+				},
+				Body: io.NopCloser(strings.NewReader("BEGIN:VCALENDAR\r\n" +
+					"VERSION:2.0\r\n" +
+					"PRODID:-//chroncal//tests//EN\r\n" +
+					"BEGIN:VTIMEZONE\r\n" +
+					"TZID:UTC\r\n" +
+					"BEGIN:STANDARD\r\n" +
+					"DTSTART:19700101T000000\r\n" +
+					"TZOFFSETFROM:+0000\r\n" +
+					"TZOFFSETTO:+0000\r\n" +
+					"END:STANDARD\r\n" +
+					"END:VTIMEZONE\r\n" +
+					"END:VCALENDAR\r\n")),
+				Request: r,
+			}, nil
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+}
+
+// TestEnginePushServerWinsKeepsDirtyWhenServerBodyEmpty reproduces issue #495: on
+// a 412 with ConflictServerWins, if the re-fetched server body carries no
+// importable VEVENT/VTODO/VJOURNAL, importICal applies nothing. The auto-resolve
+// must not clear dirty or stamp the server ETag — doing so would drop the local
+// edit behind a server version that was never adopted, the asymmetry the manual
+// ResolveConflict path already guards against (#466). With the previous
+// unconditional clear this test fails because dirty is wiped and the ETag is
+// advanced without anything applied.
+func TestEnginePushServerWinsKeepsDirtyWhenServerBodyEmpty(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+	calendarID := linkCalendarToTestAccount(t, ctx, q)
+
+	insertTestEvent(t, db, calendarID, "srv-wins-empty")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "srv-wins-empty",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/srv-wins-empty.ics",
+		Etag:         `"etag-before"`,
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	client := emptyServerWinsConflictClient(t, "srv-wins-empty")
+	if _, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: calendarID, Uid: "srv-wins-empty"})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Dirty != 1 {
+		t.Fatalf("dirty = %d, want 1 (nothing was applied, local edit must survive, #495)", res.Dirty)
+	}
+	// The ETag must NOT be stamped to the server version: nothing from the server
+	// was adopted, so claiming the local row matches the server would let the next
+	// pull overwrite the still-pending local edit.
+	if res.Etag != `"etag-before"` {
+		t.Fatalf("etag = %q, want %q (server version was never applied, #495)", res.Etag, `"etag-before"`)
 	}
 }

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -163,7 +163,7 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 		// the event/todo/journal services, which use their own connection.
 		// UpsertByUID is idempotent, so if the transaction fails to commit the
 		// conflict survives and the whole resolution replays cleanly.
-		imported, err := s.engine.importICal(ctx, conflict.CalendarID, conflict.ServerIcal)
+		imported, _, err := s.engine.importICal(ctx, conflict.CalendarID, conflict.ServerIcal)
 		if err != nil {
 			return fmt.Errorf("import server version: %w", err)
 		}


### PR DESCRIPTION
## Summary

Fixes two sibling gaps to #417/#466 on the **accept-server import** paths in `internal/sync/engine.go`.

### #494 — rev-guard misses the persist→rev-read window
`clearDirtyAfterImport` re-read the post-import rev with a *separate* `GetSyncResource` that ran **after** `persistImported` had already committed. A concurrent local edit committing between the persist-commit and the re-read was read back as the already-bumped rev, so `FinalizePushedResource`'s `WHERE rev = ?` matched and cleared `dirty=0`, stranding the edit (never pushed; adopted server ETag means the next pull won't re-fetch it).

**Fix:** `persistImported` now returns the post-import `sync_resources.rev` for each UID, read **inside the same transaction** that bumped it via `MarkResourceDirty`. Callers feed that rev to the clear, so any edit landing after the import commit leaves rev mismatched and `dirty` stays `1`. Applies to all three accept-server sites: ServerWins push, `pullFullSnapshot`, and `applySyncCollection`.

### #495 — ServerWins auto-resolve ignored `importICal`'s `imported`
The `ConflictServerWins` branch discarded `importICal`'s `imported` result and unconditionally stamped the server ETag + cleared `dirty`. If the 412'd resource's server body carried no importable `VEVENT`/`VTODO`/`VJOURNAL`, nothing was applied yet the local change was dropped behind a server ETag.

**Fix:** Mirror the manual `ResolveConflict` path — when `!imported`, keep `dirty` and skip the clear so the next push retries (the conflict is still counted).

## Tests
- `TestEnginePushServerWinsPreservesConcurrentEditAfterPersist` (#494) — a concurrent edit landing in the persist-commit→clear window (new `afterImportPersist` hook) must keep `dirty=1`. Fails before the fix.
- `TestEnginePushServerWinsKeepsDirtyWhenServerBodyEmpty` (#495) — a ServerWins resolve whose server body (VTIMEZONE-only) imports nothing must keep `dirty=1` and must NOT stamp the server ETag. Fails before the fix.

Both confirmed red before / green after. Full `go test -race ./internal/sync/` passes; `go build ./...`, `gofmt`, `go vet`, and `golangci-lint` all clean.

Closes #494
Closes #495