### PR TITLE
refactor(event): drop dead UndoMeta.MasterRRuleBefore field

### DIFF
--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -47,12 +47,10 @@ type UndoMeta struct {
 	// UndoKindSingle only, when undoing DeleteInstanceWithUndo.
 	RecurrenceID string
 
-	// UndoKindFromInstance only. MasterRRuleBefore records the pre-truncation
-	// RRULE; CutoffTime is the truncation cutoff, used to find the
-	// event_truncate_deletes log row that Undo reverses (so the RRULE, trimmed
-	// RDATEs, and the exact overrides the truncation hid are all restored).
-	// MasterUpdatedBefore is the stale-master guard baseline.
-	MasterRRuleBefore   string
+	// UndoKindFromInstance only. CutoffTime is the truncation cutoff, used to
+	// find the event_truncate_deletes log row that Undo reverses (so the RRULE,
+	// trimmed RDATEs, and the exact overrides the truncation hid are all
+	// restored). MasterUpdatedBefore is the stale-master guard baseline.
 	CutoffTime          time.Time
 	MasterUpdatedBefore time.Time
 }
@@ -100,14 +98,13 @@ func (s *Service) DeleteInstanceWithUndo(ctx context.Context, uid string, instan
 }
 
 // DeleteFromInstanceWithUndo truncates the series at instanceTime and returns
-// the pre-truncation RRULE + master UpdatedAt so Restore can reverse the
-// truncation exactly.
+// the cutoff + master UpdatedAt so Restore can reverse the truncation exactly
+// via the event_truncate_deletes log row.
 func (s *Service) DeleteFromInstanceWithUndo(ctx context.Context, uid string, instanceTime time.Time) (UndoMeta, error) {
 	master, err := s.q.GetEventByUID(ctx, uid)
 	if err != nil {
 		return UndoMeta{}, fmt.Errorf("get master: %w", err)
 	}
-	prevRRule := storage.NullableToString(master.RecurrenceRule)
 
 	// deleteFromInstance bumps the master's updated_at (UpdateEventRecurrenceRule
 	// sets updated_at=now) and returns that post-truncation value, read back
@@ -128,7 +125,6 @@ func (s *Service) DeleteFromInstanceWithUndo(ctx context.Context, uid string, in
 		UID:                 uid,
 		Label:               master.Title,
 		DeletedAt:           time.Now().UTC(),
-		MasterRRuleBefore:   prevRRule,
 		CutoffTime:          instanceTime.UTC(),
 		MasterUpdatedBefore: parseStorageTime(postUpdated),
 	}, nil

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -355,9 +355,6 @@ func TestSoftDelete_FromInstance_RRULE(t *testing.T) {
 	if meta.Kind != UndoKindFromInstance {
 		t.Fatalf("meta.Kind = %v, want UndoKindFromInstance", meta.Kind)
 	}
-	if meta.MasterRRuleBefore != originalRRULE {
-		t.Fatalf("MasterRRuleBefore = %q, want %q", meta.MasterRRuleBefore, originalRRULE)
-	}
 
 	// Verify the master's RRULE was truncated, override soft-deleted.
 	newMaster, err := svc.Get(ctx, master.ID)


### PR DESCRIPTION
## Summary

After #490 consolidated the truncation-undo path, `restoreFromInstance`
reverses a series truncation by replaying the `event_truncate_deletes`
log row (`log.PreviousRrule`) rather than reading
`UndoMeta.MasterRRuleBefore`. The field had become dead state: written in
`DeleteFromInstanceWithUndo`, never read, with a doc comment still
presenting it as load-bearing.

`grep` confirmed exactly two references before this change (the field
declaration and its single write); nothing read it.

## Changes

- Remove the `MasterRRuleBefore` field from `UndoMeta`.
- Remove its assignment and the now-unused `prevRRule` local in
  `DeleteFromInstanceWithUndo`.
- Trim the doc comments (struct field block + method) to cover only
  `CutoffTime` + `MasterUpdatedBefore`.
- Drop the test assertion on the removed field. The existing
  `RestoreUndo` assertion in the same test already verifies the RRULE is
  restored correctly from the log row, so truncation-undo coverage is
  retained.

## Verification

- `go build ./...`
- `go test ./internal/event/ ./internal/trash/` — pass
- `gofmt`, `go vet`, `golangci-lint run ./internal/event/` — 0 issues

No runtime behavior change; pure dead-code/stale-doc cleanup.

Closes #511
