### PR TITLE
fix(sync): use in-tx rev for manual accept-server conflict resolve

### DIFF
--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -130,10 +130,13 @@ func (s *Service) ListConflicts(ctx context.Context) ([]Conflict, error) {
 }
 
 // resolveConflictAfterRevCapture, when non-nil, runs inside ResolveConflict's
-// accept-server path between reading the post-import rev and the rev-guarded
-// dirty clear. It is nil in production and exists only so tests can simulate a
-// concurrent local edit landing in that window to exercise the guard. See the
-// engine's afterImportRevCapture and issue #466.
+// accept-server path between taking the import rev (from importICal's revs map)
+// and the rev-guarded dirty clear. It is nil in production and exists only so
+// tests can simulate a concurrent local edit landing in that window to exercise
+// the guard. The narrower persist-commit window — an edit landing inside
+// importICal right after persistImported commits — is covered by the engine's
+// afterImportPersist hook. See the engine's afterImportRevCapture and issues
+// #466 and #510.
 var resolveConflictAfterRevCapture func()
 
 // ResolveConflict resolves a conflict by picking local or server version.
@@ -163,7 +166,7 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 		// the event/todo/journal services, which use their own connection.
 		// UpsertByUID is idempotent, so if the transaction fails to commit the
 		// conflict survives and the whole resolution replays cleanly.
-		imported, _, err := s.engine.importICal(ctx, conflict.CalendarID, conflict.ServerIcal)
+		imported, revs, err := s.engine.importICal(ctx, conflict.CalendarID, conflict.ServerIcal)
 		if err != nil {
 			return fmt.Errorf("import server version: %w", err)
 		}
@@ -174,20 +177,17 @@ func (s *Service) ResolveConflict(ctx context.Context, conflictID int64, pick st
 			// branch exists to prevent. Refuse instead of resolving falsely.
 			return fmt.Errorf("server version has no importable data for %q", conflict.Uid)
 		}
-		// Capture the post-import rev so the dirty clear can be rev-guarded like
-		// the auto accept-server paths (engine.clearDirtyAfterImport). importICal
-		// bumps rev and re-sets dirty=1 via MarkResourceDirty; a concurrent local
-		// edit landing after this read bumps rev again, and the conditional clear
-		// below then leaves dirty=1 so the edit is still pushed instead of being
-		// silently dropped — the lost-update race of issues #92/#417/#466.
-		res, err := s.q.GetSyncResource(ctx, storage.GetSyncResourceParams{
-			CalendarID: conflict.CalendarID,
-			Uid:        conflict.Uid,
-		})
-		if err != nil {
-			return fmt.Errorf("get sync resource: %w", err)
-		}
-		serverRev = res.Rev
+		// Use the rev importICal captured inside persistImported's transaction so
+		// the dirty clear can be rev-guarded like the auto accept-server paths
+		// (engine.clearDirtyAfterImport). importICal bumps rev and re-sets dirty=1
+		// via MarkResourceDirty; a concurrent local edit committing after that
+		// capture bumps rev again, and the conditional clear below then leaves
+		// dirty=1 so the edit is still pushed instead of being silently dropped —
+		// the lost-update race of issues #92/#417/#466/#494. Re-reading the rev
+		// after commit (as this path did before #510) reopened that window: an
+		// edit landing in the persist-commit→read gap was read back and matched by
+		// the guard, wiping its dirty flag.
+		serverRev = revs[conflict.Uid]
 		if resolveConflictAfterRevCapture != nil {
 			resolveConflictAfterRevCapture()
 		}

--- a/internal/sync/service_test.go
+++ b/internal/sync/service_test.go
@@ -394,6 +394,114 @@ func TestService_ResolveConflict_ServerPreservesConcurrentEdit(t *testing.T) {
 	}
 }
 
+// TestService_ResolveConflict_ServerPreservesConcurrentEditAfterPersist is the
+// regression test for issue #510 (a reopening of #494 on the manual path): a
+// local edit committing in the persist-commit→read window of an accept-server
+// ResolveConflict must not be silently dropped. The afterImportPersist hook
+// fires inside importICal right after persistImported commits — the exact window
+// the old post-commit GetSyncResource re-read exposed — and bumps rev + re-marks
+// dirty as a real service-layer mutation would. Because the rev is now captured
+// inside persistImported's transaction (and fed back via the revs map) rather
+// than re-read after commit, the rev-guarded clear leaves the resource dirty.
+// With the old after-commit re-read this test fails: the read returns the edit's
+// bumped rev, the guard matches, and dirty is wiped. Serial (no t.Parallel)
+// because it mutates the package-level hook.
+func TestService_ResolveConflict_ServerPreservesConcurrentEditAfterPersist(t *testing.T) {
+	svc, db, q := newTestServiceWithDB(t)
+	ctx := context.Background()
+
+	// Link the calendar to an account so MarkResourceDirty (which no-ops on
+	// local-only calendars) actually writes — the hook below relies on it to
+	// bump rev and simulate the concurrent edit.
+	testutil.LinkCalendarToAccount(t, db)
+
+	cals, _ := q.ListCalendars(ctx)
+	calID := cals[0].ID
+
+	const uid = "resolve-server-persist-race"
+	events := event.NewService(db, q)
+
+	if _, err := events.UpsertByUID(ctx, event.UpsertParams{
+		UID:        uid,
+		CalendarID: calID,
+		Title:      "Local Title",
+		StartTime:  time.Date(2026, 4, 3, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 3, 11, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("seed local event: %v", err)
+	}
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calID,
+		Uid:          uid,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/resolve-server-persist-race.ics",
+		Etag:         "etag-before",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	serverIcal := "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//chroncal//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:" + uid + "\r\n" +
+		"DTSTART:20260403T120000Z\r\n" +
+		"DTEND:20260403T130000Z\r\n" +
+		"SUMMARY:Server Title\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	if err := q.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
+		CalendarID: calID,
+		OwnerType:  "event",
+		OwnerID:    1,
+		Uid:        uid,
+		LocalIcal:  "local",
+		ServerIcal: serverIcal,
+		ServerEtag: "etag-456",
+	}); err != nil {
+		t.Fatalf("CreateSyncConflict: %v", err)
+	}
+
+	// Simulate a concurrent local edit landing right after the accept-server
+	// import's persist transaction commits but before the rev-guarded dirty
+	// clear. persistImported already released its connection, so this
+	// auto-commit write is safe. It bumps rev and re-marks the resource dirty,
+	// exactly as a real service-layer mutation would.
+	var fired int
+	afterImportPersist = func() {
+		fired++
+		if err := storage.MarkResourceDirty(ctx, db, calID, uid, "event"); err != nil {
+			t.Errorf("simulate concurrent edit: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterImportPersist = nil })
+
+	conflicts, _ := q.ListSyncConflicts(ctx)
+	if err := svc.ResolveConflict(ctx, conflicts[0].ID, "server"); err != nil {
+		t.Fatalf("ResolveConflict server: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("afterImportPersist fired %d times, want 1", fired)
+	}
+
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: calID, Uid: uid})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Dirty != 1 {
+		t.Fatalf("Dirty = %d, want 1 (concurrent edit must not be dropped, #510)", res.Dirty)
+	}
+	// The ETag still advances to the server's version so the next push's If-Match
+	// matches the server, mirroring FinalizePushedResource on the push path.
+	if res.Etag != "etag-456" {
+		t.Fatalf("Etag = %q, want %q", res.Etag, "etag-456")
+	}
+}
+
 // TestService_ResolveConflict_ServerDoesNotResurrectDeleted is the regression
 // test for issue #89 (gap #2): accepting the server version of a conflict must
 // NOT un-delete a row the user has locally soft-deleted and tombstoned for


### PR DESCRIPTION
## Summary

The manual accept-server path `ResolveConflict` (interactive `sync resolve <id> server`) captured the post-import `sync_resources.rev` via a **post-commit** `GetSyncResource` read instead of the per-UID rev map `importICal` already returns. This reopened the persist→read lost-update window that #494 closed for the engine auto-sync paths.

A concurrent local edit committing in the persist-commit→read window calls `MarkResourceDirty` (`rev = rev + 1`, `dirty = 1`), so the post-commit read returned the **edit's** rev rather than the import's. `FinalizePushedResource` was then guarded on that already-advanced rev — its `CASE WHEN rev = ?` matched and cleared `dirty = 0`, silently dropping the concurrent edit.

## Fix

Use `revs[conflict.Uid]` — the rev captured **inside** `persistImported`'s transaction (`captureImportRev`) and returned by `importICal` — and delete the post-commit `GetSyncResource` block. This makes the manual path identical to the engine paths (push ServerWins, `pullFullSnapshot`, `applySyncCollection`) that #494 fixed.

## Test

Adds `TestService_ResolveConflict_ServerPreservesConcurrentEditAfterPersist`, mirroring the engine's `TestEnginePushServerWinsPreservesConcurrentEditAfterPersist`. It drives the concurrent edit through the `afterImportPersist` hook, which fires inside `importICal` right after `persistImported` commits — the exact window the old post-commit re-read exposed and the older `resolveConflictAfterRevCapture` hook could not reach. The test fails on the pre-fix code (`Dirty = 0`) and passes after.

`go build ./...`, `go vet`, `gofmt`, and `golangci-lint` (0 issues) all clean; `go test -race ./internal/sync/` passes.

Closes #510