### PR TITLE
fix(tui): include CutoffTime in undo identity to keep correct truncation entry

### DIFF
--- a/internal/tui/undo.go
+++ b/internal/tui/undo.go
@@ -80,11 +80,16 @@ func (s *UndoStack) Remove(meta event.UndoMeta) bool {
 }
 
 // sameUndoTarget reports whether two UndoMeta values describe the same
-// soft-delete operation. Kind + UID + RecurrenceID uniquely identifies a
-// reversible delete: a series and a single-instance delete of the same UID
-// differ by Kind, and distinct overrides differ by RecurrenceID.
+// soft-delete operation. Kind + UID + RecurrenceID + CutoffTime uniquely
+// identifies a reversible delete: a series and a single-instance delete of the
+// same UID differ by Kind, and distinct overrides differ by RecurrenceID.
+// CutoffTime disambiguates UndoKindFromInstance truncations, which always have
+// an empty RecurrenceID and so are otherwise identical across two truncations
+// of the same series (issue #514); it is the zero time for every other Kind,
+// so comparing it is always safe.
 func sameUndoTarget(a, b event.UndoMeta) bool {
-	return a.Kind == b.Kind && a.UID == b.UID && a.RecurrenceID == b.RecurrenceID
+	return a.Kind == b.Kind && a.UID == b.UID &&
+		a.RecurrenceID == b.RecurrenceID && a.CutoffTime.Equal(b.CutoffTime)
 }
 
 // Len returns the current depth.

--- a/internal/tui/undo_test.go
+++ b/internal/tui/undo_test.go
@@ -138,3 +138,52 @@ func TestEventRestoredMsg_RemovesRestoredEntryNotTop(t *testing.T) {
 			top.Meta.UID, entryB.Meta.UID)
 	}
 }
+
+// truncation builds an UndoKindFromInstance undo entry for series uid truncated
+// at cutoff. Such entries always have RecurrenceID == "", so CutoffTime is the
+// only field that distinguishes two truncations of the same series.
+func truncation(uid string, cutoff time.Time) UndoEntry {
+	return UndoEntry{
+		DeletedAt: time.Now(),
+		Meta: event.UndoMeta{
+			Kind:       event.UndoKindFromInstance,
+			UID:        uid,
+			Label:      "Truncated " + uid,
+			CutoffTime: cutoff,
+		},
+	}
+}
+
+// TestUndoStack_Remove_DistinguishesTruncationsByCutoff reproduces issue #514:
+// two truncations of the same series share Kind + UID and have an empty
+// RecurrenceID, so they are indistinguishable unless Remove also compares
+// CutoffTime. During the delete-during-restore race, Remove(B) must delete B
+// — not the newer truncation C that happens to sit on top of the stack.
+func TestUndoStack_Remove_DistinguishesTruncationsByCutoff(t *testing.T) {
+	s := NewUndoStack()
+
+	cutoffB := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	cutoffC := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	entryB := truncation("series-X", cutoffB)
+	entryC := truncation("series-X", cutoffC)
+
+	// B's undo restore is in flight; C (a second truncation of the same
+	// series) lands on top before B's success message arrives.
+	s.Push(entryB)
+	s.Push(entryC)
+
+	if !s.Remove(entryB.Meta) {
+		t.Fatal("Remove(B) reported no match")
+	}
+	if s.Len() != 1 {
+		t.Fatalf("Len after Remove(B) = %d, want 1", s.Len())
+	}
+	top, ok := s.Peek()
+	if !ok {
+		t.Fatal("stack unexpectedly empty after Remove(B)")
+	}
+	if !top.Meta.CutoffTime.Equal(cutoffC) {
+		t.Fatalf("Remove removed the wrong truncation: surviving CutoffTime = %v, want %v (C must survive)",
+			top.Meta.CutoffTime, cutoffC)
+	}
+}


### PR DESCRIPTION
## Summary

`sameUndoTarget` keyed undo entries on `Kind + UID + RecurrenceID` only. For `UndoKindFromInstance` (series truncation) `RecurrenceID` is always empty, so two truncations of the **same series** were indistinguishable.

During the delete-during-restore race, `UndoStack.Remove` scans top-down and deletes the first match. With two same-UID truncation entries it could remove the wrong one — silently losing one truncation's undo affordance and later producing a spurious "Undo failed" toast (the lingering already-restored entry resolves to a consumed truncate log → `ErrNotDeleted`).

Now that #490 makes each truncation cutoff individually reversible, multiple same-UID truncation entries legitimately coexist, so this is uniquely exposed.

## Fix

Add `CutoffTime` to the identity comparison in `sameUndoTarget`:

```go
a.Kind == b.Kind && a.UID == b.UID &&
    a.RecurrenceID == b.RecurrenceID && a.CutoffTime.Equal(b.CutoffTime)
```

`CutoffTime` is the zero time for every other `Kind`, so comparing it is always safe; it only disambiguates the `FromInstance` case.

## Test

Added `TestUndoStack_Remove_DistinguishesTruncationsByCutoff` in `internal/tui/undo_test.go`: pushes two `FromInstance` entries for the same UID with different `CutoffTime`, calls `Remove` on the older one, and asserts the newer one survives. Confirmed it fails before the fix (wrong entry removed) and passes after.

`go build ./...`, `go test ./internal/tui/`, `gofmt`, `go vet`, and `golangci-lint` (0 issues) all clean.

Closes #514