### PR TITLE
fix(ical): widen exported VTIMEZONE span to recurring-series horizon

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/emersion/go-ical"
+	"github.com/teambition/rrule-go"
 
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/journal"
@@ -33,9 +34,14 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 
 	// Emit VTIMEZONE components for all referenced timezones (RFC 5545 Section
 	// 3.6.5), anchored on the years the events actually fall in (issue #515).
+	// A recurring series widens the span to its last-occurrence year so the
+	// VTIMEZONE covers every DST-rule era the series crosses (issue #518).
 	var spans tzSpans
 	for _, e := range events {
 		spans.add(e.Timezone, e.StartTime.Year())
+		if e.RecurrenceRule != "" {
+			spans.add(e.Timezone, recurrenceEndYear(e.RecurrenceRule, e.StartTime))
+		}
 	}
 	spans.emit(cal)
 
@@ -312,10 +318,16 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 	}
 
 	// Emit VTIMEZONE components for all referenced timezones, anchored on the
-	// years the todos actually fall in (issue #515).
+	// years the todos actually fall in (issue #515), widened across a recurring
+	// todo's horizon so every DST-rule era it crosses is covered (issue #518).
 	var spans tzSpans
 	for _, t := range todos {
 		spans.add(t.Timezone, todoYear(t))
+		if t.RecurrenceRule != "" {
+			if a := todoAnchor(t); !a.IsZero() {
+				spans.add(t.Timezone, recurrenceEndYear(t.RecurrenceRule, a))
+			}
+		}
 	}
 	spans.emit(cal)
 
@@ -818,17 +830,52 @@ func (s *tzSpans) emit(cal *ical.Calendar) {
 	}
 }
 
+// todoAnchor returns a todo's recurrence/VTIMEZONE anchor date, preferring its
+// start date over its due date. Returns the zero time when the todo carries
+// neither.
+func todoAnchor(t todo.Todo) time.Time {
+	if d := t.ParseStartDate(); !d.IsZero() {
+		return d
+	}
+	return t.ParseDueDate()
+}
+
 // todoYear returns the calendar year to anchor a todo's VTIMEZONE on, preferring
 // its start date, then its due date, falling back to the current year when the
 // todo carries neither.
 func todoYear(t todo.Todo) int {
-	if d := t.ParseStartDate(); !d.IsZero() {
-		return d.Year()
-	}
-	if d := t.ParseDueDate(); !d.IsZero() {
-		return d.Year()
+	if a := todoAnchor(t); !a.IsZero() {
+		return a.Year()
 	}
 	return time.Now().Year()
+}
+
+// recurrenceEndYear returns the calendar year of a recurring series' last
+// occurrence, so the VTIMEZONE span (issue #518) covers every DST-rule era the
+// series crosses rather than only its start year. A series bounded by UNTIL ends
+// in that year. An open-ended or COUNT-bounded series is clamped to the current
+// year: DST-rule changes are historical and future rule revisions are
+// unknowable, so covering [start, today] is sufficient, and the clamp keeps the
+// rrule walk bounded. The result is never earlier than the start year; a
+// malformed rule degrades to the start year.
+func recurrenceEndYear(rule string, start time.Time) int {
+	startYear := start.Year()
+	r, err := rrule.StrToRRule(rule)
+	if err != nil {
+		return startYear
+	}
+	r.DTStart(start)
+	if until := r.GetUntil(); !until.IsZero() {
+		return max(startYear, until.Year())
+	}
+	// Open-ended or COUNT-bounded: take the last occurrence on or before the end
+	// of the current year. Before() walks only up to that cap (or the COUNT
+	// limit, whichever comes first), so iteration stays bounded.
+	capDate := time.Date(max(startYear, time.Now().Year())+1, 1, 1, 0, 0, 0, 0, time.UTC)
+	if last := r.Before(capDate, true); !last.IsZero() {
+		return max(startYear, last.Year())
+	}
+	return startYear
 }
 
 // journalYear returns the calendar year to anchor a journal's VTIMEZONE on,
@@ -1169,10 +1216,17 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 	}
 
 	// Emit VTIMEZONE components for all referenced timezones, anchored on the
-	// years the journals actually fall in (issue #515).
+	// years the journals actually fall in (issue #515), widened across a
+	// recurring journal's horizon to cover every DST-rule era it crosses
+	// (issue #518).
 	var spans tzSpans
 	for _, j := range journals {
 		spans.add(j.Timezone, journalYear(j))
+		if j.RecurrenceRule != "" {
+			if a := j.ParseStartDate(); !a.IsZero() {
+				spans.add(j.Timezone, recurrenceEndYear(j.RecurrenceRule, a))
+			}
+		}
 	}
 	spans.emit(cal)
 

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -593,6 +593,55 @@ func TestExport_VTimezoneRuleChangeAcrossSpan(t *testing.T) {
 	}
 }
 
+func TestExport_VTimezoneRecurringSeriesCrossesRuleChange(t *testing.T) {
+	t.Parallel()
+	// Issue #518: a single recurring series contributes only its start year to
+	// the VTIMEZONE span. A series that starts before a historical DST-rule
+	// change but recurs past it (here America/New_York, 2005 -> the 2007 US rule
+	// change) must still carry BOTH rule eras, not merely the start-year rule —
+	// otherwise occurrences after the change resolve the wrong offset for
+	// consumers relying on the embedded VTIMEZONE.
+	events := []event.Event{
+		{
+			UID:            "vtz-recur-2005",
+			Title:          "Long-running Event",
+			StartTime:      time.Date(2005, 7, 1, 14, 0, 0, 0, time.UTC),
+			EndTime:        time.Date(2005, 7, 1, 15, 0, 0, 0, time.UTC),
+			Timezone:       "America/New_York",
+			RecurrenceRule: "FREQ=YEARLY;UNTIL=20100701T140000Z",
+			Status:         "CONFIRMED",
+			Transp:         "OPAQUE",
+			CreatedAt:      time.Now(),
+			UpdatedAt:      time.Now(),
+		},
+	}
+
+	data, _ := ExportEvents(events, "")
+	ics := string(data)
+
+	start := strings.Index(ics, "BEGIN:VTIMEZONE")
+	end := strings.Index(ics, "END:VTIMEZONE")
+	if start < 0 || end < 0 {
+		t.Fatalf("missing VTIMEZONE block:\n%s", ics)
+	}
+	vtz := ics[start:end]
+
+	// Both rule periods present, even though only one (start-year) event exists.
+	for _, want := range []string{
+		"FREQ=YEARLY;BYMONTH=4;BYDAY=1SU",   // old DAYLIGHT (1st Sunday April)
+		"FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU", // old STANDARD (last Sunday October)
+		"FREQ=YEARLY;BYMONTH=3;BYDAY=2SU",   // new DAYLIGHT (2nd Sunday March)
+		"FREQ=YEARLY;BYMONTH=11;BYDAY=1SU",  // new STANDARD (1st Sunday November)
+	} {
+		if !strings.Contains(vtz, want) {
+			t.Errorf("VTIMEZONE missing rule %q across the recurring series horizon:\n%s", want, vtz)
+		}
+	}
+	if !strings.Contains(vtz, "UNTIL=") {
+		t.Errorf("VTIMEZONE missing UNTIL bound on superseded DST rule:\n%s", vtz)
+	}
+}
+
 func TestExport_VTimezoneDSTAbolishedWithinSpan(t *testing.T) {
 	t.Parallel()
 	// Issue #515: Brazil abolished DST in 2019. Exporting events that straddle


### PR DESCRIPTION
## Summary

After #515 the exported `VTIMEZONE` is anchored on the year span of the referenced items, but `tzSpans.add` keyed the span on each item's **start year** only. A recurring series that begins before a historical DST-rule change but recurs past it therefore embedded only the start-year rule era. Occurrences after the change then resolve the wrong offset for consumers that rely on the inline `VTIMEZONE` rather than their own tzdata.

Example: an `America/New_York` series starting 2005 with an RRULE crossing the 2007 US DST-rule change previously emitted only the pre-2007 rule (1st Sunday April / last Sunday October); the post-2007 rule (2nd Sunday March / 1st Sunday November) was missing.

## Fix

- Add `recurrenceEndYear(rule, start)`: parses the RRULE via the existing `teambition/rrule-go` library and returns the series' last-occurrence year.
  - **UNTIL-bounded:** the UNTIL year.
  - **COUNT-bounded / open-ended:** the last occurrence on or before the end of the current year. The current-year clamp is deliberate — historical DST-rule changes fall within `[start, today]`, future rule revisions are unknowable, and the clamp keeps the `rrule` walk bounded (`Before()` stops at the cap or the COUNT limit, whichever comes first).
  - Result is never earlier than the start year; a malformed rule degrades to the start year.
- The three export callers (events, todos, journals) fold that year into the timezone span. `buildVTimezone` already emits the correct multi-era observances across the widened span — no change needed there.
- Refactor `todoYear` to share a new `todoAnchor` helper, reused for the recurrence anchor date.

## Scope / residual

Scoped to RRULE horizons, matching the issue. RDATE-only series with far-future explicit dates are a distinct, narrower class not covered here (and not raised by #518). Open-ended series are covered through the current year only, by design (low severity; inline-VTIMEZONE consumers only, no data loss).

## Tests

- New: `TestExport_VTimezoneRecurringSeriesCrossesRuleChange` — a single `America/New_York` event starting 2005 with `RRULE:FREQ=YEARLY;UNTIL=20100701T140000Z` must yield **both** rule eras. Confirmed failing before the fix, passing after.
- Existing #467/#515 VTIMEZONE tests still pass; `go vet`, `gofmt`, and `golangci-lint` clean.

Closes #518