### PR TITLE
fix(ical): clamp VTIMEZONE span for open-ended/COUNT recurrences (#520)

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -852,12 +852,15 @@ func todoYear(t todo.Todo) int {
 
 // recurrenceEndYear returns the calendar year of a recurring series' last
 // occurrence, so the VTIMEZONE span (issue #518) covers every DST-rule era the
-// series crosses rather than only its start year. A series bounded by UNTIL ends
-// in that year. An open-ended or COUNT-bounded series is clamped to the current
-// year: DST-rule changes are historical and future rule revisions are
-// unknowable, so covering [start, today] is sufficient, and the clamp keeps the
-// rrule walk bounded. The result is never earlier than the start year; a
-// malformed rule degrades to the start year.
+// series crosses rather than only its start year. The span is capped at the end
+// of the current year: a series bounded by a past UNTIL ends in its UNTIL year,
+// while an open-ended or COUNT-bounded series is clamped to today, since DST-rule
+// changes are historical and future rule revisions are unknowable, so covering
+// [start, today] is sufficient. The cap also keeps the rrule walk bounded —
+// rrule-go reports a ~290-year sentinel UNTIL when a rule supplies none (issue
+// #520), so the cap must come from the walk, not from GetUntil(). The result is
+// never earlier than the start year; a malformed rule degrades to the start
+// year.
 func recurrenceEndYear(rule string, start time.Time) int {
 	startYear := start.Year()
 	r, err := rrule.StrToRRule(rule)
@@ -865,12 +868,10 @@ func recurrenceEndYear(rule string, start time.Time) int {
 		return startYear
 	}
 	r.DTStart(start)
-	if until := r.GetUntil(); !until.IsZero() {
-		return max(startYear, until.Year())
-	}
-	// Open-ended or COUNT-bounded: take the last occurrence on or before the end
-	// of the current year. Before() walks only up to that cap (or the COUNT
-	// limit, whichever comes first), so iteration stays bounded.
+	// Take the last occurrence on or before the end of the current year. Before()
+	// walks only up to that cap (or the rule's UNTIL/COUNT limit, whichever comes
+	// first), so iteration stays bounded for open-ended and COUNT-bounded rules
+	// alike.
 	capDate := time.Date(max(startYear, time.Now().Year())+1, 1, 1, 0, 0, 0, 0, time.UTC)
 	if last := r.Before(capDate, true); !last.IsZero() {
 		return max(startYear, last.Year())

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -642,6 +642,64 @@ func TestExport_VTimezoneRecurringSeriesCrossesRuleChange(t *testing.T) {
 	}
 }
 
+func TestRecurrenceEndYearBounded(t *testing.T) {
+	t.Parallel()
+	// Issue #520: rrule-go reports a ~290-year sentinel UNTIL when a rule
+	// supplies none, so detecting "no UNTIL" via GetUntil() mis-clamped every
+	// open-ended or COUNT-bounded series' VTIMEZONE span to startYear+~292. The
+	// span must instead stay bounded to the current year for those rules, while a
+	// real past UNTIL still clamps to its own year.
+	start := time.Date(2020, 7, 1, 14, 0, 0, 0, time.UTC)
+	currentYear := time.Now().Year()
+
+	cases := []struct {
+		name string
+		rule string
+		want int
+	}{
+		{"real past UNTIL clamps to its year", "FREQ=YEARLY;UNTIL=20230701T140000Z", 2023},
+		{"open-ended clamps to current year", "FREQ=YEARLY", currentYear},
+		{"COUNT-bounded ends at its last occurrence", "FREQ=YEARLY;COUNT=3", 2022},
+		{"malformed rule degrades to start year", "FREQ=BOGUS;;;", start.Year()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := recurrenceEndYear(tc.rule, start)
+			if got != tc.want {
+				t.Errorf("recurrenceEndYear(%q) = %d, want %d (span must not inherit the ~290-year sentinel)", tc.rule, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExport_VTimezoneOpenEndedSeriesBounded(t *testing.T) {
+	t.Parallel()
+	// Issue #520: an open-ended recurring series (no UNTIL) must clamp the
+	// VTIMEZONE span to the current year rather than rrule-go's ~290-year
+	// sentinel, so the month-by-month walk and emitted observances stay bounded.
+	events := []event.Event{{
+		UID:            "vtz-openended",
+		Title:          "Unbounded Yearly Meeting",
+		StartTime:      time.Date(2020, 7, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2020, 7, 1, 15, 0, 0, 0, time.UTC),
+		Timezone:       "America/New_York",
+		RecurrenceRule: "FREQ=YEARLY",
+		Status:         "CONFIRMED",
+		Transp:         "OPAQUE",
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}}
+
+	data, _ := ExportEvents(events, "")
+	ics := string(data)
+
+	observances := strings.Count(ics, "BEGIN:STANDARD") + strings.Count(ics, "BEGIN:DAYLIGHT")
+	if observances > 12 {
+		t.Errorf("open-ended series bloated VTIMEZONE to %d observances; span not clamped to current year:\n%s", observances, ics)
+	}
+}
+
 func TestExport_VTimezoneDSTAbolishedWithinSpan(t *testing.T) {
 	t.Parallel()
 	// Issue #515: Brazil abolished DST in 2019. Exporting events that straddle


### PR DESCRIPTION
## Summary

`recurrenceEndYear` (added in #519 for #518) detected "no UNTIL" via
`r.GetUntil().IsZero()`. But `rrule-go` never returns a zero time there — when a
rule supplies no UNTIL it sets `until = dtstart.Add(1<<63-1)` (~290 years). The
guard was therefore **always true** for open-ended and COUNT-bounded series,
returning `startYear+~292` and leaving the intended `Before(capDate)` clamp as
dead code. `buildVTimezone` then walked month-by-month to ~year 2300, wasting
iteration and conceptually over-spanning the exported VTIMEZONE — a regression
versus pre-#518 behaviour.

Confirmed empirically before the fix (`start = 2020-07-01`):

| Rule | `recurrenceEndYear` (before) | (after) |
|---|---|---|
| `FREQ=YEARLY;UNTIL=20230701T140000Z` | 2023 | 2023 |
| `FREQ=YEARLY` | 2312 | 2026 |
| `FREQ=YEARLY;COUNT=3` | 2312 | 2022 |

## Fix

Drop the `GetUntil()` special-case entirely and always run the
`Before(capDate, true)` walk. The cap (end of `max(startYear, currentYear)`)
keeps iteration bounded, and `Before()` already honours a rule's real
UNTIL/COUNT limit — yielding the correct last-occurrence year for past-UNTIL,
open-ended, and COUNT-bounded rules alike. This also simplifies the function by
removing the now-dead branch. The malformed-rule degradation to the start year
is preserved.

## Tests

- `TestRecurrenceEndYearBounded` — table test over past-UNTIL (2023),
  open-ended (current year), COUNT-bounded (last occurrence, 2022), and
  malformed (start year). The open-ended and COUNT cases failed before the fix
  (returned 2312).
- `TestExport_VTimezoneOpenEndedSeriesBounded` — end-to-end export guard
  asserting the emitted observance count stays bounded for an unbounded series.

Existing #467/#515/#518 VTIMEZONE tests still pass; `go build ./...`,
`go test ./...`, `go vet`, and `golangci-lint` (0 issues) all clean.

Closes #520
