### PR TITLE
test(cmd): make calendar connect CLI tests hermetic without a keyring (#474)

### DIFF
--- a/cmd/chroncal/calendar_cli_test.go
+++ b/cmd/chroncal/calendar_cli_test.go
@@ -60,6 +60,7 @@ func TestCalendarCreateCanConnectRemoteCalendar(t *testing.T) {
 		"--remote-url", "https://cal.example.com/dav/calendars/work/",
 		"--username", "alice",
 		"--auth", "bearer",
+		"--allow-plaintext",
 	)
 	if err != nil {
 		t.Fatalf("calendar create with remote config: %v", err)
@@ -109,6 +110,7 @@ func TestCalendarUpdateCanConnectRemoteCalendar(t *testing.T) {
 		"--remote-url", "https://cal.example.com/dav/calendars/work/",
 		"--username", "alice",
 		"--auth", "bearer",
+		"--allow-plaintext",
 	)
 	if err != nil {
 		t.Fatalf("calendar update with remote config: %v", err)
@@ -138,6 +140,7 @@ func TestCalendarUpdatePreservesAuthTypeWhenReconnectingWithoutAuthFlag(t *testi
 		"calendar", "update", "Work",
 		"--remote-url", "https://cal.example.com/dav/calendars/renamed/",
 		"--username", "alice",
+		"--allow-plaintext",
 	)
 	if err != nil {
 		t.Fatalf("calendar update with new remote URL: %v", err)
@@ -253,6 +256,10 @@ func setupCalendarCLITestEnv(t *testing.T) string {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "chroncal.db")
 	t.Setenv("CHRONCAL_DB", dbPath)
+	// XDG_CONFIG_HOME points the plaintext credential store at this temp dir.
+	// Connect flows pair this with --allow-plaintext so they store credentials
+	// hermetically and don't depend on the host OS keyring, which is absent on
+	// the Linux CI runner (no org.freedesktop.secrets) — see issue #474.
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg-config"))
 	return dbPath
 }


### PR DESCRIPTION
## Root cause
`cmd/chroncal/calendar_cli_test.go` drives the binary as a subprocess (via `TestHelperProcess`). The connect/update paths build a credential store with `auth.NewCredentialStore`. When no OS secret service is present (`org.freedesktop.secrets`) and `--allow-plaintext` is not passed, that constructor returns:

```
credential store: no secure credential store available: ... org.freedesktop.secrets was not provided ...
```

So `TestCalendarCreateCanConnectRemoteCalendar`, `TestCalendarUpdateCanConnectRemoteCalendar`, and `TestCalendarUpdatePreservesAuthTypeWhenReconnectingWithoutAuthFlag` failed on the Linux CI runner (no keyring daemon) while passing on macOS (Keychain) and on dev machines with a running keyring — masking the gap. The in-process `newCalendarCredentialStore` seam used by `calendar_remote_test.go` cannot help here because these tests run in a re-exec'd subprocess.

## Fix
Pass `--allow-plaintext` on the three connect/update commands. The tests already point `XDG_CONFIG_HOME` at a per-test temp dir, so the flag routes credential storage into `PlaintextFileStore` under that temp dir. This is hermetic everywhere:

- With a keyring present: the keyring is still selected (a `migratingCredentialStore` is returned regardless of the flag), so the flag is harmless and the real path is still exercised.
- Without a keyring: the plaintext file store is used instead of erroring.

No production code changed — test-only. Added a comment in `setupCalendarCLITestEnv` documenting why.

## Verification
- `go test ./cmd/chroncal/ -run '<the three tests>'` — green **with** keyring.
- Same run with the secret service forced unavailable (`DBUS_SESSION_BUS_ADDRESS=unix:path=/nonexistent`) — reproduced the exact failure before the fix, **green after**.
- Full `go test ./cmd/chroncal/` passes with the secret service disabled.
- `go build ./...`, `go vet ./cmd/chroncal/`, `gofmt -l`, and `golangci-lint run ./cmd/chroncal/` (0 issues) all clean.

Closes #474