### PR TITLE
chore(release): keep commit SHA prefix in changelog entries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -167,8 +167,8 @@ release:
 
 changelog:
   sort: asc
-  # Drop the commit SHA prefix so each line is just the (grouped) subject.
-  abbrev: -1
+  # Keep the commit SHA prefix on each entry; GitHub auto-links it to the
+  # commit on the rendered release page.
   # Drop non-user-facing commits. Patterns are unanchored to the scope so
   # both "docs:" and "docs(cli):" match (the old "^docs:" form silently
   # let every scoped chore/docs commit leak into the changelog).


### PR DESCRIPTION
Revert the `abbrev: -1` from #525 — keep the commit SHA prefix on each changelog entry. GitHub auto-links the SHA to the commit on the rendered release page. Install pointer + compare-link footer are unchanged.

Assisted-by: Claude:claude-opus-4-8