### PR TITLE
feat(tui): discoverable New Calendar / Add Account palette entries

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3740,9 +3740,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusToken++
 		return m, m.expireStatusAfter(10*time.Second, m.statusToken)
 
-	case AccountAddRequestedMsg:
-		return m.Update(CalendarManagerRequestedMsg{Target: CalendarManagerTargetAccountConnect})
-
 	case CalendarManagerRequestedMsg:
 		m.calendarManager = m.calendarManager.SetData(m.calendars, m.hiddenCalendars)
 		m.calendarManagerOpen = true

--- a/internal/tui/app_calendar_manager_routing_test.go
+++ b/internal/tui/app_calendar_manager_routing_test.go
@@ -142,11 +142,12 @@ func TestSidebarAccountRequestOpensManagerAccountDetail(t *testing.T) {
 }
 
 // TestAddAccountOpensAccountConnectInsideManager locks the Add Account route:
-// AccountAddRequestedMsg opens the manager with the CalDAV connection form as
-// its calendar-detail screen.
+// the canonical CalendarManagerRequestedMsg with the AccountConnect target
+// opens the manager with the CalDAV connection form as its calendar-detail
+// screen. This is the same message the palette's "Add Account…" entry emits.
 func TestAddAccountOpensAccountConnectInsideManager(t *testing.T) {
 	m := managerRoutingModel()
-	updated, cmd := m.Update(AccountAddRequestedMsg{})
+	updated, cmd := m.Update(CalendarManagerRequestedMsg{Target: CalendarManagerTargetAccountConnect})
 	m = updated.(Model)
 	if cmd != nil {
 		t.Fatalf("add account returned command %T", cmd())
@@ -416,7 +417,7 @@ func TestDirectAccountCloseReturnsToCalendarList(t *testing.T) {
 
 func TestAddAccountCancelReturnsToCalendarList(t *testing.T) {
 	m := managerRoutingModel()
-	updated, _ := m.Update(AccountAddRequestedMsg{})
+	updated, _ := m.Update(CalendarManagerRequestedMsg{Target: CalendarManagerTargetAccountConnect})
 	m = updated.(Model)
 
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})

--- a/internal/tui/palette_commands.go
+++ b/internal/tui/palette_commands.go
@@ -17,14 +17,11 @@ type ToggleSidebarMsg struct{}
 // ToggleWeekNumbersMsg toggles the ISO week-number gutter in month/week views.
 type ToggleWeekNumbersMsg struct{}
 
-// AccountAddRequestedMsg opens the account sign-in flow.
-type AccountAddRequestedMsg struct{}
-
 // buildPaletteCommands returns the default commands exposed through the
 // palette, with bindings to the current app state (cursor, etc.).
 func buildPaletteCommands(m Model) []PaletteCommand {
 	cursor, _ := m.viewCursorAndToday()
-	commands := make([]PaletteCommand, 0, 15)
+	commands := make([]PaletteCommand, 0, 17)
 	commands = append(commands,
 		PaletteCommand{
 			ID:       "nav.today",
@@ -74,6 +71,18 @@ func buildPaletteCommands(m Model) []PaletteCommand {
 			Category: "Calendar",
 			Shortcut: "C",
 			Action:   func() tea.Msg { return CalendarManagerRequestedMsg{Target: CalendarManagerTargetRoot} },
+		},
+		PaletteCommand{
+			ID:       "calendar.create",
+			Title:    "New Calendar…",
+			Category: "Calendar",
+			Action:   func() tea.Msg { return CalendarManagerRequestedMsg{Target: CalendarManagerTargetLocalCreate} },
+		},
+		PaletteCommand{
+			ID:       "calendar.add_account",
+			Title:    "Add Account…",
+			Category: "Calendar",
+			Action:   func() tea.Msg { return CalendarManagerRequestedMsg{Target: CalendarManagerTargetAccountConnect} },
 		},
 		PaletteCommand{
 			ID:       "calendar.sync",

--- a/internal/tui/palette_commands_test.go
+++ b/internal/tui/palette_commands_test.go
@@ -20,6 +20,31 @@ func TestPaletteExposesOneCalendarsEntry(t *testing.T) {
 	}
 }
 
+// TestPaletteExposesNewCalendarAndAddAccount locks issue #552's
+// discoverability: the manager's + Add actions (New Calendar, Add Account)
+// are reachable from the command palette. Each entry emits the single
+// canonical CalendarManagerRequestedMsg with the corresponding manager
+// target — there is no bespoke message per entry point.
+func TestPaletteExposesNewCalendarAndAddAccount(t *testing.T) {
+	commands := buildPaletteCommands(Model{})
+
+	create := paletteCommandByID(t, commands, "calendar.create")
+	if create.Title != "New Calendar…" || create.Category != "Calendar" {
+		t.Fatalf("calendar.create = %+v, want title New Calendar… in Calendar", create)
+	}
+	if msg, ok := create.Action().(CalendarManagerRequestedMsg); !ok || msg.Target != CalendarManagerTargetLocalCreate {
+		t.Fatalf("calendar.create action = %T %+v, want LocalCreate request", create.Action(), create.Action())
+	}
+
+	connect := paletteCommandByID(t, commands, "calendar.add_account")
+	if connect.Title != "Add Account…" || connect.Category != "Calendar" {
+		t.Fatalf("calendar.add_account = %+v, want title Add Account… in Calendar", connect)
+	}
+	if msg, ok := connect.Action().(CalendarManagerRequestedMsg); !ok || msg.Target != CalendarManagerTargetAccountConnect {
+		t.Fatalf("calendar.add_account action = %T %+v, want AccountConnect request", connect.Action(), connect.Action())
+	}
+}
+
 func TestPaletteDoesNotExposeIndividualAccountManagement(t *testing.T) {
 	commands := buildPaletteCommands(Model{accounts: map[int64]account.Account{
 		9: {ID: 9, DisplayName: "Work", DisplayOrder: 1},
@@ -33,11 +58,16 @@ func TestPaletteDoesNotExposeIndividualAccountManagement(t *testing.T) {
 	}
 }
 
-func TestAccountAddRequestOpensSignInDialog(t *testing.T) {
+// TestPaletteAddAccountOpensConnectionForm is the direct message-flow smoke
+// for the Add Account palette entry: the canonical CalendarManagerRequestedMsg
+// it emits opens the manager's account-connection form rendering the Sign In
+// surface. (AccountAddRequestedMsg was removed; every Add Account entry point
+// now emits the single canonical request.)
+func TestPaletteAddAccountOpensConnectionForm(t *testing.T) {
 	m := NewModel(nil, "")
 	m.width, m.height = 120, 40
 
-	updated, cmd := m.Update(AccountAddRequestedMsg{})
+	updated, cmd := m.Update(CalendarManagerRequestedMsg{Target: CalendarManagerTargetAccountConnect})
 	m = updated.(Model)
 	if cmd != nil {
 		t.Fatalf("opening Add Account returned command %T", cmd())


### PR DESCRIPTION
## Summary

Fixes issue #552 (calendar-manager palette discoverability + dead `AccountAddRequestedMsg`).

The calendar-manager redesign moved "New Calendar" and "Add Account" behind the + Add menu inside the Calendars manager, leaving nothing in the command palette hinting that either action is possible. This adds both as discoverable palette entries that open the manager with the corresponding + Add target preselected, and resolves the dead message.

### Changes
- **`internal/tui/palette_commands.go`**: add two palette entries that reuse the existing typed `CalendarManagerRequestedMsg` routing (the same path the manager's anchored + Add menu emits):
  - **New Calendar…** (`calendar.create`) → `Target: CalendarManagerTargetLocalCreate`
  - **Add Account…** (`calendar.add_account`) → `Target: CalendarManagerTargetAccountConnect`
- **`internal/tui/app.go`**: delete the dead `AccountAddRequestedMsg` handler. Its type is deleted from `palette_commands.go`. The canonical `CalendarManagerRequestedMsg` is now the single source of truth for opening the account-connection form, eliminating the duplicate route.

### Design notes
- Smallest single-source-of-truth: rather than wire the dead `AccountAddRequestedMsg` to the new entry (which would keep a duplicate route), it is deleted; both new palette entries emit the canonical request the host already routes.
- The new entries are palette-only (no global key binding), so they carry no `Shortcut`. Their IDs stay in the `calendar.*` namespace and do not reintroduce the obsolete standalone-account palette commands the existing guard tests reject (`calendar.new`, `account.add`, any `account.*` prefix).
- Manager focus and routing behavior are unchanged; no unrelated calendar-manager screens were refactored.

## Verification
- `go build ./...` — clean.
- `go vet ./internal/tui/` — clean.
- Targeted tests (palette + calendar-manager routing + account flow), `-count=1`:
  - `TestPaletteExposesNewCalendarAndAddAccount` — both entries exist and emit the correct canonical-target request.
  - `TestNewLocalCalendarRequestOpensCreateFormInsideManager` — New Calendar → manager create form (`id == 0`).
  - `TestAddAccountOpensAccountConnectInsideManager` — Add Account → manager connection form (`accountConnection == true`).
  - `TestPaletteAddAccountOpensConnectionForm` — direct message-flow smoke: the Add Account surface renders "Add Account" and "Sign In".
  - Existing `AccountAddRequestedMsg`-based tests migrated to the canonical message; the `account.*`-prefix and `calendar.new`/`account.add` guard tests still pass.
- Repo-wide search confirms no live references to `AccountAddRequestedMsg` remain (only an explanatory test comment).
- Skipped formatters, linters, and the project-wide test suite per issue instructions.

Two-stage review (spec-compliance + code-quality/security): both PASS.

## Risks
- Low. Pure UI message wiring; no schema, storage, or sync changes. The new palette entries reach only existing, already-tested manager targets.

Closes #552

Assisted-by: Oh My Pi:openai-codex/gpt-5.6-sol