### PR TITLE
fix(tui): make pluralize inflect and fold in accountSettingsNoun

### DIFF
--- a/internal/tui/account_settings_dialog.go
+++ b/internal/tui/account_settings_dialog.go
@@ -201,16 +201,9 @@ func (m AccountSettingsDialogModel) identityLines() []string {
 	}
 	lines = append(lines, fmt.Sprintf("Calendars: %d", m.params.CalendarCount))
 	if m.params.AttentionCount > 0 {
-		lines = append(lines, fmt.Sprintf("Needs attention · %d %s", m.params.AttentionCount, accountSettingsNoun(m.params.AttentionCount)))
+		lines = append(lines, fmt.Sprintf("Needs attention · %d %s", m.params.AttentionCount, pluralize(m.params.AttentionCount, "calendar", "calendars")))
 	}
 	return lines
-}
-
-func accountSettingsNoun(count int) string {
-	if count == 1 {
-		return "calendar"
-	}
-	return "calendars"
 }
 
 // bodyRows renders the shared dialog body — identity lines then the action

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3355,7 +3355,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			"Remove account “%s” from Chroncal?\n\n%d downloaded %s will be kept as local calendars.\nRemote links and stored sign-in will be removed.",
 			name,
 			params.CalendarCount,
-			accountSettingsNoun(params.CalendarCount),
+			pluralize(params.CalendarCount, "calendar", "calendars"),
 		)
 		if draft := m.calendarManager.LocalDraft(); m.calendarManagerOpen &&
 			draft != nil && draft.AccountID == msg.AccountID {

--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -982,24 +982,24 @@ func formatAlarm(a model.Alarm) string {
 
 	var parts []string
 	if n, rest, ok := parseLeadingInt(raw, 'W'); ok {
-		parts = append(parts, pluralize(n, "week"))
+		parts = append(parts, fmt.Sprintf("%d %s", n, pluralize(n, "week", "weeks")))
 		raw = rest
 	}
 	if n, rest, ok := parseLeadingInt(raw, 'D'); ok {
-		parts = append(parts, pluralize(n, "day"))
+		parts = append(parts, fmt.Sprintf("%d %s", n, pluralize(n, "day", "days")))
 		raw = rest
 	}
 	raw = strings.TrimPrefix(raw, "T")
 	if n, rest, ok := parseLeadingInt(raw, 'H'); ok {
-		parts = append(parts, pluralize(n, "hour"))
+		parts = append(parts, fmt.Sprintf("%d %s", n, pluralize(n, "hour", "hours")))
 		raw = rest
 	}
 	if n, rest, ok := parseLeadingInt(raw, 'M'); ok {
-		parts = append(parts, pluralize(n, "min."))
+		parts = append(parts, fmt.Sprintf("%d %s", n, pluralize(n, "min.", "min.")))
 		raw = rest
 	}
 	if n, _, ok := parseLeadingInt(raw, 'S'); ok {
-		parts = append(parts, pluralize(n, "sec."))
+		parts = append(parts, fmt.Sprintf("%d %s", n, pluralize(n, "sec.", "sec.")))
 	}
 
 	if len(parts) == 0 {
@@ -1027,11 +1027,18 @@ func parseLeadingInt(s string, suffix byte) (int, string, bool) {
 	return n, s[i+1:], true
 }
 
-func pluralize(n int, unit string) string {
+// pluralize returns the singular form of a noun when n is one, and the plural
+// form otherwise (including zero). Both forms are supplied explicitly so
+// irregular nouns — abbreviations such as "min." that don't take an "-s"
+// suffix — are handled truthfully rather than via a fake general-purpose
+// inflector. Callers own the count, so the bare form composes into both plain
+// "%d %s" counts and adjective-bearing copy like "%d downloaded %s".
+// See issue #548.
+func pluralize(n int, singular, plural string) string {
 	if n == 1 {
-		return "1 " + unit
+		return singular
 	}
-	return fmt.Sprintf("%d %s", n, unit)
+	return plural
 }
 
 // wrapWordByWidth hard-breaks word into display-width chunks each at most w

--- a/internal/tui/event_dialog_test.go
+++ b/internal/tui/event_dialog_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	lipgloss "charm.land/lipgloss/v2"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
 )
 
 // TestRsvpButtonWidthMatchesRendered is a regression test for issue #346.
@@ -27,3 +29,80 @@ func TestRsvpButtonWidthMatchesRendered(t *testing.T) {
 		t.Errorf("rsvpButtonWidth() = %d, want %d (rendered width including padding+margin)", got, want)
 	}
 }
+
+// TestFormatAlarm verifies the human-readable rendering of RFC 5545 alarm
+// triggers, with emphasis on the singular/plural agreement that pluralize()
+// now handles (issue #548). Before the fix, n>1 produced ungrammatical
+// "2 week"/"2 day"/"2 hour" strings because pluralize() never inflected the
+// unit; the "min."/"sec." abbreviations were only correct by accident.
+func TestFormatAlarm(t *testing.T) {
+	cases := []struct {
+		name string
+		alarm model.Alarm
+		want  string
+	}{
+		{"empty is event time", model.Alarm{TriggerValue: ""}, "at event time"},
+
+		// Singular form for n == 1.
+		{"one week before", model.Alarm{TriggerValue: "-P1W"}, "1 week before"},
+		{"one day before", model.Alarm{TriggerValue: "-P1D"}, "1 day before"},
+		{"one hour before", model.Alarm{TriggerValue: "-PT1H"}, "1 hour before"},
+		{"one minute before", model.Alarm{TriggerValue: "-PT1M"}, "1 min. before"},
+		{"one second before", model.Alarm{TriggerValue: "-PT1S"}, "1 sec. before"},
+
+		// Plural form for n > 1 — the actual bug under test.
+		{"two weeks before", model.Alarm{TriggerValue: "-P2W"}, "2 weeks before"},
+		{"two days before", model.Alarm{TriggerValue: "-P2D"}, "2 days before"},
+		{"two hours before", model.Alarm{TriggerValue: "-PT2H"}, "2 hours before"},
+		{"two minutes before", model.Alarm{TriggerValue: "-PT2M"}, "2 min. before"},
+		{"two seconds before", model.Alarm{TriggerValue: "-PT2S"}, "2 sec. before"},
+
+		// Plural form for n == 0 (English pluralizes zero).
+		{"zero weeks before", model.Alarm{TriggerValue: "-P0W"}, "0 weeks before"},
+
+		// Positive ("after") sign is preserved.
+		{"two hours after", model.Alarm{TriggerValue: "PT2H"}, "2 hours after"},
+
+		// Mixed durations join each component with its own agreement.
+		{"mixed day and hours before", model.Alarm{TriggerValue: "-P1DT2H"}, "1 day 2 hours before"},
+
+		// A trigger with no parseable components is returned verbatim.
+		{"absolute fallback", model.Alarm{TriggerValue: "20260101T000000Z"}, "20260101T000000Z"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatAlarm(tc.alarm); got != tc.want {
+				t.Errorf("formatAlarm(%q) = %q, want %q", tc.alarm.TriggerValue, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPluralize locks the noun-form contract of pluralize() (issue #548): one
+// yields the singular form, everything else (including zero) the plural form,
+// and irregular nouns such as the "min." abbreviation are passed through
+// explicitly rather than mangled by a "+s" rule.
+func TestPluralize(t *testing.T) {
+	cases := []struct {
+		name     string
+		n        int
+		singular string
+		plural   string
+		want     string
+	}{
+		{"one is singular", 1, "week", "weeks", "week"},
+		{"two is plural", 2, "week", "weeks", "weeks"},
+		{"zero is plural", 0, "week", "weeks", "weeks"},
+		{"many is plural", 5, "calendar", "calendars", "calendars"},
+		{"irregular abbreviation passes through", 3, "min.", "min.", "min."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pluralize(tc.n, tc.singular, tc.plural); got != tc.want {
+				t.Errorf("pluralize(%d, %q, %q) = %q, want %q", tc.n, tc.singular, tc.plural, got, tc.want)
+			}
+		})
+	}
+}
+
+


### PR DESCRIPTION
## Summary

`pluralize(n, unit)` returned the unit text unchanged in both branches, so it only formatted a count and never produced a plural despite its name. `formatAlarm` relied on it and rendered ungrammatical strings for `n>1` (`"2 week"`, `"2 day"`, `"2 hour"`); the `"min."`/`"sec."` abbreviations were only correct by accident. A second helper, `accountSettingsNoun`, existed precisely because `pluralize` couldn't do the job.

This PR replaces both with one canonical, truthful helper and migrates every caller. Closes #548.

## Change

`pluralize` is now a noun-form selector — the smallest honest API for this call set:

```go
func pluralize(n int, singular, plural string) string {
    if n == 1 {
        return singular
    }
    return plural
}
```

A noun-form selector was chosen over a `+s` inflector because the existing callers include **irregular nouns** (the `"min."`/`"sec."` abbreviations, which don't take an `-s`) **and** adjective-bearing copy (`"%d downloaded %s"` in the remove-account prompt, where the count and noun are split by the word "downloaded"). A noun-form result composes into both plain `"%d %s"` counts and such copy without rewording anything, and it swaps 1:1 with the deleted `accountSettingsNoun`.

- `event_dialog.go` `formatAlarm`: each unit now agrees with its count via `fmt.Sprintf("%d %s", n, pluralize(n, unit, unitPlural))` — fixes the real `2 week`/`2 day`/`2 hour` bug.
- `account_settings_dialog.go` & `app.go`: both `accountSettingsNoun` callers migrated to `pluralize(count, "calendar", "calendars")`; the duplicate helper is deleted.
- One canonical helper remains; no caller double-pluralizes.

## Verification

- `go build ./internal/tui/...` — clean
- `go vet ./internal/tui/` — clean
- Targeted tests pass:
  - new `TestPluralize` (noun-form contract: 1→singular, 0/many→plural, irregular passthrough)
  - new `TestFormatAlarm` (0/1/many across week/day/hour/min./sec., before/after sign, mixed `P1DT2H`, unparsable fallback)
  - `TestAlarmSummary`, the account-settings dialog test (asserts `"Needs attention · 1 calendar"`), and `TestAppAccountSettingsRemoveConfirmsAccountIdentityAndKeepsCalendarsLocal` (asserts the exact `"2 downloaded calendars will be kept as local calendars."` copy)
- `grep` confirms `accountSettingsNoun` is fully removed and `pluralize` has exactly the expected callsites.

All existing user-facing copy and its test assertions are preserved verbatim. (Formatters, linters, and the project-wide test suite were skipped per the issue scope.)

## Risks

- Minimal. Behavior change is confined to alarm-duration text (now grammatically correct for `n>1`) and is otherwise output-preserving for the migrated account copy.
- The unrelated sync-conflict inline noun selection in `app.go` (`"conflict"`/`"conflicts"`) is intentionally left untouched — out of this issue's scope and not the helper the issue names.
