### PR TITLE
refactor(tui): child-owned footer help bindings in calendar manager

### DIFF
--- a/internal/tui/account_settings_dialog.go
+++ b/internal/tui/account_settings_dialog.go
@@ -250,6 +250,17 @@ func (m AccountSettingsDialogModel) InspectorView(w, h int) string {
 	return padLines(rows, w, h)
 }
 
+// HelpBindings returns the footer help this pushed detail owns while it is
+// the manager's active screen. The manager footer defers here so a rebound
+// key no longer drifts between the child and the footer. Display-only.
+func (m AccountSettingsDialogModel) HelpBindings() []key.Binding {
+	return []key.Binding{
+		footerBinding("↑/↓", "select"),
+		footerBinding("enter", "open"),
+		footerBinding("esc", "back"),
+	}
+}
+
 func (m AccountSettingsDialogModel) View() string {
 	helpKeys := []key.Binding{
 		key.NewBinding(key.WithKeys("↑/↓"), key.WithHelp("↑/↓", "select")),

--- a/internal/tui/calendar_dialog.go
+++ b/internal/tui/calendar_dialog.go
@@ -1001,6 +1001,22 @@ func (m CalendarDialogModel) InspectorView(w, h int) string {
 	return padLines(strings.Split(strings.Join(parts, "\n"), "\n"), w, h)
 }
 
+// HelpBindings returns the footer help this pushed detail owns while it is
+// the manager's active screen: an embedded discovery picker advertises its
+// own compact set, otherwise the form's field keys. The manager footer
+// defers here so a rebound key no longer drifts between the child and the
+// footer. These are display-only; input routing is unchanged.
+func (m CalendarDialogModel) HelpBindings() []key.Binding {
+	if m.discoveryPicker != nil {
+		return m.discoveryPicker.HelpBindings()
+	}
+	return []key.Binding{
+		footerBinding("tab", "next field"),
+		footerBinding("enter", "confirm"),
+		footerBinding("esc", "back"),
+	}
+}
+
 func (m CalendarDialogModel) bodyOverflows() bool {
 	return m.body.TotalLineCount() > m.body.VisibleLineCount()
 }

--- a/internal/tui/calendar_discovery_picker.go
+++ b/internal/tui/calendar_discovery_picker.go
@@ -204,6 +204,20 @@ func (m AccountCalendarPickerModel) InspectorView(w, h int) string {
 	return padLines(rows, w, h)
 }
 
+// HelpBindings returns the compact footer help the manager shows while this
+// picker is the active screen — or embedded in a calendar detail. The
+// arrow-navigation and select-all hints from the standalone picker are
+// omitted so the set fits the manager's minimum interior with the esc hint
+// intact. The manager footer defers here so rebindings no longer drift.
+func (m AccountCalendarPickerModel) HelpBindings() []key.Binding {
+	return []key.Binding{
+		footerBinding("space", "toggle"),
+		footerBinding("tab", "switch"),
+		footerBinding("enter", "confirm"),
+		footerBinding("esc", "back"),
+	}
+}
+
 func (m AccountCalendarPickerModel) BoxSize() (int, int) { return lipgloss.Size(m.View()) }
 
 // HandleInspectorClick routes a pane-relative click on the embedded

--- a/internal/tui/calendar_manager.go
+++ b/internal/tui/calendar_manager.go
@@ -1115,26 +1115,53 @@ func (m CalendarManagerModel) renderManagerBody(w, h int) string {
 	return strings.Join(lines, "\n")
 }
 
-func (m CalendarManagerModel) activeInspectorLines(w, h int) []string {
+// footerBinding builds a display-only footer key binding whose hint label
+// doubles as the key, matching the themed help model's "key · desc" format
+// shared by every dialog footer.
+func footerBinding(k, desc string) key.Binding {
+	return key.NewBinding(key.WithKeys(k), key.WithHelp(k, desc))
+}
+
+// managerChild is the pushed-screen contract: the screen that currently owns
+// the manager's input renders its own inspector view and advertises its own
+// footer help bindings. Centralizing screen→child resolution in activeChild
+// keeps the footer and the inspector from drifting independently when a new
+// screen is added — both read the one mapping.
+type managerChild interface {
+	HelpBindings() []key.Binding
+	InspectorView(w, h int) string
+}
+
+// activeChild returns the pushed screen that currently owns input and the
+// inspector pane, or nil at the root list. It is the single source of truth
+// for the screen→child mapping shared by the footer (helpBindings) and the
+// inspector (activeInspectorLines), so the two cannot drift apart when a
+// screen is added.
+func (m CalendarManagerModel) activeChild() managerChild {
 	switch m.screen {
-	case CalendarManagerScreenList:
-		// The root selection inspector is rendered below.
 	case CalendarManagerScreenCalendar:
 		if m.calendarForm != nil {
-			return strings.Split(m.calendarForm.InspectorView(w, h), "\n")
+			return m.calendarForm
 		}
 	case CalendarManagerScreenAccount:
 		if m.accountSettings != nil {
-			return strings.Split(m.accountSettings.InspectorView(w, h), "\n")
+			return m.accountSettings
 		}
 	case CalendarManagerScreenAccountCalendars:
 		if m.accountPicker != nil {
-			return strings.Split(m.accountPicker.InspectorView(w, h), "\n")
+			return m.accountPicker
 		}
 	case CalendarManagerScreenTransfer:
 		if m.transfer != nil {
-			return strings.Split(m.transfer.InspectorView(w, h), "\n")
+			return m.transfer
 		}
+	}
+	return nil
+}
+
+func (m CalendarManagerModel) activeInspectorLines(w, h int) []string {
+	if child := m.activeChild(); child != nil {
+		return strings.Split(child.InspectorView(w, h), "\n")
 	}
 	return m.selectionInspectorLines(w, h)
 }
@@ -1344,45 +1371,30 @@ func (m CalendarManagerModel) renderHelp(w int) string {
 }
 
 // helpBindings resolves the footer bindings for the current manager state:
-// each pushed screen advertises its child's actual keys, the open Add menu
-// its menu keys, and the root its ring keys plus whatever the focused control
-// activates. Keys listed here are display-only; input routing is unchanged.
+// the discard prompt and Add menu own their own keys, each pushed screen
+// advertises its child's actual keys (HelpBindings), and the root shows its
+// ring keys plus whatever the focused control activates. Keys listed here
+// are display-only; input routing is unchanged.
 func (m CalendarManagerModel) helpBindings() []key.Binding {
-	bind := func(k, desc string) key.Binding {
-		return key.NewBinding(key.WithKeys(k), key.WithHelp(k, desc))
-	}
 	if m.discardConfirm != nil {
-		return []key.Binding{bind("tab", "switch"), bind("enter", "select"), bind("esc", "keep editing")}
+		return []key.Binding{footerBinding("tab", "switch"), footerBinding("enter", "select"), footerBinding("esc", "keep editing")}
 	}
-	// The arrow-navigation hint is omitted so the picker set fits the
-	// manager's minimum interior with the esc hint intact.
-	pickerBindings := []key.Binding{bind("space", "toggle"), bind("tab", "switch"), bind("enter", "confirm"), bind("esc", "back")}
-	switch m.screen {
-	case CalendarManagerScreenCalendar, CalendarManagerScreenTransfer:
-		if m.calendarForm != nil && m.calendarForm.discoveryPicker != nil {
-			return pickerBindings
-		}
-		return []key.Binding{bind("tab", "next field"), bind("enter", "confirm"), bind("esc", "back")}
-	case CalendarManagerScreenAccount:
-		return []key.Binding{bind("↑/↓", "select"), bind("enter", "open"), bind("esc", "back")}
-	case CalendarManagerScreenAccountCalendars:
-		return pickerBindings
-	case CalendarManagerScreenList:
-		// Resolved below by root focus.
+	if child := m.activeChild(); child != nil {
+		return child.HelpBindings()
 	}
 	if m.addMenuOpen {
-		return []key.Binding{bind("↑↓", "select"), bind("enter", "choose"), bind("esc", "dismiss")}
+		return []key.Binding{footerBinding("↑↓", "select"), footerBinding("enter", "choose"), footerBinding("esc", "dismiss")}
 	}
 	switch m.rootFocus {
 	case rootFocusAdd:
-		return []key.Binding{bind("tab", "next"), bind("enter", "add"), bind("esc", "close")}
+		return []key.Binding{footerBinding("tab", "next"), footerBinding("enter", "add"), footerBinding("esc", "close")}
 	case rootFocusInspector:
-		return []key.Binding{bind("tab", "next"), bind("enter", "activate"), bind("esc", "close")}
+		return []key.Binding{footerBinding("tab", "next"), footerBinding("enter", "activate"), footerBinding("esc", "close")}
 	default:
 		// "a add" is omitted: + Add is a visible tab stop in the root ring and
 		// the accelerator keeps working; the compact set keeps esc visible at
 		// the manager's minimum widths.
-		return []key.Binding{bind("↑↓", "select"), bind("space", "toggle"), bind("enter", "open"), bind("tab", "next"), bind("esc", "close")}
+		return []key.Binding{footerBinding("↑↓", "select"), footerBinding("space", "toggle"), footerBinding("enter", "open"), footerBinding("tab", "next"), footerBinding("esc", "close")}
 	}
 }
 

--- a/internal/tui/calendar_manager.go
+++ b/internal/tui/calendar_manager.go
@@ -1139,6 +1139,8 @@ type managerChild interface {
 // screen is added.
 func (m CalendarManagerModel) activeChild() managerChild {
 	switch m.screen {
+	case CalendarManagerScreenList:
+		return nil
 	case CalendarManagerScreenCalendar:
 		if m.calendarForm != nil {
 			return m.calendarForm

--- a/internal/tui/calendar_manager_footer_test.go
+++ b/internal/tui/calendar_manager_footer_test.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	"charm.land/bubbles/v2/key"
 	lipgloss "charm.land/lipgloss/v2"
 
 	"github.com/douglasdemoura/chroncal/internal/account"
@@ -69,5 +71,186 @@ func TestCalendarManagerFooterNeverWraps(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// footerBindingsEqual compares two footer binding slices by the rendered help
+// hint (key label + description) — the only attributes the footer displays —
+// so the contract tests assert the user-visible contract, not binding identity.
+func footerBindingsEqual(a, b []key.Binding) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		ah, bh := a[i].Help(), b[i].Help()
+		if ah.Key != bh.Key || ah.Desc != bh.Desc {
+			return false
+		}
+	}
+	return true
+}
+
+// For #547 the pushed-screen footer is owned by the active child: the manager
+// defers to each child's HelpBindings instead of a hardcoded copy that drifts
+// when a key is rebound. Every pushed screen must defer to its own child.
+func TestManagerFooterDefersToActiveChildHelp(t *testing.T) {
+	base := footerTestManager()
+
+	cal := base.OpenCalendar(CalendarDialogParams{ID: 1, Name: "Personal", ManagerEmbedded: true})
+	if got := cal.helpBindings(); !footerBindingsEqual(got, cal.calendarForm.HelpBindings()) {
+		t.Errorf("calendar footer does not defer to calendarForm.HelpBindings(): %#v", got)
+	}
+
+	acc := base.OpenAccount(AccountSettingsParams{AccountID: 7, DisplayName: "iCloud"})
+	if got := acc.helpBindings(); !footerBindingsEqual(got, acc.accountSettings.HelpBindings()) {
+		t.Errorf("account footer does not defer to accountSettings.HelpBindings(): %#v", got)
+	}
+
+	picker := base.OpenAccountCalendars(pickerDiscovery())
+	if got := picker.helpBindings(); !footerBindingsEqual(got, picker.accountPicker.HelpBindings()) {
+		t.Errorf("account-calendars footer does not defer to accountPicker.HelpBindings(): %#v", got)
+	}
+
+	transfer := base.OpenImport()
+	if got := transfer.helpBindings(); !footerBindingsEqual(got, transfer.transfer.HelpBindings()) {
+		t.Errorf("transfer footer does not defer to transfer.HelpBindings(): %#v", got)
+	}
+}
+
+// A calendar detail with an embedded discovery picker advertises the picker's
+// compact help (via the calendar child), so connecting an account never shows
+// the form's field hints.
+func TestCalendarDetailHelpDelegatesToEmbeddedPicker(t *testing.T) {
+	m := footerTestManager().OpenCalendar(CalendarDialogParams{ID: 1, Name: "Personal", ManagerEmbedded: true})
+	m = m.ShowDiscovery(pickerDiscovery())
+	if m.calendarForm == nil || m.calendarForm.discoveryPicker == nil {
+		t.Fatalf("embedded discovery picker not mounted: form=%v", m.calendarForm != nil)
+	}
+	want := m.calendarForm.discoveryPicker.HelpBindings()
+	if got := m.helpBindings(); !footerBindingsEqual(got, want) {
+		t.Errorf("calendar+picker footer does not defer to discoveryPicker.HelpBindings(): %#v", got)
+	}
+}
+
+// The child-owned footer must keep the exact hint text the manager showed
+// before #547, so centralizing the dispatch is a no-op for users.
+func TestManagerFooterHintsPreserved(t *testing.T) {
+	wide := footerTestManager().SetSize(140, 40)
+	cases := []struct {
+		name  string
+		state CalendarManagerModel
+		hints []string
+	}{
+		{"calendar", wide.OpenCalendar(CalendarDialogParams{ID: 1, Name: "Personal", ManagerEmbedded: true}), []string{"next field", "confirm", "back"}},
+		{"account", wide.OpenAccount(AccountSettingsParams{AccountID: 7, DisplayName: "iCloud"}), []string{"select", "open", "back"}},
+		{"picker", wide.OpenAccountCalendars(pickerDiscovery()), []string{"toggle", "switch", "confirm", "back"}},
+		{"transfer", wide.OpenImport(), []string{"next field", "confirm", "back"}},
+		{"calendar+picker", wide.OpenCalendar(CalendarDialogParams{ID: 1, Name: "Personal", ManagerEmbedded: true}).ShowDiscovery(pickerDiscovery()), []string{"toggle", "switch", "confirm", "back"}},
+	}
+	for _, c := range cases {
+		boxW, _ := c.state.boxSize()
+		innerW := max(boxW-5, 10)
+		plain := stripANSI(c.state.renderHelp(innerW))
+		for _, h := range c.hints {
+			if !strings.Contains(plain, h) {
+				t.Errorf("%s: footer %q lost hint %q", c.name, plain, h)
+			}
+		}
+	}
+}
+
+// activeChild is the single screen→child mapping shared by the footer and the
+// inspector. For every pushed screen both must read the same child, and at the
+// root list it must be nil so the selection inspector renders. This locks the
+// two dispatches in lockstep so a newly added screen cannot drift between them.
+func TestActiveChildDrivesFooterAndInspector(t *testing.T) {
+	wide := footerTestManager().SetSize(140, 40)
+
+	if wide.activeChild() != nil {
+		t.Errorf("root list has an active child %T, want nil", wide.activeChild())
+	}
+
+	pushed := []struct {
+		name     string
+		state    CalendarManagerModel
+		wantType string
+	}{
+		{"calendar", wide.OpenCalendar(CalendarDialogParams{ID: 1, Name: "Personal", ManagerEmbedded: true}), "*tui.CalendarDialogModel"},
+		{"account", wide.OpenAccount(AccountSettingsParams{AccountID: 7, DisplayName: "iCloud"}), "*tui.AccountSettingsDialogModel"},
+		{"picker", wide.OpenAccountCalendars(pickerDiscovery()), "*tui.AccountCalendarPickerModel"},
+		{"transfer", wide.OpenImport(), "*tui.CalendarTransferDialogModel"},
+	}
+	for _, c := range pushed {
+		child := c.state.activeChild()
+		if child == nil {
+			t.Errorf("%s: activeChild is nil for a pushed screen", c.name)
+			continue
+		}
+		// The single dispatch maps each screen to its owning child.
+		if got := fmt.Sprintf("%T", child); got != c.wantType {
+			t.Errorf("%s: activeChild type %s, want %s", c.name, got, c.wantType)
+		}
+		// The footer defers to that same child (deterministic: bindings, not render).
+		if got := c.state.helpBindings(); !footerBindingsEqual(got, child.HelpBindings()) {
+			t.Errorf("%s: footer does not defer to activeChild().HelpBindings()", c.name)
+		}
+		// The inspector is rendered by that same child, not the root fallback.
+		// Compare with ANSI stripped: the child's view carries a blinking
+		// text-cursor color phase that varies between render calls, but the
+		// visible text is identical — so stripping isolates the dispatch
+		// contract (activeInspectorLines routed to activeChild, not
+		// selectionInspectorLines) without flaking on cursor phase.
+		w, h := c.state.inspectorPaneSize()
+		got := stripANSI(strings.Join(c.state.activeInspectorLines(w, h), "\n"))
+		want := stripANSI(child.InspectorView(w, h))
+		if got != want {
+			t.Errorf("%s: inspector does not defer to activeChild().InspectorView()", c.name)
+		}
+	}
+}
+
+// Direct screen-switch smoke: opening and closing each pushed screen flips the
+// active child and footer, and the embedded discovery picker hands the footer
+// off and back without leaving the calendar screen.
+func TestManagerScreenSwitchSmoke(t *testing.T) {
+	m := footerTestManager().SetSize(140, 40)
+	if m.activeChild() != nil {
+		t.Fatalf("initial active child %T, want nil", m.activeChild())
+	}
+
+	// Push the calendar detail: footer switches to the form's field hints.
+	m = m.OpenCalendar(CalendarDialogParams{ID: 1, Name: "Personal", ManagerEmbedded: true})
+	if m.Screen() != CalendarManagerScreenCalendar || m.activeChild() == nil {
+		t.Fatalf("OpenCalendar: screen=%v child=%v", m.Screen(), m.activeChild())
+	}
+	if got := stripANSI(m.renderHelp(120)); !strings.Contains(got, "next field") || !strings.Contains(got, "back") {
+		t.Errorf("calendar footer %q lost field/back hints", got)
+	}
+
+	// Embed the discovery picker: footer switches to the picker's toggle hint.
+	m = m.ShowDiscovery(pickerDiscovery())
+	if got := stripANSI(m.renderHelp(120)); !strings.Contains(got, "toggle") {
+		t.Errorf("embedded-picker footer %q lost toggle hint", got)
+	}
+
+	// Drop the picker: footer returns to the form hints.
+	m = m.HideDiscovery()
+	if got := stripANSI(m.renderHelp(120)); !strings.Contains(got, "next field") {
+		t.Errorf("post-picker footer %q lost field hint", got)
+	}
+
+	// Push transfer (export) on top of the retained calendar detail.
+	m = m.OpenExport(1, "Personal")
+	if m.Screen() != CalendarManagerScreenTransfer || m.transfer == nil {
+		t.Fatalf("OpenExport: screen=%v transfer=%v", m.Screen(), m.transfer != nil)
+	}
+	if got := stripANSI(m.renderHelp(120)); !strings.Contains(got, "next field") {
+		t.Errorf("transfer footer %q lost field hint", got)
+	}
+
+	// Close transfer: returns to the calendar detail underneath.
+	m = m.CloseTransfer()
+	if m.Screen() != CalendarManagerScreenCalendar {
+		t.Fatalf("CloseTransfer: screen=%v, want calendar", m.Screen())
 	}
 }

--- a/internal/tui/calendar_transfer_dialog.go
+++ b/internal/tui/calendar_transfer_dialog.go
@@ -251,6 +251,18 @@ func (m CalendarTransferDialogModel) InspectorView(w, h int) string {
 	return padLines(strings.Split(strings.Join(parts, "\n"), "\n"), w, h)
 }
 
+// HelpBindings returns the footer help this pushed transfer screen owns
+// while it is the manager's active screen. The manager footer defers here
+// so a rebound key no longer drifts between the child and the footer.
+// Display-only.
+func (m CalendarTransferDialogModel) HelpBindings() []key.Binding {
+	return []key.Binding{
+		footerBinding("tab", "next field"),
+		footerBinding("enter", "confirm"),
+		footerBinding("esc", "back"),
+	}
+}
+
 func (m CalendarTransferDialogModel) BoxSize() (int, int) { return lipgloss.Size(m.View()) }
 
 func (m CalendarTransferDialogModel) Update(msg tea.Msg) (CalendarTransferDialogModel, tea.Cmd) {


### PR DESCRIPTION
## Summary

`CalendarManagerModel.helpBindings()` hardcoded each pushed child's footer key hints instead of asking the child, so a rebound key silently drifted between the child and the footer. The same screen→child/nil dispatch was also duplicated across `helpBindings()` and `activeInspectorLines()`, so the two could fall out of lockstep when a screen is added. This introduces the smallest coherent pushed-screen contract to fix both (#547).

## Changes

- **Child-owned footer help.** Added `HelpBindings() []key.Binding` to `CalendarDialogModel`, `AccountSettingsDialogModel`, `AccountCalendarPickerModel`, and `CalendarTransferDialogModel`. The calendar detail delegates to its embedded discovery picker when one is mounted.
- **One dispatch.** Added a `managerChild` interface (`HelpBindings` + `InspectorView`) and a single `activeChild()` screen→child mapping shared by `helpBindings()` and `activeInspectorLines()`, so the footer and inspector cannot drift independently when a screen is added.
- **Cleanup.** Replaced the manager's per-screen binding literals and the `bind()` closure with a shared `footerBinding` helper; removed the old `pickerBindings` local and screen switch. Footer text and order are unchanged.

Nil safety, screen-specific behavior, and input routing are preserved; the footer is display-only.

### Behavioral note
The original `helpBindings` lumped the Calendar and Transfer cases and checked `calendarForm.discoveryPicker` for both. The export/import button is not rendered or interactive while the discovery picker is open (`View()`/`Update()` delegate to the picker), so the Transfer+picker case was unreachable — and `activeInspectorLines` already treated Transfer uniformly. `activeChild` now treats Transfer the same way both places, making footer and inspector consistent with no observable change.

## Verification
- `go build ./...` — clean.
- Targeted footer/contract tests (new): defer-to-child, embedded-picker delegation, hint preservation, `activeChild` dispatch, and a direct screen-switch smoke check — all pass.
- Full `internal/tui` package test suite — passes.
- `gofmt` — clean.
- (Formatters/linters/project-wide suites skipped per issue scope.)

## Risk
Low. Display-only change; no input routing or data flow touched. The one normalized edge case (Transfer footer while a discovery picker is mounted underneath) was unreachable and already inconsistent between footer and inspector.

Closes #547
