### PR TITLE
refactor(tui): unify calendar visibility ownership

### DIFF
--- a/internal/tui/app_review_fixes_test.go
+++ b/internal/tui/app_review_fixes_test.go
@@ -78,8 +78,8 @@ func TestVisibilityToggleReachesOpenManager(t *testing.T) {
 
 	updated, _ := m.Update(CalendarVisibilityToggledMsg{ID: 1, Hidden: true})
 	m = updated.(Model)
-	if !m.calendarManager.hidden[1] {
-		t.Fatal("visibility toggle did not reach the open manager's hidden map")
+	if !m.calendarManager.list.IsHidden(1) {
+		t.Fatal("visibility toggle did not reach the open manager's list-owned hidden set")
 	}
 }
 

--- a/internal/tui/calendar_list_model.go
+++ b/internal/tui/calendar_list_model.go
@@ -238,16 +238,20 @@ func (m CalendarListModel) RowCount() int  { return len(m.rows) }
 
 // SetItems replaces the items, prunes stale hidden IDs, and clamps the cursor.
 func (m CalendarListModel) SetItems(items []CalendarListItem) CalendarListModel {
+	return m.setItemsAndHidden(items, m.hidden)
+}
+
+func (m CalendarListModel) setItemsAndHidden(items []CalendarListItem, hidden map[int64]bool) CalendarListModel {
 	m.items = slices.Clone(items)
 	m.grouped = hasAccountGroups(items)
 	valid := make(map[int64]bool, len(items))
 	for _, item := range items {
 		valid[item.ID] = true
 	}
-	m.hidden = maps.Clone(m.hidden)
-	for id := range m.hidden {
-		if !valid[id] {
-			delete(m.hidden, id)
+	m.hidden = make(map[int64]bool, len(hidden))
+	for id, h := range hidden {
+		if h && valid[id] {
+			m.hidden[id] = true
 		}
 	}
 	m.rebuildRows()
@@ -265,20 +269,24 @@ func (m CalendarListModel) SetItemsPreservingCursor(items []CalendarListItem) Ca
 	return m.ensureCursorVisible()
 }
 
+// SetItemsAndHiddenPreservingCursor replaces list data and visibility in one
+// pass, cloning the caller-owned hidden map while pruning IDs absent from items.
+func (m CalendarListModel) SetItemsAndHiddenPreservingCursor(items []CalendarListItem, hidden map[int64]bool) CalendarListModel {
+	identity, ok := m.currentIdentity()
+	m = m.setItemsAndHidden(items, hidden)
+	if ok {
+		m.selectIdentity(identity)
+	}
+	return m.ensureCursorVisible()
+}
+
 func (m CalendarListModel) HiddenSet() map[int64]bool { return maps.Clone(m.hidden) }
 
-// SetHiddenSet replaces the whole visibility set in one clone, for hosts
-// that mirror an external hidden map (the manager's rebuild); the per-ID
-// SetHidden would clone the map once per calendar.
-func (m CalendarListModel) SetHiddenSet(hidden map[int64]bool) CalendarListModel {
-	m.hidden = make(map[int64]bool, len(hidden))
-	for id, h := range hidden {
-		if h {
-			m.hidden[id] = true
-		}
-	}
-	return m
-}
+// IsHidden reports whether the given calendar is currently hidden. It is the
+// read-only view of the owned visibility set: callers that share the list
+// (the unified Calendars manager) read visibility through here instead of
+// keeping a second mirrored map, so there is a single source of truth.
+func (m CalendarListModel) IsHidden(id int64) bool { return m.hidden[id] }
 
 // SetHidden applies an explicit visibility state without emitting another
 // toggle message. The app uses it to keep the sidebar projection aligned when

--- a/internal/tui/calendar_manager.go
+++ b/internal/tui/calendar_manager.go
@@ -109,10 +109,11 @@ type CalendarManagerModel struct {
 	rootFocus calendarManagerRootFocus
 
 	calendars map[int64]CalendarInfo
-	hidden    map[int64]bool
 	// list is the shared grouped calendar hierarchy used by the sidebar. It
-	// keeps account headers, collapse state, visibility controls, and stable
-	// identity selection consistent across both surfaces.
+	// is the single owner of the calendar visibility (hidden) set within the
+	// manager: account headers, collapse state, visibility dots, and stable
+	// identity selection all read through it, so there is no second mirrored
+	// hidden map to drift out of sync.
 	list CalendarListModel
 
 	pendingSelectionID int64
@@ -156,7 +157,6 @@ func NewCalendarManagerModel(calendars map[int64]CalendarInfo, hidden map[int64]
 	m := CalendarManagerModel{
 		screen:    CalendarManagerScreenList,
 		calendars: calendars,
-		hidden:    hidden,
 		theme:     activeTheme,
 		keys:      defaultCalendarManagerKeys(),
 		help:      h,
@@ -386,8 +386,10 @@ func (m CalendarManagerModel) SetData(calendars map[int64]CalendarInfo, hidden m
 	}
 
 	m.calendars = calendars
-	m.hidden = hidden
-	m = m.rebuild()
+	// Replace items and visibility together so the list clones the host map and
+	// prunes stale IDs in one pass without a transient second projection.
+	m.list = m.list.SetItemsAndHiddenPreservingCursor(sortedCalendarListItems(m.calendars), hidden)
+	m = m.sizeList()
 
 	switch {
 	case !hadIdentity && len(m.list.items) > 0:
@@ -430,25 +432,8 @@ func (m CalendarManagerModel) SelectCalendar(id int64) CalendarManagerModel {
 	return m.selectCalendar(id)
 }
 
-// setHidden returns a copy of hidden with id set to val. Copying keeps the
-// optimistic toggle off the host's (possibly shared) hidden map and is safe
-// when hidden is nil.
-func setHidden(hidden map[int64]bool, id int64, val bool) map[int64]bool {
-	out := make(map[int64]bool, len(hidden)+1)
-	for k, v := range hidden {
-		if k != id {
-			out[k] = v
-		}
-	}
-	if val {
-		out[id] = true
-	}
-	return out
-}
-
 func (m CalendarManagerModel) rebuild() CalendarManagerModel {
-	m.list = m.list.SetItemsPreservingCursor(sortedCalendarListItems(m.calendars)).
-		SetHiddenSet(m.hidden)
+	m.list = m.list.SetItemsPreservingCursor(sortedCalendarListItems(m.calendars))
 	return m.sizeList()
 }
 
@@ -523,7 +508,7 @@ func (m CalendarManagerModel) selectedCalendar() (int64, CalendarInfo, bool) {
 // openSelectedCalendar pushes the edit form for an existing calendar row,
 // wiring its current visibility into the params.
 func (m CalendarManagerModel) openSelectedCalendar(id int64, info CalendarInfo) CalendarManagerModel {
-	return m.OpenCalendar(calendarDialogParamsFor(id, info, m.hidden[id]))
+	return m.OpenCalendar(calendarDialogParamsFor(id, info, m.list.IsHidden(id)))
 }
 
 // cycleRootFocus moves root focus one step around the available ring. Forward
@@ -786,12 +771,7 @@ func (m CalendarManagerModel) handleKey(msg tea.KeyPressMsg) (CalendarManagerMod
 	m = m.applyRootFocus()
 	next, cmd := m.list.Update(msg)
 	m.list = next
-	return m.syncListProjection().normalizeRootFocus(), cmd
-}
-
-func (m CalendarManagerModel) syncListProjection() CalendarManagerModel {
-	m.hidden = m.list.HiddenSet()
-	return m
+	return m.normalizeRootFocus(), cmd
 }
 
 func (m CalendarManagerModel) handleMouse(msg tea.MouseClickMsg) (CalendarManagerModel, tea.Cmd) {
@@ -824,12 +804,14 @@ func (m CalendarManagerModel) handleMouse(msg tea.MouseClickMsg) (CalendarManage
 	if msg.X < lx || msg.X >= lx+lw || msg.Y < ly || msg.Y >= ly+lh {
 		return m, nil
 	}
-	// A source-list click always restores list focus before routing.
+	// A source-list click always restores list focus before routing. The list
+	// owns the visibility set, so a click that toggles a dot updates the single
+	// source directly — no projection to mirror back.
 	m = m.setRootFocus(rootFocusList)
 	relX := msg.X - lx
 	next, cmd := m.list.HandleClick(relX, msg.Y-ly)
 	m.list = next
-	m = m.syncListProjection().normalizeRootFocus()
+	m = m.normalizeRootFocus()
 	identity, selected := m.list.currentIdentity()
 	indicatorEnd := m.list.visibilityIndicatorWidth()
 	if m.list.grouped {
@@ -896,8 +878,8 @@ func (m CalendarManagerModel) updateAccountCalendars(msg tea.Msg) (CalendarManag
 
 // updateCalendar delegates input to the pushed calendar detail and intercepts
 // only navigation messages. CalendarDialogClosedMsg pops back to the root
-// list; CalendarVisibilityToggledMsg is mirrored into the root hidden map so
-// the dot stays consistent on Back. The Account opener's
+// list; CalendarVisibilityToggledMsg is mirrored into the list-owned hidden
+// set so the dot stays consistent on Back. The Account opener's
 // AccountSettingsRequestedMsg is NOT intercepted here — it passes through to
 // the host, which owns the canonical account record and later calls
 // OpenAccount with full params. Every other domain/action message (Save, Set
@@ -930,11 +912,11 @@ func (m CalendarManagerModel) updateCalendar(msg tea.Msg) (CalendarManagerModel,
 		m.screen = CalendarManagerScreenList
 		return m, nil
 	case CalendarVisibilityToggledMsg:
-		// Mirror the detail's optimistic toggle into the root so the row's
-		// checkbox is already correct when the user pops back. The host also
+		// Mirror the detail's optimistic toggle into the list-owned set so
+		// the row's dot is already correct when the user pops back. The list
+		// is the single source of truth within the manager; the host also
 		// persists this message when it receives the child command.
-		m.hidden = setHidden(m.hidden, typed.ID, typed.Hidden)
-		m = m.rebuild()
+		m.list = m.list.SetHidden(typed.ID, typed.Hidden)
 		return m, nil
 	}
 
@@ -1176,7 +1158,7 @@ func (m CalendarManagerModel) activeInspectorLines(w, h int) []string {
 // the summary header plus one bottom action pinned to the final row.
 func (m CalendarManagerModel) selectionInspectorLines(w, h int) []string {
 	if id, info, ok := m.selectedCalendar(); ok {
-		params := calendarDialogParamsFor(id, info, m.hidden[id])
+		params := calendarDialogParamsFor(id, info, m.list.IsHidden(id))
 		preview := NewCalendarDialogModel(params, m.theme).Blur().SetInspectorSize(w, h)
 		return strings.Split(preview.InspectorView(w, h), "\n")
 	}

--- a/internal/tui/calendar_manager_test.go
+++ b/internal/tui/calendar_manager_test.go
@@ -113,8 +113,8 @@ func TestCalendarManagerRootMouseCheckboxTogglesVisibility(t *testing.T) {
 	if !ok || msg.ID != 2 || !msg.Hidden {
 		t.Fatalf("checkbox click message = %#v, want calendar 2 hidden", cmd())
 	}
-	if toggled.Screen() != CalendarManagerScreenList || !toggled.hidden[2] {
-		t.Fatalf("checkbox click opened edit or failed optimistic toggle: screen=%v hidden=%v", toggled.Screen(), toggled.hidden[2])
+	if toggled.Screen() != CalendarManagerScreenList || !toggled.list.IsHidden(2) {
+		t.Fatalf("checkbox click opened edit or failed optimistic toggle: screen=%v hidden=%v", toggled.Screen(), toggled.list.IsHidden(2))
 	}
 }
 
@@ -734,7 +734,7 @@ func TestCalendarManagerDetailActionsTargetImmutableID(t *testing.T) {
 
 func TestCalendarManagerRootSpaceTogglesBothDirections(t *testing.T) {
 	m := newFlatManager().selectCalendar(2)
-	if m.hidden[2] {
+	if m.list.IsHidden(2) {
 		t.Fatal("calendar 2 should start visible")
 	}
 	// Visible -> hidden.
@@ -746,7 +746,7 @@ func TestCalendarManagerRootSpaceTogglesBothDirections(t *testing.T) {
 	if msg.ID != 2 || !msg.Hidden {
 		t.Fatalf("visible->hidden: msg = %+v, want {ID:2 Hidden:true}", msg)
 	}
-	if !m1.hidden[2] {
+	if !m1.list.IsHidden(2) {
 		t.Error("local hidden state not flipped to true")
 	}
 	if row := managerCalendarLine(t, m1, 2); !strings.HasPrefix(row, "○") {
@@ -761,11 +761,54 @@ func TestCalendarManagerRootSpaceTogglesBothDirections(t *testing.T) {
 	if msg.ID != 2 || msg.Hidden {
 		t.Fatalf("hidden->visible: msg = %+v, want {ID:2 Hidden:false}", msg)
 	}
-	if m2.hidden[2] {
+	if m2.list.IsHidden(2) {
 		t.Error("local hidden state not flipped back to false")
 	}
 	if row := managerCalendarLine(t, m2, 2); !strings.HasPrefix(row, "●") {
 		t.Errorf("row did not flip back to the filled visibility circle: %q", row)
+	}
+}
+
+// TestCalendarManagerListOwnsHiddenSet is the regression guard for issue #543:
+// the calendar manager keeps a single source of truth for visibility — the
+// embedded list — instead of a second mirrored map. After every toggle path
+// the list-owned set, the reopened detail form, and a reload all agree, and a
+// reload replaces (never merges) the set so no stale or cleared ID can linger.
+func TestCalendarManagerListOwnsHiddenSet(t *testing.T) {
+	cals := flatManagerCalendars()
+	initialHidden := map[int64]bool{3: true}
+	m := NewCalendarManagerModel(cals, initialHidden, help.New()).
+		SetSize(120, 40).selectCalendar(1)
+	initialHidden[1] = true
+	delete(initialHidden, 3)
+	if hidden := m.list.HiddenSet(); hidden[1] || !hidden[3] {
+		t.Fatalf("constructor retained caller hidden-map alias: %v", hidden)
+	}
+
+	// Open the detail so a forwarded CalendarVisibilityToggledMsg mirrors into
+	// the list owner via updateCalendar (the path the app uses).
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.Screen() != CalendarManagerScreenCalendar {
+		t.Fatalf("setup: detail form not open, screen=%v", m.Screen())
+	}
+	m, _ = m.Update(CalendarVisibilityToggledMsg{ID: 1, Hidden: true})
+	if !m.list.IsHidden(1) {
+		t.Fatal("forwarded detail toggle did not update the list-owned hidden set")
+	}
+	// The detail reopen path (inspector preview / openSelectedCalendar) reads
+	// the same single owner, so it can never diverge from the row dot.
+	if got := calendarDialogParamsFor(1, cals[1], m.list.IsHidden(1)).Hidden; !got {
+		t.Fatalf("detail reopen reads hidden=%v while the list owns hidden=true", got)
+	}
+
+	// A reload replaces the whole set from the host map: no stale ID survives
+	// and no previously-cleared ID lingers (the old two-map merge bug class).
+	reloadedHidden := map[int64]bool{2: true}
+	m = m.SetData(cals, reloadedHidden)
+	reloadedHidden[1] = true
+	delete(reloadedHidden, 2)
+	if hidden := m.list.HiddenSet(); !hidden[2] || hidden[1] || hidden[3] {
+		t.Fatalf("SetData did not clone and replace the owned hidden set: %v", hidden)
 	}
 }
 
@@ -1070,12 +1113,12 @@ func TestCalendarManagerDetailAccountBackPreservesDraft(t *testing.T) {
 
 // TestCalendarManagerDetailVisibilityToggleEmitsDesiredState verifies the
 // detail's Display Calendar toggle emits CalendarVisibilityToggledMsg with the
-// desired Hidden state immediately, and mirrors the change into the root's
-// hidden map so the dot stays consistent on Back.
+// desired Hidden state immediately, and mirrors the change into the list-owned
+// hidden set so the dot stays consistent on Back.
 func TestCalendarManagerDetailVisibilityToggleEmitsDesiredState(t *testing.T) {
 	m := newFlatManager().selectCalendar(1) // On device, visible
 	pushed, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if pushed.hidden[1] {
+	if pushed.list.IsHidden(1) {
 		t.Fatal("calendar 1 should start visible")
 	}
 	focused, ok := focusCalendarDetailField(pushed, "checkbox")
@@ -1094,8 +1137,8 @@ func TestCalendarManagerDetailVisibilityToggleEmitsDesiredState(t *testing.T) {
 		t.Fatalf("toggle msg = %+v, want {ID:1 Hidden:true}", msg)
 	}
 	hidden, _ = hidden.Update(msg)
-	if !hidden.hidden[1] {
-		t.Error("root hidden map not mirrored to true")
+	if !hidden.list.IsHidden(1) {
+		t.Error("list-owned hidden set not mirrored to true")
 	}
 	// Toggling back emits the opposite desired state.
 	visible, cmd := hidden.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
@@ -1104,8 +1147,8 @@ func TestCalendarManagerDetailVisibilityToggleEmitsDesiredState(t *testing.T) {
 		t.Fatalf("toggle back msg = %+v, want {ID:1 Hidden:false}", msg)
 	}
 	visible, _ = visible.Update(msg)
-	if visible.hidden[1] {
-		t.Error("root hidden map not mirrored back to false")
+	if visible.list.IsHidden(1) {
+		t.Error("list-owned hidden set not mirrored back to false")
 	}
 }
 
@@ -1405,7 +1448,7 @@ func TestCalendarManagerDetailLeftPopsAccountToCalendar(t *testing.T) {
 func TestCalendarManagerDetailVisibilityMouseToggleEmitsDesiredState(t *testing.T) {
 	m := newFlatManager().selectCalendar(1).SetSize(120, 40)
 	pushed, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if pushed.calendarForm == nil || pushed.hidden[1] {
+	if pushed.calendarForm == nil || pushed.list.IsHidden(1) {
 		t.Fatal("precondition: calendar 1 detail open and visible")
 	}
 	cbIdx := calendarDetailFieldIndex(pushed, "checkbox")
@@ -1428,8 +1471,8 @@ func TestCalendarManagerDetailVisibilityMouseToggleEmitsDesiredState(t *testing.
 		t.Fatalf("mouse toggle msg = %+v, want {ID:1 Hidden:true}", msg)
 	}
 	hidden, _ = hidden.Update(msg)
-	if !hidden.hidden[1] {
-		t.Error("root hidden map not mirrored to true after mouse toggle")
+	if !hidden.list.IsHidden(1) {
+		t.Error("list-owned hidden set not mirrored to true after mouse toggle")
 	}
 }
 

--- a/internal/tui/event_dialog_test.go
+++ b/internal/tui/event_dialog_test.go
@@ -37,7 +37,7 @@ func TestRsvpButtonWidthMatchesRendered(t *testing.T) {
 // unit; the "min."/"sec." abbreviations were only correct by accident.
 func TestFormatAlarm(t *testing.T) {
 	cases := []struct {
-		name string
+		name  string
 		alarm model.Alarm
 		want  string
 	}{
@@ -104,5 +104,3 @@ func TestPluralize(t *testing.T) {
 		})
 	}
 }
-
-


### PR DESCRIPTION
## Summary
- make `CalendarListModel` the calendar manager's sole owner of hidden-calendar state
- remove manager/list projection sync choreography
- clone and prune externally supplied hidden maps in one pass
- cover keyboard, detail-message, reload, and aliasing paths

## Verification
- `go test ./internal/tui -run 'TestCalendarManagerListOwnsHiddenSet|TestCalendarManagerRootSpaceTogglesBothDirections|TestCalendarManagerDetailVisibility|TestVisibilityToggleReachesOpenManager' -count=1`
- spec review: PASS
- quality review findings fixed: single-pass reload, accurate test wording, defensive-copy coverage

Closes #543