### PR TITLE
refactor(auth): centralize credential compensation

### DIFF
--- a/internal/account/service.go
+++ b/internal/account/service.go
@@ -582,33 +582,15 @@ func (s *Service) ReconcileSelection(
 	}
 
 	removeAccount := len(selectedKeys) == 0
-	var (
-		previous    auth.Credential
-		hasPrevious bool
-	)
+	var prior auth.PriorCredential
 	if removeAccount {
 		if store == nil {
 			return SelectionResult{}, fmt.Errorf("credential store is required to remove an empty account")
 		}
-		previous, err = store.Get(
-			discovery.Account.ID,
-			discovery.Account.CredentialFingerprint(),
-		)
-		if err != nil &&
-			!auth.IsCredentialNotFound(err) &&
-			!errors.Is(err, auth.ErrCredentialIdentityMismatch) {
+		prior, err = auth.CapturePriorCredential(store, discovery.Account.ID, discovery.Account.CredentialFingerprint())
+		if err != nil {
 			return SelectionResult{}, fmt.Errorf("read account credentials before removal: %w", err)
 		}
-		hasPrevious = err == nil
-	}
-	restorePrevious := func(cause error, operation string) error {
-		if !hasPrevious {
-			return fmt.Errorf("%s: %w", operation, cause)
-		}
-		if restoreErr := store.Set(previous); restoreErr != nil {
-			return fmt.Errorf("%s: %w (restore credentials: %w)", operation, cause, restoreErr)
-		}
-		return fmt.Errorf("%s: %w", operation, cause)
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -762,16 +744,13 @@ func (s *Service) ReconcileSelection(
 			return SelectionResult{}, fmt.Errorf("remove empty account: %w", err)
 		}
 		if err := store.Delete(discovery.Account.ID); err != nil {
-			return SelectionResult{}, restorePrevious(err, "delete empty account credentials")
+			return SelectionResult{}, prior.Restore(store, discovery.Account.ID, false, "delete empty account credentials", err)
 		}
 		result.AccountRemoved = true
 	}
 
-	if err := tx.Commit(); err != nil {
-		if removeAccount {
-			return SelectionResult{}, restorePrevious(err, "commit account calendar reconciliation")
-		}
-		return SelectionResult{}, fmt.Errorf("commit account calendar reconciliation: %w", err)
+	if err := auth.CommitWithCredentialCompensation(tx, store, discovery.Account.ID, prior, false, "commit account calendar reconciliation"); err != nil {
+		return SelectionResult{}, err
 	}
 	return result, nil
 }
@@ -798,21 +777,9 @@ func (s *Service) RemoveWithCalendars(
 	if err != nil {
 		return RemoveResult{}, fmt.Errorf("get account: %w", err)
 	}
-	previous, previousErr := store.Get(accountID, configured.CredentialFingerprint())
-	if previousErr != nil &&
-		!auth.IsCredentialNotFound(previousErr) &&
-		!errors.Is(previousErr, auth.ErrCredentialIdentityMismatch) {
-		return RemoveResult{}, fmt.Errorf("read account credentials before removal: %w", previousErr)
-	}
-	hasPrevious := previousErr == nil
-	restorePrevious := func(cause error, operation string) error {
-		if !hasPrevious {
-			return fmt.Errorf("%s: %w", operation, cause)
-		}
-		if restoreErr := store.Set(previous); restoreErr != nil {
-			return fmt.Errorf("%s: %w (restore credentials: %w)", operation, cause, restoreErr)
-		}
-		return fmt.Errorf("%s: %w", operation, cause)
+	prior, err := auth.CapturePriorCredential(store, accountID, configured.CredentialFingerprint())
+	if err != nil {
+		return RemoveResult{}, fmt.Errorf("read account credentials before removal: %w", err)
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -874,10 +841,10 @@ func (s *Service) RemoveWithCalendars(
 		return RemoveResult{}, fmt.Errorf("delete account: %w", err)
 	}
 	if err := store.Delete(accountID); err != nil {
-		return RemoveResult{}, restorePrevious(err, "delete account credentials")
+		return RemoveResult{}, prior.Restore(store, accountID, false, "delete account credentials", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return RemoveResult{}, restorePrevious(err, "commit account removal")
+	if err := auth.CommitWithCredentialCompensation(tx, store, accountID, prior, false, "commit account removal"); err != nil {
+		return RemoveResult{}, err
 	}
 	return result, nil
 }
@@ -903,23 +870,11 @@ func (s *Service) Delete(ctx context.Context, accountID int64, store auth.Creden
 	if err != nil {
 		return fmt.Errorf("get account: %w", err)
 	}
-	previous, previousErr := store.Get(accountID, auth.AccountFingerprint(
+	prior, err := auth.CapturePriorCredential(store, accountID, auth.AccountFingerprint(
 		account.ServerUrl, account.AuthType, account.Username,
 	))
-	if previousErr != nil &&
-		!auth.IsCredentialNotFound(previousErr) &&
-		!errors.Is(previousErr, auth.ErrCredentialIdentityMismatch) {
-		return fmt.Errorf("read account credentials before delete: %w", previousErr)
-	}
-	hasPrevious := previousErr == nil
-	restorePrevious := func(cause error, operation string) error {
-		if !hasPrevious {
-			return fmt.Errorf("%s: %w", operation, cause)
-		}
-		if restoreErr := store.Set(previous); restoreErr != nil {
-			return fmt.Errorf("%s: %w (restore credentials: %w)", operation, cause, restoreErr)
-		}
-		return fmt.Errorf("%s: %w", operation, cause)
+	if err != nil {
+		return fmt.Errorf("read account credentials before delete: %w", err)
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -946,10 +901,10 @@ func (s *Service) Delete(ctx context.Context, accountID int64, store auth.Creden
 		return fmt.Errorf("delete account: %w", err)
 	}
 	if err := store.Delete(accountID); err != nil {
-		return restorePrevious(err, "delete account credentials")
+		return prior.Restore(store, accountID, false, "delete account credentials", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return restorePrevious(err, "commit account delete")
+	if err := auth.CommitWithCredentialCompensation(tx, store, accountID, prior, false, "commit account delete"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/account/service_test.go
+++ b/internal/account/service_test.go
@@ -1387,6 +1387,7 @@ func TestCreateRejectsUnsafeServerURLWithoutPersisting(t *testing.T) {
 type selectionFixture struct {
 	svc       *Service
 	q         *storage.Queries
+	db        *sql.DB
 	store     *memoryCredentialStore
 	discovery Discovery
 }
@@ -1419,7 +1420,7 @@ func newSelectionFixture(t *testing.T) selectionFixture {
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
-	return selectionFixture{svc: svc, q: q, store: store, discovery: discovery}
+	return selectionFixture{svc: svc, q: q, db: db, store: store, discovery: discovery}
 }
 
 func (f selectionFixture) importAndRefresh(t *testing.T, paths ...string) (ImportResult, Discovery) {
@@ -1706,5 +1707,96 @@ func TestReconcileSelectionRefusesLastApplicationCalendar(t *testing.T) {
 	}
 	if _, err := f.q.GetCalendar(ctx, imported.CreatedIDs[0]); err != nil {
 		t.Fatalf("last calendar was removed: %v", err)
+	}
+}
+
+// installAccountDeleteCommitFailure installs a deferred foreign-key trigger
+// that makes the transaction's COMMIT (not DeleteAccount itself) fail, so the
+// commit-failure compensation leg runs end to end against a real credential
+// store. It mirrors the deferred-trigger technique used by the calendar
+// Connect tests.
+func installAccountDeleteCommitFailure(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`
+		CREATE TABLE deferred_account_delete_failure (
+			parent_id INTEGER REFERENCES accounts(id) DEFERRABLE INITIALLY DEFERRED
+		);
+		CREATE TRIGGER fail_account_delete
+		AFTER DELETE ON accounts
+		BEGIN
+			INSERT INTO deferred_account_delete_failure(parent_id) VALUES (-1);
+		END;
+	`); err != nil {
+		t.Fatalf("install deferred account delete failure: %v", err)
+	}
+}
+
+func TestServiceDeleteRestoresCredentialOnCommitFailure(t *testing.T) {
+	db, q, err := storage.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	store := newMemoryCredentialStore()
+	svc := NewService(db, q)
+	account, err := svc.Create(ctx, CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
+	}, auth.Credential{Username: "alice", Password: "secret"}, store)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	installAccountDeleteCommitFailure(t, db)
+
+	if err := svc.Delete(ctx, account.ID, store); err == nil {
+		t.Fatal("Delete: expected deferred commit error, got nil")
+	}
+	// The account row rolls back because the transaction never committed.
+	if _, err := q.GetAccount(ctx, account.ID); err != nil {
+		t.Fatalf("account was not rolled back after commit failure: %v", err)
+	}
+	// The credential was deleted inside the transaction; the commit then failed,
+	// so compensation must restore the prior credential the keyring held.
+	if _, err := store.Get(account.ID, ""); err != nil {
+		t.Fatalf("credential was not restored after commit failure: %v", err)
+	}
+}
+
+func TestServiceRemoveWithCalendarsRestoresCredentialOnCommitFailure(t *testing.T) {
+	f := newSelectionFixture(t)
+	imported, discovery := f.importAndRefresh(t, "/cal/a/")
+	installAccountDeleteCommitFailure(t, f.db)
+
+	_, err := f.svc.RemoveWithCalendars(context.Background(), discovery.Account.ID, RemoveParams{}, f.store)
+	if err == nil {
+		t.Fatal("RemoveWithCalendars: expected deferred commit error, got nil")
+	}
+	if _, err := f.q.GetAccount(context.Background(), discovery.Account.ID); err != nil {
+		t.Fatalf("account was not rolled back after commit failure: %v", err)
+	}
+	if _, err := f.q.GetCalendar(context.Background(), imported.CreatedIDs[0]); err != nil {
+		t.Fatalf("calendar was not rolled back after commit failure: %v", err)
+	}
+	if _, err := f.store.Get(discovery.Account.ID, ""); err != nil {
+		t.Fatalf("credential was not restored after commit failure: %v", err)
+	}
+}
+
+func TestReconcileSelectionRestoresCredentialOnCommitFailure(t *testing.T) {
+	f := newSelectionFixture(t)
+	_, discovery := f.importAndRefresh(t, "/cal/a/")
+	installAccountDeleteCommitFailure(t, f.db)
+
+	// Selecting nothing removes the now-empty account, so the credential is
+	// deleted inside the transaction and must be restored when commit fails.
+	_, err := f.svc.ReconcileSelection(context.Background(), discovery, SelectionParams{}, f.store)
+	if err == nil {
+		t.Fatal("ReconcileSelection: expected deferred commit error, got nil")
+	}
+	if _, err := f.q.GetAccount(context.Background(), discovery.Account.ID); err != nil {
+		t.Fatalf("account was not rolled back after commit failure: %v", err)
+	}
+	if _, err := f.store.Get(discovery.Account.ID, ""); err != nil {
+		t.Fatalf("credential was not restored after commit failure: %v", err)
 	}
 }

--- a/internal/account/service_test.go
+++ b/internal/account/service_test.go
@@ -1717,7 +1717,7 @@ func TestReconcileSelectionRefusesLastApplicationCalendar(t *testing.T) {
 // Connect tests.
 func installAccountDeleteCommitFailure(t *testing.T, db *sql.DB) {
 	t.Helper()
-	if _, err := db.Exec(`
+	if _, err := db.ExecContext(context.Background(), `
 		CREATE TABLE deferred_account_delete_failure (
 			parent_id INTEGER REFERENCES accounts(id) DEFERRABLE INITIALLY DEFERRED
 		);

--- a/internal/auth/compensation.go
+++ b/internal/auth/compensation.go
@@ -1,0 +1,79 @@
+package auth
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// PriorCredential captures the credential-store entry that existed before a
+// lifecycle operation mutated it. A failed transaction uses it to roll the
+// keyring back to a state consistent with the rolled-back database row so the
+// two never silently diverge (issue #300 family).
+//
+// The zero value means "no prior credential": either the lookup found no entry
+// or the operation stores a brand-new credential with nothing to restore. It is
+// the value callers pass when they know there is no prior state to capture.
+type PriorCredential struct {
+	cred        Credential
+	hasPrevious bool
+}
+
+// CapturePriorCredential reads the current credential for accountID, tolerating
+// only the established not-found and identity-mismatch outcomes a destructive
+// lifecycle operation must proceed past. Any other (typically transient
+// backend) error is returned so the caller aborts instead of orphaning the
+// credential or clobbering it with a mismatched replacement.
+func CapturePriorCredential(store CredentialStore, accountID int64, fingerprint string) (PriorCredential, error) {
+	prev, err := store.Get(accountID, fingerprint)
+	if err != nil && !IsCredentialNotFound(err) && !errors.Is(err, ErrCredentialIdentityMismatch) {
+		return PriorCredential{}, err
+	}
+	return PriorCredential{cred: prev, hasPrevious: err == nil}, nil
+}
+
+// Restore rolls the credential store back to the captured prior state after a
+// failure, returning an error that surfaces both the original cause and any
+// compensation failure rather than hiding either.
+//
+// wroteNew reports whether the failed operation stored a brand-new credential
+// for accountID (a Set on an account whose prior lookup found no entry). Such
+// an entry cannot match the rolled-back row, so it is deleted. When wroteNew is
+// false the prior lookup either found an entry to restore or found nothing to
+// undo, so no delete is needed.
+//
+// This is the single canonical compensation implementation shared by the
+// account lifecycle methods and calendar Connect (issue #545): every
+// commit-then-rollback-credential path funnels through it.
+func (p PriorCredential) Restore(store CredentialStore, accountID int64, wroteNew bool, operation string, cause error) error {
+	if p.hasPrevious {
+		if restoreErr := store.Set(p.cred); restoreErr != nil {
+			return fmt.Errorf("%s: %w (restore credentials: %w)", operation, cause, restoreErr)
+		}
+		return fmt.Errorf("%s: %w", operation, cause)
+	}
+	if wroteNew {
+		if deleteErr := store.Delete(accountID); deleteErr != nil {
+			return fmt.Errorf("%s: %w (delete credentials: %w)", operation, cause, deleteErr)
+		}
+	}
+	return fmt.Errorf("%s: %w", operation, cause)
+}
+
+// CommitWithCredentialCompensation commits tx and, on failure, restores the
+// credential store to the prior state captured before the in-transaction
+// credential mutation. It owns the commit-then-rollback-credential invariant so
+// the account lifecycle methods and calendar Connect share one implementation.
+//
+// Pass wroteNew true when the transaction stored a brand-new credential for
+// accountID on an account whose prior lookup found no entry: the rollback must
+// delete it. Pass false for destructive operations that deleted the credential
+// (a missing prior then has nothing to undo).
+//
+// On a successful commit no credential store is touched.
+func CommitWithCredentialCompensation(tx *sql.Tx, store CredentialStore, accountID int64, prior PriorCredential, wroteNew bool, operation string) error {
+	if err := tx.Commit(); err != nil {
+		return prior.Restore(store, accountID, wroteNew, operation, err)
+	}
+	return nil
+}

--- a/internal/auth/compensation_test.go
+++ b/internal/auth/compensation_test.go
@@ -1,0 +1,284 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
+)
+
+// fakeCredStore is a minimal CredentialStore for compensation tests: it records
+// Set/Delete calls and their targets and can inject failures. Get returns a
+// configured error (used to exercise not-found / identity-mismatch / transient
+// outcomes) or the stored credential.
+type fakeCredStore struct {
+	creds       map[int64]Credential
+	getErr      error
+	setErr      error
+	deleteErr   error
+	setCalls    int
+	deleteCalls int
+	setIDs      []int64
+	deleteIDs   []int64
+}
+
+func (s *fakeCredStore) Get(accountID int64, _ string) (Credential, error) {
+	if s.getErr != nil {
+		return Credential{}, s.getErr
+	}
+	if c, ok := s.creds[accountID]; ok {
+		return c, nil
+	}
+	return Credential{}, nil
+}
+
+func (s *fakeCredStore) Set(c Credential) error {
+	s.setCalls++
+	s.setIDs = append(s.setIDs, c.AccountID)
+	if s.setErr != nil {
+		return s.setErr
+	}
+	if s.creds == nil {
+		s.creds = make(map[int64]Credential)
+	}
+	s.creds[c.AccountID] = c
+	return nil
+}
+
+func (s *fakeCredStore) Delete(accountID int64) error {
+	s.deleteCalls++
+	s.deleteIDs = append(s.deleteIDs, accountID)
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	delete(s.creds, accountID)
+	return nil
+}
+
+func TestCapturePriorCredential(t *testing.T) {
+	accountID := int64(7)
+	stored := Credential{AccountID: accountID, Password: "secret"}
+
+	t.Run("found", func(t *testing.T) {
+		store := &fakeCredStore{creds: map[int64]Credential{accountID: stored}}
+		prior, err := CapturePriorCredential(store, accountID, "fp")
+		if err != nil {
+			t.Fatalf("CapturePriorCredential error = %v", err)
+		}
+		if !prior.hasPrevious {
+			t.Fatal("hasPrevious = false, want true")
+		}
+		if prior.cred.Password != "secret" {
+			t.Fatalf("captured credential = %+v, want the stored one", prior.cred)
+		}
+	})
+
+	t.Run("not found is tolerated", func(t *testing.T) {
+		store := &fakeCredStore{getErr: errCredentialNotFound}
+		prior, err := CapturePriorCredential(store, accountID, "fp")
+		if err != nil {
+			t.Fatalf("CapturePriorCredential error = %v, want nil for not-found", err)
+		}
+		if prior.hasPrevious {
+			t.Fatal("hasPrevious = true, want false for not-found")
+		}
+	})
+
+	t.Run("identity mismatch is tolerated", func(t *testing.T) {
+		store := &fakeCredStore{getErr: ErrCredentialIdentityMismatch}
+		prior, err := CapturePriorCredential(store, accountID, "fp")
+		if err != nil {
+			t.Fatalf("CapturePriorCredential error = %v, want nil for identity mismatch", err)
+		}
+		if prior.hasPrevious {
+			t.Fatal("hasPrevious = true, want false for identity mismatch")
+		}
+	})
+
+	t.Run("transient error aborts", func(t *testing.T) {
+		transient := errors.New("keyring backend down")
+		store := &fakeCredStore{getErr: transient}
+		if _, err := CapturePriorCredential(store, accountID, "fp"); !errors.Is(err, transient) {
+			t.Fatalf("CapturePriorCredential error = %v, want transient error", err)
+		}
+	})
+}
+
+func TestPriorCredentialRestore(t *testing.T) {
+	accountID := int64(9)
+	cause := errors.New("commit failed")
+
+	t.Run("previous present restores and wraps cause", func(t *testing.T) {
+		store := &fakeCredStore{}
+		prior := PriorCredential{cred: Credential{AccountID: accountID, Password: "old"}, hasPrevious: true}
+
+		err := prior.Restore(store, accountID, false, "commit op", cause)
+
+		if !errors.Is(err, cause) {
+			t.Fatalf("Restore error = %v, want it to wrap the cause", err)
+		}
+		if store.setCalls != 1 || store.setIDs[0] != accountID {
+			t.Fatalf("Set calls = %v, want one Set of account %d", store.setIDs, accountID)
+		}
+		if store.deleteCalls != 0 {
+			t.Fatalf("Delete calls = %d, want 0 when a previous credential exists", store.deleteCalls)
+		}
+		if got := store.creds[accountID].Password; got != "old" {
+			t.Fatalf("restored credential password = %q, want %q", got, "old")
+		}
+	})
+
+	t.Run("restore failure is surfaced alongside cause", func(t *testing.T) {
+		setErr := errors.New("keyring write failed")
+		store := &fakeCredStore{setErr: setErr}
+		prior := PriorCredential{cred: Credential{AccountID: accountID}, hasPrevious: true}
+
+		err := prior.Restore(store, accountID, false, "commit op", cause)
+
+		if !errors.Is(err, cause) {
+			t.Fatalf("Restore error must wrap the cause, got %v", err)
+		}
+		if !errors.Is(err, setErr) {
+			t.Fatalf("Restore error must surface the restore failure, got %v", err)
+		}
+		if store.deleteCalls != 0 {
+			t.Fatalf("Delete calls = %d, want 0 on restore path", store.deleteCalls)
+		}
+	})
+
+	t.Run("no previous and no new credential only wraps cause", func(t *testing.T) {
+		store := &fakeCredStore{}
+		var prior PriorCredential // zero value: no previous, destructive op
+
+		err := prior.Restore(store, accountID, false, "commit op", cause)
+
+		if !errors.Is(err, cause) {
+			t.Fatalf("Restore error = %v, want it to wrap the cause", err)
+		}
+		if store.setCalls != 0 || store.deleteCalls != 0 {
+			t.Fatalf("Set/Delete calls = %d/%d, want 0/0 when there is nothing to undo", store.setCalls, store.deleteCalls)
+		}
+	})
+
+	t.Run("no previous with new credential deletes replacement", func(t *testing.T) {
+		store := &fakeCredStore{}
+		var prior PriorCredential // no previous, but a brand-new credential was written
+
+		err := prior.Restore(store, accountID, true, "commit op", cause)
+
+		if !errors.Is(err, cause) {
+			t.Fatalf("Restore error = %v, want it to wrap the cause", err)
+		}
+		if store.deleteCalls != 1 || store.deleteIDs[0] != accountID {
+			t.Fatalf("Delete calls = %v, want one Delete of account %d", store.deleteIDs, accountID)
+		}
+		if store.setCalls != 0 {
+			t.Fatalf("Set calls = %d, want 0 when deleting a replacement", store.setCalls)
+		}
+	})
+
+	t.Run("replacement delete failure is surfaced alongside cause", func(t *testing.T) {
+		deleteErr := errors.New("keyring delete failed")
+		store := &fakeCredStore{deleteErr: deleteErr}
+		var prior PriorCredential
+
+		err := prior.Restore(store, accountID, true, "commit op", cause)
+
+		if !errors.Is(err, cause) {
+			t.Fatalf("Restore error must wrap the cause, got %v", err)
+		}
+		if !errors.Is(err, deleteErr) {
+			t.Fatalf("Restore error must surface the delete failure, got %v", err)
+		}
+	})
+}
+
+func TestCommitWithCredentialCompensation(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	accountID := int64(11)
+
+	// finalizedTx returns a transaction whose Commit always fails: it has
+	// already been rolled back, so a later Commit reports sql.ErrTxDone. This
+	// exercises the commit-failure leg without a deferred-foreign-key fixture.
+	finalizedTx := func(t *testing.T) *sql.Tx {
+		t.Helper()
+		tx, err := db.BeginTx(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		if err := tx.Rollback(); err != nil {
+			t.Fatalf("rollback to finalize tx: %v", err)
+		}
+		return tx
+	}
+
+	t.Run("successful commit touches no credential", func(t *testing.T) {
+		tx, err := db.BeginTx(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("begin tx: %v", err)
+		}
+		store := &fakeCredStore{}
+		prior := PriorCredential{cred: Credential{AccountID: accountID}, hasPrevious: true}
+
+		if err := CommitWithCredentialCompensation(tx, store, accountID, prior, false, "commit op"); err != nil {
+			t.Fatalf("CommitWithCredentialCompensation error = %v, want nil", err)
+		}
+		if store.setCalls != 0 || store.deleteCalls != 0 {
+			t.Fatalf("Set/Delete calls = %d/%d, want 0/0 on a successful commit", store.setCalls, store.deleteCalls)
+		}
+	})
+
+	t.Run("failed commit restores previous credential", func(t *testing.T) {
+		store := &fakeCredStore{}
+		prior := PriorCredential{cred: Credential{AccountID: accountID, Password: "old"}, hasPrevious: true}
+
+		err := CommitWithCredentialCompensation(finalizedTx(t), store, accountID, prior, false, "commit op")
+
+		if err == nil {
+			t.Fatal("CommitWithCredentialCompensation error = nil, want commit failure")
+		}
+		if store.setCalls != 1 || store.setIDs[0] != accountID {
+			t.Fatalf("Set calls = %v, want one restore of account %d", store.setIDs, accountID)
+		}
+		if got := store.creds[accountID].Password; got != "old" {
+			t.Fatalf("restored credential password = %q, want %q", got, "old")
+		}
+	})
+
+	t.Run("failed commit with no previous and no new credential only wraps", func(t *testing.T) {
+		store := &fakeCredStore{}
+		var prior PriorCredential
+
+		err := CommitWithCredentialCompensation(finalizedTx(t), store, accountID, prior, false, "commit op")
+
+		if err == nil {
+			t.Fatal("CommitWithCredentialCompensation error = nil, want commit failure")
+		}
+		if store.setCalls != 0 || store.deleteCalls != 0 {
+			t.Fatalf("Set/Delete calls = %d/%d, want 0/0 when nothing was written", store.setCalls, store.deleteCalls)
+		}
+	})
+
+	t.Run("failed commit with new credential deletes replacement", func(t *testing.T) {
+		store := &fakeCredStore{}
+		var prior PriorCredential // a brand-new credential was stored, no prior to restore
+
+		err := CommitWithCredentialCompensation(finalizedTx(t), store, accountID, prior, true, "commit op")
+
+		if err == nil {
+			t.Fatal("CommitWithCredentialCompensation error = nil, want commit failure")
+		}
+		if store.deleteCalls != 1 || store.deleteIDs[0] != accountID {
+			t.Fatalf("Delete calls = %v, want one Delete of account %d", store.deleteIDs, accountID)
+		}
+		if store.setCalls != 0 {
+			t.Fatalf("Set calls = %d, want 0 when deleting a replacement", store.setCalls)
+		}
+	})
+}

--- a/internal/calendar/remote.go
+++ b/internal/calendar/remote.go
@@ -114,13 +114,10 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 			}
 			cred.AccountID = existing.ID
 			oldFingerprint := auth.AccountFingerprint(existing.ServerUrl, existing.AuthType, existing.Username)
-			prevCred, prevErr := credStore.Get(existing.ID, oldFingerprint)
-			if prevErr != nil &&
-				!auth.IsCredentialNotFound(prevErr) &&
-				!errors.Is(prevErr, auth.ErrCredentialIdentityMismatch) {
+			prior, prevErr := auth.CapturePriorCredential(credStore, existing.ID, oldFingerprint)
+			if prevErr != nil {
 				return fmt.Errorf("read credentials before relink: %w", prevErr)
 			}
-			hasPrevCred := prevErr == nil
 			cred.AccountFingerprint = auth.AccountFingerprint(serverURL, link.AuthType, link.Username)
 
 			tx, err := s.db.BeginTx(ctx, nil)
@@ -165,15 +162,8 @@ func (s *Service) Connect(ctx context.Context, cal Calendar, link RemoteLink, cr
 			if err := credStore.Set(cred); err != nil {
 				return fmt.Errorf("store credentials: %w", err)
 			}
-			if err := tx.Commit(); err != nil {
-				if hasPrevCred {
-					if restoreErr := credStore.Set(prevCred); restoreErr != nil {
-						return fmt.Errorf("commit remote calendar link: %w (restore credentials: %w)", err, restoreErr)
-					}
-				} else if deleteErr := credStore.Delete(existing.ID); deleteErr != nil {
-					return fmt.Errorf("commit remote calendar link: %w (delete replacement credentials: %w)", err, deleteErr)
-				}
-				return fmt.Errorf("commit remote calendar link: %w", err)
+			if err := auth.CommitWithCredentialCompensation(tx, credStore, existing.ID, prior, true, "commit remote calendar link"); err != nil {
+				return err
 			}
 			return nil
 		}
@@ -237,11 +227,8 @@ createAccount:
 	if err := credStore.Set(cred); err != nil {
 		return fmt.Errorf("store credentials: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		if deleteErr := credStore.Delete(account.ID); deleteErr != nil {
-			return fmt.Errorf("commit remote calendar link: %w (delete credentials: %w)", err, deleteErr)
-		}
-		return fmt.Errorf("commit remote calendar link: %w", err)
+	if err := auth.CommitWithCredentialCompensation(tx, credStore, account.ID, auth.PriorCredential{}, true, "commit remote calendar link"); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- centralize prior-credential capture with only established not-found and identity-mismatch tolerance
- centralize commit-failure restore/delete compensation
- migrate account reconciliation/removal/delete and calendar Connect
- preserve both the original failure and any compensation failure

## Verification
- `go test ./internal/auth ./internal/account ./internal/calendar -count=1`
- focused tests cover prior present/absent, transient lookup error, successful commit, commit failure, restore failure, and replacement-delete failure
- reviewed callsites for lock ordering, fingerprint identity checks, and error precedence

Closes #545