### PR TITLE
refactor(calendar): centralize default promotion

### DIFF
--- a/internal/account/service.go
+++ b/internal/account/service.go
@@ -664,14 +664,6 @@ func (s *Service) ReconcileSelection(
 	}
 
 	replacementID := params.NewDefaultID
-	if removedDefault && replacementID != 0 {
-		if _, removed := removedIDs[replacementID]; removed {
-			return SelectionResult{}, calendar.ErrInvalidPromotionTarget
-		}
-		if _, err := qtx.GetCalendar(ctx, replacementID); err != nil {
-			return SelectionResult{}, calendar.ErrInvalidPromotionTarget
-		}
-	}
 
 	taken := make(map[string]struct{}, len(allCalendars))
 	for _, row := range allCalendars {
@@ -728,14 +720,8 @@ func (s *Service) ReconcileSelection(
 				return SelectionResult{}, calendar.ErrInvalidPromotionTarget
 			}
 		}
-		if replacementID == 0 {
-			return SelectionResult{}, calendar.ErrInvalidPromotionTarget
-		}
-		if err := qtx.ClearDefaultCalendar(ctx); err != nil {
-			return SelectionResult{}, fmt.Errorf("clear default calendar: %w", err)
-		}
-		if err := qtx.SetCalendarAsDefault(ctx, replacementID); err != nil {
-			return SelectionResult{}, fmt.Errorf("set replacement default: %w", err)
+		if err := calendar.PromoteDefault(ctx, qtx, removedIDs, replacementID); err != nil {
+			return SelectionResult{}, err
 		}
 	}
 
@@ -814,12 +800,6 @@ func (s *Service) RemoveWithCalendars(
 		if params.NewDefaultID == 0 {
 			return RemoveResult{}, calendar.ErrDefaultCalendarRequiresPromotion
 		}
-		if _, removed := removedIDs[params.NewDefaultID]; removed {
-			return RemoveResult{}, calendar.ErrInvalidPromotionTarget
-		}
-		if _, err := qtx.GetCalendar(ctx, params.NewDefaultID); err != nil {
-			return RemoveResult{}, calendar.ErrInvalidPromotionTarget
-		}
 	} else if params.NewDefaultID != 0 {
 		return RemoveResult{}, calendar.ErrInvalidPromotionTarget
 	}
@@ -830,11 +810,8 @@ func (s *Service) RemoveWithCalendars(
 		}
 	}
 	if removedDefault {
-		if err := qtx.ClearDefaultCalendar(ctx); err != nil {
-			return RemoveResult{}, fmt.Errorf("clear default calendar: %w", err)
-		}
-		if err := qtx.SetCalendarAsDefault(ctx, params.NewDefaultID); err != nil {
-			return RemoveResult{}, fmt.Errorf("set replacement default: %w", err)
+		if err := calendar.PromoteDefault(ctx, qtx, removedIDs, params.NewDefaultID); err != nil {
+			return RemoveResult{}, err
 		}
 	}
 	if err := qtx.DeleteAccount(ctx, accountID); err != nil {

--- a/internal/account/service_test.go
+++ b/internal/account/service_test.go
@@ -1800,3 +1800,61 @@ func TestReconcileSelectionRestoresCredentialOnCommitFailure(t *testing.T) {
 		t.Fatalf("credential was not restored after commit failure: %v", err)
 	}
 }
+
+// TestReconcileSelectionRejectsIDAndPathPromotionTarget locks the intentional
+// difference that a replacement default may be specified by ID OR path, not
+// both: supplying both is ambiguous and must be rejected before any work.
+func TestReconcileSelectionRejectsIDAndPathPromotionTarget(t *testing.T) {
+	f := newSelectionFixture(t)
+	imported, discovery := f.importAndRefresh(t, "/cal/a/")
+	ctx := context.Background()
+	if err := f.q.ClearDefaultCalendar(ctx); err != nil {
+		t.Fatalf("clear default: %v", err)
+	}
+	if err := f.q.SetCalendarAsDefault(ctx, imported.CreatedIDs[0]); err != nil {
+		t.Fatalf("set imported default: %v", err)
+	}
+
+	// /cal/a/ (the default) is deselected, so a promotion is required;
+	// specifying the replacement by both ID and path is rejected.
+	_, err := f.svc.ReconcileSelection(ctx, discovery, SelectionParams{
+		SelectedPaths:  []string{"/cal/b/"},
+		NewDefaultID:   imported.CreatedIDs[0],
+		NewDefaultPath: "/cal/b/",
+	}, f.store)
+	if !errors.Is(err, calendar.ErrInvalidPromotionTarget) {
+		t.Fatalf("err = %v, want calendar.ErrInvalidPromotionTarget", err)
+	}
+}
+
+// TestServiceRemoveWithCalendarsRejectsReplacementWhenDefaultNotRemoved locks
+// the intentional difference that RemoveWithCalendars rejects a replacement
+// default when the removed account does not own the current default (no
+// promotion is required in that case).
+func TestServiceRemoveWithCalendarsRejectsReplacementWhenDefaultNotRemoved(t *testing.T) {
+	f := newSelectionFixture(t)
+	f.importAndRefresh(t, "/cal/a/")
+	ctx := context.Background()
+
+	// The application default is the seeded calendar, not the account's
+	// imported /cal/a/, so removing the account needs no promotion.
+	all, err := f.q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("list calendars: %v", err)
+	}
+	var defaultID int64
+	for _, row := range all {
+		if row.IsDefault == 1 {
+			defaultID = row.ID
+			break
+		}
+	}
+	if defaultID == 0 {
+		t.Fatal("fixture has no default calendar")
+	}
+
+	_, err = f.svc.RemoveWithCalendars(ctx, f.discovery.Account.ID, RemoveParams{NewDefaultID: defaultID}, f.store)
+	if !errors.Is(err, calendar.ErrInvalidPromotionTarget) {
+		t.Fatalf("err = %v, want calendar.ErrInvalidPromotionTarget", err)
+	}
+}

--- a/internal/calendar/promote.go
+++ b/internal/calendar/promote.go
@@ -1,0 +1,45 @@
+package calendar
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// PromoteDefault is the single implementation of the default-calendar
+// promotion invariant: whenever the current default calendar is among
+// removedIDs, target must identify a surviving calendar — one that exists and
+// is not itself being removed — and becomes the new default atomically within
+// qtx's transaction.
+//
+// Clearing the old default and setting the new one run in the caller's
+// already-open transaction (qtx), so the database never observes a missing
+// default. Because the survival check reads through that same transaction, a
+// target removed inside this operation — or one that never existed in it —
+// fails before any default is cleared; the caller then rolls back.
+//
+// Each caller decides whether a promotion is required (i.e. whether the
+// current default is among the calendars being deleted) and resolves target to
+// a concrete calendar ID — including path-based resolution for discovered
+// collections in the account service — before calling. removedIDs is the set of
+// calendar IDs being deleted in this transaction, so target must not be among
+// them.
+func PromoteDefault(ctx context.Context, qtx *storage.Queries, removedIDs map[int64]struct{}, target int64) error {
+	if target == 0 {
+		return ErrDefaultCalendarRequiresPromotion
+	}
+	if _, removed := removedIDs[target]; removed {
+		return ErrInvalidPromotionTarget
+	}
+	if _, err := qtx.GetCalendar(ctx, target); err != nil {
+		return ErrInvalidPromotionTarget
+	}
+	if err := qtx.ClearDefaultCalendar(ctx); err != nil {
+		return fmt.Errorf("clear default calendar: %w", err)
+	}
+	if err := qtx.SetCalendarAsDefault(ctx, target); err != nil {
+		return fmt.Errorf("promote default calendar: %w", err)
+	}
+	return nil
+}

--- a/internal/calendar/promote_test.go
+++ b/internal/calendar/promote_test.go
@@ -1,0 +1,151 @@
+package calendar
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// newPromoteTx starts a transaction and returns a qtx bound to it plus a commit
+// helper, mirroring how the delete/reconcile paths invoke PromoteDefault inside
+// their own transactions.
+func newPromoteTx(t *testing.T, q *storage.Queries, db *sql.DB) (*storage.Queries, func(), func()) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	qtx := q.WithTx(tx)
+	commit := func() {
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+	}
+	rollback := func() { _ = tx.Rollback() }
+	return qtx, commit, rollback
+}
+
+func TestPromoteDefault_PromotesSurvivingTarget(t *testing.T) {
+	svc, q, db := newTestServiceWithDB(t)
+	ctx := context.Background()
+
+	personal, _ := svc.GetDefault(ctx)
+	work, err := svc.Create(ctx, "Work", "#0284C7", "")
+	if err != nil {
+		t.Fatalf("Create Work: %v", err)
+	}
+
+	qtx, commit, rollback := newPromoteTx(t, q, db)
+	defer rollback()
+	if err := PromoteDefault(ctx, qtx, map[int64]struct{}{personal.ID: {}}, work.ID); err != nil {
+		t.Fatalf("PromoteDefault: %v", err)
+	}
+	commit()
+
+	def, err := svc.GetDefault(ctx)
+	if err != nil {
+		t.Fatalf("GetDefault: %v", err)
+	}
+	if def.ID != work.ID || !def.IsDefault {
+		t.Fatalf("default = %+v, want id=%d IsDefault=true", def, work.ID)
+	}
+}
+
+func TestPromoteDefault_ZeroTargetRequiresPromotion(t *testing.T) {
+	svc, q, db := newTestServiceWithDB(t)
+	ctx := context.Background()
+	personal, _ := svc.GetDefault(ctx)
+
+	qtx, _, rollback := newPromoteTx(t, q, db)
+	defer rollback()
+	err := PromoteDefault(ctx, qtx, map[int64]struct{}{personal.ID: {}}, 0)
+	if !errors.Is(err, ErrDefaultCalendarRequiresPromotion) {
+		t.Fatalf("err = %v, want ErrDefaultCalendarRequiresPromotion", err)
+	}
+}
+
+func TestPromoteDefault_RemovedTargetIsInvalid(t *testing.T) {
+	svc, q, db := newTestServiceWithDB(t)
+	ctx := context.Background()
+	personal, _ := svc.GetDefault(ctx)
+
+	qtx, _, rollback := newPromoteTx(t, q, db)
+	defer rollback()
+	// personal is among the calendars being removed, so it cannot be its own
+	// replacement — the surviving-target check must reject it.
+	err := PromoteDefault(ctx, qtx, map[int64]struct{}{personal.ID: {}}, personal.ID)
+	if !errors.Is(err, ErrInvalidPromotionTarget) {
+		t.Fatalf("err = %v, want ErrInvalidPromotionTarget", err)
+	}
+}
+
+func TestPromoteDefault_NonexistentTargetIsInvalid(t *testing.T) {
+	svc, q, db := newTestServiceWithDB(t)
+	ctx := context.Background()
+	personal, _ := svc.GetDefault(ctx)
+
+	qtx, _, rollback := newPromoteTx(t, q, db)
+	defer rollback()
+	err := PromoteDefault(ctx, qtx, map[int64]struct{}{personal.ID: {}}, 9999)
+	if !errors.Is(err, ErrInvalidPromotionTarget) {
+		t.Fatalf("err = %v, want ErrInvalidPromotionTarget", err)
+	}
+}
+
+// TestPromoteDefault_FailureLeavesDefaultIntact locks the rollback half of the
+// invariant: when the target does not survive, the helper refuses before the
+// caller commits, so the committed default is never observed missing.
+func TestPromoteDefault_FailureLeavesDefaultIntact(t *testing.T) {
+	svc, q, db := newTestServiceWithDB(t)
+	ctx := context.Background()
+	personal, _ := svc.GetDefault(ctx)
+
+	qtx, _, rollback := newPromoteTx(t, q, db)
+	if err := PromoteDefault(ctx, qtx, map[int64]struct{}{personal.ID: {}}, 9999); !errors.Is(err, ErrInvalidPromotionTarget) {
+		t.Fatalf("err = %v, want ErrInvalidPromotionTarget", err)
+	}
+	rollback()
+
+	def, err := svc.GetDefault(ctx)
+	if err != nil {
+		t.Fatalf("GetDefault after refused promotion: %v", err)
+	}
+	if def.ID != personal.ID {
+		t.Fatalf("default = %d, want %d (must survive a refused promotion)", def.ID, personal.ID)
+	}
+}
+
+// TestPromoteDefault_AcceptsTargetCreatedInSameTransaction documents why the
+// survival check runs through qtx: ReconcileSelection promotes a calendar it
+// just created in the same transaction, which is invisible outside it.
+func TestPromoteDefault_AcceptsTargetCreatedInSameTransaction(t *testing.T) {
+	svc, q, db := newTestServiceWithDB(t)
+	ctx := context.Background()
+	personal, _ := svc.GetDefault(ctx)
+
+	qtx, commit, rollback := newPromoteTx(t, q, db)
+	defer rollback()
+	created, err := qtx.CreateCalendar(ctx, storage.CreateCalendarParams{
+		Name:  "Newly Added",
+		Color: "#10B981",
+	})
+	if err != nil {
+		t.Fatalf("CreateCalendar in tx: %v", err)
+	}
+	if err := PromoteDefault(ctx, qtx, map[int64]struct{}{personal.ID: {}}, created.ID); err != nil {
+		t.Fatalf("PromoteDefault for in-tx target: %v", err)
+	}
+	commit()
+
+	def, err := svc.GetDefault(ctx)
+	if err != nil {
+		t.Fatalf("GetDefault: %v", err)
+	}
+	if def.ID != created.ID {
+		t.Fatalf("default = %d, want %d", def.ID, created.ID)
+	}
+}

--- a/internal/calendar/remote.go
+++ b/internal/calendar/remote.go
@@ -372,18 +372,6 @@ func (s *Service) DeleteWithRemoteCleanup(ctx context.Context, id, newDefaultID 
 		return ErrLastCalendar
 	}
 
-	if cal.IsDefault {
-		if newDefaultID == 0 {
-			return ErrDefaultCalendarRequiresPromotion
-		}
-		if newDefaultID == id {
-			return ErrInvalidPromotionTarget
-		}
-		if _, err := s.q.GetCalendar(ctx, newDefaultID); err != nil {
-			return ErrInvalidPromotionTarget
-		}
-	}
-
 	var (
 		account       storage.Account
 		hasAccount    bool
@@ -410,11 +398,8 @@ func (s *Service) DeleteWithRemoteCleanup(ctx context.Context, id, newDefaultID 
 	}
 
 	if cal.IsDefault {
-		if err := qtx.ClearDefaultCalendar(ctx); err != nil {
-			return fmt.Errorf("clear default: %w", err)
-		}
-		if err := qtx.SetCalendarAsDefault(ctx, newDefaultID); err != nil {
-			return fmt.Errorf("promote default: %w", err)
+		if err := PromoteDefault(ctx, qtx, map[int64]struct{}{id: {}}, newDefaultID); err != nil {
+			return err
 		}
 	}
 

--- a/internal/calendar/remote_test.go
+++ b/internal/calendar/remote_test.go
@@ -770,3 +770,47 @@ func TestDeleteWithRemoteCleanup_HiddenAccountWithMultipleCalendars_PreservesCre
 		t.Errorf("DeleteWithRemoteCleanup: credential wrongly deleted when account survived; password = %q, want %q", got.Password, "secret")
 	}
 }
+
+// TestDeleteWithRemoteCleanup_PromotesDefault exercises the default-promotion
+// path: deleting the current default must refuse without a replacement (and
+// roll back), then succeed by promoting a surviving calendar atomically.
+func TestDeleteWithRemoteCleanup_PromotesDefault(t *testing.T) {
+	svc, q, _ := newTestServiceWithDB(t)
+	ctx := context.Background()
+
+	personal, _ := svc.GetDefault(ctx) // the seeded default calendar
+	work, err := q.CreateCalendar(ctx, storage.CreateCalendarParams{
+		Name:  "Work",
+		Color: "#0000ff",
+	})
+	if err != nil {
+		t.Fatalf("CreateCalendar Work: %v", err)
+	}
+
+	// Deleting the default without a replacement must refuse, leaving the
+	// default intact (the delete is rolled back inside the same transaction).
+	if err := svc.DeleteWithRemoteCleanup(ctx, personal.ID, 0, &memCredStore{}); !errors.Is(err, ErrDefaultCalendarRequiresPromotion) {
+		t.Fatalf("delete default without replacement: err = %v, want ErrDefaultCalendarRequiresPromotion", err)
+	}
+	if def, err := svc.GetDefault(ctx); err != nil || def.ID != personal.ID {
+		t.Fatalf("default = (%+v, %v) after refused delete, want id=%d", def, err, personal.ID)
+	}
+	if _, err := svc.Get(ctx, personal.ID); err != nil {
+		t.Fatalf("personal calendar should still exist after refused delete: %v", err)
+	}
+
+	// Promoting a surviving calendar moves the default atomically.
+	if err := svc.DeleteWithRemoteCleanup(ctx, personal.ID, work.ID, &memCredStore{}); err != nil {
+		t.Fatalf("DeleteWithRemoteCleanup with promotion: %v", err)
+	}
+	if _, err := svc.Get(ctx, personal.ID); err == nil {
+		t.Fatal("personal calendar should be deleted after promotion")
+	}
+	def, err := svc.GetDefault(ctx)
+	if err != nil {
+		t.Fatalf("GetDefault after promotion: %v", err)
+	}
+	if def.ID != work.ID || !def.IsDefault {
+		t.Fatalf("default = %+v, want id=%d IsDefault=true", def, work.ID)
+	}
+}

--- a/internal/calendar/service.go
+++ b/internal/calendar/service.go
@@ -17,14 +17,17 @@ var ErrLastCalendar = errors.New("cannot delete the last calendar")
 // ErrDuplicateName is returned when a calendar name already exists.
 var ErrDuplicateName = errors.New("a calendar with this name already exists")
 
-// ErrDefaultCalendarRequiresPromotion is returned by Delete when the target
-// row is the current default. Callers must pick a replacement and call
-// DeleteAndPromote instead, so the default is never silently moved.
+// ErrDefaultCalendarRequiresPromotion is returned when the current default
+// calendar is among those being deleted but no surviving replacement was
+// supplied. Delete surfaces it directly; the other delete/reconcile paths
+// surface it through the shared PromoteDefault helper.
 var ErrDefaultCalendarRequiresPromotion = errors.New("cannot delete the default calendar without promoting a replacement")
 
-// ErrInvalidPromotionTarget is returned by DeleteAndPromote when the
-// replacement default ID is the same as the calendar being deleted, or
-// does not exist.
+// ErrInvalidPromotionTarget is returned when a default-calendar promotion
+// target does not survive the operation: it is the calendar being removed, is
+// among the calendars being removed, or does not exist. DeleteAndPromote,
+// DeleteWithRemoteCleanup, and the account selection/removal paths surface it
+// through the shared PromoteDefault helper.
 var ErrInvalidPromotionTarget = errors.New("invalid promotion target for default calendar")
 
 type Service struct {
@@ -206,28 +209,17 @@ func (s *Service) deleteWithOptionalPromotion(ctx context.Context, id, newDefaul
 		return ErrLastCalendar
 	}
 
-	if target.IsDefault == 1 {
-		if newDefaultID == 0 {
-			return ErrDefaultCalendarRequiresPromotion
-		}
-		if newDefaultID == id {
-			return ErrInvalidPromotionTarget
-		}
-		if _, err := qtx.GetCalendar(ctx, newDefaultID); err != nil {
-			return ErrInvalidPromotionTarget
-		}
-	}
-
 	if err := qtx.DeleteCalendar(ctx, id); err != nil {
 		return fmt.Errorf("delete calendar: %w", err)
 	}
 
+	// When the target held the default, PromoteDefault validates that the
+	// replacement survives the deletion (it is not id and still exists in this
+	// transaction) and clears+sets the default atomically, so the database is
+	// never observed without a default.
 	if target.IsDefault == 1 {
-		if err := qtx.ClearDefaultCalendar(ctx); err != nil {
-			return fmt.Errorf("clear default: %w", err)
-		}
-		if err := qtx.SetCalendarAsDefault(ctx, newDefaultID); err != nil {
-			return fmt.Errorf("promote default: %w", err)
+		if err := PromoteDefault(ctx, qtx, map[int64]struct{}{id: {}}, newDefaultID); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add one transaction-bound `calendar.PromoteDefault` invariant
- validate that replacement targets exist and survive removal before clearing the old default
- migrate local delete, remote cleanup, account reconciliation, and account removal paths
- preserve ID/path exclusivity and caller-specific validation

## Verification
- `go test ./internal/calendar ./internal/account -count=1`
- tests cover missing/removed/nonexistent targets, path-vs-ID resolution, non-default removals, remote cleanup promotion, and rollback
- spec and quality review findings fixed, including the intentional validation branches and helper documentation

Closes #546