### PR TITLE
feat(tui): update account credentials in place

### DIFF
--- a/internal/tui/account_credentials_update_test.go
+++ b/internal/tui/account_credentials_update_test.go
@@ -1,0 +1,188 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/account"
+	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/zalando/go-keyring"
+)
+
+// basicAccountModel seeds a Model with one basic-auth account and opens its
+// Account Settings panel, the state from which Update Credentials is launched.
+func basicAccountModel(t *testing.T, authType string) Model {
+	t.Helper()
+	m := NewModel(nil, "")
+	m.accounts = map[int64]account.Account{
+		7: {
+			ID:          7,
+			DisplayName: "Work",
+			AuthType:    authType,
+			Username:    "alice@example.com",
+			ServerURL:   "https://cal.example.com/dav/",
+		},
+	}
+	m = updateModel(t, m, AccountSettingsRequestedMsg{AccountID: 7})
+	if !accountManagerOpen(m) {
+		t.Fatalf("setup: account settings did not open")
+	}
+	return m
+}
+
+func TestAccountSettingsUpdateCredentialsOpensDialogBasic(t *testing.T) {
+	m := basicAccountModel(t, "basic")
+	m = updateModel(t, m, AccountSettingsUpdateCredentialsRequestedMsg{AccountID: 7})
+
+	if !m.accountCredentialsOpen {
+		t.Fatal("Update Credentials request did not open the credentials dialog")
+	}
+	if accountManagerOpen(m) {
+		t.Fatal("Account Settings stayed open over the credentials dialog")
+	}
+	if m.accountCredentials.accountID != 7 || m.accountCredentials.authType != "basic" {
+		t.Fatalf("credentials dialog = %+v, want account 7 basic", m.accountCredentials)
+	}
+}
+
+func TestAccountSettingsUpdateCredentialsOpensDialogBearer(t *testing.T) {
+	m := basicAccountModel(t, "bearer")
+	m = updateModel(t, m, AccountSettingsUpdateCredentialsRequestedMsg{AccountID: 7})
+
+	if !m.accountCredentialsOpen || m.accountCredentials.authType != "bearer" {
+		t.Fatalf("bearer Update Credentials: open=%v dialog=%+v",
+			m.accountCredentialsOpen, m.accountCredentials)
+	}
+}
+
+func TestAccountSettingsUpdateCredentialsIgnoredForOAuth(t *testing.T) {
+	m := NewModel(nil, "")
+	m.accounts = map[int64]account.Account{
+		7: {ID: 7, DisplayName: "Personal Google", AuthType: "oauth2"},
+	}
+	m = updateModel(t, m, AccountSettingsRequestedMsg{AccountID: 7})
+
+	m = updateModel(t, m, AccountSettingsUpdateCredentialsRequestedMsg{AccountID: 7})
+	if m.accountCredentialsOpen {
+		t.Fatal("Update Credentials opened for an OAuth account; OAuth must stay on Sign In Again")
+	}
+	if !accountManagerOpen(m) {
+		t.Fatal("OAuth Account Settings should remain open after the ignored request")
+	}
+}
+
+func TestAccountSettingsUpdateCredentialsIgnoredWhileSyncing(t *testing.T) {
+	m := basicAccountModel(t, "basic")
+	m.syncing = true
+	m = updateModel(t, m, AccountSettingsUpdateCredentialsRequestedMsg{AccountID: 7})
+	if m.accountCredentialsOpen {
+		t.Fatal("Update Credentials opened while syncing; it must be blocked mid-sync")
+	}
+}
+
+func TestAccountCredentialsUpdateCancelReturnsToSettings(t *testing.T) {
+	m := basicAccountModel(t, "basic")
+	m = updateModel(t, m, AccountSettingsUpdateCredentialsRequestedMsg{AccountID: 7})
+	m = updateModel(t, m, AccountCredentialsUpdateClosedMsg{AccountID: 7})
+
+	if m.accountCredentialsOpen {
+		t.Fatal("credentials dialog stayed open after cancel")
+	}
+	if !accountManagerOpen(m) {
+		t.Fatal("cancel did not return to Account Settings")
+	}
+	if !strings.Contains(m.syncStatus, "cancelled") {
+		t.Fatalf("syncStatus = %q, want cancelled notice", m.syncStatus)
+	}
+}
+
+func TestAccountCredentialsUpdateSubmitStartsStore(t *testing.T) {
+	m := basicAccountModel(t, "basic")
+	m = updateModel(t, m, AccountSettingsUpdateCredentialsRequestedMsg{AccountID: 7})
+	// Mirror the dialog's own submit: the secret the user typed.
+	m = updateModel(t, m, AccountCredentialsUpdateSubmittedMsg{
+		AccountID: 7, Secret: "rotated-pw",
+	})
+
+	if m.accountCredentialsOpen {
+		t.Fatal("credentials dialog stayed open after submit")
+	}
+	if !m.syncing {
+		t.Fatal("submit did not enter the syncing state to store the credential")
+	}
+}
+
+func TestAccountCredentialsUpdateIgnoresWrongAccountMessages(t *testing.T) {
+	m := basicAccountModel(t, "basic")
+	m = updateModel(t, m, AccountSettingsUpdateCredentialsRequestedMsg{AccountID: 7})
+
+	afterSubmit := updateModel(t, m, AccountCredentialsUpdateSubmittedMsg{
+		AccountID: 99, Secret: "wrong-account-secret",
+	})
+	if !afterSubmit.accountCredentialsOpen || afterSubmit.syncing {
+		t.Fatalf("wrong-account submit changed dialog state: open=%v syncing=%v",
+			afterSubmit.accountCredentialsOpen, afterSubmit.syncing)
+	}
+	afterClose := updateModel(t, m, AccountCredentialsUpdateClosedMsg{AccountID: 99})
+	if !afterClose.accountCredentialsOpen || accountManagerOpen(afterClose) {
+		t.Fatalf("wrong-account close changed dialog state: open=%v settings=%v",
+			afterClose.accountCredentialsOpen, accountManagerOpen(afterClose))
+	}
+}
+
+func TestAccountCredentialStoreFailureReopensSettingsAndKeepsOldCredential(t *testing.T) {
+	m := basicAccountModel(t, "basic")
+	m.syncing = true
+
+	m = updateModel(t, m, accountCredentialStoredMsg{
+		accountID: 7, name: "Work", err: errTestReauth,
+	})
+	if m.syncing {
+		t.Fatal("syncing stayed true after a failed credential store")
+	}
+	if !accountManagerOpen(m) {
+		t.Fatal("failed credential store did not reopen Account Settings")
+	}
+	if !strings.Contains(m.syncStatus, "Couldn't update credentials") ||
+		!strings.Contains(m.syncStatus, "unchanged") {
+		t.Fatalf("failure status = %q, want an unchanged-credential notice", m.syncStatus)
+	}
+}
+
+// TestCredentialForRotationToleratesBrokenKeyring locks the repair contract:
+// a rotation must proceed from an empty credential when the keyring entry is
+// missing or belongs to a different connection — those are exactly the broken
+// states the user is trying to fix — and abort only on other (transient
+// backend) errors.
+func TestCredentialForRotationToleratesBrokenKeyring(t *testing.T) {
+	existing := auth.Credential{AccountID: 7, Username: "alice", Password: "old"}
+	if cred, err := credentialForRotation(existing, nil); err != nil || cred != existing {
+		t.Fatalf("healthy Get: cred=%+v err=%v, want existing credential", cred, err)
+	}
+	if cred, err := credentialForRotation(auth.Credential{}, keyring.ErrNotFound); err != nil || cred != (auth.Credential{}) {
+		t.Fatalf("not-found: cred=%+v err=%v, want empty credential and nil error", cred, err)
+	}
+	if cred, err := credentialForRotation(auth.Credential{}, auth.ErrCredentialIdentityMismatch); err != nil || cred != (auth.Credential{}) {
+		t.Fatalf("identity mismatch: cred=%+v err=%v, want empty credential and nil error", cred, err)
+	}
+	transient := errors.New("keyring backend unavailable")
+	if _, err := credentialForRotation(auth.Credential{}, transient); !errors.Is(err, transient) {
+		t.Fatalf("transient error: err=%v, want wrapped %v", err, transient)
+	}
+}
+
+func TestAccountCredentialStoreSuccessStartsSync(t *testing.T) {
+	m := basicAccountModel(t, "basic")
+
+	m = updateModel(t, m, accountCredentialStoredMsg{accountID: 7, name: "Work"})
+	if !m.syncing {
+		t.Fatal("successful credential store did not start a confirming sync")
+	}
+	if !accountManagerOpen(m) {
+		t.Fatal("successful credential store did not reopen Account Settings")
+	}
+	if !strings.Contains(m.syncStatus, "Syncing") || !strings.Contains(m.syncStatus, "Work") {
+		t.Fatalf("syncStatus = %q, want a Work sync notice", m.syncStatus)
+	}
+}

--- a/internal/tui/account_settings_dialog.go
+++ b/internal/tui/account_settings_dialog.go
@@ -38,6 +38,7 @@ type AccountSettingsRenameRequestedMsg struct{ AccountID int64 }
 type AccountSettingsReauthRequestedMsg struct{ AccountID int64 }
 
 type AccountSettingsRemoveRequestedMsg struct{ AccountID int64 }
+type AccountSettingsUpdateCredentialsRequestedMsg struct{ AccountID int64 }
 
 type AccountSettingsClosedMsg struct{}
 
@@ -97,6 +98,13 @@ func NewAccountSettingsDialogModel(params AccountSettingsParams, theme Theme) Ac
 			label: "Sign In Again…",
 			onPress: func() tea.Msg {
 				return AccountSettingsReauthRequestedMsg{AccountID: params.AccountID}
+			},
+		})
+	} else if accountAuthIsBasicOrBearer(params.AuthType) {
+		actions = append(actions, accountSettingsAction{
+			label: "Update Credentials…",
+			onPress: func() tea.Msg {
+				return AccountSettingsUpdateCredentialsRequestedMsg{AccountID: params.AccountID}
 			},
 		})
 	}
@@ -358,4 +366,122 @@ func (m AccountOAuthConfigDialogModel) View() string {
 	contextLine := lipgloss.NewStyle().Foreground(m.muted).
 		Render("OAuth client configuration for " + m.accountName)
 	return m.dialog.Box(contextLine + "\n\n" + m.form.View())
+}
+
+// AccountCredentialsUpdateSubmittedMsg carries the freshly entered secret for
+// an in-place basic/bearer credential rotation. AuthType selects which field
+// StoreCredential writes; the account identity (server URL, username) is
+// preserved untouched.
+type AccountCredentialsUpdateSubmittedMsg struct {
+	AccountID int64
+	Secret    string
+}
+
+// AccountCredentialsUpdateClosedMsg reports a cancel from the credential
+// update dialog; no credential was changed.
+type AccountCredentialsUpdateClosedMsg struct{ AccountID int64 }
+
+// AccountCredentialsDialogModel collects the single secret needed to rotate a
+// basic (password) or bearer (token) account credential in place. It is the
+// non-OAuth counterpart of AccountOAuthConfigDialogModel: the account and its
+// calendars stay linked, only the stored secret is replaced.
+type AccountCredentialsDialogModel struct {
+	accountID   int64
+	accountName string
+	authType    string
+	username    string
+	dialog      Dialog
+	form        Form
+	help        help.Model
+	muted       color.Color
+}
+
+// NewAccountCredentialsDialogModel builds the credential-rotation form for one
+// account. Bearer auth collects a token; every other basic-or-bearer type
+// collects a password — matching the field the calendar connect flow uses.
+func NewAccountCredentialsDialogModel(
+	accountID int64,
+	accountName, authType, username string,
+	theme Theme,
+) AccountCredentialsDialogModel {
+	var fieldLabel string
+	secret := newPasswordField()
+	if accountAuthIsBearer(authType) {
+		fieldLabel = "Token"
+		secret.SetPlaceholder("paste your API token")
+	} else {
+		fieldLabel = "Password"
+	}
+	styles := DefaultFormStyles()
+	styles.LabelLayout = LabelTop
+	form := NewForm(
+		"Update",
+		styles,
+		FormItem{Label: fieldLabel, Field: secret, Required: true},
+	)
+	form.OnSubmit(func(f *Form) tea.Cmd {
+		msg := AccountCredentialsUpdateSubmittedMsg{
+			AccountID: accountID,
+			Secret:    strings.TrimSpace(f.Field(0).(*TextField).Value()),
+		}
+		return func() tea.Msg { return msg }
+	})
+	form.OnCancel(func(*Form) tea.Cmd {
+		return func() tea.Msg { return AccountCredentialsUpdateClosedMsg{AccountID: accountID} }
+	})
+	return AccountCredentialsDialogModel{
+		accountID:   accountID,
+		accountName: accountName,
+		authType:    authType,
+		username:    username,
+		dialog:      NewDialog("Update Credentials", DefaultDialogStyles()),
+		form:        form,
+		help:        newThemedHelp(theme),
+		muted:       theme.TextDim,
+	}
+}
+
+func (m AccountCredentialsDialogModel) SetSize(w, h int) AccountCredentialsDialogModel {
+	const maxWidth = 56
+	m.dialog = m.dialog.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	m.dialog.SetWidth(min(w, maxWidth))
+	m.form.SetWidth(m.dialog.ContentWidth())
+	return m
+}
+
+func (m AccountCredentialsDialogModel) BoxSize() (int, int) {
+	return lipgloss.Size(m.View())
+}
+
+func (m AccountCredentialsDialogModel) Update(
+	msg tea.Msg,
+) (AccountCredentialsDialogModel, tea.Cmd) {
+	if size, ok := msg.(tea.WindowSizeMsg); ok {
+		return m.SetSize(size.Width, size.Height), nil
+	}
+	if press, ok := msg.(tea.KeyPressMsg); ok &&
+		key.Matches(press, key.NewBinding(key.WithKeys("esc"))) {
+		return m, func() tea.Msg { return AccountCredentialsUpdateClosedMsg{AccountID: m.accountID} }
+	}
+	var cmd tea.Cmd
+	m.form, cmd = m.form.Update(msg)
+	return m, cmd
+}
+
+func (m AccountCredentialsDialogModel) View() string {
+	m.dialog.SetFooter(m.help.ShortHelpView([]key.Binding{
+		key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "switch")),
+		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "update")),
+		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel")),
+	}))
+	noun := "password"
+	if accountAuthIsBearer(m.authType) {
+		noun = "token"
+	}
+	muted := lipgloss.NewStyle().Foreground(m.muted)
+	context := []string{"New " + noun + " for " + m.accountName}
+	if identity := strings.TrimSpace(m.username); identity != "" {
+		context = append(context, "Identity: "+identity)
+	}
+	return m.dialog.Box(muted.Render(strings.Join(context, "\n")) + "\n\n" + m.form.View())
 }

--- a/internal/tui/account_settings_dialog_test.go
+++ b/internal/tui/account_settings_dialog_test.go
@@ -88,11 +88,22 @@ func TestAccountSettingsDialogNonOAuthOmitsSignIn(t *testing.T) {
 	}
 	got := strings.Join(labels, "|")
 	if strings.Contains(got, "Sign In Again") {
-		t.Fatalf("non-OAuth actions contain sign-in: %q", got)
+		t.Fatalf("basic-auth actions contain sign-in: %q", got)
 	}
-	if got != "Manage Calendars…|Sync Now|Rename Account…|Remove Account…|Done" {
-		t.Fatalf("non-OAuth actions = %q", got)
+	want := "Manage Calendars…|Sync Now|Rename Account…|Update Credentials…|Remove Account…|Done"
+	if got != want {
+		t.Fatalf("basic-auth actions = %q, want %q", got, want)
 	}
+	// The new action must be account-scoped so it cannot mutate a sibling.
+	for _, a := range m.actions {
+		if a.label == "Update Credentials…" {
+			if msg, ok := a.onPress().(AccountSettingsUpdateCredentialsRequestedMsg); !ok || msg.AccountID != 9 {
+				t.Fatalf("Update Credentials action = %#v, want AccountSettingsUpdateCredentialsRequestedMsg{9}", a.onPress())
+			}
+			return
+		}
+	}
+	t.Fatalf("basic-auth actions missing Update Credentials: %q", got)
 }
 
 func TestAccountSettingsDialogRendersQuietIdentityAndHealth(t *testing.T) {
@@ -143,5 +154,96 @@ func TestAccountOAuthConfigDialogSubmitsAccountScopedConfig(t *testing.T) {
 	msg, ok := cmd().(AccountOAuthConfigSubmittedMsg)
 	if !ok || msg.AccountID != 7 || msg.ClientID != "new-client" || msg.ClientSecret != "new-secret" {
 		t.Fatalf("OAuth config submission = %#v", cmd())
+	}
+}
+
+func TestAccountSettingsDialogBearerOffersUpdateCredentials(t *testing.T) {
+	m := NewAccountSettingsDialogModel(AccountSettingsParams{
+		AccountID:   11,
+		DisplayName: "API Token Account",
+		AuthType:    "bearer",
+	}, NewTheme(true))
+
+	labels := make([]string, len(m.actions))
+	for i := range m.actions {
+		labels[i] = m.actions[i].label
+	}
+	got := strings.Join(labels, "|")
+	want := "Manage Calendars…|Sync Now|Rename Account…|Update Credentials…|Remove Account…|Done"
+	if got != want {
+		t.Fatalf("bearer actions = %q, want %q", got, want)
+	}
+	for _, a := range m.actions {
+		if a.label == "Update Credentials…" {
+			if msg, ok := a.onPress().(AccountSettingsUpdateCredentialsRequestedMsg); !ok || msg.AccountID != 11 {
+				t.Fatalf("Update Credentials action = %#v, want AccountSettingsUpdateCredentialsRequestedMsg{11}", a.onPress())
+			}
+			return
+		}
+	}
+	t.Fatalf("bearer actions missing Update Credentials: %q", got)
+}
+
+func TestAccountSettingsDialogOAuthOmitsUpdateCredentials(t *testing.T) {
+	m := NewAccountSettingsDialogModel(AccountSettingsParams{
+		AccountID: 7, DisplayName: "Personal Google", AuthType: "oauth2",
+	}, NewTheme(true))
+	for _, a := range m.actions {
+		if a.label == "Update Credentials…" {
+			t.Fatalf("OAuth account must keep Sign In Again, not Update Credentials")
+		}
+		if a.label == "Sign In Again…" {
+			return
+		}
+	}
+	t.Fatalf("OAuth actions missing Sign In Again")
+}
+
+func TestAccountCredentialsDialogBasicCollectsPassword(t *testing.T) {
+	m := NewAccountCredentialsDialogModel(7, "Work", "basic", "alice@example.com", NewTheme(true)).
+		SetSize(80, 30)
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "Password") || !strings.Contains(view, "New password for Work") {
+		t.Fatalf("basic dialog missing Password field/context:\n%s", view)
+	}
+	m.form.Field(0).(*TextField).SetValue("hunter2")
+	form, cmd := m.form.Submit()
+	m.form = form
+	if cmd == nil {
+		t.Fatal("basic credential form did not submit")
+	}
+	msg, ok := cmd().(AccountCredentialsUpdateSubmittedMsg)
+	if !ok || msg.AccountID != 7 || msg.Secret != "hunter2" {
+		t.Fatalf("basic submission = %#v, want account 7 secret hunter2", cmd())
+	}
+}
+
+func TestAccountCredentialsDialogBearerCollectsToken(t *testing.T) {
+	m := NewAccountCredentialsDialogModel(11, "API Token Account", "bearer", "svc", NewTheme(true)).
+		SetSize(80, 30)
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "Token") || !strings.Contains(view, "New token for API Token Account") {
+		t.Fatalf("bearer dialog missing Token field/context:\n%s", view)
+	}
+	m.form.Field(0).(*TextField).SetValue("abc123")
+	form, cmd := m.form.Submit()
+	m.form = form
+	if cmd == nil {
+		t.Fatal("bearer credential form did not submit")
+	}
+	msg, ok := cmd().(AccountCredentialsUpdateSubmittedMsg)
+	if !ok || msg.AccountID != 11 || msg.Secret != "abc123" {
+		t.Fatalf("bearer submission = %#v, want account 11 secret abc123", cmd())
+	}
+}
+
+func TestAccountCredentialsDialogEscapeCancels(t *testing.T) {
+	m := NewAccountCredentialsDialogModel(7, "Work", "basic", "alice@example.com", NewTheme(true))
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("Escape returned nil command")
+	}
+	if _, ok := cmd().(AccountCredentialsUpdateClosedMsg); !ok {
+		t.Fatalf("Escape message = %T, want AccountCredentialsUpdateClosedMsg", cmd())
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -311,6 +311,15 @@ type oauthCredentialStoredMsg struct {
 	err       error
 }
 
+// accountCredentialStoredMsg reports the in-place basic/bearer credential
+// rotation. A failure leaves the previous credential untouched (StoreCredential
+// only replaces it on success), so retrying is safe and nothing is torn down.
+type accountCredentialStoredMsg struct {
+	accountID int64
+	name      string
+	err       error
+}
+
 type accountDiscoveryReadyMsg struct {
 	discovery      account.Discovery
 	err            error
@@ -446,6 +455,8 @@ type Model struct {
 	accountRenameFromSettings   bool
 	accountOAuthConfig          AccountOAuthConfigDialogModel
 	accountOAuthConfigOpen      bool
+	accountCredentials          AccountCredentialsDialogModel
+	accountCredentialsOpen      bool
 	accountManagementGeneration uint64
 	pendingAccountManagementID  int64
 	pendingDiscoveryAccountID   int64
@@ -1529,6 +1540,84 @@ func (m Model) finishOAuthCredentialStore(msg oauthCredentialStoredMsg) (Model, 
 	)
 }
 
+// updateAccountCredentials rotates one account's secret in place. The existing
+// credential is loaded so its non-secret identity (username, client config) is
+// preserved; only the password (basic) or access token (bearer) is replaced.
+// StoreCredential re-checks the account fingerprint under the lifecycle lock,
+// so a concurrent rename or removal aborts the write instead of corrupting it.
+func (m Model) updateAccountCredentials(configured account.Account, secret string) tea.Cmd {
+	storedMsg := func(err error) accountCredentialStoredMsg {
+		return accountCredentialStoredMsg{
+			accountID: configured.ID,
+			name:      configured.DisplayName,
+			err:       err,
+		}
+	}
+	return func() tea.Msg {
+		ctx := context.Background()
+		credStore, err := auth.NewCredentialStoreWithWarnings(
+			m.app.CredentialNamespace,
+			m.app.PreviousCredentialNamespaces,
+			m.app.MigrateLegacyCredentials,
+			m.app.AllowPlaintext,
+			io.Discard,
+		)
+		if err != nil {
+			return storedMsg(err)
+		}
+		fingerprint := configured.CredentialFingerprint()
+		cred, err := credentialForRotation(credStore.Get(configured.ID, fingerprint))
+		if err != nil {
+			return storedMsg(err)
+		}
+		if accountAuthIsBearer(configured.AuthType) {
+			cred.AccessToken = secret
+		} else {
+			cred.Password = secret
+		}
+		err = m.app.Accounts.StoreCredential(ctx, configured.ID, fingerprint, cred, credStore)
+		return storedMsg(err)
+	}
+}
+
+// credentialForRotation maps the pre-rotation Get outcome to the credential
+// the new secret is written into. A missing or identity-mismatched keyring
+// entry is one of the broken states rotation exists to repair, so those
+// start from an empty credential instead of refusing (StoreCredential
+// re-seeds the account identity); any other error aborts the rotation.
+func credentialForRotation(cred auth.Credential, err error) (auth.Credential, error) {
+	if err == nil {
+		return cred, nil
+	}
+	if auth.IsCredentialNotFound(err) || errors.Is(err, auth.ErrCredentialIdentityMismatch) {
+		return auth.Credential{}, nil
+	}
+	return auth.Credential{}, fmt.Errorf("load current credentials: %w", err)
+}
+
+// finishAccountCredentialStore lands the in-place rotation. Success reopens
+// Account Settings and syncs to confirm the new secret works; failure reopens
+// Settings with the error and leaves the previous credential intact.
+func (m Model) finishAccountCredentialStore(msg accountCredentialStoredMsg) (Model, tea.Cmd) {
+	if msg.err != nil {
+		m.syncing = false
+		m.statusToken++
+		m.syncStatus = fmt.Sprintf(
+			"Couldn't update credentials: %s — the previous sign-in is unchanged",
+			msg.err,
+		)
+		m = m.reopenAccountSettings(msg.accountID)
+		return m, m.expireStatusAfter(10*time.Second, m.statusToken)
+	}
+	m = m.reopenAccountSettings(msg.accountID)
+	m.syncing = true
+	m.syncStatus = fmt.Sprintf("Syncing %s…", syncProgressLabel(msg.name))
+	return m, tea.Batch(
+		m.syncSpinner.Tick,
+		m.runSyncAccount(msg.accountID, msg.name),
+	)
+}
+
 func calendarDiscoveryAccountName(accounts []account.Account, username string) string {
 	base := account.SuggestedName(username)
 	if base == "" {
@@ -2169,7 +2258,7 @@ func (m Model) interceptGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 		return m.openQuitConfirm(), nil, true
 	}
 	textEntryActive := m.paletteOpen || m.formOpen || m.calendarManagerOpen ||
-		m.oauthFlowOpen || m.accountOAuthConfigOpen
+		m.oauthFlowOpen || m.accountOAuthConfigOpen || m.accountCredentialsOpen
 	// q opens the quit confirm only from the bare grid. Any open overlay —
 	// text-entry (palette, form) or read-only/choice (event view, list,
 	// choice, calendar list, trash, help) — owns q so its own `q`-to-close
@@ -2290,7 +2379,7 @@ func (m Model) undoIsAllowed() bool {
 func (m Model) anyOverlayOpen() bool {
 	return m.paletteOpen || m.formOpen || m.viewDialogOpen || m.dialogOpen ||
 		m.confirmOpen || m.choiceOpen || m.calendarManagerOpen ||
-		m.accountRenameOpen || m.accountOAuthConfigOpen ||
+		m.accountRenameOpen || m.accountOAuthConfigOpen || m.accountCredentialsOpen ||
 		m.helpDialogOpen || m.trashOpen || m.oauthFlowOpen
 }
 
@@ -2309,6 +2398,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.finishSync(msg)
 	case oauthCredentialStoredMsg:
 		return m.finishOAuthCredentialStore(msg)
+	case accountCredentialStoredMsg:
+		return m.finishAccountCredentialStore(msg)
 	case accountReauthReadyMsg:
 		m.oauthPending = false
 		configured, ok := m.accounts[msg.accountID]
@@ -2409,6 +2500,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	if m.accountCredentialsOpen {
+		switch msg.(type) {
+		case AccountCredentialsUpdateSubmittedMsg, AccountCredentialsUpdateClosedMsg,
+			syncStatusExpiredMsg, toastTickMsg, spinner.TickMsg,
+			tea.BackgroundColorMsg, tea.WindowSizeMsg:
+			// fall through to main switch
+		default:
+			var cmd tea.Cmd
+			m.accountCredentials, cmd = m.accountCredentials.Update(msg)
+			return m, cmd
+		}
+	}
+
 	if m.accountRenameOpen {
 		switch msg.(type) {
 		case AccountRenameRequestedMsg, accountRenameCancelledMsg,
@@ -2425,7 +2529,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Calendar manager is the canonical calendar management overlay.
 	// It hosts calendar detail, account detail, and discovery flows.
 	if m.calendarManagerOpen && !m.accountRenameOpen &&
-		!m.accountOAuthConfigOpen &&
+		!m.accountOAuthConfigOpen && !m.accountCredentialsOpen &&
 		!m.confirmOpen && !m.choiceOpen {
 		switch msg.(type) {
 		case CalendarManagerClosedMsg, CalendarManagerRequestedMsg, CalendarTransferClosedMsg,
@@ -2438,6 +2542,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			calendarImportPreviewReadyMsg, calendarImportFinishedMsg, calendarExportFinishedMsg,
 			AccountSettingsRequestedMsg, AccountSettingsClosedMsg, AccountSettingsManageRequestedMsg, AccountSettingsSyncRequestedMsg,
 			AccountSettingsRenameRequestedMsg, AccountSettingsReauthRequestedMsg,
+			AccountSettingsUpdateCredentialsRequestedMsg,
 			AccountSettingsRemoveRequestedMsg, AccountRenameRequestedMsg,
 			CalendarSetDefaultRequestedMsg,
 			AccountCalendarsImportRequestedMsg, AccountCalendarsReconcileRequestedMsg,
@@ -2537,6 +2642,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.calendarManager = m.calendarManager.SetSize(m.width, m.height)
 		m.accountRename = m.accountRename.SetSize(m.width, m.height)
 		m.accountOAuthConfig = m.accountOAuthConfig.SetSize(m.width, m.height)
+		m.accountCredentials = m.accountCredentials.SetSize(m.width, m.height)
 		m.form = m.form.SetSize(m.width, m.height)
 		m.palette = m.palette.SetSize(m.width, m.height)
 		m.helpDialog = m.helpDialog.SetSize(m.width, m.height)
@@ -3340,6 +3446,49 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.oauthPending = true
 		m.syncStatus = "Preparing sign-in…"
 		return m, m.prepareAccountReauth(configured, "", "")
+
+	case AccountSettingsUpdateCredentialsRequestedMsg:
+		if m.syncing || m.oauthFlowOpen || m.oauthPending ||
+			!m.calendarManagerOpen || m.calendarManager.ActiveAccountID() != msg.AccountID {
+			return m, nil
+		}
+		configured, ok := m.accounts[msg.AccountID]
+		if !ok || !accountAuthIsBasicOrBearer(configured.AuthType) {
+			return m, nil
+		}
+		m.calendarManagerOpen = false
+		m.accountCredentials = NewAccountCredentialsDialogModel(
+			configured.ID, configured.DisplayName, configured.AuthType, configured.Username, m.theme,
+		).SetSize(m.width, m.height)
+		m.accountCredentialsOpen = true
+		return m, nil
+
+	case AccountCredentialsUpdateSubmittedMsg:
+		if m.syncing || m.oauthFlowOpen || m.oauthPending || !m.accountCredentialsOpen ||
+			m.accountCredentials.accountID != msg.AccountID {
+			return m, nil
+		}
+		configured, ok := m.accounts[msg.AccountID]
+		if !ok || !accountAuthIsBasicOrBearer(configured.AuthType) {
+			return m, nil
+		}
+		m.accountCredentialsOpen = false
+		m.syncing = true
+		m.syncStatus = "Updating credentials…"
+		return m, tea.Batch(
+			m.syncSpinner.Tick,
+			m.updateAccountCredentials(configured, msg.Secret),
+		)
+
+	case AccountCredentialsUpdateClosedMsg:
+		if !m.accountCredentialsOpen || m.accountCredentials.accountID != msg.AccountID {
+			return m, nil
+		}
+		m.accountCredentialsOpen = false
+		m.statusToken++
+		m.syncStatus = "Credential update cancelled"
+		m = m.reopenAccountSettings(msg.AccountID)
+		return m, m.expireStatusAfter(6*time.Second, m.statusToken)
 
 	case AccountSettingsRemoveRequestedMsg:
 		if m.syncing || !m.calendarManagerOpen ||
@@ -4943,6 +5092,10 @@ func (m Model) View() tea.View {
 	if m.accountOAuthConfigOpen {
 		bw, bh := m.accountOAuthConfig.BoxSize()
 		v.Content = m.compositeOverlay(v.Content, m.accountOAuthConfig.View(), bw, bh)
+	}
+	if m.accountCredentialsOpen {
+		bw, bh := m.accountCredentials.BoxSize()
+		v.Content = m.compositeOverlay(v.Content, m.accountCredentials.View(), bw, bh)
 	}
 	if m.oauthFlowOpen {
 		bw, bh := m.oauthFlow.BoxSize()

--- a/internal/tui/calendar_dialog.go
+++ b/internal/tui/calendar_dialog.go
@@ -758,6 +758,22 @@ func calendarAuthIsOAuth(authType string) bool {
 	return strings.EqualFold(strings.TrimSpace(authType), "oauth2")
 }
 
+// accountAuthIsBasicOrBearer reports whether an auth-type string selects an
+// in-place credential update: the non-OAuth flows whose secret (password or
+// bearer token) can be rotated without re-running discovery or re-consent.
+func accountAuthIsBasicOrBearer(authType string) bool {
+	t := strings.ToLower(strings.TrimSpace(authType))
+	return t == "basic" || t == "bearer"
+}
+
+// accountAuthIsBearer reports whether the rotated secret is a bearer token
+// (stored in AccessToken) rather than a password. The dialog's field label
+// and the credential write must agree on this split, so both use this
+// single predicate.
+func accountAuthIsBearer(authType string) bool {
+	return strings.EqualFold(strings.TrimSpace(authType), "bearer")
+}
+
 func newOAuthClientIDField(value string) *TextField {
 	f := NewTextField("xxxx.apps.googleusercontent.com")
 	f.SetValue(value)


### PR DESCRIPTION
## Summary
- add Update Credentials to Account Settings for basic and bearer accounts
- rotate only the password or access token while preserving account identity and calendars
- use canonical account auth state and fingerprint-checked `StoreCredential`
- keep OAuth accounts on the existing Sign In Again flow
- return safely to settings on cancel or storage failure

## Verification
- `go test ./internal/tui -run 'Account.*Credential|Credential.*Account|AccountSettings|Basic|Bearer|OAuth' -count=1`
- spec review: PASS
- quality/security findings fixed: submit no longer trusts message-carried auth type; wrong-account submit/close messages are ignored and tested

Closes #549