### PR TITLE
perf(tui): cache calendar manager root preview

### DIFF
--- a/internal/tui/calendar_manager.go
+++ b/internal/tui/calendar_manager.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"image/color"
 	"slices"
 	"strings"
 
@@ -149,6 +150,19 @@ type CalendarManagerModel struct {
 	// when Esc/Cancel would drop a dirty calendar draft. Non-nil only while
 	// the prompt is open; it owns all input until answered.
 	discardConfirm *ConfirmDialogModel
+	// inspector memoizes the rendered calendar-selection preview so the
+	// edit-form preview is not rebuilt on every root render (held-arrow
+	// idle, clock ticks, mouse motion, focus cycling) until one of its
+	// inputs changes. It is a pointer so a value-receiver render writes
+	// through to the model the runtime keeps: the manager is passed by
+	// value between Update and View, so a value field would be discarded
+	// with each copy while a shared pointer survives.
+	inspector *inspectorPreviewCache
+	// themeFP is a fingerprint of theme (see fingerprintTheme), recomputed
+	// only when the theme is assigned. It enters the preview cache key so a
+	// theme or style change invalidates the memo without re-scanning every
+	// color on each render.
+	themeFP string
 }
 
 // NewCalendarManagerModel builds a grouped calendar manager populated from
@@ -158,6 +172,8 @@ func NewCalendarManagerModel(calendars map[int64]CalendarInfo, hidden map[int64]
 		screen:    CalendarManagerScreenList,
 		calendars: calendars,
 		theme:     activeTheme,
+		themeFP:   fingerprintTheme(activeTheme),
+		inspector: &inspectorPreviewCache{},
 		keys:      defaultCalendarManagerKeys(),
 		help:      h,
 	}
@@ -336,6 +352,7 @@ func (m CalendarManagerModel) Screen() CalendarManagerScreen { return m.screen }
 // screens use the current terminal theme.
 func (m CalendarManagerModel) SetTheme(theme Theme) CalendarManagerModel {
 	m.theme = theme
+	m.themeFP = fingerprintTheme(theme)
 	m.help = newThemedHelp(theme)
 	m.list = m.list.SetTheme(theme.Selected, theme.Muted, theme.Text, theme.SelectedText, theme.Error).
 		WithInactiveSelection(theme.ButtonBg, oklch.ContrastingFg(theme.ButtonBg))
@@ -1150,6 +1167,81 @@ func (m CalendarManagerModel) activeInspectorLines(w, h int) []string {
 	return m.selectionInspectorLines(w, h)
 }
 
+// inspectorPreviewCache memoizes the calendar-selection inspector so the
+// edit-form preview is not rebuilt on every root render. Held-arrow idle,
+// clock ticks, mouse motion, and focus cycling all re-render the identical
+// preview until one of its inputs changes; the memo skips that rebuild. It
+// lives behind a pointer on CalendarManagerModel so a value-receiver render
+// (the manager is copied between Update and View) still writes through to
+// the model the runtime keeps.
+type inspectorPreviewCache struct {
+	key   inspectorPreviewKey
+	lines []string
+}
+
+// inspectorPreviewKey captures every input to the calendar-selection
+// preview. CalendarDialogParams folds in the selected calendar's immutable
+// ID, its display metadata, its default flag, and its sidebar visibility;
+// it is a comparable value type, so equality is exact and any field added
+// to calendarDialogParamsFor automatically participates in invalidation.
+// themeFP covers the theme/style; w and h are the inspector pane size.
+// Everything else the preview depends on is read live when the key is
+// built, so a changed selection, resize, data reload, or visibility toggle
+// produces a different key and forces a rebuild — no separate invalidation
+// hooks are needed.
+type inspectorPreviewKey struct {
+	params  CalendarDialogParams
+	themeFP string
+	w, h    int
+}
+
+// fingerprintTheme reduces a Theme to a comparable string covering every
+// color token and the calendar swatch list. color.Color is an interface, so
+// RGBA() is the canonical way to tell whether two themes render identically.
+// It is computed only when the manager's theme is assigned (construction and
+// SetTheme); the per-render cost is a single string compare against the
+// cached key, never a re-scan of the palette.
+func fingerprintTheme(t Theme) string {
+	var b strings.Builder
+	fp := func(name string, c color.Color) {
+		b.WriteString(name)
+		if c == nil {
+			b.WriteString("|n;")
+			return
+		}
+		r, g, bl, a := c.RGBA()
+		fmt.Fprintf(&b, "|%d,%d,%d,%d;", r, g, bl, a)
+	}
+	fp("primary", t.Primary)
+	fp("secondary", t.Secondary)
+	fp("accent", t.Accent)
+	fp("muted", t.Muted)
+	fp("text", t.Text)
+	fp("textdim", t.TextDim)
+	fp("border", t.Border)
+	fp("today", t.Today)
+	fp("selected", t.Selected)
+	fp("selectedtext", t.SelectedText)
+	fp("surface", t.Surface)
+	fp("error", t.Error)
+	fp("badgeok", t.BadgeOK)
+	fp("badgewarn", t.BadgeWarn)
+	fp("badgedanger", t.BadgeDanger)
+	fp("badgeinfo", t.BadgeInfo)
+	fp("badgeneutral", t.BadgeNeutral)
+	fp("formlabel", t.FormLabel)
+	fp("formrequired", t.FormRequired)
+	fp("formerror", t.FormError)
+	fp("formhighlight", t.FormHighlight)
+	fp("buttonbg", t.ButtonBg)
+	b.WriteString("sw:")
+	for _, s := range t.CalendarSwatches {
+		b.WriteString(s)
+		b.WriteByte(',')
+	}
+	return b.String()
+}
+
 // selectionInspectorLines composes the root inspector for the current
 // selection to exactly h rows. A selected calendar shows a live, unfocused
 // preview of its edit form — the same surface Enter, Tab, or a pane click
@@ -1159,8 +1251,16 @@ func (m CalendarManagerModel) activeInspectorLines(w, h int) []string {
 func (m CalendarManagerModel) selectionInspectorLines(w, h int) []string {
 	if id, info, ok := m.selectedCalendar(); ok {
 		params := calendarDialogParamsFor(id, info, m.list.IsHidden(id))
+		key := inspectorPreviewKey{params: params, themeFP: m.themeFP, w: w, h: h}
+		if m.inspector != nil && m.inspector.key == key && len(m.inspector.lines) > 0 {
+			return m.inspector.lines
+		}
 		preview := NewCalendarDialogModel(params, m.theme).Blur().SetInspectorSize(w, h)
-		return strings.Split(preview.InspectorView(w, h), "\n")
+		lines := strings.Split(preview.InspectorView(w, h), "\n")
+		if m.inspector != nil {
+			*m.inspector = inspectorPreviewCache{key: key, lines: lines}
+		}
+		return lines
 	}
 	identity, ok := m.list.currentIdentity()
 	faint := lipgloss.NewStyle().Foreground(m.theme.Muted)

--- a/internal/tui/calendar_manager_cache_test.go
+++ b/internal/tui/calendar_manager_cache_test.go
@@ -1,0 +1,83 @@
+package tui
+
+import (
+	"image/color"
+	"strings"
+	"testing"
+)
+
+func renderManagerPreview(t *testing.T, m CalendarManagerModel, w, h int) (inspectorPreviewKey, []string) {
+	t.Helper()
+	lines := m.selectionInspectorLines(w, h)
+	if m.inspector == nil || len(lines) == 0 {
+		t.Fatal("calendar preview did not populate the inspector cache")
+	}
+	return m.inspector.key, lines
+}
+
+func TestCalendarManagerPreviewCacheReusesStableRender(t *testing.T) {
+	m := newFlatManager().SetSize(120, 40).selectCalendar(1)
+	w, h := m.inspectorPaneSize()
+	key, first := renderManagerPreview(t, m, w, h)
+	secondKey, second := renderManagerPreview(t, m, w, h)
+
+	if secondKey != key {
+		t.Fatalf("stable render changed cache key: before=%+v after=%+v", key, secondKey)
+	}
+	if &first[0] != &second[0] {
+		t.Fatal("stable render rebuilt preview lines instead of reusing the memo")
+	}
+}
+
+func TestCalendarManagerPreviewCacheInvalidatesEveryRenderedInput(t *testing.T) {
+	m := newFlatManager().SetSize(120, 40).selectCalendar(1)
+	w, h := m.inspectorPaneSize()
+	previousKey, previousLines := renderManagerPreview(t, m, w, h)
+
+	assertInvalidated := func(label string, next CalendarManagerModel, nextW, nextH int) CalendarManagerModel {
+		t.Helper()
+		nextKey, nextLines := renderManagerPreview(t, next, nextW, nextH)
+		if nextKey == previousKey {
+			t.Fatalf("%s did not invalidate preview key %+v", label, nextKey)
+		}
+		if len(previousLines) > 0 && len(nextLines) > 0 && &previousLines[0] == &nextLines[0] {
+			t.Fatalf("%s reused stale preview lines", label)
+		}
+		previousKey, previousLines = nextKey, nextLines
+		return next
+	}
+
+	m = assertInvalidated("selection", m.selectCalendar(2), w, h)
+	m = assertInvalidated("pane size", m, w+1, h)
+	w++
+
+	m = m.selectCalendar(1)
+	info := m.calendars[1]
+	info.Name = "Renamed Local"
+	m.calendars[1] = info
+	m = assertInvalidated("calendar data", m, w, h)
+	if got := stripANSI(strings.Join(previousLines, "\n")); !strings.Contains(got, "Renamed Local") {
+		t.Fatalf("calendar data invalidated the key but rendered stale text:\n%s", got)
+	}
+
+	m.list = m.list.SetHidden(1, true)
+	m = assertInvalidated("visibility", m, w, h)
+
+	info = m.calendars[1]
+	info.IsDefault = !info.IsDefault
+	m.calendars[1] = info
+	m = assertInvalidated("default metadata", m, w, h)
+
+	info = m.calendars[1]
+	info.Synced = true
+	info.AccountID = 7
+	info.AccountName = "Work Account"
+	info.RemoteAccess = "read-write"
+	m.calendars[1] = info
+	m = assertInvalidated("remote metadata", m, w, h)
+
+	theme := m.theme
+	theme.Text = color.RGBA{R: 1, G: 2, B: 3, A: 255}
+	m = m.SetTheme(theme)
+	assertInvalidated("theme", m, w, h)
+}


### PR DESCRIPTION
## Summary
- profile the calendar-manager root inspector and confirm it dominates stable root renders
- memoize rendered calendar preview lines by exact dialog params, pane size, and theme fingerprint
- avoid separate invalidation choreography: every rendered input participates in the cache key
- prove freshness for selection, resize, calendar data, visibility, default status, remote metadata, and theme changes

## Performance
Existing baseline: about 2.07 ms/op, 164 KB/op, 3,124 allocs/op.

After cache: 0.36 ms/op, 43 KB/op, 595 allocs/op on the same host, approximately 83% less time, 74% fewer bytes, and 81% fewer allocations for stable root renders.

## Verification
- `go test ./internal/tui -run 'TestCalendarManagerPreviewCache|TestCalendarManagerRoot' -count=1`
- `go test ./internal/tui -run '^$' -bench '^BenchmarkCalendarManagerViewRoot$' -benchmem -count=1`
- direct stable-render and invalidation smoke paths are covered by the cache tests

Closes #544