### PR TITLE
feat(tui): move local calendars to accounts

### DIFF
--- a/db/queries/calendars.sql
+++ b/db/queries/calendars.sql
@@ -188,3 +188,12 @@ UPDATE calendars SET
     remote_missing = 0,
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ?;
+
+-- name: RenameCalendar :exec
+-- Changes only the name (and updated_at). Calendar migration uses this to
+-- give the destination calendar a non-colliding name during the transaction
+-- (the source still holds the chosen name until it is deleted in the same tx).
+UPDATE calendars SET
+    name = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE id = ?;

--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -167,3 +167,34 @@ SELECT * FROM events WHERE (recurrence_rule IS NOT NULL OR (rdates IS NOT NULL A
 
 -- name: CountEventsByCalendar :one
 SELECT COUNT(*) FROM events WHERE calendar_id = ? AND deleted_at IS NULL;
+
+-- name: ReassignEventsCalendar :execrows
+-- Bulk-move every event (live or soft-deleted) from one calendar to another.
+-- Used by calendar migration ("Move to Account"): the destination calendar is
+-- created/linked inside the same transaction before this runs, so the
+-- calendar_id FK always resolves. No deleted_at filter - soft-deleted rows
+-- move too so the trash view and purge keep working after migration.
+UPDATE events SET
+    calendar_id = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE calendar_id = ?;
+
+-- name: CountEventIdentitiesByCalendar :one
+-- Distinct live event identities on a calendar. A recurring master and its
+-- overrides share a uid, so a series counts once - the number a
+-- "Moved N events" summary should report.
+SELECT COUNT(DISTINCT uid) FROM events WHERE calendar_id = ? AND uid != '' AND deleted_at IS NULL;
+
+-- name: MarkEventIdentitiesDirtyForMigration :exec
+-- Flags every distinct live event identity on the source calendar dirty on
+-- the destination so the first sync after a migration uploads it. Runs before
+-- reassignment, while the source rows still identify exactly what moves, as
+-- one set-based statement instead of a per-UID loop. The destination is
+-- always account-linked (migration targets a discovered collection), so the
+-- account gate in MarkResourceDirty is not needed here.
+INSERT INTO sync_resources (calendar_id, uid, owner_type, dirty, sync_strategy)
+SELECT ?, uid, 'event', 1, 'sync-token'
+FROM events AS src
+WHERE src.calendar_id = ? AND src.deleted_at IS NULL AND src.uid != ''
+GROUP BY uid
+ON CONFLICT(calendar_id, uid) DO UPDATE SET dirty = 1, rev = rev + 1;

--- a/db/queries/journals.sql
+++ b/db/queries/journals.sql
@@ -135,3 +135,24 @@ DELETE FROM journals WHERE id = ? AND deleted_at IS NOT NULL;
 SELECT * FROM journals
 WHERE calendar_id = ? AND deleted_at IS NOT NULL
 ORDER BY deleted_at DESC;
+
+-- name: ReassignJournalsCalendar :execrows
+-- Bulk-move every journal (live or soft-deleted) from one calendar to another
+-- during calendar migration. See ReassignEventsCalendar.
+UPDATE journals SET
+    calendar_id = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE calendar_id = ?;
+
+-- name: CountJournalIdentitiesByCalendar :one
+-- See CountEventIdentitiesByCalendar.
+SELECT COUNT(DISTINCT uid) FROM journals WHERE calendar_id = ? AND uid != '' AND deleted_at IS NULL;
+
+-- name: MarkJournalIdentitiesDirtyForMigration :exec
+-- See MarkEventIdentitiesDirtyForMigration.
+INSERT INTO sync_resources (calendar_id, uid, owner_type, dirty, sync_strategy)
+SELECT ?, uid, 'journal', 1, 'sync-token'
+FROM journals AS src
+WHERE src.calendar_id = ? AND src.deleted_at IS NULL AND src.uid != ''
+GROUP BY uid
+ON CONFLICT(calendar_id, uid) DO UPDATE SET dirty = 1, rev = rev + 1;

--- a/db/queries/todos.sql
+++ b/db/queries/todos.sql
@@ -150,3 +150,24 @@ DELETE FROM todos WHERE id = ? AND deleted_at IS NOT NULL;
 SELECT * FROM todos
 WHERE calendar_id = ? AND deleted_at IS NOT NULL
 ORDER BY deleted_at DESC;
+
+-- name: ReassignTodosCalendar :execrows
+-- Bulk-move every todo (live or soft-deleted) from one calendar to another
+-- during calendar migration. See ReassignEventsCalendar.
+UPDATE todos SET
+    calendar_id = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE calendar_id = ?;
+
+-- name: CountTodoIdentitiesByCalendar :one
+-- See CountEventIdentitiesByCalendar.
+SELECT COUNT(DISTINCT uid) FROM todos WHERE calendar_id = ? AND uid != '' AND deleted_at IS NULL;
+
+-- name: MarkTodoIdentitiesDirtyForMigration :exec
+-- See MarkEventIdentitiesDirtyForMigration.
+INSERT INTO sync_resources (calendar_id, uid, owner_type, dirty, sync_strategy)
+SELECT ?, uid, 'todo', 1, 'sync-token'
+FROM todos AS src
+WHERE src.calendar_id = ? AND src.deleted_at IS NULL AND src.uid != ''
+GROUP BY uid
+ON CONFLICT(calendar_id, uid) DO UPDATE SET dirty = 1, rev = rev + 1;

--- a/internal/account/migrate.go
+++ b/internal/account/migrate.go
@@ -1,0 +1,275 @@
+package account
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/douglasdemoura/chroncal/internal/caldav"
+	"github.com/douglasdemoura/chroncal/internal/calendar"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/synclock"
+)
+
+// ErrCannotMigrateRemoteCalendar is returned when the source calendar is
+// already linked to a remote account. Only local-only calendars can be moved
+// into an account; a calendar that already belongs to an account has nothing
+// to migrate.
+var ErrCannotMigrateRemoteCalendar = errors.New("only a local calendar can be moved to an account")
+
+// MigrateResult summarizes a successful "Move to Account" migration.
+type MigrateResult struct {
+	// DestinationID is the local calendar row now linked to the chosen
+	// remote collection. It is either a freshly created row or, when the
+	// collection was already linked locally, that existing row.
+	DestinationID int64
+
+	// CreatedDestination is true when migration created a new local calendar
+	// row for the collection, and false when it merged into one that already
+	// existed.
+	CreatedDestination bool
+
+	// Events, Todos, and Journals count the distinct live (non-soft-deleted)
+	// identities reassigned to the destination and marked dirty for the first
+	// sync. A recurring master and its overrides share a UID, so a series
+	// counts once.
+	Events   int
+	Todos    int
+	Journals int
+}
+
+// MigrateCalendarToAccount moves a local calendar's contents into an existing
+// remote collection on the destination account, then retires the local
+// calendar — chroncal's "Move to Account…" flow.
+//
+// The destination account and collection are described by discovery, which the
+// caller obtains from [Service.Discover]; selectedPath must identify one of its
+// collections. Migration never contacts the server: discovery already proved
+// the account is reachable, and the first sync (the caller initiates it with
+// the returned DestinationID) performs the upload.
+//
+// Within a single transaction the method:
+//  1. resolves or creates the destination calendar row linked to the chosen
+//     collection (idempotent — reusing an existing row when the collection is
+//     already linked locally, mirroring [Service.Import]);
+//  2. flags every live identity on the source dirty on the destination (one
+//     set-based statement per table) so the next sync uploads it;
+//  3. reassigns every event, todo, and journal — live and soft-deleted — from
+//     the source to the destination;
+//  4. promotes the destination to default when the source was the default;
+//  5. deletes the source calendar; and
+//  6. settles a freshly created destination on its preferred name, which the
+//     source may have held until it was deleted.
+//
+// Every failure rolls the transaction back, leaving the source calendar and
+// its data untouched. A successful commit followed by a failed first sync is
+// still non-destructive: the moved data lives on the destination calendar,
+// dirty, and retries on the next sync.
+func (s *Service) MigrateCalendarToAccount(
+	ctx context.Context,
+	sourceID int64,
+	discovery Discovery,
+	selectedPath string,
+) (MigrateResult, error) {
+	if discovery.Account.ID == 0 {
+		return MigrateResult{}, errors.New("migration requires a discovered account")
+	}
+	chosen, ok := discovery.calendarByPath(selectedPath)
+	if !ok {
+		return MigrateResult{}, fmt.Errorf("calendar %q was not part of this discovery", selectedPath)
+	}
+	if !chosen.Importable {
+		return MigrateResult{}, fmt.Errorf("calendar %q has no supported event, todo, or journal components", chosen.Name)
+	}
+	if chosen.Access == caldav.CalendarAccessRead {
+		return MigrateResult{}, fmt.Errorf("calendar %q is read-only", chosen.Name)
+	}
+
+	release, err := synclock.Account(ctx, s.db, discovery.Account.ID)
+	if err != nil {
+		return MigrateResult{}, fmt.Errorf("lock migration destination account: %w", err)
+	}
+	defer release()
+
+	source, err := s.q.GetCalendar(ctx, sourceID)
+	if err != nil {
+		return MigrateResult{}, fmt.Errorf("get source calendar: %w", err)
+	}
+	if source.AccountID != nil && *source.AccountID != 0 {
+		return MigrateResult{}, ErrCannotMigrateRemoteCalendar
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MigrateResult{}, fmt.Errorf("begin migration: %w", err)
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+
+	destinationID, created, err := s.resolveDestinationCalendar(ctx, qtx, discovery, chosen)
+	if err != nil {
+		return MigrateResult{}, err
+	}
+
+	// Count and dirty-flag the source's live identities before reassignment,
+	// while the source rows still identify exactly what moves. Re-flagging an
+	// identity the destination already tracks is a harmless idempotent
+	// re-push of content the remote already holds.
+	eventCount, err := qtx.CountEventIdentitiesByCalendar(ctx, sourceID)
+	if err != nil {
+		return MigrateResult{}, fmt.Errorf("count source events: %w", err)
+	}
+	todoCount, err := qtx.CountTodoIdentitiesByCalendar(ctx, sourceID)
+	if err != nil {
+		return MigrateResult{}, fmt.Errorf("count source todos: %w", err)
+	}
+	journalCount, err := qtx.CountJournalIdentitiesByCalendar(ctx, sourceID)
+	if err != nil {
+		return MigrateResult{}, fmt.Errorf("count source journals: %w", err)
+	}
+	if err := qtx.MarkEventIdentitiesDirtyForMigration(ctx, storage.MarkEventIdentitiesDirtyForMigrationParams{
+		CalendarID:   destinationID,
+		CalendarID_2: sourceID,
+	}); err != nil {
+		return MigrateResult{}, fmt.Errorf("mark events dirty: %w", err)
+	}
+	if err := qtx.MarkTodoIdentitiesDirtyForMigration(ctx, storage.MarkTodoIdentitiesDirtyForMigrationParams{
+		CalendarID:   destinationID,
+		CalendarID_2: sourceID,
+	}); err != nil {
+		return MigrateResult{}, fmt.Errorf("mark todos dirty: %w", err)
+	}
+	if err := qtx.MarkJournalIdentitiesDirtyForMigration(ctx, storage.MarkJournalIdentitiesDirtyForMigrationParams{
+		CalendarID:   destinationID,
+		CalendarID_2: sourceID,
+	}); err != nil {
+		return MigrateResult{}, fmt.Errorf("mark journals dirty: %w", err)
+	}
+
+	if _, err := qtx.ReassignEventsCalendar(ctx, storage.ReassignEventsCalendarParams{
+		CalendarID:   destinationID,
+		CalendarID_2: sourceID,
+	}); err != nil {
+		return MigrateResult{}, fmt.Errorf("reassign events: %w", err)
+	}
+	if _, err := qtx.ReassignTodosCalendar(ctx, storage.ReassignTodosCalendarParams{
+		CalendarID:   destinationID,
+		CalendarID_2: sourceID,
+	}); err != nil {
+		return MigrateResult{}, fmt.Errorf("reassign todos: %w", err)
+	}
+	if _, err := qtx.ReassignJournalsCalendar(ctx, storage.ReassignJournalsCalendarParams{
+		CalendarID:   destinationID,
+		CalendarID_2: sourceID,
+	}); err != nil {
+		return MigrateResult{}, fmt.Errorf("reassign journals: %w", err)
+	}
+
+	if source.IsDefault != 0 {
+		if err := calendar.PromoteDefault(ctx, qtx, map[int64]struct{}{sourceID: {}}, destinationID); err != nil {
+			return MigrateResult{}, fmt.Errorf("promote destination default: %w", err)
+		}
+	}
+
+	if err := qtx.DeleteCalendar(ctx, sourceID); err != nil {
+		return MigrateResult{}, fmt.Errorf("retire source calendar: %w", err)
+	}
+
+	if created {
+		if err := settleDestinationName(ctx, qtx, destinationID, remoteCalendarName(chosen.RemoteCalendar)); err != nil {
+			return MigrateResult{}, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return MigrateResult{}, fmt.Errorf("commit migration: %w", err)
+	}
+
+	return MigrateResult{
+		DestinationID:      destinationID,
+		CreatedDestination: created,
+		Events:             int(eventCount),
+		Todos:              int(todoCount),
+		Journals:           int(journalCount),
+	}, nil
+}
+
+// settleDestinationName renames a freshly created destination calendar to the
+// best available local name once the source row is gone. The destination was
+// named while the source still held its own name, so a same-name move gets a
+// collision suffix ("Personal (2)") that would otherwise persist after the
+// only calendar holding the plain name was deleted.
+func settleDestinationName(ctx context.Context, qtx *storage.Queries, destinationID int64, preferred string) error {
+	all, err := qtx.ListCalendars(ctx)
+	if err != nil {
+		return fmt.Errorf("list calendar names: %w", err)
+	}
+	taken := make(map[string]struct{}, len(all))
+	var current string
+	for _, row := range all {
+		if row.ID == destinationID {
+			current = row.Name
+			continue
+		}
+		taken[row.Name] = struct{}{}
+	}
+	best := uniqueLocalName(preferred, taken)
+	if best == current {
+		return nil
+	}
+	if err := qtx.RenameCalendar(ctx, storage.RenameCalendarParams{
+		Name: best,
+		ID:   destinationID,
+	}); err != nil {
+		return fmt.Errorf("rename destination calendar: %w", err)
+	}
+	return nil
+}
+
+// resolveDestinationCalendar returns the local calendar row linked to the
+// chosen collection, creating one (mirroring Import) when no such row exists
+// yet. The returned created flag distinguishes the two cases for the result.
+func (s *Service) resolveDestinationCalendar(
+	ctx context.Context,
+	qtx *storage.Queries,
+	discovery Discovery,
+	chosen DiscoveredCalendar,
+) (int64, bool, error) {
+	accountID := discovery.Account.ID
+	existing, err := qtx.ListCalendarsByAccount(ctx, &accountID)
+	if err != nil {
+		return 0, false, fmt.Errorf("list destination account calendars: %w", err)
+	}
+	wantKey := remoteIdentityKey(chosen.Path, discovery.Account.ServerURL)
+	for _, row := range existing {
+		if remoteIdentityKey(storage.NullableToString(row.RemoteUrl), discovery.Account.ServerURL) == wantKey {
+			return row.ID, false, nil
+		}
+	}
+
+	// No local row yet: create one exactly as Import does, reserving a
+	// non-colliding local name while the source still holds its own.
+	all, err := qtx.ListCalendars(ctx)
+	if err != nil {
+		return 0, false, fmt.Errorf("list calendar names: %w", err)
+	}
+	taken := make(map[string]struct{}, len(all))
+	for _, row := range all {
+		taken[row.Name] = struct{}{}
+	}
+	row, err := createDiscoveredCalendarRow(ctx, qtx, discovery.Account, chosen, taken)
+	if err != nil {
+		return 0, false, fmt.Errorf("create destination calendar: %w", err)
+	}
+	return row.ID, true, nil
+}
+
+// calendarByPath looks up a discovered collection by its remote path.
+func (d Discovery) calendarByPath(path string) (DiscoveredCalendar, bool) {
+	for _, c := range d.Calendars {
+		if c.Path == path {
+			return c, true
+		}
+	}
+	return DiscoveredCalendar{}, false
+}

--- a/internal/account/migrate_test.go
+++ b/internal/account/migrate_test.go
@@ -1,0 +1,404 @@
+package account
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/douglasdemoura/chroncal/internal/caldav"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// newMigrationFixture opens a fresh DB, creates a destination account, and
+// returns the service plus the seeded local "Personal" calendar (id 1). Tests
+// add events/todos/journals to a local source and assert migration outcomes.
+func newMigrationFixture(t *testing.T) (*Service, *storage.Queries, *sql.DB, Account) {
+	t.Helper()
+	db, q, err := storage.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	svc := NewService(db, q)
+	ctx := context.Background()
+	acct, err := svc.Create(ctx, CreateParams{
+		Name:      "Google",
+		ServerURL: "https://apidata.googleusercontent.com/caldav/v2/",
+		Username:  "me@example.test",
+		AuthType:  "oauth2",
+	}, auth.Credential{Username: "me@example.test", AccessToken: "token"}, newMemoryCredentialStore())
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	return svc, q, db, acct
+}
+
+// discoveryFor builds a Discovery whose single importable collection is the
+// chosen destination path, owned by acct.
+func discoveryFor(acct Account, path, name string) Discovery {
+	return Discovery{
+		Account: acct,
+		Calendars: []DiscoveredCalendar{{
+			RemoteCalendar: caldav.RemoteCalendar{
+				Path:                  path,
+				Name:                  name,
+				Color:                 "#9e69af",
+				Access:                caldav.CalendarAccessOwner,
+				SupportedComponentSet: []string{"VEVENT", "VTODO", "VJOURNAL"},
+			},
+			Importable: true,
+		}},
+	}
+}
+
+func insertEvent(t *testing.T, db *sql.DB, calendarID int64, uid, title string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `INSERT INTO events (uid, calendar_id, title, start_time, end_time)
+		VALUES (?, ?, ?, '2026-05-01T10:00:00Z', '2026-05-01T11:00:00Z')`,
+		uid, calendarID, title)
+	if err != nil {
+		t.Fatalf("insert event %q: %v", uid, err)
+	}
+}
+
+func insertTodo(t *testing.T, db *sql.DB, calendarID int64, uid, summary string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `INSERT INTO todos (uid, calendar_id, summary, due_date)
+		VALUES (?, ?, ?, '2026-05-01T17:00:00Z')`, uid, calendarID, summary)
+	if err != nil {
+		t.Fatalf("insert todo %q: %v", uid, err)
+	}
+}
+
+func insertJournal(t *testing.T, db *sql.DB, calendarID int64, uid, summary string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `INSERT INTO journals (uid, calendar_id, summary, start_date)
+		VALUES (?, ?, ?, '2026-05-01T00:00:00Z')`, uid, calendarID, summary)
+	if err != nil {
+		t.Fatalf("insert journal %q: %v", uid, err)
+	}
+}
+
+func insertSoftDeletedEvent(t *testing.T, db *sql.DB, calendarID int64, uid string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `INSERT INTO events (uid, calendar_id, title, start_time, end_time, deleted_at)
+		VALUES (?, ?, 'gone', '2026-05-01T10:00:00Z', '2026-05-01T11:00:00Z', '2026-04-01T00:00:00Z')`,
+		uid, calendarID)
+	if err != nil {
+		t.Fatalf("insert soft-deleted event %q: %v", uid, err)
+	}
+}
+
+func calendarExists(t *testing.T, q *storage.Queries, id int64) bool {
+	t.Helper()
+	_, err := q.GetCalendar(context.Background(), id)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false
+	}
+	t.Fatalf("GetCalendar %d: %v", id, err)
+	return false
+}
+
+func eventCalendarID(t *testing.T, q *storage.Queries, uid string) int64 {
+	t.Helper()
+	row, err := q.GetEventByUID(context.Background(), uid)
+	if err != nil {
+		t.Fatalf("GetEventByUID %q: %v", uid, err)
+	}
+	return row.CalendarID
+}
+
+func dirtyCount(t *testing.T, db *sql.DB, calendarID int64) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM sync_resources WHERE calendar_id = ? AND dirty = 1`, calendarID).Scan(&n); err != nil {
+		t.Fatalf("count dirty: %v", err)
+	}
+	return n
+}
+
+// TestMigrateCalendarToAccount_MovesContentsAndRetiresSource is the direct
+// end-to-end smoke scenario: a local calendar's events and todos move onto a
+// newly linked destination calendar, get flagged dirty for upload, and the
+// source calendar is retired — all atomically.
+func TestMigrateCalendarToAccount_MovesContentsAndRetiresSource(t *testing.T) {
+	svc, q, db, acct := newMigrationFixture(t)
+	ctx := context.Background()
+
+	source, err := q.GetCalendar(ctx, 1) // seeded "Personal"
+	if err != nil {
+		t.Fatalf("get source: %v", err)
+	}
+	insertEvent(t, db, source.ID, "evt-1", "Standup")
+	insertEvent(t, db, source.ID, "evt-2", "Review")
+	insertTodo(t, db, source.ID, "todo-1", "Pay bill")
+	insertJournal(t, db, source.ID, "journal-1", "Daily note")
+	insertSoftDeletedEvent(t, db, source.ID, "evt-deleted")
+
+	disc := discoveryFor(acct, "/cal/me/work/", "Work")
+
+	res, err := svc.MigrateCalendarToAccount(ctx, source.ID, disc, "/cal/me/work/")
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if !res.CreatedDestination {
+		t.Errorf("CreatedDestination = false, want true (no prior local row)")
+	}
+	if res.Events != 2 || res.Todos != 1 || res.Journals != 1 {
+		t.Errorf("counts = events:%d todos:%d journals:%d, want 2/1/1", res.Events, res.Todos, res.Journals)
+	}
+
+	if calendarExists(t, q, source.ID) {
+		t.Error("source calendar still exists; it must be retired")
+	}
+	dest, err := q.GetCalendar(ctx, res.DestinationID)
+	if err != nil {
+		t.Fatalf("get destination: %v", err)
+	}
+	if dest.AccountID == nil || *dest.AccountID != acct.ID {
+		t.Errorf("destination account_id = %v, want %d", dest.AccountID, acct.ID)
+	}
+	if got := storage.NullableToString(dest.RemoteUrl); got != "/cal/me/work/" {
+		t.Errorf("destination remote_url = %q, want /cal/me/work/", got)
+	}
+
+	// Live events + todo moved to destination; soft-deleted event moved too.
+	for _, uid := range []string{"evt-1", "evt-2"} {
+		if got := eventCalendarID(t, q, uid); got != res.DestinationID {
+			t.Errorf("event %q calendar_id = %d, want %d", uid, got, res.DestinationID)
+		}
+	}
+	deleted, err := q.GetEventByUIDIncludingDeleted(ctx, "evt-deleted")
+	if err != nil {
+		t.Fatalf("get soft-deleted event: %v", err)
+	}
+	if deleted.CalendarID != res.DestinationID {
+		t.Errorf("soft-deleted event calendar_id = %d, want %d", deleted.CalendarID, res.DestinationID)
+	}
+	var todoCal int64
+	if err := db.QueryRowContext(context.Background(), `SELECT calendar_id FROM todos WHERE uid = 'todo-1'`).Scan(&todoCal); err != nil {
+		t.Fatalf("read todo: %v", err)
+	}
+	if todoCal != res.DestinationID {
+		t.Errorf("todo calendar_id = %d, want %d", todoCal, res.DestinationID)
+	}
+	var journalCal int64
+	if err := db.QueryRowContext(context.Background(), `SELECT calendar_id FROM journals WHERE uid = 'journal-1'`).Scan(&journalCal); err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	if journalCal != res.DestinationID {
+		t.Errorf("journal calendar_id = %d, want %d", journalCal, res.DestinationID)
+	}
+
+	// Every live resource must be flagged dirty for the first upload.
+	if got := dirtyCount(t, db, res.DestinationID); got != 4 {
+		t.Errorf("dirty sync_resources = %d, want 4 (2 events + 1 todo + 1 journal)", got)
+	}
+}
+
+// TestMigrateCalendarToAccount_ReusesExistingDestinationRow merges the source
+// into a collection that is already linked locally instead of creating a
+// duplicate row that would sync the same remote URL twice.
+func TestMigrateCalendarToAccount_ReusesExistingDestinationRow(t *testing.T) {
+	svc, q, db, acct := newMigrationFixture(t)
+	ctx := context.Background()
+
+	disc := discoveryFor(acct, "/cal/me/work/", "Work")
+	existing, err := svc.Import(ctx, disc, []string{"/cal/me/work/"})
+	if err != nil {
+		t.Fatalf("Import destination: %v", err)
+	}
+	if len(existing.CreatedIDs) != 1 {
+		t.Fatalf("import created = %+v, want one", existing)
+	}
+	destID := existing.CreatedIDs[0]
+
+	source, _ := q.GetCalendar(ctx, 1)
+	insertEvent(t, db, source.ID, "evt-merge", "Migrate me")
+
+	res, err := svc.MigrateCalendarToAccount(ctx, source.ID, disc, "/cal/me/work/")
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if res.CreatedDestination {
+		t.Error("CreatedDestination = true, want false (row already existed)")
+	}
+	if res.DestinationID != destID {
+		t.Errorf("DestinationID = %d, want existing %d", res.DestinationID, destID)
+	}
+	if calendarExists(t, q, source.ID) {
+		t.Error("source still exists")
+	}
+	if got := eventCalendarID(t, q, "evt-merge"); got != destID {
+		t.Errorf("moved event calendar_id = %d, want %d", got, destID)
+	}
+}
+
+// TestMigrateCalendarToAccount_PromotesDefault transfers defaultness to the
+// destination so the app never observes a missing default.
+func TestMigrateCalendarToAccount_PromotesDefault(t *testing.T) {
+	svc, q, db, acct := newMigrationFixture(t)
+	ctx := context.Background()
+
+	source, _ := q.GetCalendar(ctx, 1)
+	if source.IsDefault == 0 {
+		t.Fatalf("seed calendar is not default: %+v", source)
+	}
+	insertEvent(t, db, source.ID, "evt-def", "Default event")
+
+	disc := discoveryFor(acct, "/cal/me/work/", "Work")
+	res, err := svc.MigrateCalendarToAccount(ctx, source.ID, disc, "/cal/me/work/")
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	def, err := q.GetDefaultCalendar(ctx)
+	if err != nil {
+		t.Fatalf("GetDefaultCalendar: %v", err)
+	}
+	if def.ID != res.DestinationID {
+		t.Errorf("default = %d, want destination %d", def.ID, res.DestinationID)
+	}
+}
+
+// TestMigrateCalendarToAccount_RejectsRemoteSource enforces that only local
+// calendars can enter the flow.
+func TestMigrateCalendarToAccount_RejectsRemoteSource(t *testing.T) {
+	svc, q, _, acct := newMigrationFixture(t)
+	ctx := context.Background()
+
+	disc := discoveryFor(acct, "/cal/me/work/", "Work")
+	imported, err := svc.Import(ctx, disc, []string{"/cal/me/work/"})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	remoteID := imported.CreatedIDs[0]
+
+	_, err = svc.MigrateCalendarToAccount(ctx, remoteID, disc, "/cal/me/work/")
+	if !errors.Is(err, ErrCannotMigrateRemoteCalendar) {
+		t.Errorf("migrating a remote calendar: err = %v, want ErrCannotMigrateRemoteCalendar", err)
+	}
+	// Remote calendar must be untouched.
+	if !calendarExists(t, q, remoteID) {
+		t.Error("remote calendar was removed by a rejected migration")
+	}
+}
+
+func TestMigrateCalendarToAccount_RejectsReadOnlyDestination(t *testing.T) {
+	svc, q, _, acct := newMigrationFixture(t)
+	ctx := context.Background()
+	source, _ := q.GetCalendar(ctx, 1)
+	disc := discoveryFor(acct, "/cal/me/read-only/", "Read only")
+	disc.Calendars[0].Access = caldav.CalendarAccessRead
+
+	if _, err := svc.MigrateCalendarToAccount(ctx, source.ID, disc, "/cal/me/read-only/"); err == nil {
+		t.Fatal("migration into a read-only collection succeeded")
+	}
+	if !calendarExists(t, q, source.ID) {
+		t.Fatal("read-only rejection retired the source calendar")
+	}
+}
+
+// TestMigrateCalendarToAccount_RejectsUnknownPath guards the contract that the
+// selected path must come from the supplied discovery, and that a rejected
+// migration leaves the source intact.
+func TestMigrateCalendarToAccount_RejectsUnknownPath(t *testing.T) {
+	svc, q, _, acct := newMigrationFixture(t)
+	ctx := context.Background()
+	source, _ := q.GetCalendar(ctx, 1)
+	disc := discoveryFor(acct, "/cal/me/work/", "Work")
+	if _, err := svc.MigrateCalendarToAccount(ctx, source.ID, disc, "/cal/me/elsewhere/"); err == nil {
+		t.Error("migrating to an unknown path succeeded; want error")
+	}
+	if !calendarExists(t, q, source.ID) {
+		t.Error("source removed by a rejected migration")
+	}
+}
+
+// TestMigrateCalendarToAccount_RollbackOnFailure confirms a migration against
+// a since-deleted account fails cleanly and leaves the source and its data
+// untouched — no partial state leaks.
+func TestMigrateCalendarToAccount_RollbackOnFailure(t *testing.T) {
+	svc, q, db, acct := newMigrationFixture(t)
+	ctx := context.Background()
+	source, _ := q.GetCalendar(ctx, 1)
+	insertEvent(t, db, source.ID, "evt-rb", "Keep me")
+
+	disc := discoveryFor(acct, "/cal/me/work/", "Work")
+	if err := q.DeleteAccount(ctx, acct.ID); err != nil {
+		t.Fatalf("delete account row: %v", err)
+	}
+	_, err := svc.MigrateCalendarToAccount(ctx, source.ID, disc, "/cal/me/work/")
+	if err == nil {
+		t.Error("migration against a deleted account succeeded; want error")
+	}
+	if !calendarExists(t, q, source.ID) {
+		t.Error("source calendar removed by a failed migration")
+	}
+	if got := eventCalendarID(t, q, "evt-rb"); got != source.ID {
+		t.Errorf("event moved during a failed migration: calendar_id = %d, want %d", got, source.ID)
+	}
+}
+
+// TestMigrateCalendarToAccount_SettlesCollidingDestinationName covers the
+// common same-name move: the destination is created while the source still
+// holds the name, so it gets a collision suffix mid-transaction — but once the
+// source is deleted the plain name is free and must be settled on before
+// commit.
+func TestMigrateCalendarToAccount_SettlesCollidingDestinationName(t *testing.T) {
+	svc, q, _, acct := newMigrationFixture(t)
+	ctx := context.Background()
+	source, err := q.GetCalendar(ctx, 1) // seeded "Personal"
+	if err != nil {
+		t.Fatalf("get source: %v", err)
+	}
+
+	disc := discoveryFor(acct, "/cal/me/personal/", source.Name)
+	res, err := svc.MigrateCalendarToAccount(ctx, source.ID, disc, "/cal/me/personal/")
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	dest, err := q.GetCalendar(ctx, res.DestinationID)
+	if err != nil {
+		t.Fatalf("get destination: %v", err)
+	}
+	if dest.Name != source.Name {
+		t.Errorf("destination name = %q, want %q (collision suffix must not outlive the source)", dest.Name, source.Name)
+	}
+}
+
+// TestMigrateCalendarToAccount_CountsSeriesOnce locks the MigrateResult
+// contract: a recurring master and its overrides share one UID, so the series
+// counts once and yields a single dirty sync resource — not one per row.
+func TestMigrateCalendarToAccount_CountsSeriesOnce(t *testing.T) {
+	svc, q, db, acct := newMigrationFixture(t)
+	ctx := context.Background()
+	source, err := q.GetCalendar(ctx, 1)
+	if err != nil {
+		t.Fatalf("get source: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO events (uid, calendar_id, title, start_time, end_time, recurrence_rule)
+		VALUES ('rec-1', ?, 'Standup', '2026-05-01T10:00:00Z', '2026-05-01T11:00:00Z', 'FREQ=DAILY')`, source.ID); err != nil {
+		t.Fatalf("insert recurring master: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO events (uid, calendar_id, title, start_time, end_time, recurrence_id)
+		VALUES ('rec-1', ?, 'Standup (moved)', '2026-05-02T12:00:00Z', '2026-05-02T13:00:00Z', '2026-05-02T10:00:00Z')`, source.ID); err != nil {
+		t.Fatalf("insert override: %v", err)
+	}
+
+	res, err := svc.MigrateCalendarToAccount(ctx, source.ID, discoveryFor(acct, "/cal/me/work/", "Work"), "/cal/me/work/")
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if res.Events != 1 {
+		t.Errorf("Events = %d, want 1 (master + override share a uid)", res.Events)
+	}
+	if got := dirtyCount(t, db, res.DestinationID); got != 1 {
+		t.Errorf("dirty sync_resources = %d, want 1 for the shared uid", got)
+	}
+}

--- a/internal/account/service.go
+++ b/internal/account/service.go
@@ -501,24 +501,7 @@ func (s *Service) Import(ctx context.Context, discovery Discovery, selectedPaths
 			continue
 		}
 
-		remoteName := remoteCalendarName(item.RemoteCalendar)
-		color := item.Color
-		if color == "" {
-			color = defaultCalendarColor
-		}
-		accountID := discovery.Account.ID
-		row, err := qtx.CreateDiscoveredCalendar(ctx, storage.CreateDiscoveredCalendarParams{
-			Name:             uniqueLocalName(remoteName, taken),
-			Color:            color,
-			Description:      storage.StringToNullable(item.Description),
-			AccountID:        &accountID,
-			RemoteUrl:        storage.StringToNullable(path),
-			RemoteColor:      storage.StringToNullable(item.Color),
-			RemoteName:       remoteName,
-			RemoteAccess:     string(normalizedAccess(item.Access)),
-			RemoteComponents: strings.Join(normalizedComponents(item.SupportedComponentSet), ","),
-			OwnerEmail:       discovery.Account.Username,
-		})
+		row, err := createDiscoveredCalendarRow(ctx, qtx, discovery.Account, item, taken)
 		if err != nil {
 			return ImportResult{}, fmt.Errorf("import calendar %q: %w", item.Name, err)
 		}
@@ -685,24 +668,7 @@ func (s *Service) ReconcileSelection(
 			continue
 		}
 		item := discoveredByKey[key]
-		remoteName := remoteCalendarName(item.RemoteCalendar)
-		color := item.Color
-		if color == "" {
-			color = defaultCalendarColor
-		}
-		accountID := discovery.Account.ID
-		row, err := qtx.CreateDiscoveredCalendar(ctx, storage.CreateDiscoveredCalendarParams{
-			Name:             uniqueLocalName(remoteName, taken),
-			Color:            color,
-			Description:      storage.StringToNullable(item.Description),
-			AccountID:        &accountID,
-			RemoteUrl:        storage.StringToNullable(item.Path),
-			RemoteColor:      storage.StringToNullable(item.Color),
-			RemoteName:       remoteName,
-			RemoteAccess:     string(normalizedAccess(item.Access)),
-			RemoteComponents: strings.Join(normalizedComponents(item.SupportedComponentSet), ","),
-			OwnerEmail:       discovery.Account.Username,
-		})
+		row, err := createDiscoveredCalendarRow(ctx, qtx, discovery.Account, item, taken)
 		if err != nil {
 			return SelectionResult{}, fmt.Errorf("add calendar %q: %w", item.Name, err)
 		}
@@ -944,6 +910,39 @@ func normalizedComponents(components []string) []string {
 	}
 	slices.Sort(out)
 	return out
+}
+
+// createDiscoveredCalendarRow creates the local calendar row for a discovered
+// remote collection, reserving a non-colliding local name from taken (the
+// caller adds the returned row's name to taken when creating in a loop). It is
+// the single DiscoveredCalendar-to-row mapping shared by Import,
+// ReconcileSelection, and calendar migration, so remote-metadata columns stay
+// in lockstep no matter which flow creates the row.
+func createDiscoveredCalendarRow(
+	ctx context.Context,
+	qtx *storage.Queries,
+	acct Account,
+	item DiscoveredCalendar,
+	taken map[string]struct{},
+) (storage.Calendar, error) {
+	remoteName := remoteCalendarName(item.RemoteCalendar)
+	color := item.Color
+	if color == "" {
+		color = defaultCalendarColor
+	}
+	accountID := acct.ID
+	return qtx.CreateDiscoveredCalendar(ctx, storage.CreateDiscoveredCalendarParams{
+		Name:             uniqueLocalName(remoteName, taken),
+		Color:            color,
+		Description:      storage.StringToNullable(item.Description),
+		AccountID:        &accountID,
+		RemoteUrl:        storage.StringToNullable(item.Path),
+		RemoteColor:      storage.StringToNullable(item.Color),
+		RemoteName:       remoteName,
+		RemoteAccess:     string(normalizedAccess(item.Access)),
+		RemoteComponents: strings.Join(normalizedComponents(item.SupportedComponentSet), ","),
+		OwnerEmail:       acct.Username,
+	})
 }
 
 func supportsChroncal(components []string) bool {

--- a/internal/storage/calendars.sql.go
+++ b/internal/storage/calendars.sql.go
@@ -464,6 +464,26 @@ func (q *Queries) MarkCalendarColorDirty(ctx context.Context, id int64) error {
 	return err
 }
 
+const renameCalendar = `-- name: RenameCalendar :exec
+UPDATE calendars SET
+    name = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE id = ?
+`
+
+type RenameCalendarParams struct {
+	Name string
+	ID   int64
+}
+
+// Changes only the name (and updated_at). Calendar migration uses this to
+// give the destination calendar a non-colliding name during the transaction
+// (the source still holds the chosen name until it is deleted in the same tx).
+func (q *Queries) RenameCalendar(ctx context.Context, arg RenameCalendarParams) error {
+	_, err := q.db.ExecContext(ctx, renameCalendar, arg.Name, arg.ID)
+	return err
+}
+
 const setCalendarAsDefault = `-- name: SetCalendarAsDefault :exec
 UPDATE calendars SET
     is_default = 1,

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -9,6 +9,20 @@ import (
 	"context"
 )
 
+const countEventIdentitiesByCalendar = `-- name: CountEventIdentitiesByCalendar :one
+SELECT COUNT(DISTINCT uid) FROM events WHERE calendar_id = ? AND uid != '' AND deleted_at IS NULL
+`
+
+// Distinct live event identities on a calendar. A recurring master and its
+// overrides share a uid, so a series counts once - the number a
+// "Moved N events" summary should report.
+func (q *Queries) CountEventIdentitiesByCalendar(ctx context.Context, calendarID int64) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countEventIdentitiesByCalendar, calendarID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countEventsByCalendar = `-- name: CountEventsByCalendar :one
 SELECT COUNT(*) FROM events WHERE calendar_id = ? AND deleted_at IS NULL
 `
@@ -675,6 +689,31 @@ func (q *Queries) ListRecurringEvents(ctx context.Context) ([]Event, error) {
 	return items, nil
 }
 
+const markEventIdentitiesDirtyForMigration = `-- name: MarkEventIdentitiesDirtyForMigration :exec
+INSERT INTO sync_resources (calendar_id, uid, owner_type, dirty, sync_strategy)
+SELECT ?, uid, 'event', 1, 'sync-token'
+FROM events AS src
+WHERE src.calendar_id = ? AND src.deleted_at IS NULL AND src.uid != ''
+GROUP BY uid
+ON CONFLICT(calendar_id, uid) DO UPDATE SET dirty = 1, rev = rev + 1
+`
+
+type MarkEventIdentitiesDirtyForMigrationParams struct {
+	CalendarID   int64
+	CalendarID_2 int64
+}
+
+// Flags every distinct live event identity on the source calendar dirty on
+// the destination so the first sync after a migration uploads it. Runs before
+// reassignment, while the source rows still identify exactly what moves, as
+// one set-based statement instead of a per-UID loop. The destination is
+// always account-linked (migration targets a discovered collection), so the
+// account gate in MarkResourceDirty is not needed here.
+func (q *Queries) MarkEventIdentitiesDirtyForMigration(ctx context.Context, arg MarkEventIdentitiesDirtyForMigrationParams) error {
+	_, err := q.db.ExecContext(ctx, markEventIdentitiesDirtyForMigration, arg.CalendarID, arg.CalendarID_2)
+	return err
+}
+
 const purgeEventByID = `-- name: PurgeEventByID :execrows
 DELETE FROM events WHERE id = ? AND deleted_at IS NOT NULL
 `
@@ -693,6 +732,31 @@ DELETE FROM events WHERE deleted_at IS NOT NULL AND deleted_at < ?
 
 func (q *Queries) PurgeSoftDeletedEvents(ctx context.Context, deletedAt *string) (int64, error) {
 	result, err := q.db.ExecContext(ctx, purgeSoftDeletedEvents, deletedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const reassignEventsCalendar = `-- name: ReassignEventsCalendar :execrows
+UPDATE events SET
+    calendar_id = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE calendar_id = ?
+`
+
+type ReassignEventsCalendarParams struct {
+	CalendarID   int64
+	CalendarID_2 int64
+}
+
+// Bulk-move every event (live or soft-deleted) from one calendar to another.
+// Used by calendar migration ("Move to Account"): the destination calendar is
+// created/linked inside the same transaction before this runs, so the
+// calendar_id FK always resolves. No deleted_at filter - soft-deleted rows
+// move too so the trash view and purge keep working after migration.
+func (q *Queries) ReassignEventsCalendar(ctx context.Context, arg ReassignEventsCalendarParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, reassignEventsCalendar, arg.CalendarID, arg.CalendarID_2)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/storage/journals.sql.go
+++ b/internal/storage/journals.sql.go
@@ -9,6 +9,18 @@ import (
 	"context"
 )
 
+const countJournalIdentitiesByCalendar = `-- name: CountJournalIdentitiesByCalendar :one
+SELECT COUNT(DISTINCT uid) FROM journals WHERE calendar_id = ? AND uid != '' AND deleted_at IS NULL
+`
+
+// See CountEventIdentitiesByCalendar.
+func (q *Queries) CountJournalIdentitiesByCalendar(ctx context.Context, calendarID int64) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countJournalIdentitiesByCalendar, calendarID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createJournal = `-- name: CreateJournal :one
 INSERT INTO journals (
     uid, calendar_id, summary, description,
@@ -720,6 +732,26 @@ func (q *Queries) ListRecurringJournalsByCalendar(ctx context.Context, calendarI
 	return items, nil
 }
 
+const markJournalIdentitiesDirtyForMigration = `-- name: MarkJournalIdentitiesDirtyForMigration :exec
+INSERT INTO sync_resources (calendar_id, uid, owner_type, dirty, sync_strategy)
+SELECT ?, uid, 'journal', 1, 'sync-token'
+FROM journals AS src
+WHERE src.calendar_id = ? AND src.deleted_at IS NULL AND src.uid != ''
+GROUP BY uid
+ON CONFLICT(calendar_id, uid) DO UPDATE SET dirty = 1, rev = rev + 1
+`
+
+type MarkJournalIdentitiesDirtyForMigrationParams struct {
+	CalendarID   int64
+	CalendarID_2 int64
+}
+
+// See MarkEventIdentitiesDirtyForMigration.
+func (q *Queries) MarkJournalIdentitiesDirtyForMigration(ctx context.Context, arg MarkJournalIdentitiesDirtyForMigrationParams) error {
+	_, err := q.db.ExecContext(ctx, markJournalIdentitiesDirtyForMigration, arg.CalendarID, arg.CalendarID_2)
+	return err
+}
+
 const purgeJournalByID = `-- name: PurgeJournalByID :execrows
 DELETE FROM journals WHERE id = ? AND deleted_at IS NOT NULL
 `
@@ -738,6 +770,28 @@ DELETE FROM journals WHERE deleted_at IS NOT NULL AND deleted_at < ?
 
 func (q *Queries) PurgeSoftDeletedJournals(ctx context.Context, deletedAt *string) (int64, error) {
 	result, err := q.db.ExecContext(ctx, purgeSoftDeletedJournals, deletedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const reassignJournalsCalendar = `-- name: ReassignJournalsCalendar :execrows
+UPDATE journals SET
+    calendar_id = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE calendar_id = ?
+`
+
+type ReassignJournalsCalendarParams struct {
+	CalendarID   int64
+	CalendarID_2 int64
+}
+
+// Bulk-move every journal (live or soft-deleted) from one calendar to another
+// during calendar migration. See ReassignEventsCalendar.
+func (q *Queries) ReassignJournalsCalendar(ctx context.Context, arg ReassignJournalsCalendarParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, reassignJournalsCalendar, arg.CalendarID, arg.CalendarID_2)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/storage/todos.sql.go
+++ b/internal/storage/todos.sql.go
@@ -53,6 +53,18 @@ func (q *Queries) CompleteTodo(ctx context.Context, id int64) (Todo, error) {
 	return i, err
 }
 
+const countTodoIdentitiesByCalendar = `-- name: CountTodoIdentitiesByCalendar :one
+SELECT COUNT(DISTINCT uid) FROM todos WHERE calendar_id = ? AND uid != '' AND deleted_at IS NULL
+`
+
+// See CountEventIdentitiesByCalendar.
+func (q *Queries) CountTodoIdentitiesByCalendar(ctx context.Context, calendarID int64) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countTodoIdentitiesByCalendar, calendarID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createTodo = `-- name: CreateTodo :one
 INSERT INTO todos (
     uid, calendar_id, summary, description, location,
@@ -884,6 +896,26 @@ func (q *Queries) ListTodosByStatus(ctx context.Context, status string) ([]Todo,
 	return items, nil
 }
 
+const markTodoIdentitiesDirtyForMigration = `-- name: MarkTodoIdentitiesDirtyForMigration :exec
+INSERT INTO sync_resources (calendar_id, uid, owner_type, dirty, sync_strategy)
+SELECT ?, uid, 'todo', 1, 'sync-token'
+FROM todos AS src
+WHERE src.calendar_id = ? AND src.deleted_at IS NULL AND src.uid != ''
+GROUP BY uid
+ON CONFLICT(calendar_id, uid) DO UPDATE SET dirty = 1, rev = rev + 1
+`
+
+type MarkTodoIdentitiesDirtyForMigrationParams struct {
+	CalendarID   int64
+	CalendarID_2 int64
+}
+
+// See MarkEventIdentitiesDirtyForMigration.
+func (q *Queries) MarkTodoIdentitiesDirtyForMigration(ctx context.Context, arg MarkTodoIdentitiesDirtyForMigrationParams) error {
+	_, err := q.db.ExecContext(ctx, markTodoIdentitiesDirtyForMigration, arg.CalendarID, arg.CalendarID_2)
+	return err
+}
+
 const purgeSoftDeletedTodos = `-- name: PurgeSoftDeletedTodos :execrows
 DELETE FROM todos WHERE deleted_at IS NOT NULL AND deleted_at < ?
 `
@@ -902,6 +934,28 @@ DELETE FROM todos WHERE id = ? AND deleted_at IS NOT NULL
 
 func (q *Queries) PurgeTodoByID(ctx context.Context, id int64) (int64, error) {
 	result, err := q.db.ExecContext(ctx, purgeTodoByID, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const reassignTodosCalendar = `-- name: ReassignTodosCalendar :execrows
+UPDATE todos SET
+    calendar_id = ?,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE calendar_id = ?
+`
+
+type ReassignTodosCalendarParams struct {
+	CalendarID   int64
+	CalendarID_2 int64
+}
+
+// Bulk-move every todo (live or soft-deleted) from one calendar to another
+// during calendar migration. See ReassignEventsCalendar.
+func (q *Queries) ReassignTodosCalendar(ctx context.Context, arg ReassignTodosCalendarParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, reassignTodosCalendar, arg.CalendarID, arg.CalendarID_2)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -171,6 +171,8 @@ const (
 	pendingScopeEdit
 	pendingScopeCalendarPromote
 	pendingScopeAccountSelectionPromote
+	pendingScopeCalendarMoveAccount
+	pendingScopeCalendarMoveCollection
 )
 
 type eventViewLoadedMsg struct {
@@ -488,6 +490,7 @@ type Model struct {
 	pendingAccountDefaultCandidates []accountDefaultCandidate
 	pendingAccountRemoveID          int64
 	pendingAccountRemoveName        string
+	pendingCalendarMove             *calendarMoveState
 
 	// pendingQuit is true while the confirm dialog is asking the user to
 	// confirm a 'q' quit. Distinguishes the quit flow from event/calendar
@@ -2218,6 +2221,9 @@ func (m Model) clearConfirmPending() Model {
 	m.pendingAccountDefaultCandidates = nil
 	m.pendingAccountRemoveID = 0
 	m.pendingAccountRemoveName = ""
+	if m.choiceOpen {
+		m.pendingCalendarMove = nil
+	}
 	m.choiceOpen = false
 	m.pendingScopeKind = pendingScopeNone
 	return m
@@ -2429,6 +2435,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.startOAuthFlow(msg.cred.OAuthClientID, msg.cred.OAuthClientSecret)
 	case accountManagementDiscoveryReadyMsg:
 		return m.finishAccountManagementDiscovery(msg)
+	case calendarMoveDiscoveryReadyMsg:
+		return m.finishCalendarMoveDiscovery(msg)
+	case calendarMoveFinishedMsg:
+		return m.finishCalendarMove(msg)
 	case accountRenameFinishedMsg:
 		return m.finishAccountRename(msg)
 	case accountRemovalFinishedMsg:
@@ -2534,7 +2544,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.(type) {
 		case CalendarManagerClosedMsg, CalendarManagerRequestedMsg, CalendarTransferClosedMsg,
 			CalendarSavedMsg, CalendarDiscoveryRequestedMsg,
-			CalendarDeleteRequestedMsg, CalendarKeepLocalRequestedMsg, CalendarTestRequestedMsg,
+			CalendarDeleteRequestedMsg, CalendarKeepLocalRequestedMsg, CalendarMoveToAccountRequestedMsg, CalendarTestRequestedMsg,
 			CalendarVisibilityToggledMsg, CalendarReorderedMsg, AccountReorderedMsg,
 			calendarOrderSavedMsg, accountOrderSavedMsg,
 			CalendarExportRequestedMsg, CalendarImportPreviewRequestedMsg,
@@ -4030,6 +4040,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case CalendarMoveToAccountRequestedMsg:
+		return m.beginCalendarMove(msg)
+
 	case CalendarKeepLocalRequestedMsg:
 		// Keep the edit dialog open behind the confirm, mirroring the delete
 		// flow: cancelling returns to the editor with the draft intact.
@@ -4337,7 +4350,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.pendingAccountSelection = nil
 				m.pendingAccountDefaultCandidates = nil
 			}
+			if kind == pendingScopeCalendarMoveAccount || kind == pendingScopeCalendarMoveCollection {
+				m.pendingCalendarMove = nil
+			}
 			return m, nil
+		}
+		if next, cmd, handled := m.handleCalendarMoveChoice(kind, msg.Choice); handled {
+			return next, cmd
 		}
 		if kind == pendingScopeAccountSelectionPromote {
 			if msg.Choice >= len(m.pendingAccountDefaultCandidates) ||

--- a/internal/tui/calendar_dialog.go
+++ b/internal/tui/calendar_dialog.go
@@ -99,6 +99,13 @@ type CalendarExportRequestedMsg struct {
 	Name string
 }
 
+// CalendarMoveToAccountRequestedMsg starts migration of a local calendar into
+// an existing collection owned by a configured account.
+type CalendarMoveToAccountRequestedMsg struct {
+	ID   int64
+	Name string
+}
+
 // CalendarSetDefaultRequestedMsg asks the app to promote a calendar to default.
 type CalendarSetDefaultRequestedMsg struct {
 	ID   int64
@@ -443,6 +450,11 @@ func NewCalendarDialogModel(params CalendarDialogParams, theme Theme) CalendarDi
 			form.SetUtilityActionButton("Export Calendar…", Button, func() tea.Msg {
 				return CalendarExportRequestedMsg{ID: id, Name: name}
 			})
+			if !params.RemoteLinked {
+				form.SetUtilityActionButton("Move to Account…", Button, func() tea.Msg {
+					return CalendarMoveToAccountRequestedMsg{ID: id, Name: name}
+				})
+			}
 		}
 		if params.RemoteLinked {
 			// The keep-local counterpart to Delete: unlink from the account

--- a/internal/tui/calendar_manager_test.go
+++ b/internal/tui/calendar_manager_test.go
@@ -702,7 +702,7 @@ func TestCalendarManagerDetailActionsTargetImmutableID(t *testing.T) {
 	for _, b := range buttons {
 		labels = append(labels, b.Label)
 	}
-	if got, want := strings.Join(labels, ","), "Set as Default,Export Calendar…,Delete Calendar…"; got != want {
+	if got, want := strings.Join(labels, ","), "Set as Default,Export Calendar…,Move to Account…,Delete Calendar…"; got != want {
 		t.Fatalf("local detail actions = %q, want %q", got, want)
 	}
 	for _, b := range buttons {
@@ -715,6 +715,10 @@ func TestCalendarManagerDetailActionsTargetImmutableID(t *testing.T) {
 		case CalendarExportRequestedMsg:
 			if msg.ID != 1 || msg.Name != "On device" {
 				t.Errorf("Export = %+v, want ID 1", msg)
+			}
+		case CalendarMoveToAccountRequestedMsg:
+			if msg.ID != 1 || msg.Name != "On device" {
+				t.Errorf("Move = %+v, want ID 1", msg)
 			}
 		case CalendarDeleteRequestedMsg:
 			if msg.ID != 1 || msg.Name != "On device" {
@@ -1221,16 +1225,19 @@ func TestCalendarManagerDetailButtonDisposition(t *testing.T) {
 		t.Fatal("Enter did not push a calendar form")
 	}
 	rows := strings.Split(stripANSI(m.calendarForm.form.ButtonRowView()), "\n")
-	if len(rows) != 3 {
-		t.Fatalf("button block = %d rows, want tier, blank, commit:\n%s", len(rows), strings.Join(rows, "\n"))
+	if len(rows) < 3 {
+		t.Fatalf("button block = %d rows, want utility tier, blank, commit:\n%s", len(rows), strings.Join(rows, "\n"))
 	}
-	if !strings.Contains(rows[0], "Set as Default") || !strings.Contains(rows[0], "Export Calendar…") {
-		t.Fatalf("utility tier row = %q, want Set as Default beside Export", rows[0])
+	utility := strings.Join(rows[:len(rows)-2], "\n")
+	for _, label := range []string{"Set as Default", "Export Calendar…", "Move to Account…"} {
+		if !strings.Contains(utility, label) {
+			t.Fatalf("utility tier missing %q:\n%s", label, utility)
+		}
 	}
-	if strings.TrimSpace(rows[1]) != "" {
-		t.Fatalf("row between tiers = %q, want blank", rows[1])
+	if strings.TrimSpace(rows[len(rows)-2]) != "" {
+		t.Fatalf("row between tiers = %q, want blank", rows[len(rows)-2])
 	}
-	commit := rows[2]
+	commit := rows[len(rows)-1]
 	if !strings.Contains(commit, "Delete Calendar…") || !strings.Contains(commit, "Save") || !strings.Contains(commit, "Cancel") {
 		t.Fatalf("commit row = %q, want Delete flush-left beside Save/Cancel", commit)
 	}

--- a/internal/tui/calendar_move.go
+++ b/internal/tui/calendar_move.go
@@ -1,0 +1,203 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/douglasdemoura/chroncal/internal/account"
+	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/douglasdemoura/chroncal/internal/caldav"
+	"github.com/douglasdemoura/chroncal/internal/textsafe"
+)
+
+type calendarMoveState struct {
+	sourceID    int64
+	sourceName  string
+	accounts    []account.Account
+	account     account.Account
+	discovery   account.Discovery
+	collections []account.DiscoveredCalendar
+}
+
+type calendarMoveDiscoveryReadyMsg struct {
+	sourceID  int64
+	accountID int64
+	discovery account.Discovery
+	err       error
+}
+
+type calendarMoveFinishedMsg struct {
+	sourceID int64
+	account  account.Account
+	result   account.MigrateResult
+	err      error
+}
+
+func (m Model) beginCalendarMove(msg CalendarMoveToAccountRequestedMsg) (Model, tea.Cmd) {
+	if m.syncing || m.pendingCalendarMove != nil {
+		return m, m.toast.Failed("Finish the current account operation before moving a calendar")
+	}
+	info, ok := m.calendars[msg.ID]
+	if !ok || info.Synced || info.AccountID != 0 {
+		return m, m.toast.Failed("Only a local calendar can be moved to an account")
+	}
+	accounts := make([]account.Account, 0, len(m.accounts))
+	for _, configured := range m.accounts {
+		accounts = append(accounts, configured)
+	}
+	slices.SortFunc(accounts, func(a, b account.Account) int {
+		if a.DisplayOrder != b.DisplayOrder {
+			return int(a.DisplayOrder - b.DisplayOrder)
+		}
+		return strings.Compare(strings.ToLower(a.DisplayName), strings.ToLower(b.DisplayName))
+	})
+	if len(accounts) == 0 {
+		return m, m.toast.Failed("Add an account before moving this calendar")
+	}
+	labels := make([]string, len(accounts))
+	for i, configured := range accounts {
+		labels[i] = textsafe.Display(configured.DisplayName)
+		if labels[i] == "" {
+			labels[i] = textsafe.Display(configured.Name)
+		}
+	}
+	m.pendingCalendarMove = &calendarMoveState{
+		sourceID: msg.ID, sourceName: msg.Name, accounts: accounts,
+	}
+	m.pendingScopeKind = pendingScopeCalendarMoveAccount
+	m.choiceDialog = NewChoiceDialogModel(
+		fmt.Sprintf("Move %q to which account?", msg.Name), m.theme, labels...,
+	).SetSize(m.width, m.height)
+	m.choiceOpen = true
+	return m, nil
+}
+
+func (m Model) discoverCalendarMove(sourceID, accountID int64) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		store, err := auth.NewCredentialStoreWithWarnings(
+			m.app.CredentialNamespace,
+			m.app.PreviousCredentialNamespaces,
+			m.app.MigrateLegacyCredentials,
+			m.app.AllowPlaintext,
+			io.Discard,
+		)
+		if err != nil {
+			return calendarMoveDiscoveryReadyMsg{sourceID: sourceID, accountID: accountID, err: fmt.Errorf("open credential store: %w", err)}
+		}
+		discovery, err := m.app.Accounts.Discover(ctx, accountID, store)
+		return calendarMoveDiscoveryReadyMsg{sourceID: sourceID, accountID: accountID, discovery: discovery, err: err}
+	}
+}
+
+func (m Model) finishCalendarMoveDiscovery(msg calendarMoveDiscoveryReadyMsg) (Model, tea.Cmd) {
+	pending := m.pendingCalendarMove
+	if pending == nil || pending.sourceID != msg.sourceID || pending.account.ID != msg.accountID {
+		return m, nil
+	}
+	m.syncing = false
+	if msg.err != nil {
+		m.pendingCalendarMove = nil
+		m.statusToken++
+		m.syncStatus = "Couldn't load destination calendars: " + msg.err.Error()
+		return m, m.expireStatusAfter(10*time.Second, m.statusToken)
+	}
+	collections := make([]account.DiscoveredCalendar, 0, len(msg.discovery.Calendars))
+	for _, remote := range msg.discovery.Calendars {
+		if remote.Importable && remote.Access != caldav.CalendarAccessRead {
+			collections = append(collections, remote)
+		}
+	}
+	if len(collections) == 0 {
+		m.pendingCalendarMove = nil
+		return m, m.toast.Failed("This account has no writable calendar collections")
+	}
+	slices.SortFunc(collections, func(a, b account.DiscoveredCalendar) int {
+		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
+	labels := make([]string, len(collections))
+	for i, remote := range collections {
+		labels[i] = textsafe.Display(remote.Name)
+		if labels[i] == "" {
+			labels[i] = textsafe.Display(remote.Path)
+		}
+	}
+	pending.discovery = msg.discovery
+	pending.collections = collections
+	m.pendingScopeKind = pendingScopeCalendarMoveCollection
+	m.choiceDialog = NewChoiceDialogModel(
+		fmt.Sprintf("Move %q into which calendar?", pending.sourceName), m.theme, labels...,
+	).SetSize(m.width, m.height)
+	m.choiceOpen = true
+	m.syncStatus = ""
+	return m, nil
+}
+
+func (m Model) migrateCalendarMove(pending calendarMoveState, path string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		result, err := m.app.Accounts.MigrateCalendarToAccount(ctx, pending.sourceID, pending.discovery, path)
+		return calendarMoveFinishedMsg{sourceID: pending.sourceID, account: pending.account, result: result, err: err}
+	}
+}
+
+func (m Model) finishCalendarMove(msg calendarMoveFinishedMsg) (Model, tea.Cmd) {
+	pending := m.pendingCalendarMove
+	if pending == nil || pending.sourceID != msg.sourceID || pending.account.ID != msg.account.ID {
+		return m, nil
+	}
+	m.syncing = false
+	m.pendingCalendarMove = nil
+	if msg.err != nil {
+		m.statusToken++
+		m.syncStatus = "Couldn't move calendar: " + msg.err.Error()
+		return m, m.expireStatusAfter(10*time.Second, m.statusToken)
+	}
+	m.calendarManagerOpen = false
+	m.syncing = true
+	m.syncStatus = "Uploading moved calendar to " + textsafe.Display(msg.account.DisplayName) + "…"
+	return m, tea.Batch(
+		m.syncSpinner.Tick,
+		m.loadCalendars(),
+		m.loadEvents(),
+		m.runSyncAccount(msg.account.ID, msg.account.DisplayName),
+	)
+}
+
+func (m Model) handleCalendarMoveChoice(kind pendingScopeKind, choice int) (Model, tea.Cmd, bool) {
+	pending := m.pendingCalendarMove
+	switch kind {
+	case pendingScopeCalendarMoveAccount:
+		if pending == nil || choice < 0 || choice >= len(pending.accounts) {
+			m.pendingCalendarMove = nil
+			return m, nil, true
+		}
+		pending.account = pending.accounts[choice]
+		m.syncing = true
+		m.syncStatus = "Loading calendars for " + textsafe.Display(pending.account.DisplayName) + "…"
+		return m, tea.Batch(
+			m.syncSpinner.Tick,
+			m.discoverCalendarMove(pending.sourceID, pending.account.ID),
+		), true
+	case pendingScopeCalendarMoveCollection:
+		if pending == nil || choice < 0 || choice >= len(pending.collections) {
+			m.pendingCalendarMove = nil
+			return m, nil, true
+		}
+		path := pending.collections[choice].Path
+		state := *pending
+		m.syncing = true
+		m.syncStatus = "Moving " + textsafe.Display(pending.sourceName) + "…"
+		return m, tea.Batch(m.syncSpinner.Tick, m.migrateCalendarMove(state, path)), true
+	default:
+		return m, nil, false
+	}
+}

--- a/internal/tui/calendar_move_test.go
+++ b/internal/tui/calendar_move_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/account"
+	"github.com/douglasdemoura/chroncal/internal/caldav"
+)
+
+func calendarMoveModel() Model {
+	m := NewModel(nil, "")
+	m.width, m.height = 120, 40
+	m.calendars = map[int64]CalendarInfo{
+		1: {Name: "Local", IsDefault: true},
+		2: {Name: "Remote", Synced: true, AccountID: 7},
+	}
+	m.accounts = map[int64]account.Account{
+		7: {ID: 7, DisplayName: "Work", Name: "Work", DisplayOrder: 2},
+		8: {ID: 8, DisplayName: "Personal", Name: "Personal", DisplayOrder: 1},
+	}
+	m.calendarManagerOpen = true
+	return m
+}
+
+func TestCalendarMoveBeginsWithAccountChoiceForLocalCalendar(t *testing.T) {
+	m, cmd := calendarMoveModel().beginCalendarMove(CalendarMoveToAccountRequestedMsg{ID: 1, Name: "Local"})
+	if cmd != nil {
+		t.Fatal("opening account choice unexpectedly started async work")
+	}
+	if !m.choiceOpen || m.pendingScopeKind != pendingScopeCalendarMoveAccount || m.pendingCalendarMove == nil {
+		t.Fatalf("move account choice not open: open=%v kind=%v pending=%+v", m.choiceOpen, m.pendingScopeKind, m.pendingCalendarMove)
+	}
+	plain := stripANSI(m.choiceDialog.View())
+	if !strings.Contains(plain, "Move \"Local\" to which account?") ||
+		!strings.Contains(plain, "Personal") || !strings.Contains(plain, "Work") {
+		t.Fatalf("account choice missing expected content:\n%s", plain)
+	}
+	if got := m.pendingCalendarMove.accounts[0].ID; got != 8 {
+		t.Fatalf("first account ID = %d, want display-order account 8", got)
+	}
+}
+
+func TestCalendarMoveRejectsRemoteSource(t *testing.T) {
+	m, _ := calendarMoveModel().beginCalendarMove(CalendarMoveToAccountRequestedMsg{ID: 2, Name: "Remote"})
+	if m.choiceOpen || m.pendingCalendarMove != nil {
+		t.Fatal("remote calendar entered Move to Account flow")
+	}
+}
+
+func TestCalendarMoveAccountChoiceStartsDiscoveryAndCancelIsNonDestructive(t *testing.T) {
+	m, _ := calendarMoveModel().beginCalendarMove(CalendarMoveToAccountRequestedMsg{ID: 1, Name: "Local"})
+	m, cmd, handled := m.handleCalendarMoveChoice(pendingScopeCalendarMoveAccount, 0)
+	if !handled || cmd == nil || !m.syncing || m.pendingCalendarMove.account.ID != 8 {
+		t.Fatalf("account choice not routed: handled=%v cmd=%v syncing=%v pending=%+v", handled, cmd != nil, m.syncing, m.pendingCalendarMove)
+	}
+
+	cancelled, _, handled := m.handleCalendarMoveChoice(pendingScopeCalendarMoveAccount, -1)
+	if !handled || cancelled.pendingCalendarMove != nil {
+		t.Fatalf("cancel left migration state behind: handled=%v pending=%+v", handled, cancelled.pendingCalendarMove)
+	}
+	if _, ok := cancelled.calendars[1]; !ok {
+		t.Fatal("cancel removed the local calendar")
+	}
+}
+
+func TestCalendarMoveDiscoveryOffersOnlyWritableCollections(t *testing.T) {
+	m, _ := calendarMoveModel().beginCalendarMove(CalendarMoveToAccountRequestedMsg{ID: 1, Name: "Local"})
+	m.pendingCalendarMove.account = m.pendingCalendarMove.accounts[0]
+	m.syncing = true
+	discovery := account.Discovery{
+		Account: m.pendingCalendarMove.account,
+		Calendars: []account.DiscoveredCalendar{
+			{RemoteCalendar: caldav.RemoteCalendar{Path: "/write/", Name: "Writable", Access: caldav.CalendarAccessWrite}, Importable: true},
+			{RemoteCalendar: caldav.RemoteCalendar{Path: "/read/", Name: "Read only", Access: caldav.CalendarAccessRead}, Importable: true},
+			{RemoteCalendar: caldav.RemoteCalendar{Path: "/freebusy/", Name: "Availability", Access: caldav.CalendarAccessWrite}, Importable: false},
+		},
+	}
+	m, cmd := m.finishCalendarMoveDiscovery(calendarMoveDiscoveryReadyMsg{
+		sourceID: 1, accountID: m.pendingCalendarMove.account.ID, discovery: discovery,
+	})
+	if cmd != nil || !m.choiceOpen || m.pendingScopeKind != pendingScopeCalendarMoveCollection {
+		t.Fatalf("collection choice not opened: cmd=%v open=%v kind=%v", cmd != nil, m.choiceOpen, m.pendingScopeKind)
+	}
+	if got := len(m.pendingCalendarMove.collections); got != 1 || m.pendingCalendarMove.collections[0].Path != "/write/" {
+		t.Fatalf("destination collections = %+v, want only writable collection", m.pendingCalendarMove.collections)
+	}
+	plain := stripANSI(m.choiceDialog.View())
+	if !strings.Contains(plain, "Writable") || strings.Contains(plain, "Read only") || strings.Contains(plain, "Availability") {
+		t.Fatalf("collection choice contains wrong rows:\n%s", plain)
+	}
+}
+
+func TestCalendarMoveCollectionChoiceStartsAtomicMigration(t *testing.T) {
+	m, _ := calendarMoveModel().beginCalendarMove(CalendarMoveToAccountRequestedMsg{ID: 1, Name: "Local"})
+	m.pendingCalendarMove.account = m.pendingCalendarMove.accounts[0]
+	m.pendingCalendarMove.discovery = account.Discovery{Account: m.pendingCalendarMove.account}
+	m.pendingCalendarMove.collections = []account.DiscoveredCalendar{{
+		RemoteCalendar: caldav.RemoteCalendar{Path: "/write/", Name: "Writable", Access: caldav.CalendarAccessWrite},
+		Importable:     true,
+	}}
+	m, cmd, handled := m.handleCalendarMoveChoice(pendingScopeCalendarMoveCollection, 0)
+	if !handled || cmd == nil || !m.syncing {
+		t.Fatalf("collection choice did not start migration: handled=%v cmd=%v syncing=%v", handled, cmd != nil, m.syncing)
+	}
+	if _, ok := m.calendars[1]; !ok {
+		t.Fatal("calendar was retired before migration command succeeded")
+	}
+}
+
+func TestCalendarMoveFailureKeepsManagerAndSource(t *testing.T) {
+	m, _ := calendarMoveModel().beginCalendarMove(CalendarMoveToAccountRequestedMsg{ID: 1, Name: "Local"})
+	m.pendingCalendarMove.account = m.pendingCalendarMove.accounts[0]
+	m.syncing = true
+	m, _ = m.finishCalendarMove(calendarMoveFinishedMsg{
+		sourceID: 1, account: m.pendingCalendarMove.account, err: errTestReauth,
+	})
+	if !m.calendarManagerOpen || m.syncing {
+		t.Fatalf("failed move changed host state: manager=%v syncing=%v", m.calendarManagerOpen, m.syncing)
+	}
+	if _, ok := m.calendars[1]; !ok {
+		t.Fatal("failed move removed source calendar")
+	}
+	if !strings.Contains(m.syncStatus, "Couldn't move calendar") {
+		t.Fatalf("failure status = %q", m.syncStatus)
+	}
+}
+
+func TestCalendarMoveGlobalPendingCleanupAndStaleMessages(t *testing.T) {
+	m, _ := calendarMoveModel().beginCalendarMove(CalendarMoveToAccountRequestedMsg{ID: 1, Name: "Local"})
+	m = m.clearConfirmPending()
+	if m.pendingCalendarMove != nil || m.pendingScopeKind != pendingScopeNone || m.choiceOpen {
+		t.Fatalf("global cleanup left move state armed: pending=%+v kind=%v choice=%v", m.pendingCalendarMove, m.pendingScopeKind, m.choiceOpen)
+	}
+
+	m.syncing = true // an unrelated sync started after the move was cancelled
+	m, _ = m.finishCalendarMoveDiscovery(calendarMoveDiscoveryReadyMsg{sourceID: 1, accountID: 8})
+	if !m.syncing {
+		t.Fatal("stale discovery result cleared unrelated sync state")
+	}
+	m, _ = m.finishCalendarMove(calendarMoveFinishedMsg{sourceID: 1, account: account.Account{ID: 8}})
+	if !m.syncing {
+		t.Fatal("stale migration result cleared unrelated sync state")
+	}
+}


### PR DESCRIPTION
## Summary
- add **Move to Account…** to local calendar details in the Calendars manager
- choose a configured account, then an existing writable remote collection
- atomically resolve/create the linked destination row, move live and soft-deleted events/todos/journals, transfer default status, and retire the source
- mark every moved live resource dirty and immediately run the destination account sync so local data uploads
- reject remote sources, unknown/read-only/unsupported collections, and preserve local data on cancellation or every pre-commit failure
- guard stale async results and global quit/cancel state

No MKCALENDAR support is added; the flow targets existing server collections only.

## Verification
- `make generate`
- `go test ./internal/account -count=1`
- `go test ./internal/tui -count=1`
- direct service smoke covers events, todos, journals, soft-deleted rows, dirty resources, default promotion, destination reuse, and source retirement
- UI tests cover account/collection selection, writable filtering, cancellation, remote rejection, async start, failure preservation, global cleanup, and stale-result races
- spec review: PASS
- quality review findings fixed: pending move cleanup on quit-choice cancellation and stale-message sync-state mutation

## Risk
The migration is intentionally transactional through the source retirement. A first-sync failure after commit does not lose data: moved resources remain on the destination calendar with dirty markers and retry on the next sync.

Closes #550