### PR TITLE
feat(cli): add colored compact list tables

### DIFF
--- a/cmd/chroncal/event_cli_test.go
+++ b/cmd/chroncal/event_cli_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -9,80 +11,79 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/event"
 )
 
-func TestFormatCompactEventUsesSharedTableLayout(t *testing.T) {
+func TestWriteCompactEventTableLayout(t *testing.T) {
 	t.Parallel()
 
 	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.Local)
-	e := event.Event{
-		ID:         42,
-		CalendarID: 7,
-		Title:      "Team Standup",
-		StartTime:  start,
-		EndTime:    start.Add(30 * time.Minute),
-		Categories: "work,meeting",
+	events := []event.Event{
+		{ID: 42, CalendarID: 7, Title: "Team Standup", StartTime: start,
+			EndTime: start.Add(30 * time.Minute), Categories: "work,meeting"},
+		{ID: 7, CalendarID: 8, Title: "Offsite", StartTime: start,
+			EndTime: start.Add(48 * time.Hour), AllDay: true},
 	}
-	header := formatCompactEventHeader(true, false)
-	if got, want := strings.Fields(header), []string{"ID", "DATE", "TIME", "CATEGORIES", "CALENDAR", "SUMMARY"}; strings.Join(got, ",") != strings.Join(want, ",") {
-		t.Fatalf("event compact header fields = %v, want %v", got, want)
+
+	var b bytes.Buffer
+	writeCompactEventTable(&b, events, map[int64]string{7: "Work", 8: "Fun"}, true, true, false)
+	lines := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("lines = %d, want header + 2 rows", len(lines))
 	}
-	got := formatCompactEvent(e, map[int64]string{7: "Work"}, true, false)
-	want := "42    2026-04-21             09:00-09:30  work,meeting        Work              Team Standup"
-	if got != want {
-		t.Fatalf("formatCompactEvent() = %q, want %q", got, want)
+	if got := strings.Fields(lines[0]); !reflect.DeepEqual(got,
+		[]string{"ID", "DATE", "TIME", "CATEGORIES", "CALENDAR", "SUMMARY"}) {
+		t.Fatalf("header fields = %v", got)
 	}
-	colored := formatCompactEvent(e, map[int64]string{7: "Work"}, true, true)
-	for _, code := range []string{"\x1b[1;36m", "\x1b[2m", "\x1b[33m", "\x1b[35m"} {
-		if !strings.Contains(colored, code) {
-			t.Fatalf("colored event row = %q, want ANSI code %q", colored, code)
+	// The summary column starts at the same offset in every row.
+	col := strings.Index(lines[0], "SUMMARY")
+	for i, line := range lines[1:] {
+		if got := strings.Index(line, []string{"Team Standup", "Offsite"}[i]); got != col {
+			t.Fatalf("row %d summary at %d, want %d: %q", i, got, col, line)
 		}
+	}
+	// Categories keep the stored order.
+	if !strings.Contains(lines[1], "work,meeting") {
+		t.Fatalf("row 1 = %q, want stored category order", lines[1])
+	}
+	// The recurrence marker flags a series in the date column.
+	events[0].RecurrenceRule = "FREQ=DAILY"
+	b.Reset()
+	writeCompactEventTable(&b, events, nil, false, true, false)
+	if !strings.Contains(b.String(), "\u21bb") {
+		t.Fatalf("table = %q, want a recurrence marker", b.String())
 	}
 }
 
-func TestEventListCompactIDCanBePassedToGet(t *testing.T) {
-	setupCalendarCLITestEnv(t)
-	t.Setenv("TZ", "UTC")
+// TestWriteCompactEventTableHidesEmptyCategories drops the categories column
+// when no event in the result set carries one.
+func TestWriteCompactEventTableHidesEmptyCategories(t *testing.T) {
+	t.Parallel()
 
-	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
-		t.Fatalf("calendar create: %v", err)
+	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.Local)
+	events := []event.Event{{ID: 1, Title: "Plain", StartTime: start, EndTime: start.Add(time.Hour)}}
+	var b bytes.Buffer
+	writeCompactEventTable(&b, events, nil, false, true, false)
+	if strings.Contains(b.String(), "CATEGORIES") {
+		t.Fatalf("table = %q, want no categories column", b.String())
 	}
-	if _, _, err := runChroncalCommand(t,
-		"event", "add", "Team Standup",
-		"--calendar", "Work",
-		"--date", "2026-04-21",
-		"--time", "09:00",
-		"--duration", "30m",
-		"--categories", "work,meeting",
-	); err != nil {
-		t.Fatalf("event add: %v", err)
-	}
+}
 
-	stdout, _, err := runChroncalCommand(t,
-		"event", "list", "--compact", "--show-calendar",
-		"--calendar", "Work",
-		"--from", "2026-04-21",
-		"--to", "2026-04-22",
-	)
-	if err != nil {
-		t.Fatalf("event list --compact: %v", err)
+// TestWriteCompactTableTruncatesToTerminal pins the overflow rule: flexible
+// columns and the summary shrink with an ellipsis when the terminal is narrow.
+func TestWriteCompactTableTruncatesToTerminal(t *testing.T) {
+	t.Parallel()
+
+	headers := []string{"ID", "SUMMARY"}
+	codes := []string{"1;36", ""}
+	rows := [][]compactCell{
+		{{"1", "1;36"}, {"a very long summary that does not fit", ""}},
 	}
-	if strings.Contains(stdout, "\x1b[") {
-		t.Fatalf("piped compact output contains ANSI styling: %q", stdout)
+	var b bytes.Buffer
+	writeCompactTable(&b, headers, codes, rows, map[int]bool{1: true}, false, true, 30)
+	line := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")[1]
+	if w := displayWidth(line); w > 30 {
+		t.Fatalf("row width = %d, want <= 30: %q", w, line)
 	}
-	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	if len(lines) < 2 {
-		t.Fatalf("compact output contains no data row: %q", stdout)
-	}
-	if !strings.Contains(lines[0], "ID") || !strings.Contains(lines[0], "CALENDAR") ||
-		!strings.Contains(lines[1], "meeting,work") || !strings.Contains(lines[1], "Work") {
-		t.Fatalf("compact event table missing expected columns: %q", stdout)
-	}
-	id := strings.Fields(lines[1])[0]
-	getOut, _, err := runChroncalCommand(t, "event", "get", id)
-	if err != nil {
-		t.Fatalf("event get %q: %v", id, err)
-	}
-	if !strings.Contains(getOut, "Team Standup") {
-		t.Fatalf("event get output = %q, want summary", getOut)
+	if !strings.Contains(line, "\u2026") {
+		t.Fatalf("row = %q, want an ellipsis on the truncated summary", line)
 	}
 }
 

--- a/cmd/chroncal/event_cli_test.go
+++ b/cmd/chroncal/event_cli_test.go
@@ -4,7 +4,87 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
 )
+
+func TestFormatCompactEventUsesSharedTableLayout(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.Local)
+	e := event.Event{
+		ID:         42,
+		CalendarID: 7,
+		Title:      "Team Standup",
+		StartTime:  start,
+		EndTime:    start.Add(30 * time.Minute),
+		Categories: "work,meeting",
+	}
+	header := formatCompactEventHeader(true, false)
+	if got, want := strings.Fields(header), []string{"ID", "DATE", "TIME", "CATEGORIES", "CALENDAR", "SUMMARY"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("event compact header fields = %v, want %v", got, want)
+	}
+	got := formatCompactEvent(e, map[int64]string{7: "Work"}, true, false)
+	want := "42    2026-04-21             09:00-09:30  work,meeting        Work              Team Standup"
+	if got != want {
+		t.Fatalf("formatCompactEvent() = %q, want %q", got, want)
+	}
+	colored := formatCompactEvent(e, map[int64]string{7: "Work"}, true, true)
+	for _, code := range []string{"\x1b[1;36m", "\x1b[2m", "\x1b[33m", "\x1b[35m"} {
+		if !strings.Contains(colored, code) {
+			t.Fatalf("colored event row = %q, want ANSI code %q", colored, code)
+		}
+	}
+}
+
+func TestEventListCompactIDCanBePassedToGet(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Team Standup",
+		"--calendar", "Work",
+		"--date", "2026-04-21",
+		"--time", "09:00",
+		"--duration", "30m",
+		"--categories", "work,meeting",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t,
+		"event", "list", "--compact", "--show-calendar",
+		"--calendar", "Work",
+		"--from", "2026-04-21",
+		"--to", "2026-04-22",
+	)
+	if err != nil {
+		t.Fatalf("event list --compact: %v", err)
+	}
+	if strings.Contains(stdout, "\x1b[") {
+		t.Fatalf("piped compact output contains ANSI styling: %q", stdout)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("compact output contains no data row: %q", stdout)
+	}
+	if !strings.Contains(lines[0], "ID") || !strings.Contains(lines[0], "CALENDAR") ||
+		!strings.Contains(lines[1], "meeting,work") || !strings.Contains(lines[1], "Work") {
+		t.Fatalf("compact event table missing expected columns: %q", stdout)
+	}
+	id := strings.Fields(lines[1])[0]
+	getOut, _, err := runChroncalCommand(t, "event", "get", id)
+	if err != nil {
+		t.Fatalf("event get %q: %v", id, err)
+	}
+	if !strings.Contains(getOut, "Team Standup") {
+		t.Fatalf("event get output = %q, want summary", getOut)
+	}
+}
 
 func TestEventListVerboseUsesTimeRailView(t *testing.T) {
 	setupCalendarCLITestEnv(t)

--- a/cmd/chroncal/event_list.go
+++ b/cmd/chroncal/event_list.go
@@ -36,7 +36,7 @@ Without flags, the window defaults to today through the next 30 days.`,
 		Example: `  chroncal event list
   chroncal event list --calendar Work --from 2026-04-01 --to 2026-04-07
   chroncal event list --status CONFIRMED --output json
-  chroncal event list --compact   # one line per event (script-friendly)`,
+  chroncal event list --compact   # table with ID, date, time, categories, and summary`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a, err := initApp()
 			if err != nil {
@@ -94,8 +94,10 @@ Without flags, the window defaults to today through the next 30 days.`,
 				return nil
 			}
 			if compact {
+				useColor := compactTableColorEnabled(w)
+				fmt.Fprintln(w, formatCompactEventHeader(showCalendar, useColor))
 				for _, e := range events {
-					fmt.Fprintln(w, formatCompactEvent(e, calendarNames, showID, showCalendar))
+					fmt.Fprintln(w, formatCompactEvent(e, calendarNames, showCalendar, useColor))
 				}
 				return nil
 			}
@@ -123,25 +125,39 @@ Without flags, the window defaults to today through the next 30 days.`,
 	cmd.Flags().StringVar(&status, "status", "", "filter by status (TENTATIVE, CONFIRMED, CANCELLED)")
 	cmd.Flags().BoolVar(&showWeekday, "show-weekday", false, "show weekday abbreviation next to the date")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "render a detailed time-rail view for each event")
-	cmd.Flags().BoolVar(&compact, "compact", false, "one line per event (DATE  TIME  TITLE); skips empty-day stubs")
-	cmd.Flags().BoolVar(&showID, "show-id", false, "show each event's numeric ID in text output")
+	cmd.Flags().BoolVar(&compact, "compact", false, "table with one line per event (ID  DATE  TIME  CATEGORIES  SUMMARY); skips empty-day stubs")
+	cmd.Flags().BoolVar(&showID, "show-id", false, "show each event's numeric ID in non-compact text output (compact always includes it)")
 	cmd.Flags().BoolVar(&showCalendar, "show-calendar", false, "show the calendar name in text output")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted events (see `events restore`)")
 	mutuallyExclusive(cmd, "compact", "verbose")
 	return cmd
 }
 
-// formatCompactEvent renders one event as three whitespace-separated columns
-// for line-per-event scripts: date(-range), time(-range or all-day),
-// and title. The columns are padded to fixed widths so an awk/cut user can
-// extract them by position. The title still contains arbitrary text. Read it
-// as "rest of line". Date ranges use ISO 8601 interval syntax
-// (start/end). --show-id prefixes "[id]". --show-calendar suffixes "(name)".
-func formatCompactEvent(e event.Event, calendarNames map[int64]string, showID, showCalendar bool) string {
-	const (
-		dateColWidth = 23 // "YYYY-MM-DD/YYYY-MM-DD" + 2 trailing spaces
-		timeColWidth = 13 // "HH:MM-HH:MM" + 2 trailing spaces
-	)
+const (
+	compactEventIDWidth         = 6
+	compactEventDateWidth       = 23 // "YYYY-MM-DD/YYYY-MM-DD" + 2 trailing spaces
+	compactEventTimeWidth       = 13 // "HH:MM-HH:MM" + 2 trailing spaces
+	compactEventCategoriesWidth = 20
+	compactEventCalendarWidth   = 18
+)
+
+func formatCompactEventHeader(showCalendar, useColor bool) string {
+	header := fmt.Sprintf("%-*s%-*s%-*s%-*s",
+		compactEventIDWidth, "ID",
+		compactEventDateWidth, "DATE",
+		compactEventTimeWidth, "TIME",
+		compactEventCategoriesWidth, "CATEGORIES")
+	if showCalendar {
+		header += fmt.Sprintf("%-*s", compactEventCalendarWidth, "CALENDAR")
+	}
+	header += "SUMMARY"
+	return compactTableColor(useColor, "1;36", header)
+}
+
+// formatCompactEvent renders one event as a table row. Date ranges use ISO
+// 8601 interval syntax (start/end); summary remains last so arbitrary text
+// does not disturb the preceding columns.
+func formatCompactEvent(e event.Event, calendarNames map[int64]string, showCalendar, useColor bool) string {
 	start := e.StartTime.Local()
 	end := e.EndTime.Local()
 	var dateCol, timeCol string
@@ -160,15 +176,23 @@ func formatCompactEvent(e event.Event, calendarNames map[int64]string, showID, s
 		dateCol = start.Format("2006-01-02") + "/" + end.Format("2006-01-02")
 		timeCol = start.Format("15:04") + "-" + end.Format("15:04")
 	}
+	categories := textsafe.Display(e.Categories)
+	if categories == "" {
+		categories = "-"
+	}
+
 	var b strings.Builder
-	if showID {
-		fmt.Fprintf(&b, "[%d]  ", e.ID)
-	}
-	fmt.Fprintf(&b, "%-*s%-*s%s", dateColWidth, dateCol, timeColWidth, timeCol, textsafe.Display(e.Title))
+	b.WriteString(compactTableColor(useColor, "1;36", fmt.Sprintf("%-*d", compactEventIDWidth, e.ID)))
+	b.WriteString(compactTableColor(useColor, "2", fmt.Sprintf("%-*s", compactEventDateWidth, dateCol)))
+	b.WriteString(compactTableColor(useColor, "2", fmt.Sprintf("%-*s", compactEventTimeWidth, timeCol)))
+	b.WriteString(compactTableColor(useColor, "33", fmt.Sprintf("%-*s", compactEventCategoriesWidth, categories)))
 	if showCalendar {
-		if name, ok := calendarNames[e.CalendarID]; ok && name != "" {
-			fmt.Fprintf(&b, "  (%s)", textsafe.Display(name))
+		name := "-"
+		if calendarName, ok := calendarNames[e.CalendarID]; ok && calendarName != "" {
+			name = textsafe.Display(calendarName)
 		}
+		b.WriteString(compactTableColor(useColor, "35", fmt.Sprintf("%-*s", compactEventCalendarWidth, name)))
 	}
+	b.WriteString(textsafe.Display(e.Title))
 	return b.String()
 }

--- a/cmd/chroncal/event_list.go
+++ b/cmd/chroncal/event_list.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -22,6 +22,7 @@ func eventListCmd() *cobra.Command {
 		showWeekday    bool
 		verbose        bool
 		compact        bool
+		noHeader       bool
 		showID         bool
 		showCalendar   bool
 		includeDeleted bool
@@ -94,11 +95,7 @@ Without flags, the window defaults to today through the next 30 days.`,
 				return nil
 			}
 			if compact {
-				useColor := compactTableColorEnabled(w)
-				fmt.Fprintln(w, formatCompactEventHeader(showCalendar, useColor))
-				for _, e := range events {
-					fmt.Fprintln(w, formatCompactEvent(e, calendarNames, showCalendar, useColor))
-				}
+				writeCompactEventTable(w, events, calendarNames, showCalendar, !noHeader, compactTableColorEnabled(w))
 				return nil
 			}
 			// ShowAllDays:false suppresses date-only stub lines for days
@@ -127,40 +124,74 @@ Without flags, the window defaults to today through the next 30 days.`,
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "render a detailed time-rail view for each event")
 	cmd.Flags().BoolVar(&compact, "compact", false, "table with one line per event (ID  DATE  TIME  CATEGORIES  SUMMARY); skips empty-day stubs")
 	cmd.Flags().BoolVar(&showID, "show-id", false, "show each event's numeric ID in non-compact text output (compact always includes it)")
+	cmd.Flags().BoolVar(&noHeader, "no-header", false, "omit the compact table header (for scripts)")
 	cmd.Flags().BoolVar(&showCalendar, "show-calendar", false, "show the calendar name in text output")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted events (see `events restore`)")
 	mutuallyExclusive(cmd, "compact", "verbose")
 	return cmd
 }
 
-const (
-	compactEventIDWidth         = 6
-	compactEventDateWidth       = 23 // "YYYY-MM-DD/YYYY-MM-DD" + 2 trailing spaces
-	compactEventTimeWidth       = 13 // "HH:MM-HH:MM" + 2 trailing spaces
-	compactEventCategoriesWidth = 20
-	compactEventCalendarWidth   = 18
-)
-
-func formatCompactEventHeader(showCalendar, useColor bool) string {
-	header := fmt.Sprintf("%-*s%-*s%-*s%-*s",
-		compactEventIDWidth, "ID",
-		compactEventDateWidth, "DATE",
-		compactEventTimeWidth, "TIME",
-		compactEventCategoriesWidth, "CATEGORIES")
+// writeCompactEventTable renders the event compact table: one header row and
+// one row per event. The categories column disappears when no event in the
+// result set carries one, and a recurrence marker (\u21bb) flags series and
+// moved overrides in the date column.
+func writeCompactEventTable(w io.Writer, events []event.Event, calendarNames map[int64]string, showCalendar, showHeader, useColor bool) {
+	termWidth := terminalWidth(w)
+	headers := []string{"ID", "DATE", "TIME", "CATEGORIES", "SUMMARY"}
+	codes := []string{"1;36", "2", "2", "33", ""}
 	if showCalendar {
-		header += fmt.Sprintf("%-*s", compactEventCalendarWidth, "CALENDAR")
+		headers = append(headers[:4], append([]string{"CALENDAR"}, headers[4:]...)...)
+		codes = append(codes[:4], append([]string{"35"}, codes[4:]...)...)
 	}
-	header += "SUMMARY"
-	return compactTableColor(useColor, "1;36", header)
+	rows := make([][]compactCell, len(events))
+	hasCategories := false
+	for i, e := range events {
+		dateCol, timeCol := compactEventDateColumns(e)
+		if e.RecurrenceRule != "" || e.RecurrenceID != "" {
+			dateCol += " \u21bb"
+		}
+		categories := textsafe.Display(e.Categories)
+		if categories == "" {
+			categories = "-"
+		} else {
+			hasCategories = true
+		}
+		row := []compactCell{
+			{fmt.Sprintf("%d", e.ID), "1;36"},
+			{dateCol, "2"},
+			{timeCol, "2"},
+			{categories, "33"},
+			{textsafe.Display(e.Title), ""},
+		}
+		if showCalendar {
+			name := "-"
+			if calendarName, ok := calendarNames[e.CalendarID]; ok && calendarName != "" {
+				name = textsafe.Display(calendarName)
+			}
+			row = append(row[:4], append([]compactCell{{name, "35"}}, row[4:]...)...)
+		}
+		rows[i] = row
+	}
+	flex := map[int]bool{3: true, len(headers) - 1: true}
+	if showCalendar {
+		flex[4] = true
+	}
+	if !hasCategories {
+		headers = dropCompactColumn(headers, 3)
+		codes = dropCompactColumn(codes, 3)
+		flex = remapFlex(flex, 3, len(headers))
+		for i := range rows {
+			rows[i] = dropCompactCell(rows[i], 3)
+		}
+	}
+	writeCompactTable(w, headers, codes, rows, flex, useColor, showHeader, termWidth)
 }
 
-// formatCompactEvent renders one event as a table row. Date ranges use ISO
-// 8601 interval syntax (start/end); summary remains last so arbitrary text
-// does not disturb the preceding columns.
-func formatCompactEvent(e event.Event, calendarNames map[int64]string, showCalendar, useColor bool) string {
+// compactEventDateColumns formats the date and time columns for one event.
+// Date ranges use ISO 8601 interval syntax (start/end).
+func compactEventDateColumns(e event.Event) (dateCol, timeCol string) {
 	start := e.StartTime.Local()
 	end := e.EndTime.Local()
-	var dateCol, timeCol string
 	if e.AllDay {
 		last := end.AddDate(0, 0, -1)
 		if start.Year() == last.Year() && start.YearDay() == last.YearDay() {
@@ -168,31 +199,11 @@ func formatCompactEvent(e event.Event, calendarNames map[int64]string, showCalen
 		} else {
 			dateCol = start.Format("2006-01-02") + "/" + last.Format("2006-01-02")
 		}
-		timeCol = "all-day"
-	} else if start.Year() == end.Year() && start.YearDay() == end.YearDay() {
-		dateCol = start.Format("2006-01-02")
-		timeCol = start.Format("15:04") + "-" + end.Format("15:04")
-	} else {
-		dateCol = start.Format("2006-01-02") + "/" + end.Format("2006-01-02")
-		timeCol = start.Format("15:04") + "-" + end.Format("15:04")
+		return dateCol, "all-day"
 	}
-	categories := textsafe.Display(e.Categories)
-	if categories == "" {
-		categories = "-"
+	if start.Year() == end.Year() && start.YearDay() == end.YearDay() {
+		return start.Format("2006-01-02"), start.Format("15:04") + "-" + end.Format("15:04")
 	}
-
-	var b strings.Builder
-	b.WriteString(compactTableColor(useColor, "1;36", fmt.Sprintf("%-*d", compactEventIDWidth, e.ID)))
-	b.WriteString(compactTableColor(useColor, "2", fmt.Sprintf("%-*s", compactEventDateWidth, dateCol)))
-	b.WriteString(compactTableColor(useColor, "2", fmt.Sprintf("%-*s", compactEventTimeWidth, timeCol)))
-	b.WriteString(compactTableColor(useColor, "33", fmt.Sprintf("%-*s", compactEventCategoriesWidth, categories)))
-	if showCalendar {
-		name := "-"
-		if calendarName, ok := calendarNames[e.CalendarID]; ok && calendarName != "" {
-			name = textsafe.Display(calendarName)
-		}
-		b.WriteString(compactTableColor(useColor, "35", fmt.Sprintf("%-*s", compactEventCalendarWidth, name)))
-	}
-	b.WriteString(textsafe.Display(e.Title))
-	return b.String()
+	return start.Format("2006-01-02") + "/" + end.Format("2006-01-02"),
+		start.Format("15:04") + "-" + end.Format("15:04")
 }

--- a/cmd/chroncal/event_search.go
+++ b/cmd/chroncal/event_search.go
@@ -93,8 +93,10 @@ roughly when the event occurred.`,
 				return nil
 			}
 			if compact {
+				useColor := compactTableColorEnabled(w)
+				fmt.Fprintln(w, formatCompactEventHeader(false, useColor))
 				for _, e := range events {
-					fmt.Fprintln(w, formatCompactEvent(e, nil, false, false))
+					fmt.Fprintln(w, formatCompactEvent(e, nil, false, useColor))
 				}
 				return nil
 			}
@@ -110,6 +112,6 @@ roughly when the event occurred.`,
 	cmd.Flags().StringVar(&fromStr, "from", "", "start date filter (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&toStr, "to", "", "end date filter (YYYY-MM-DD, inclusive)")
 	cmd.Flags().StringVar(&status, "status", "", "status filter (TENTATIVE, CONFIRMED, CANCELLED)")
-	cmd.Flags().BoolVar(&compact, "compact", false, "one line per event (DATE  TIME  TITLE); same shape as event list --compact")
+	cmd.Flags().BoolVar(&compact, "compact", false, "table with one line per event; same shape as event list --compact")
 	return cmd
 }

--- a/cmd/chroncal/event_search.go
+++ b/cmd/chroncal/event_search.go
@@ -18,6 +18,7 @@ func eventSearchCmd() *cobra.Command {
 		toStr        string
 		status       string
 		compact      bool
+		noHeader     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "search <query>",
@@ -93,11 +94,7 @@ roughly when the event occurred.`,
 				return nil
 			}
 			if compact {
-				useColor := compactTableColorEnabled(w)
-				fmt.Fprintln(w, formatCompactEventHeader(false, useColor))
-				for _, e := range events {
-					fmt.Fprintln(w, formatCompactEvent(e, nil, false, useColor))
-				}
+				writeCompactEventTable(w, events, nil, false, !noHeader, compactTableColorEnabled(w))
 				return nil
 			}
 			fmt.Fprint(w, tui.FormatEventList(tui.FormatEventListOptions{
@@ -113,5 +110,6 @@ roughly when the event occurred.`,
 	cmd.Flags().StringVar(&toStr, "to", "", "end date filter (YYYY-MM-DD, inclusive)")
 	cmd.Flags().StringVar(&status, "status", "", "status filter (TENTATIVE, CONFIRMED, CANCELLED)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "table with one line per event; same shape as event list --compact")
+	cmd.Flags().BoolVar(&noHeader, "no-header", false, "omit the compact table header (for scripts)")
 	return cmd
 }

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -45,6 +46,7 @@ func journalListCmd() *cobra.Command {
 		fromStr        string
 		toStr          string
 		compact        bool
+		noHeader       bool
 		includeDeleted bool
 	)
 	cmd := &cobra.Command{
@@ -101,11 +103,7 @@ CANCELLED entries.`,
 					fmt.Fprintln(w, "No journal entries found.")
 					return nil
 				}
-				useColor := compactTableColorEnabled(w)
-				fmt.Fprintln(w, formatCompactJournalHeader(useColor))
-				for _, j := range journals {
-					fmt.Fprintln(w, formatCompactJournal(j, useColor))
-				}
+				writeCompactJournalTable(w, journals, !noHeader, compactTableColorEnabled(w))
 				return nil
 			}
 			printJournals(w, journals)
@@ -118,41 +116,43 @@ CANCELLED entries.`,
 	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD); with no date flags, past entries are included")
 	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days after --from)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "table with one line per entry (ID  DATE  CATEGORIES  SUMMARY)")
+	cmd.Flags().BoolVar(&noHeader, "no-header", false, "omit the compact table header (for scripts)")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted journals (see `journal restore`)")
 	return cmd
 }
 
-const (
-	compactJournalIDWidth         = 6
-	compactJournalDateWidth       = 12 // YYYY-MM-DD + 2 trailing spaces
-	compactJournalCategoriesWidth = 20
-)
-
-func formatCompactJournalHeader(useColor bool) string {
-	header := fmt.Sprintf("%-*s%-*s%-*s%s",
-		compactJournalIDWidth, "ID",
-		compactJournalDateWidth, "DATE",
-		compactJournalCategoriesWidth, "CATEGORIES",
-		"SUMMARY")
-	return compactTableColor(useColor, "1;36", header)
-}
-
-// formatCompactJournal renders one journal entry as a table row:
-// "19    2026-05-15  work                Notes". ID, date, and categories are
-// minimum-width columns; missing dates and categories show "-". Summary is
-// last so arbitrary text does not disturb the preceding columns.
-func formatCompactJournal(j journal.Journal, useColor bool) string {
-	categories := textsafe.Display(j.Categories)
-	if categories == "" {
-		categories = "-"
+// writeCompactJournalTable renders the journal compact table. The categories
+// column disappears when no entry in the result set carries one.
+func writeCompactJournalTable(w io.Writer, journals []journal.Journal, showHeader, useColor bool) {
+	termWidth := terminalWidth(w)
+	headers := []string{"ID", "DATE", "CATEGORIES", "SUMMARY"}
+	codes := []string{"1;36", "2", "33", ""}
+	rows := make([][]compactCell, len(journals))
+	hasCategories := false
+	for i, j := range journals {
+		categories := textsafe.Display(j.Categories)
+		if categories == "" {
+			categories = "-"
+		} else {
+			hasCategories = true
+		}
+		rows[i] = []compactCell{
+			{fmt.Sprintf("%d", j.ID), "1;36"},
+			{compactDateColumn(j.StartDate), "2"},
+			{categories, "33"},
+			{textsafe.Display(j.Summary), ""},
+		}
 	}
-	idCell := fmt.Sprintf("%-*d", compactJournalIDWidth, j.ID)
-	dateCell := fmt.Sprintf("%-*s", compactJournalDateWidth, compactDateColumn(j.StartDate))
-	categoriesCell := fmt.Sprintf("%-*s", compactJournalCategoriesWidth, categories)
-	return compactTableColor(useColor, "1;36", idCell) +
-		compactTableColor(useColor, "2", dateCell) +
-		compactTableColor(useColor, "33", categoriesCell) +
-		textsafe.Display(j.Summary)
+	flex := map[int]bool{2: true, 3: true}
+	if !hasCategories {
+		headers = dropCompactColumn(headers, 2)
+		codes = dropCompactColumn(codes, 2)
+		flex = remapFlex(flex, 2, len(headers))
+		for i := range rows {
+			rows[i] = dropCompactCell(rows[i], 2)
+		}
+	}
+	writeCompactTable(w, headers, codes, rows, flex, useColor, showHeader, termWidth)
 }
 
 func journalGetCmd() *cobra.Command {

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -58,7 +58,7 @@ CANCELLED entries.`,
 		Example: `  chroncal journal list
   chroncal journal list --calendar Work --from 2026-04-01 --to 2026-04-30
   chroncal journal list --status DRAFT --output json
-  chroncal journal list --compact   # one line per entry (script-friendly)`,
+  chroncal journal list --compact   # table with ID, date, categories, and summary`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a, err := initApp()
 			if err != nil {
@@ -101,8 +101,10 @@ CANCELLED entries.`,
 					fmt.Fprintln(w, "No journal entries found.")
 					return nil
 				}
+				useColor := compactTableColorEnabled(w)
+				fmt.Fprintln(w, formatCompactJournalHeader(useColor))
 				for _, j := range journals {
-					fmt.Fprintln(w, formatCompactJournal(j))
+					fmt.Fprintln(w, formatCompactJournal(j, useColor))
 				}
 				return nil
 			}
@@ -115,17 +117,42 @@ CANCELLED entries.`,
 	cmd.Flags().BoolVar(&all, "all", false, "include cancelled entries (hidden by default)")
 	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD); with no date flags, past entries are included")
 	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days after --from)")
-	cmd.Flags().BoolVar(&compact, "compact", false, "one line per entry (DATE  SUMMARY)")
+	cmd.Flags().BoolVar(&compact, "compact", false, "table with one line per entry (ID  DATE  CATEGORIES  SUMMARY)")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted journals (see `journal restore`)")
 	return cmd
 }
 
-// formatCompactJournal renders one journal entry as a single line:
-// "2026-05-15  Notes". Entries without a start date show "-" in the
-// date column (12-char width).
-func formatCompactJournal(j journal.Journal) string {
-	const dateColWidth = 12
-	return fmt.Sprintf("%-*s%s", dateColWidth, compactDateColumn(j.StartDate), textsafe.Display(j.Summary))
+const (
+	compactJournalIDWidth         = 6
+	compactJournalDateWidth       = 12 // YYYY-MM-DD + 2 trailing spaces
+	compactJournalCategoriesWidth = 20
+)
+
+func formatCompactJournalHeader(useColor bool) string {
+	header := fmt.Sprintf("%-*s%-*s%-*s%s",
+		compactJournalIDWidth, "ID",
+		compactJournalDateWidth, "DATE",
+		compactJournalCategoriesWidth, "CATEGORIES",
+		"SUMMARY")
+	return compactTableColor(useColor, "1;36", header)
+}
+
+// formatCompactJournal renders one journal entry as a table row:
+// "19    2026-05-15  work                Notes". ID, date, and categories are
+// minimum-width columns; missing dates and categories show "-". Summary is
+// last so arbitrary text does not disturb the preceding columns.
+func formatCompactJournal(j journal.Journal, useColor bool) string {
+	categories := textsafe.Display(j.Categories)
+	if categories == "" {
+		categories = "-"
+	}
+	idCell := fmt.Sprintf("%-*d", compactJournalIDWidth, j.ID)
+	dateCell := fmt.Sprintf("%-*s", compactJournalDateWidth, compactDateColumn(j.StartDate))
+	categoriesCell := fmt.Sprintf("%-*s", compactJournalCategoriesWidth, categories)
+	return compactTableColor(useColor, "1;36", idCell) +
+		compactTableColor(useColor, "2", dateCell) +
+		compactTableColor(useColor, "33", categoriesCell) +
+		textsafe.Display(j.Summary)
 }
 
 func journalGetCmd() *cobra.Command {

--- a/cmd/chroncal/journal_cli_test.go
+++ b/cmd/chroncal/journal_cli_test.go
@@ -4,7 +4,94 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/journal"
 )
+
+func TestFormatCompactJournalIncludesIDAndCategories(t *testing.T) {
+	t.Parallel()
+
+	gotHeader := formatCompactJournalHeader(false)
+	wantHeader := "ID    DATE        CATEGORIES          SUMMARY"
+	if gotHeader != wantHeader {
+		t.Fatalf("formatCompactJournalHeader() = %q, want %q", gotHeader, wantHeader)
+	}
+
+	entry := journal.Journal{
+		ID:         19,
+		StartDate:  "2026-08-11",
+		Summary:    "Journal ID check",
+		Categories: "work, personal",
+	}
+	got := formatCompactJournal(entry, false)
+	want := "19    2026-08-11  work, personal      Journal ID check"
+	if got != want {
+		t.Fatalf("formatCompactJournal() = %q, want %q", got, want)
+	}
+
+	coloredHeader := formatCompactJournalHeader(true)
+	coloredRow := formatCompactJournal(entry, true)
+	if !strings.Contains(coloredHeader, "\x1b[1;36m") {
+		t.Fatalf("colored header = %q, want bold cyan ANSI styling", coloredHeader)
+	}
+	for _, code := range []string{"\x1b[1;36m", "\x1b[2m", "\x1b[33m"} {
+		if !strings.Contains(coloredRow, code) {
+			t.Fatalf("colored row = %q, want ANSI code %q", coloredRow, code)
+		}
+	}
+}
+
+func TestJournalListCompactIDCanBePassedToGet(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"journal", "add", "Sprint notes",
+		"--calendar", "Work",
+		"--date", "2026-08-11",
+		"--categories", "work,personal",
+	); err != nil {
+		t.Fatalf("journal add: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t,
+		"journal", "list", "--compact",
+		"--calendar", "Work",
+		"--from", "2026-08-11",
+		"--to", "2026-08-12",
+	)
+	if err != nil {
+		t.Fatalf("journal list --compact: %v", err)
+	}
+	if !strings.Contains(stdout, "ID    DATE        CATEGORIES          SUMMARY\n") {
+		t.Fatalf("compact output = %q, want table header", stdout)
+	}
+	if strings.Contains(stdout, "\x1b[") {
+		t.Fatalf("piped compact output contains ANSI styling: %q", stdout)
+	}
+	if !strings.Contains(stdout, "personal,work       Sprint notes") {
+		t.Fatalf("compact output = %q, want summary and categories on one line", stdout)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("compact output contains no data row: %q", stdout)
+	}
+	fields := strings.Fields(lines[1])
+	if len(fields) == 0 {
+		t.Fatalf("compact output contains no ID: %q", stdout)
+	}
+
+	getOut, _, err := runChroncalCommand(t, "journal", "get", fields[0])
+	if err != nil {
+		t.Fatalf("journal get %q: %v", fields[0], err)
+	}
+	if !strings.Contains(getOut, "Sprint notes") {
+		t.Fatalf("journal get output = %q, want summary %q", getOut, "Sprint notes")
+	}
+}
 
 // TestJournalListHidesCancelledByDefault verifies that `journal list` hides
 // CANCELLED entries by default and that `--all` brings them back. That

--- a/cmd/chroncal/journal_cli_test.go
+++ b/cmd/chroncal/journal_cli_test.go
@@ -1,95 +1,40 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/journal"
 )
 
-func TestFormatCompactJournalIncludesIDAndCategories(t *testing.T) {
+func TestWriteCompactJournalTableLayout(t *testing.T) {
 	t.Parallel()
 
-	gotHeader := formatCompactJournalHeader(false)
-	wantHeader := "ID    DATE        CATEGORIES          SUMMARY"
-	if gotHeader != wantHeader {
-		t.Fatalf("formatCompactJournalHeader() = %q, want %q", gotHeader, wantHeader)
+	journals := []journal.Journal{
+		{ID: 19, StartDate: "2026-08-11", Summary: "Journal ID check",
+			Categories: "work, personal"},
 	}
 
-	entry := journal.Journal{
-		ID:         19,
-		StartDate:  "2026-08-11",
-		Summary:    "Journal ID check",
-		Categories: "work, personal",
+	var b bytes.Buffer
+	writeCompactJournalTable(&b, journals, true, false)
+	lines := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
+	if got := strings.Fields(lines[0]); !reflect.DeepEqual(got,
+		[]string{"ID", "DATE", "CATEGORIES", "SUMMARY"}) {
+		t.Fatalf("header fields = %v", got)
 	}
-	got := formatCompactJournal(entry, false)
-	want := "19    2026-08-11  work, personal      Journal ID check"
-	if got != want {
-		t.Fatalf("formatCompactJournal() = %q, want %q", got, want)
-	}
-
-	coloredHeader := formatCompactJournalHeader(true)
-	coloredRow := formatCompactJournal(entry, true)
-	if !strings.Contains(coloredHeader, "\x1b[1;36m") {
-		t.Fatalf("colored header = %q, want bold cyan ANSI styling", coloredHeader)
-	}
-	for _, code := range []string{"\x1b[1;36m", "\x1b[2m", "\x1b[33m"} {
-		if !strings.Contains(coloredRow, code) {
-			t.Fatalf("colored row = %q, want ANSI code %q", coloredRow, code)
-		}
-	}
-}
-
-func TestJournalListCompactIDCanBePassedToGet(t *testing.T) {
-	setupCalendarCLITestEnv(t)
-	t.Setenv("TZ", "UTC")
-
-	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
-		t.Fatalf("calendar create: %v", err)
-	}
-	if _, _, err := runChroncalCommand(t,
-		"journal", "add", "Sprint notes",
-		"--calendar", "Work",
-		"--date", "2026-08-11",
-		"--categories", "work,personal",
-	); err != nil {
-		t.Fatalf("journal add: %v", err)
+	if !strings.Contains(lines[1], "work, personal") ||
+		!strings.HasSuffix(lines[1], "Journal ID check") {
+		t.Fatalf("row = %q, want categories and summary", lines[1])
 	}
 
-	stdout, _, err := runChroncalCommand(t,
-		"journal", "list", "--compact",
-		"--calendar", "Work",
-		"--from", "2026-08-11",
-		"--to", "2026-08-12",
-	)
-	if err != nil {
-		t.Fatalf("journal list --compact: %v", err)
-	}
-	if !strings.Contains(stdout, "ID    DATE        CATEGORIES          SUMMARY\n") {
-		t.Fatalf("compact output = %q, want table header", stdout)
-	}
-	if strings.Contains(stdout, "\x1b[") {
-		t.Fatalf("piped compact output contains ANSI styling: %q", stdout)
-	}
-	if !strings.Contains(stdout, "personal,work       Sprint notes") {
-		t.Fatalf("compact output = %q, want summary and categories on one line", stdout)
-	}
-	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	if len(lines) < 2 {
-		t.Fatalf("compact output contains no data row: %q", stdout)
-	}
-	fields := strings.Fields(lines[1])
-	if len(fields) == 0 {
-		t.Fatalf("compact output contains no ID: %q", stdout)
-	}
-
-	getOut, _, err := runChroncalCommand(t, "journal", "get", fields[0])
-	if err != nil {
-		t.Fatalf("journal get %q: %v", fields[0], err)
-	}
-	if !strings.Contains(getOut, "Sprint notes") {
-		t.Fatalf("journal get output = %q, want summary %q", getOut, "Sprint notes")
+	// The categories column disappears when no entry carries one.
+	b.Reset()
+	writeCompactJournalTable(&b, []journal.Journal{{ID: 1, Summary: "Plain"}}, true, false)
+	if strings.Contains(b.String(), "CATEGORIES") {
+		t.Fatalf("table = %q, want no categories column", b.String())
 	}
 }
 

--- a/cmd/chroncal/output.go
+++ b/cmd/chroncal/output.go
@@ -10,6 +10,8 @@ import (
 
 	"golang.org/x/term"
 
+	"github.com/mattn/go-runewidth"
+
 	"github.com/douglasdemoura/chroncal/internal/calendar"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/journal"
@@ -651,3 +653,106 @@ func printJournals(w io.Writer, journals []journal.Journal) {
 		printJournal(w, j)
 	}
 }
+
+// compactCell is one table cell: the sanitized text and its ANSI color code.
+// An empty code means unstyled.
+type compactCell struct {
+	text string
+	code string
+}
+
+// compactTable renders a fixed-column table. Columns pad to the widest cell;
+// two spaces separate columns, and the last column (the summary) is never
+// padded. Columns whose index appears in flex truncate with an ellipsis when
+// the total width exceeds termWidth (0 = unlimited); the summary absorbs any
+// remaining overflow first. Padding measures display width, so wide glyphs
+// (CJK) keep the columns aligned.
+func writeCompactTable(w io.Writer, headers []string, codes []string, rows [][]compactCell, flex map[int]bool, useColor, header bool, termWidth int) {
+	last := len(headers) - 1
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = displayWidth(h)
+	}
+	for _, row := range rows {
+		for i, c := range row {
+			if w := displayWidth(c.text); w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+	trimFlex := func(budget int) {
+		for i := last; i >= 0 && budget < 0; i-- {
+			if !flex[i] {
+				continue
+			}
+			shrink := -budget
+			if shrink > widths[i] {
+				shrink = widths[i]
+			}
+			widths[i] -= shrink
+			budget += shrink
+		}
+	}
+	if termWidth > 0 {
+		fixed := 0
+		for i := range headers {
+			if i < last {
+				fixed += widths[i] + 2
+			}
+		}
+		if over := fixed + widths[last] - termWidth; over > 0 {
+			before := append([]int(nil), widths...)
+			trimFlex(over)
+			summary := termWidth - (fixed - (before[last] - widths[last]) + widths[last] + 2*last)
+			if summary < 8 {
+				summary = 8
+			}
+			widths[last] = summary
+		}
+	}
+	writeCell := func(text, code string, width int) {
+		text = runewidth.Truncate(text, width, "…")
+		if useColor && code != "" {
+			fmt.Fprintf(w, "\x1b[%sm%s\x1b[0m", code, text)
+		} else {
+			fmt.Fprint(w, text)
+		}
+		if pad := width - displayWidth(text); pad > 0 {
+			fmt.Fprint(w, strings.Repeat(" ", pad))
+		}
+	}
+	if header {
+		for i, h := range headers {
+			if i < last {
+				writeCell(h, "1;36", widths[i])
+				fmt.Fprint(w, "  ")
+			}
+		}
+		writeCell(headers[last], "1;36", widths[last])
+		fmt.Fprintln(w)
+	}
+	for _, row := range rows {
+		for i := range headers {
+			cell := row[i]
+			if i < last {
+				writeCell(cell.text, cell.code, widths[i])
+				fmt.Fprint(w, "  ")
+			}
+		}
+		writeCell(row[last].text, row[last].code, widths[last])
+		fmt.Fprintln(w)
+	}
+}
+
+// compactCategoriesColumn reports whether any row carries a category. When
+// none does, the caller drops the column instead of printing a wall of "-".
+func compactCategoriesColumn(rows [][]compactCell, categoriesIdx int) bool {
+	for _, row := range rows {
+		if row[categoriesIdx].text != "-" {
+			return true
+		}
+	}
+	return false
+}
+
+func displayWidth(s string) int { return runewidth.StringWidth(s) }

--- a/cmd/chroncal/output.go
+++ b/cmd/chroncal/output.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/term"
 
 	"github.com/douglasdemoura/chroncal/internal/calendar"
 	"github.com/douglasdemoura/chroncal/internal/event"
@@ -15,6 +18,21 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/timeutil"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
+
+func compactTableColorEnabled(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+func compactTableColor(enabled bool, code, text string) string {
+	if !enabled {
+		return text
+	}
+	return "\x1b[" + code + "m" + text + "\x1b[0m"
+}
 
 type jsonEvent struct {
 	ID             int64            `json:"id"`

--- a/cmd/chroncal/output.go
+++ b/cmd/chroncal/output.go
@@ -710,12 +710,15 @@ func writeCompactTable(w io.Writer, headers []string, codes []string, rows [][]c
 			widths[last] = summary
 		}
 	}
-	writeCell := func(text, code string, width int) {
+	writeCell := func(text, code string, width int, pad bool) {
 		text = runewidth.Truncate(text, width, "…")
 		if useColor && code != "" {
 			fmt.Fprintf(w, "\x1b[%sm%s\x1b[0m", code, text)
 		} else {
 			fmt.Fprint(w, text)
+		}
+		if !pad {
+			return
 		}
 		if pad := width - displayWidth(text); pad > 0 {
 			fmt.Fprint(w, strings.Repeat(" ", pad))
@@ -724,22 +727,22 @@ func writeCompactTable(w io.Writer, headers []string, codes []string, rows [][]c
 	if header {
 		for i, h := range headers {
 			if i < last {
-				writeCell(h, "1;36", widths[i])
+				writeCell(h, "1;36", widths[i], true)
 				fmt.Fprint(w, "  ")
 			}
 		}
-		writeCell(headers[last], "1;36", widths[last])
+		writeCell(headers[last], "1;36", widths[last], false)
 		fmt.Fprintln(w)
 	}
 	for _, row := range rows {
 		for i := range headers {
 			cell := row[i]
 			if i < last {
-				writeCell(cell.text, cell.code, widths[i])
+				writeCell(cell.text, cell.code, widths[i], true)
 				fmt.Fprint(w, "  ")
 			}
 		}
-		writeCell(row[last].text, row[last].code, widths[last])
+		writeCell(row[last].text, row[last].code, widths[last], false)
 		fmt.Fprintln(w)
 	}
 }
@@ -756,3 +759,39 @@ func compactCategoriesColumn(rows [][]compactCell, categoriesIdx int) bool {
 }
 
 func displayWidth(s string) int { return runewidth.StringWidth(s) }
+
+// terminalWidth returns the terminal width of w, or 0 when w is not a
+// terminal or the size is unavailable. 0 means "no limit" for tables.
+func terminalWidth(w io.Writer) int {
+	f, ok := w.(*os.File)
+	if !ok {
+		return 0
+	}
+	width, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || width <= 0 {
+		return 0
+	}
+	return width
+}
+
+func dropCompactColumn(s []string, i int) []string {
+	return append(s[:i:i], s[i+1:]...)
+}
+
+func dropCompactCell(s []compactCell, i int) []compactCell {
+	return append(s[:i:i], s[i+1:]...)
+}
+
+// remapFlex shifts the flexible-column indexes after a column removal.
+func remapFlex(flex map[int]bool, removed, newLen int) map[int]bool {
+	out := make(map[int]bool, len(flex))
+	for i, v := range flex {
+		switch {
+		case i < removed:
+			out[i] = v
+		case i > removed:
+			out[i-1] = v
+		}
+	}
+	return out
+}

--- a/cmd/chroncal/output_test.go
+++ b/cmd/chroncal/output_test.go
@@ -32,7 +32,6 @@ func assertASCII(t *testing.T, s string) {
 	}
 }
 
-
 func TestToJSONEvent_ExposesConferenceURI(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/chroncal/todo_cli_test.go
+++ b/cmd/chroncal/todo_cli_test.go
@@ -1,83 +1,54 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
-func TestFormatCompactTodoUsesSharedTableLayout(t *testing.T) {
+func TestWriteCompactTodoTableLayout(t *testing.T) {
 	t.Parallel()
 
-	td := todo.Todo{
-		ID:         7,
-		Summary:    "Pay invoice",
-		DueDate:    "2026-08-12",
-		Status:     "COMPLETED",
-		Categories: "home,urgent",
+	todos := []todo.Todo{
+		{ID: 7, Summary: "Pay invoice", DueDate: "2026-08-12",
+			Status: "COMPLETED", Categories: "home,urgent"},
+		{ID: 9, Summary: "Read Go spec"},
 	}
-	header := formatCompactTodoHeader(false)
-	if got, want := strings.Fields(header), []string{"ID", "STATE", "DUE", "CATEGORIES", "SUMMARY"}; strings.Join(got, ",") != strings.Join(want, ",") {
-		t.Fatalf("todo compact header fields = %v, want %v", got, want)
+
+	var b bytes.Buffer
+	writeCompactTodoTable(&b, todos, true, false)
+	lines := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
+	if got := strings.Fields(lines[0]); !reflect.DeepEqual(got,
+		[]string{"ID", "STATE", "DUE", "CATEGORIES", "SUMMARY"}) {
+		t.Fatalf("header fields = %v", got)
 	}
-	got := formatCompactTodo(td, false)
-	want := "7     [x]    2026-08-12  home,urgent         Pay invoice"
-	if got != want {
-		t.Fatalf("formatCompactTodo() = %q, want %q", got, want)
-	}
-	colored := formatCompactTodo(td, true)
-	for _, code := range []string{"\x1b[1;36m", "\x1b[32m", "\x1b[2m", "\x1b[33m"} {
-		if !strings.Contains(colored, code) {
-			t.Fatalf("colored todo row = %q, want ANSI code %q", colored, code)
+	col := strings.Index(lines[0], "SUMMARY")
+	wantSummaries := []string{"Pay invoice", "Read Go spec"}
+	for i, line := range lines[1:] {
+		if got := strings.Index(line, wantSummaries[i]); got != col {
+			t.Fatalf("row %d summary at %d, want %d: %q", i, got, col, line)
 		}
 	}
-}
-
-func TestTodoListCompactIDCanBePassedToGet(t *testing.T) {
-	setupCalendarCLITestEnv(t)
-	t.Setenv("TZ", "UTC")
-
-	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
-		t.Fatalf("calendar create: %v", err)
-	}
-	if _, _, err := runChroncalCommand(t,
-		"todo", "add", "Pay invoice",
-		"--calendar", "Work",
-		"--due", "2026-08-12",
-		"--categories", "home,urgent",
-	); err != nil {
-		t.Fatalf("todo add: %v", err)
+	if !strings.Contains(lines[1], "[x]") {
+		t.Fatalf("row 1 = %q, want completed checkbox", lines[1])
 	}
 
-	stdout, _, err := runChroncalCommand(t,
-		"todo", "list", "--compact",
-		"--calendar", "Work",
-		"--from", "2026-08-11",
-		"--to", "2026-08-13",
-	)
-	if err != nil {
-		t.Fatalf("todo list --compact: %v", err)
+	// Completed todos render green; open ones render dim.
+	b.Reset()
+	writeCompactTodoTable(&b, todos, false, true)
+	if !strings.Contains(b.String(), "\x1b[32m") {
+		t.Fatalf("table = %q, want green for the completed todo", b.String())
 	}
-	if strings.Contains(stdout, "\x1b[") {
-		t.Fatalf("piped compact output contains ANSI styling: %q", stdout)
-	}
-	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	if len(lines) < 2 {
-		t.Fatalf("compact output contains no data row: %q", stdout)
-	}
-	if !strings.Contains(lines[0], "STATE") || !strings.Contains(lines[0], "CATEGORIES") ||
-		!strings.Contains(lines[1], "home,urgent") {
-		t.Fatalf("compact todo table missing expected columns: %q", stdout)
-	}
-	id := strings.Fields(lines[1])[0]
-	getOut, _, err := runChroncalCommand(t, "todo", "get", id)
-	if err != nil {
-		t.Fatalf("todo get %q: %v", id, err)
-	}
-	if !strings.Contains(getOut, "Pay invoice") {
-		t.Fatalf("todo get output = %q, want summary", getOut)
+
+	// The categories column disappears when no todo carries one.
+	b.Reset()
+	writeCompactTodoTable(&b, []todo.Todo{{ID: 1, Summary: "Plain"}}, true, false)
+	if strings.Contains(b.String(), "CATEGORIES") {
+		t.Fatalf("table = %q, want no categories column", b.String())
 	}
 }
 

--- a/cmd/chroncal/todo_cli_test.go
+++ b/cmd/chroncal/todo_cli_test.go
@@ -4,7 +4,82 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/todo"
 )
+
+func TestFormatCompactTodoUsesSharedTableLayout(t *testing.T) {
+	t.Parallel()
+
+	td := todo.Todo{
+		ID:         7,
+		Summary:    "Pay invoice",
+		DueDate:    "2026-08-12",
+		Status:     "COMPLETED",
+		Categories: "home,urgent",
+	}
+	header := formatCompactTodoHeader(false)
+	if got, want := strings.Fields(header), []string{"ID", "STATE", "DUE", "CATEGORIES", "SUMMARY"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("todo compact header fields = %v, want %v", got, want)
+	}
+	got := formatCompactTodo(td, false)
+	want := "7     [x]    2026-08-12  home,urgent         Pay invoice"
+	if got != want {
+		t.Fatalf("formatCompactTodo() = %q, want %q", got, want)
+	}
+	colored := formatCompactTodo(td, true)
+	for _, code := range []string{"\x1b[1;36m", "\x1b[32m", "\x1b[2m", "\x1b[33m"} {
+		if !strings.Contains(colored, code) {
+			t.Fatalf("colored todo row = %q, want ANSI code %q", colored, code)
+		}
+	}
+}
+
+func TestTodoListCompactIDCanBePassedToGet(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("TZ", "UTC")
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"todo", "add", "Pay invoice",
+		"--calendar", "Work",
+		"--due", "2026-08-12",
+		"--categories", "home,urgent",
+	); err != nil {
+		t.Fatalf("todo add: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t,
+		"todo", "list", "--compact",
+		"--calendar", "Work",
+		"--from", "2026-08-11",
+		"--to", "2026-08-13",
+	)
+	if err != nil {
+		t.Fatalf("todo list --compact: %v", err)
+	}
+	if strings.Contains(stdout, "\x1b[") {
+		t.Fatalf("piped compact output contains ANSI styling: %q", stdout)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("compact output contains no data row: %q", stdout)
+	}
+	if !strings.Contains(lines[0], "STATE") || !strings.Contains(lines[0], "CATEGORIES") ||
+		!strings.Contains(lines[1], "home,urgent") {
+		t.Fatalf("compact todo table missing expected columns: %q", stdout)
+	}
+	id := strings.Fields(lines[1])[0]
+	getOut, _, err := runChroncalCommand(t, "todo", "get", id)
+	if err != nil {
+		t.Fatalf("todo get %q: %v", id, err)
+	}
+	if !strings.Contains(getOut, "Pay invoice") {
+		t.Fatalf("todo get output = %q, want summary", getOut)
+	}
+}
 
 // TestTodoSearchCompletedAndIncompleteAreMutuallyExclusive reproduces issue
 // #361. Both --completed and --incomplete on `todo search` were

--- a/cmd/chroncal/todo_list.go
+++ b/cmd/chroncal/todo_list.go
@@ -74,8 +74,10 @@ By default completed and cancelled todos are hidden unless you pass
 					fmt.Fprintln(w, "No todos found.")
 					return nil
 				}
+				useColor := compactTableColorEnabled(w)
+				fmt.Fprintln(w, formatCompactTodoHeader(useColor))
 				for _, t := range todos {
-					fmt.Fprintln(w, formatCompactTodo(t))
+					fmt.Fprintln(w, formatCompactTodo(t, useColor))
 				}
 				return nil
 			}
@@ -88,16 +90,43 @@ By default completed and cancelled todos are hidden unless you pass
 	cmd.Flags().BoolVar(&all, "all", false, "include completed and cancelled")
 	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD); with no date flags, overdue todos are included")
 	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days after --from)")
-	cmd.Flags().BoolVar(&compact, "compact", false, "one line per todo ([STATUS] DUE  TITLE)")
+	cmd.Flags().BoolVar(&compact, "compact", false, "table with one line per todo (ID  STATE  DUE  CATEGORIES  SUMMARY)")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted todos (see `todo restore`)")
 	return cmd
 }
 
-// formatCompactTodo renders one todo as a single line for scripts:
-// "[x] 2026-05-25  Write report". The checkbox uses [x] when completed,
-// [ ] otherwise. The date column is YYYY-MM-DD or "-" (no due date)
-// padded to 12 chars so titles line up.
-func formatCompactTodo(t todo.Todo) string {
-	const dueColWidth = 12
-	return fmt.Sprintf("%s %-*s%s", todoCheckbox(t), dueColWidth, compactDateColumn(t.DueDate), textsafe.Display(t.Summary))
+const (
+	compactTodoIDWidth         = 6
+	compactTodoStateWidth      = 7
+	compactTodoDueWidth        = 12 // YYYY-MM-DD + 2 trailing spaces
+	compactTodoCategoriesWidth = 20
+)
+
+func formatCompactTodoHeader(useColor bool) string {
+	header := fmt.Sprintf("%-*s%-*s%-*s%-*s%s",
+		compactTodoIDWidth, "ID",
+		compactTodoStateWidth, "STATE",
+		compactTodoDueWidth, "DUE",
+		compactTodoCategoriesWidth, "CATEGORIES",
+		"SUMMARY")
+	return compactTableColor(useColor, "1;36", header)
+}
+
+// formatCompactTodo renders one todo as a table row. The state uses [x] when
+// completed and [ ] otherwise; missing due dates and categories show "-".
+// Summary remains last so arbitrary text does not disturb earlier columns.
+func formatCompactTodo(t todo.Todo, useColor bool) string {
+	categories := textsafe.Display(t.Categories)
+	if categories == "" {
+		categories = "-"
+	}
+	stateColor := "2"
+	if t.IsCompleted() {
+		stateColor = "32"
+	}
+	return compactTableColor(useColor, "1;36", fmt.Sprintf("%-*d", compactTodoIDWidth, t.ID)) +
+		compactTableColor(useColor, stateColor, fmt.Sprintf("%-*s", compactTodoStateWidth, todoCheckbox(t))) +
+		compactTableColor(useColor, "2", fmt.Sprintf("%-*s", compactTodoDueWidth, compactDateColumn(t.DueDate))) +
+		compactTableColor(useColor, "33", fmt.Sprintf("%-*s", compactTodoCategoriesWidth, categories)) +
+		textsafe.Display(t.Summary)
 }

--- a/cmd/chroncal/todo_list.go
+++ b/cmd/chroncal/todo_list.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -19,6 +20,7 @@ func todoListCmd() *cobra.Command {
 		fromStr        string
 		toStr          string
 		compact        bool
+		noHeader       bool
 		includeDeleted bool
 	)
 	cmd := &cobra.Command{
@@ -74,11 +76,7 @@ By default completed and cancelled todos are hidden unless you pass
 					fmt.Fprintln(w, "No todos found.")
 					return nil
 				}
-				useColor := compactTableColorEnabled(w)
-				fmt.Fprintln(w, formatCompactTodoHeader(useColor))
-				for _, t := range todos {
-					fmt.Fprintln(w, formatCompactTodo(t, useColor))
-				}
+				writeCompactTodoTable(w, todos, !noHeader, compactTableColorEnabled(w))
 				return nil
 			}
 			printTodos(w, todos)
@@ -91,6 +89,7 @@ By default completed and cancelled todos are hidden unless you pass
 	cmd.Flags().StringVar(&fromStr, "from", "", "start date (YYYY-MM-DD); with no date flags, overdue todos are included")
 	cmd.Flags().StringVar(&toStr, "to", "", "end date (YYYY-MM-DD, default: 30 days after --from)")
 	cmd.Flags().BoolVar(&compact, "compact", false, "table with one line per todo (ID  STATE  DUE  CATEGORIES  SUMMARY)")
+	cmd.Flags().BoolVar(&noHeader, "no-header", false, "omit the compact table header (for scripts)")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted todos (see `todo restore`)")
 	return cmd
 }
@@ -112,21 +111,46 @@ func formatCompactTodoHeader(useColor bool) string {
 	return compactTableColor(useColor, "1;36", header)
 }
 
-// formatCompactTodo renders one todo as a table row. The state uses [x] when
-// completed and [ ] otherwise; missing due dates and categories show "-".
-// Summary remains last so arbitrary text does not disturb earlier columns.
-func formatCompactTodo(t todo.Todo, useColor bool) string {
-	categories := textsafe.Display(t.Categories)
-	if categories == "" {
-		categories = "-"
+// writeCompactTodoTable renders the todo compact table. The categories
+// column disappears when no todo in the result set carries one, and a
+// recurrence marker (\u21bb) flags recurring todos in the due column.
+func writeCompactTodoTable(w io.Writer, todos []todo.Todo, showHeader, useColor bool) {
+	termWidth := terminalWidth(w)
+	headers := []string{"ID", "STATE", "DUE", "CATEGORIES", "SUMMARY"}
+	codes := []string{"1;36", "", "2", "33", ""}
+	rows := make([][]compactCell, len(todos))
+	hasCategories := false
+	for i, td := range todos {
+		due := compactDateColumn(td.DueDate)
+		if td.RecurrenceRule != "" || td.RecurrenceID != "" {
+			due += " \u21bb"
+		}
+		categories := textsafe.Display(td.Categories)
+		if categories == "" {
+			categories = "-"
+		} else {
+			hasCategories = true
+		}
+		stateColor := "2"
+		if td.IsCompleted() {
+			stateColor = "32"
+		}
+		rows[i] = []compactCell{
+			{fmt.Sprintf("%d", td.ID), "1;36"},
+			{todoCheckbox(td), stateColor},
+			{due, "2"},
+			{categories, "33"},
+			{textsafe.Display(td.Summary), ""},
+		}
 	}
-	stateColor := "2"
-	if t.IsCompleted() {
-		stateColor = "32"
+	flex := map[int]bool{3: true, 4: true}
+	if !hasCategories {
+		headers = dropCompactColumn(headers, 3)
+		codes = dropCompactColumn(codes, 3)
+		flex = remapFlex(flex, 3, len(headers))
+		for i := range rows {
+			rows[i] = dropCompactCell(rows[i], 3)
+		}
 	}
-	return compactTableColor(useColor, "1;36", fmt.Sprintf("%-*d", compactTodoIDWidth, t.ID)) +
-		compactTableColor(useColor, stateColor, fmt.Sprintf("%-*s", compactTodoStateWidth, todoCheckbox(t))) +
-		compactTableColor(useColor, "2", fmt.Sprintf("%-*s", compactTodoDueWidth, compactDateColumn(t.DueDate))) +
-		compactTableColor(useColor, "33", fmt.Sprintf("%-*s", compactTodoCategoriesWidth, categories)) +
-		textsafe.Display(t.Summary)
+	writeCompactTable(w, headers, codes, rows, flex, useColor, showHeader, termWidth)
 }

--- a/db/migrations/049_category_position.sql
+++ b/db/migrations/049_category_position.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- Categories keep the order the user wrote. A position column lets reads
+-- return that order instead of an alphabetical sort. Backfill numbers the
+-- existing rows by rowid, which matches the original insert order.
+ALTER TABLE event_categories ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE todo_categories ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE journal_categories ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+UPDATE event_categories SET position = (
+    SELECT COUNT(*) FROM event_categories AS e2
+    WHERE e2.event_id = event_categories.event_id AND e2.rowid <= event_categories.rowid);
+UPDATE todo_categories SET position = (
+    SELECT COUNT(*) FROM todo_categories AS t2
+    WHERE t2.todo_id = todo_categories.todo_id AND t2.rowid <= todo_categories.rowid);
+UPDATE journal_categories SET position = (
+    SELECT COUNT(*) FROM journal_categories AS j2
+    WHERE j2.journal_id = journal_categories.journal_id AND j2.rowid <= journal_categories.rowid);
+
+-- +goose Down
+ALTER TABLE event_categories DROP COLUMN position;
+ALTER TABLE todo_categories DROP COLUMN position;
+ALTER TABLE journal_categories DROP COLUMN position;

--- a/db/queries/event_categories.sql
+++ b/db/queries/event_categories.sql
@@ -1,8 +1,8 @@
 -- name: CreateEventCategory :one
-INSERT INTO event_categories (event_id, category) VALUES (?, ?) RETURNING *;
+INSERT INTO event_categories (event_id, category, position) VALUES (?, ?, ?) RETURNING *;
 
 -- name: ListCategoriesByEventID :many
-SELECT * FROM event_categories WHERE event_id = ? ORDER BY category;
+SELECT * FROM event_categories WHERE event_id = ? ORDER BY position;
 
 -- name: DeleteCategoriesByEventID :exec
 DELETE FROM event_categories WHERE event_id = ?;

--- a/db/queries/journal_categories.sql
+++ b/db/queries/journal_categories.sql
@@ -1,8 +1,8 @@
 -- name: CreateJournalCategory :one
-INSERT INTO journal_categories (journal_id, category) VALUES (?, ?) RETURNING *;
+INSERT INTO journal_categories (journal_id, category, position) VALUES (?, ?, ?) RETURNING *;
 
 -- name: ListCategoriesByJournalID :many
-SELECT * FROM journal_categories WHERE journal_id = ? ORDER BY category;
+SELECT * FROM journal_categories WHERE journal_id = ? ORDER BY position;
 
 -- name: DeleteCategoriesByJournalID :exec
 DELETE FROM journal_categories WHERE journal_id = ?;

--- a/db/queries/todo_categories.sql
+++ b/db/queries/todo_categories.sql
@@ -1,8 +1,8 @@
 -- name: CreateTodoCategory :one
-INSERT INTO todo_categories (todo_id, category) VALUES (?, ?) RETURNING *;
+INSERT INTO todo_categories (todo_id, category, position) VALUES (?, ?, ?) RETURNING *;
 
 -- name: ListCategoriesByTodoID :many
-SELECT * FROM todo_categories WHERE todo_id = ? ORDER BY category;
+SELECT * FROM todo_categories WHERE todo_id = ? ORDER BY position;
 
 -- name: DeleteCategoriesByTodoID :exec
 DELETE FROM todo_categories WHERE todo_id = ?;

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.25.7
 toolchain go1.26.6
 
 require (
-	charm.land/bubbles/v2 v2.1.1
-	charm.land/bubbletea/v2 v2.0.8
+	charm.land/bubbles/v2 v2.2.1
+	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/atotto/clipboard v0.1.4
-	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886
+	github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/emersion/go-ical v0.0.0-20250609112844-439c63cef608

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
-charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
-charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
-charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
+charm.land/bubbles/v2 v2.2.1 h1:Fq1+qm5hV6GkvzLQDhCBpXXE5tLgvh1PRriCLwSvIQU=
+charm.land/bubbles/v2 v2.2.1/go.mod h1:wdMgn+sje1KNXdwFizIWjbf328fIUBxqEmJ/vYPo8yc=
+charm.land/bubbletea/v2 v2.0.9 h1:DpJCMWKgzQK8SJv4zbKKFHAI10ymWy/evClPFk0k0f8=
+charm.land/bubbletea/v2 v2.0.9/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.6 h1:EaGKeuA8FvF+v2BT5VmZd2LoYLaMZJXA5n34th8nCIQ=
 charm.land/lipgloss/v2 v2.0.6/go.mod h1:ipDDJNSGa1hlwDtSfW1s2/xR8Vdhbut4PXh2zEKZd0Q=
 git.sr.ht/~jackmordaunt/go-toast v1.1.2 h1:/yrfI55LRt1M7H1vkaw+NaH1+L1CDxrqDltwm5euVuE=
@@ -14,8 +14,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 h1:rdnVWKgJpTVXKuKuJyxDJ+NFJdUaUqGvyGy61OcvlbA=
-github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886/go.mod h1:nAw0d9PhFp1qdzi2xhQU5YOu5sVpDIHWlaW2Uz/bCro=
+github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be h1:qEvkJy1sjJXP+yf8IH2o13NV+Rh4nIUHjaLNJ+pWxpI=
+github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be/go.mod h1:nAw0d9PhFp1qdzi2xhQU5YOu5sVpDIHWlaW2Uz/bCro=
 github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
 github.com/charmbracelet/x/ansi v0.11.8/go.mod h1:ZNN+3mXny/516oTQPLMPIBeSINvNJJQ8uQXDgbeJxY0=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=

--- a/internal/event/relations.go
+++ b/internal/event/relations.go
@@ -49,10 +49,11 @@ func replaceCategoriesTx(ctx context.Context, qtx *storage.Queries, eventID int6
 	if err := qtx.DeleteCategoriesByEventID(ctx, eventID); err != nil {
 		return fmt.Errorf("delete categories: %w", err)
 	}
-	for _, c := range categories {
+	for i, c := range categories {
 		_, err := qtx.CreateEventCategory(ctx, storage.CreateEventCategoryParams{
 			EventID:  eventID,
 			Category: c,
+			Position: int64(i),
 		})
 		if err != nil {
 			return fmt.Errorf("create category: %w", err)

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -474,10 +474,11 @@ func replaceCategoriesTx(ctx context.Context, qtx *storage.Queries, journalID in
 	if err := qtx.DeleteCategoriesByJournalID(ctx, journalID); err != nil {
 		return fmt.Errorf("delete categories: %w", err)
 	}
-	for _, c := range categories {
+	for i, c := range categories {
 		_, err := qtx.CreateJournalCategory(ctx, storage.CreateJournalCategoryParams{
 			JournalID: journalID,
 			Category:  c,
+			Position:  int64(i),
 		})
 		if err != nil {
 			return fmt.Errorf("create category: %w", err)

--- a/internal/storage/categories_dynamic.go
+++ b/internal/storage/categories_dynamic.go
@@ -9,7 +9,7 @@ import "context"
 func (q *Queries) ListCategoriesByEventIDs(ctx context.Context, ids []int64) ([]EventCategory, error) {
 	return loadByIDChunks(ctx, ids, func(ctx context.Context, chunk []int64) ([]EventCategory, error) {
 		placeholders, args := expandInPlaceholders(chunk)
-		query := "SELECT event_id, category FROM event_categories WHERE event_id IN (" + placeholders + ") ORDER BY event_id, category"
+		query := "SELECT event_id, category FROM event_categories WHERE event_id IN (" + placeholders + ") ORDER BY event_id, position"
 
 		rows, err := q.db.QueryContext(ctx, query, args...)
 		if err != nil {
@@ -34,7 +34,7 @@ func (q *Queries) ListCategoriesByEventIDs(ctx context.Context, ids []int64) ([]
 func (q *Queries) ListCategoriesByTodoIDs(ctx context.Context, ids []int64) ([]TodoCategory, error) {
 	return loadByIDChunks(ctx, ids, func(ctx context.Context, chunk []int64) ([]TodoCategory, error) {
 		placeholders, args := expandInPlaceholders(chunk)
-		query := "SELECT todo_id, category FROM todo_categories WHERE todo_id IN (" + placeholders + ") ORDER BY todo_id, category"
+		query := "SELECT todo_id, category FROM todo_categories WHERE todo_id IN (" + placeholders + ") ORDER BY todo_id, position"
 
 		rows, err := q.db.QueryContext(ctx, query, args...)
 		if err != nil {
@@ -59,7 +59,7 @@ func (q *Queries) ListCategoriesByTodoIDs(ctx context.Context, ids []int64) ([]T
 func (q *Queries) ListCategoriesByJournalIDs(ctx context.Context, ids []int64) ([]JournalCategory, error) {
 	return loadByIDChunks(ctx, ids, func(ctx context.Context, chunk []int64) ([]JournalCategory, error) {
 		placeholders, args := expandInPlaceholders(chunk)
-		query := "SELECT journal_id, category FROM journal_categories WHERE journal_id IN (" + placeholders + ") ORDER BY journal_id, category"
+		query := "SELECT journal_id, category FROM journal_categories WHERE journal_id IN (" + placeholders + ") ORDER BY journal_id, position"
 
 		rows, err := q.db.QueryContext(ctx, query, args...)
 		if err != nil {

--- a/internal/storage/event_categories.sql.go
+++ b/internal/storage/event_categories.sql.go
@@ -10,18 +10,19 @@ import (
 )
 
 const createEventCategory = `-- name: CreateEventCategory :one
-INSERT INTO event_categories (event_id, category) VALUES (?, ?) RETURNING event_id, category
+INSERT INTO event_categories (event_id, category, position) VALUES (?, ?, ?) RETURNING event_id, category, position
 `
 
 type CreateEventCategoryParams struct {
 	EventID  int64
 	Category string
+	Position int64
 }
 
 func (q *Queries) CreateEventCategory(ctx context.Context, arg CreateEventCategoryParams) (EventCategory, error) {
-	row := q.db.QueryRowContext(ctx, createEventCategory, arg.EventID, arg.Category)
+	row := q.db.QueryRowContext(ctx, createEventCategory, arg.EventID, arg.Category, arg.Position)
 	var i EventCategory
-	err := row.Scan(&i.EventID, &i.Category)
+	err := row.Scan(&i.EventID, &i.Category, &i.Position)
 	return i, err
 }
 
@@ -65,15 +66,20 @@ const listAllEventCategoriesWithIDs = `-- name: ListAllEventCategoriesWithIDs :m
 SELECT event_id, category FROM event_categories ORDER BY event_id, category
 `
 
-func (q *Queries) ListAllEventCategoriesWithIDs(ctx context.Context) ([]EventCategory, error) {
+type ListAllEventCategoriesWithIDsRow struct {
+	EventID  int64
+	Category string
+}
+
+func (q *Queries) ListAllEventCategoriesWithIDs(ctx context.Context) ([]ListAllEventCategoriesWithIDsRow, error) {
 	rows, err := q.db.QueryContext(ctx, listAllEventCategoriesWithIDs)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []EventCategory
+	var items []ListAllEventCategoriesWithIDsRow
 	for rows.Next() {
-		var i EventCategory
+		var i ListAllEventCategoriesWithIDsRow
 		if err := rows.Scan(&i.EventID, &i.Category); err != nil {
 			return nil, err
 		}
@@ -89,7 +95,7 @@ func (q *Queries) ListAllEventCategoriesWithIDs(ctx context.Context) ([]EventCat
 }
 
 const listCategoriesByEventID = `-- name: ListCategoriesByEventID :many
-SELECT event_id, category FROM event_categories WHERE event_id = ? ORDER BY category
+SELECT event_id, category, position FROM event_categories WHERE event_id = ? ORDER BY position
 `
 
 func (q *Queries) ListCategoriesByEventID(ctx context.Context, eventID int64) ([]EventCategory, error) {
@@ -101,7 +107,7 @@ func (q *Queries) ListCategoriesByEventID(ctx context.Context, eventID int64) ([
 	var items []EventCategory
 	for rows.Next() {
 		var i EventCategory
-		if err := rows.Scan(&i.EventID, &i.Category); err != nil {
+		if err := rows.Scan(&i.EventID, &i.Category, &i.Position); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/storage/journal_categories.sql.go
+++ b/internal/storage/journal_categories.sql.go
@@ -10,18 +10,19 @@ import (
 )
 
 const createJournalCategory = `-- name: CreateJournalCategory :one
-INSERT INTO journal_categories (journal_id, category) VALUES (?, ?) RETURNING journal_id, category
+INSERT INTO journal_categories (journal_id, category, position) VALUES (?, ?, ?) RETURNING journal_id, category, position
 `
 
 type CreateJournalCategoryParams struct {
 	JournalID int64
 	Category  string
+	Position  int64
 }
 
 func (q *Queries) CreateJournalCategory(ctx context.Context, arg CreateJournalCategoryParams) (JournalCategory, error) {
-	row := q.db.QueryRowContext(ctx, createJournalCategory, arg.JournalID, arg.Category)
+	row := q.db.QueryRowContext(ctx, createJournalCategory, arg.JournalID, arg.Category, arg.Position)
 	var i JournalCategory
-	err := row.Scan(&i.JournalID, &i.Category)
+	err := row.Scan(&i.JournalID, &i.Category, &i.Position)
 	return i, err
 }
 
@@ -62,7 +63,7 @@ func (q *Queries) ListAllJournalCategories(ctx context.Context) ([]string, error
 }
 
 const listCategoriesByJournalID = `-- name: ListCategoriesByJournalID :many
-SELECT journal_id, category FROM journal_categories WHERE journal_id = ? ORDER BY category
+SELECT journal_id, category, position FROM journal_categories WHERE journal_id = ? ORDER BY position
 `
 
 func (q *Queries) ListCategoriesByJournalID(ctx context.Context, journalID int64) ([]JournalCategory, error) {
@@ -74,7 +75,7 @@ func (q *Queries) ListCategoriesByJournalID(ctx context.Context, journalID int64
 	var items []JournalCategory
 	for rows.Next() {
 		var i JournalCategory
-		if err := rows.Scan(&i.JournalID, &i.Category); err != nil {
+		if err := rows.Scan(&i.JournalID, &i.Category, &i.Position); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -145,6 +145,7 @@ type EventAttendee struct {
 type EventCategory struct {
 	EventID  int64
 	Category string
+	Position int64
 }
 
 type EventComment struct {
@@ -250,6 +251,7 @@ type JournalAttendee struct {
 type JournalCategory struct {
 	JournalID int64
 	Category  string
+	Position  int64
 }
 
 type JournalComment struct {
@@ -420,6 +422,7 @@ type TodoAttendee struct {
 type TodoCategory struct {
 	TodoID   int64
 	Category string
+	Position int64
 }
 
 type TodoComment struct {

--- a/internal/storage/todo_categories.sql.go
+++ b/internal/storage/todo_categories.sql.go
@@ -10,18 +10,19 @@ import (
 )
 
 const createTodoCategory = `-- name: CreateTodoCategory :one
-INSERT INTO todo_categories (todo_id, category) VALUES (?, ?) RETURNING todo_id, category
+INSERT INTO todo_categories (todo_id, category, position) VALUES (?, ?, ?) RETURNING todo_id, category, position
 `
 
 type CreateTodoCategoryParams struct {
 	TodoID   int64
 	Category string
+	Position int64
 }
 
 func (q *Queries) CreateTodoCategory(ctx context.Context, arg CreateTodoCategoryParams) (TodoCategory, error) {
-	row := q.db.QueryRowContext(ctx, createTodoCategory, arg.TodoID, arg.Category)
+	row := q.db.QueryRowContext(ctx, createTodoCategory, arg.TodoID, arg.Category, arg.Position)
 	var i TodoCategory
-	err := row.Scan(&i.TodoID, &i.Category)
+	err := row.Scan(&i.TodoID, &i.Category, &i.Position)
 	return i, err
 }
 
@@ -62,7 +63,7 @@ func (q *Queries) ListAllTodoCategories(ctx context.Context) ([]string, error) {
 }
 
 const listCategoriesByTodoID = `-- name: ListCategoriesByTodoID :many
-SELECT todo_id, category FROM todo_categories WHERE todo_id = ? ORDER BY category
+SELECT todo_id, category, position FROM todo_categories WHERE todo_id = ? ORDER BY position
 `
 
 func (q *Queries) ListCategoriesByTodoID(ctx context.Context, todoID int64) ([]TodoCategory, error) {
@@ -74,7 +75,7 @@ func (q *Queries) ListCategoriesByTodoID(ctx context.Context, todoID int64) ([]T
 	var items []TodoCategory
 	for rows.Next() {
 		var i TodoCategory
-		if err := rows.Scan(&i.TodoID, &i.Category); err != nil {
+		if err := rows.Scan(&i.TodoID, &i.Category, &i.Position); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/todo/components.go
+++ b/internal/todo/components.go
@@ -49,10 +49,11 @@ func replaceCategoriesTx(ctx context.Context, qtx *storage.Queries, todoID int64
 	if err := qtx.DeleteCategoriesByTodoID(ctx, todoID); err != nil {
 		return fmt.Errorf("delete categories: %w", err)
 	}
-	for _, c := range categories {
+	for i, c := range categories {
 		if _, err := qtx.CreateTodoCategory(ctx, storage.CreateTodoCategoryParams{
 			TodoID:   todoID,
 			Category: c,
+			Position: int64(i),
 		}); err != nil {
 			return fmt.Errorf("create category: %w", err)
 		}


### PR DESCRIPTION
## What

This PR redesigns compact event, todo, and journal output as consistent terminal tables.

  - Adds aligned headers and columns.
  - Displays the local numeric ID first, allowing direct use with get, update, or delete.
  - Includes categories in every compact list.
  - Keeps summaries as the final, unrestricted column.
  - Adds terminal-aware colors:
      - Cyan headers and IDs
      - Dimmed dates and times
      - Yellow categories
      - Green completed todo state
      - Magenta calendar names
  - Preserves event list --show-calendar with an optional CALENDAR column.
  - Applies the event table layout to event search --compact.
  - Disables ANSI colors for redirected output, NO_COLOR, and TERM=dumb.

## Why

Previously, compact output differed between resource types and journal rows did not include an identifier. Users could see an entry but could not conveniently pass it to commands such as:

```
chroncal journal get <id>
```

The new layouts make compact output easier to scan and provide short, actionable local IDs without displaying long iCalendar UIDs.

Because compact text output now includes headers and changed columns, scripts should use the stable machine-readable interface:
```
chroncal journal list --output json
```

## Verification

  - go test ./... — passes
  - make lint — 0 issues

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter is clean (`make lint`)
- [x] New tests added for new functionality
- [x] Documentation updated (if applicable)
