### PR TITLE
fix(ical): drop VALARM alarms with an unsupported ACTION

### DIFF
--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1735,7 +1735,7 @@ func parseOneAlarm(val string) (model.Alarm, error) {
 	}
 
 	// Cross-field validation per RFC 5545.
-	if (a.Repeat > 0) != (a.Duration != "") {
+	if !a.RepeatPaired() {
 		return model.Alarm{}, fmt.Errorf("alarm %q: REPEAT and DURATION must be specified together", val)
 	}
 

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1654,7 +1654,7 @@ func parseOneAlarm(val string) (model.Alarm, error) {
 	// Check for ACTION: prefix
 	if idx := strings.Index(val, ":"); idx > 0 {
 		prefix := strings.ToUpper(val[:idx])
-		if prefix == "DISPLAY" || prefix == "EMAIL" || prefix == "AUDIO" {
+		if model.ValidAlarmAction(prefix) {
 			action = prefix
 			rest = val[idx+1:]
 		}

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1709,8 +1709,8 @@ func parseOneAlarm(val string) (model.Alarm, error) {
 		a.Repeat = r
 	}
 	if len(parts) > 3 && parts[3] != "" {
-		if err := duration.Validate(parts[3]); err != nil {
-			return model.Alarm{}, fmt.Errorf("alarm %q: invalid repeat duration %q", val, parts[3])
+		if !model.ValidAlarmDuration(parts[3]) {
+			return model.Alarm{}, fmt.Errorf("alarm %q: repeat duration %q must be a positive RFC 5545 duration", val, parts[3])
 		}
 		a.Duration = parts[3]
 	}

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1716,7 +1716,7 @@ func parseOneAlarm(val string) (model.Alarm, error) {
 	}
 	if len(parts) > 4 && parts[4] != "" {
 		rel := strings.ToUpper(parts[4])
-		if rel != "START" && rel != "END" {
+		if !model.ValidAlarmRelated(rel) {
 			return model.Alarm{}, fmt.Errorf("alarm %q: related must be START or END, got %q", val, parts[4])
 		}
 		a.Related = rel

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -759,9 +759,11 @@ func computeTriggerTime(evt event.Event, a model.Alarm) (time.Time, error) {
 // at the specified duration interval, up to the repeat count. The count is
 // clamped to model.MaxAlarmRepeat as defense in depth. Rows written before
 // the cap existed (or by other tools) must not blow up the check loop.
+// The ValidAlarmDuration guard covers legacy rows with a negative or zero
+// interval: those must not walk the repeat firings backwards or stall.
 func buildRepeatTriggers(triggerAt time.Time, repeat int, durStr string) []time.Time {
 	triggers := []time.Time{triggerAt}
-	if repeat <= 0 || durStr == "" {
+	if repeat <= 0 || !model.ValidAlarmDuration(durStr) {
 		return triggers
 	}
 	repeat = min(repeat, model.MaxAlarmRepeat)

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -794,10 +794,10 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	// RFC 5545 §3.8.6.3: DURATION and REPEAT MUST appear together; emitting
 	// either one without the other yields an invalid VALARM that strict CalDAV
 	// servers (e.g. Google) reject with HTTP 400, blocking the whole resource.
-	// The duration.Validate guard exists for DB rows written before import
-	// validated DURATION (the same reason as the RFC 3339 branch above): a
-	// stored malformed value must not push verbatim and wedge the resource.
-	if alarm.Repeat > 0 && alarm.Duration != "" && duration.Validate(alarm.Duration) == nil {
+	// The ValidAlarmDuration guard exists for DB rows written before the
+	// parsers validated DURATION (the same reason as the RFC 3339 branch
+	// above). A stored bad value must not reach the server verbatim.
+	if alarm.Repeat > 0 && model.ValidAlarmDuration(alarm.Duration) {
 		p := &ical.Prop{Name: ical.PropDuration}
 		p.Value = alarm.Duration
 		valarm.Props.Set(p)

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -794,7 +794,10 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	// RFC 5545 §3.8.6.3: DURATION and REPEAT MUST appear together; emitting
 	// either one without the other yields an invalid VALARM that strict CalDAV
 	// servers (e.g. Google) reject with HTTP 400, blocking the whole resource.
-	if alarm.Repeat > 0 && alarm.Duration != "" {
+	// The duration.Validate guard exists for DB rows written before import
+	// validated DURATION (the same reason as the RFC 3339 branch above): a
+	// stored malformed value must not push verbatim and wedge the resource.
+	if alarm.Repeat > 0 && alarm.Duration != "" && duration.Validate(alarm.Duration) == nil {
 		p := &ical.Prop{Name: ical.PropDuration}
 		p.Value = alarm.Duration
 		valarm.Props.Set(p)

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -802,7 +802,9 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 		p.Value = alarm.Duration
 		valarm.Props.Set(p)
 		p2 := &ical.Prop{Name: "REPEAT"}
-		p2.Value = strconv.Itoa(alarm.Repeat)
+		// Clamp like import does. A pre-clamp DB row must not push a
+		// count the next pull would rewrite.
+		p2.Value = strconv.Itoa(min(alarm.Repeat, model.MaxAlarmRepeat))
 		valarm.Props.Set(p2)
 	}
 	// ACKNOWLEDGED (RFC 9074) — round-trip only.

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -619,7 +619,9 @@ func parseCategories(ve ical.Event) string {
 // parseAlarm extracts a model.Alarm from a VALARM component.
 // The second return value is a warning string (empty if no issues). A VALARM
 // with several problems reports all of them. Each one changes what the alarm
-// does in silence. The user needs to see every reason.
+// does in silence. The user needs to see every reason. The one exception is
+// an unsupported ACTION: it drops the whole alarm at once, so the function
+// reports only that problem.
 func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	alarm := model.Alarm{Action: "DISPLAY", Related: "START"}
 	var warns []string
@@ -627,18 +629,15 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	if prop := comp.Props.Get(ical.PropAction); prop != nil {
 		alarm.Action = strings.ToUpper(prop.Value)
 	}
-	// The alarm tables accept only these three actions (the CHECK constraint
-	// in db/migrations/003 and 006). An unsupported action must not reach
-	// storage: the failed insert rolls back the whole resource transaction,
-	// and sync then retries the resource forever (issue #575). Google
-	// Calendar emits ACTION:NONE as a "no reminder" sentinel. Drop the alarm
-	// and warn. The alarm does nothing, so the other VALARM properties do
-	// not matter and this returns early. The next push omits the VALARM, so
-	// Google can re-apply its default reminders. That loss is smaller than a
-	// wedged sync.
-	switch alarm.Action {
-	case "AUDIO", "DISPLAY", "EMAIL":
-	default:
+	// The alarm tables accept only the actions in model.ValidAlarmAction.
+	// An unsupported action must not reach storage: the failed insert rolls
+	// back the whole resource transaction, and sync then retries the
+	// resource forever (issue #575). Google Calendar emits ACTION:NONE as a
+	// "no reminder" sentinel. Drop the alarm, warn, and return: a dropped
+	// alarm makes the other VALARM properties irrelevant. The next push
+	// omits the VALARM, so Google can re-apply its default reminders. That
+	// loss is smaller than a sync that never converges.
+	if !model.ValidAlarmAction(alarm.Action) {
 		return model.Alarm{}, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", alarm.Action)
 	}
 	if prop := comp.Props.Get(ical.PropTrigger); prop != nil {
@@ -705,8 +704,17 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		// (push+pull resets it to START) and that silently resurfaces if the
 		// user later switches the trigger to a duration. Keep the default
 		// "START" for absolute triggers.
-		if rel := prop.Params.Get("RELATED"); rel != "" && isDuration {
-			alarm.Related = strings.ToUpper(rel)
+		if rel := strings.ToUpper(prop.Params.Get("RELATED")); rel != "" && isDuration {
+			// The alarm tables accept only START and END (the CHECK
+			// constraint in db/migrations/003 and 006). Any other value
+			// would roll back the whole resource, the same failure class
+			// as an unsupported ACTION (issue #575). Keep the default
+			// START and warn.
+			if rel == "START" || rel == "END" {
+				alarm.Related = rel
+			} else {
+				warns = append(warns, fmt.Sprintf("VALARM TRIGGER RELATED=%s: unsupported value, using START", rel))
+			}
 		}
 	}
 	if prop := comp.Props.Get(ical.PropDescription); prop != nil {
@@ -723,7 +731,15 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		}
 	}
 	if prop := comp.Props.Get(ical.PropDuration); prop != nil {
-		alarm.Duration = prop.Value
+		// A malformed DURATION stores without error, but the next push
+		// re-emits it verbatim and a strict CalDAV server rejects the
+		// whole resource with 400. Drop it and warn. Export pairs
+		// DURATION with REPEAT, so the repeat count alone emits nothing.
+		if duration.Validate(prop.Value) == nil {
+			alarm.Duration = prop.Value
+		} else {
+			warns = append(warns, fmt.Sprintf("VALARM DURATION: unparseable value %q; repeat interval dropped", prop.Value))
+		}
 	}
 
 	// UID (RFC 9074)

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -620,8 +620,8 @@ func parseCategories(ve ical.Event) string {
 // The second return value is a warning string (empty if no issues). A VALARM
 // with several problems reports all of them. Each one changes what the alarm
 // does in silence. The user needs to see every reason. An unsupported ACTION
-// is the one early exit: it drops the whole alarm and stops the parse, and
-// the warnings found before it stay in the report.
+// is the one early exit. It drops the whole alarm and stops the parse.
+// Warnings found before it stay in the report.
 func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	alarm := model.Alarm{Action: "DISPLAY", Related: "START"}
 	var warns []string
@@ -683,9 +683,10 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		}
 		if valid {
 			alarm.TriggerValue = tv
-		} else if tv != "" {
-			// Unparseable TRIGGER: leave TriggerValue empty so the caller's
-			// `TriggerValue != ""` gate drops the alarm, and warn.
+		} else {
+			// Unparseable (or empty) TRIGGER: leave TriggerValue empty so
+			// the caller's `TriggerValue != ""` gate drops the alarm, and
+			// warn.
 			//
 			// Preserving the raw value here looks like it protects round-trip
 			// fidelity, but it cannot. The value is not expressible as valid
@@ -716,6 +717,10 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 				warns = append(warns, fmt.Sprintf("VALARM TRIGGER RELATED=%q: unsupported value, using START", rel))
 			}
 		}
+	} else {
+		// RFC 5545 requires TRIGGER. Without it the caller's gate drops
+		// the alarm, and the drop must not be silent.
+		warns = append(warns, "VALARM TRIGGER: missing; alarm dropped (it could never fire)")
 	}
 	if prop := comp.Props.Get(ical.PropDescription); prop != nil {
 		alarm.Description = prop.Value
@@ -726,17 +731,22 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	if prop := comp.Props.Get("REPEAT"); prop != nil {
 		// Clamp: REPEAT expands into per-trigger state in the check loop,
 		// so an absurd imported value must not hang or OOM every check.
-		if v, err := strconv.Atoi(prop.Value); err == nil && v > 0 {
+		// An unreadable value must warn: the pairing rule below drops the
+		// DURATION over it, and the report must name the cause.
+		v, err := strconv.Atoi(strings.TrimSpace(prop.Value))
+		switch {
+		case err != nil || v < 0:
+			warns = append(warns, fmt.Sprintf("VALARM REPEAT: invalid value %q; ignored", prop.Value))
+		case v > 0:
 			alarm.Repeat = min(v, model.MaxAlarmRepeat)
 		}
 	}
 	if prop := comp.Props.Get(ical.PropDuration); prop != nil {
-		// A malformed DURATION stores without error, but the next push
-		// re-emits it verbatim and a strict CalDAV server rejects the
-		// whole resource with 400. A negative value passes
-		// duration.Validate, and the repeat triggers then walk backwards
-		// from the first trigger. Drop the bad value and warn.
-		if duration.Validate(prop.Value) == nil && !strings.HasPrefix(prop.Value, "-") {
+		// A malformed DURATION pushes verbatim, and a strict CalDAV
+		// server rejects the whole resource with 400. A negative or zero
+		// value breaks the repeat triggers (see model.ValidAlarmDuration).
+		// Drop the bad value and warn.
+		if model.ValidAlarmDuration(prop.Value) {
 			alarm.Duration = prop.Value
 		} else {
 			warns = append(warns, fmt.Sprintf("VALARM DURATION: invalid value %q; dropped", prop.Value))
@@ -745,11 +755,15 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	// RFC 5545 §3.8.6.3 requires REPEAT and DURATION together. An unpaired
 	// value cannot round-trip: buildValarm omits it, and the next pull then
 	// deletes and recreates the alarm row, which loses the alarm state.
-	// Clear the incomplete pair and warn.
+	// Clear the incomplete pair and name the dropped side.
 	if (alarm.Repeat > 0) != (alarm.Duration != "") {
+		dropped := "REPEAT"
+		if alarm.Duration != "" {
+			dropped = "DURATION"
+		}
 		alarm.Repeat = 0
 		alarm.Duration = ""
-		warns = append(warns, "VALARM: REPEAT and DURATION must appear together; repeat dropped")
+		warns = append(warns, fmt.Sprintf("VALARM: REPEAT and DURATION must appear together; %s dropped", dropped))
 	}
 
 	// UID (RFC 9074)

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -628,17 +628,14 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 
 	if prop := comp.Props.Get(ical.PropAction); prop != nil {
 		alarm.Action = strings.ToUpper(prop.Value)
-	}
-	// The alarm tables accept only the actions in model.ValidAlarmAction.
-	// An unsupported action must not reach storage: the failed insert rolls
-	// back the whole resource transaction, and sync then retries the
-	// resource forever (issue #575). Google Calendar emits ACTION:NONE as a
-	// "no reminder" sentinel. Drop the alarm, warn, and return: a dropped
-	// alarm makes the other VALARM properties irrelevant. The next push
-	// omits the VALARM, so Google can re-apply its default reminders. That
-	// loss is smaller than a sync that never converges.
-	if !model.ValidAlarmAction(alarm.Action) {
-		return model.Alarm{}, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", alarm.Action)
+		// Google Calendar emits ACTION:NONE as a "no reminder" sentinel.
+		// An unsupported action must not reach the alarm tables (issue
+		// #575, see model.ValidAlarmAction). The next push then omits the
+		// VALARM, so Google can re-apply its default reminders. That loss
+		// is smaller than a sync that never converges.
+		if !model.ValidAlarmAction(alarm.Action) {
+			return model.Alarm{}, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", alarm.Action)
+		}
 	}
 	if prop := comp.Props.Get(ical.PropTrigger); prop != nil {
 		tv := prop.Value
@@ -704,13 +701,12 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		// (push+pull resets it to START) and that silently resurfaces if the
 		// user later switches the trigger to a duration. Keep the default
 		// "START" for absolute triggers.
-		if rel := strings.ToUpper(prop.Params.Get("RELATED")); rel != "" && isDuration {
-			// The alarm tables accept only START and END (the CHECK
-			// constraint in db/migrations/003 and 006). Any other value
-			// would roll back the whole resource, the same failure class
-			// as an unsupported ACTION (issue #575). Keep the default
-			// START and warn.
-			if rel == "START" || rel == "END" {
+		if rel := prop.Params.Get("RELATED"); rel != "" && isDuration {
+			// Same failure class as an unsupported ACTION (issue #575,
+			// see model.ValidAlarmRelated). Keep the default START and
+			// warn.
+			rel = strings.ToUpper(rel)
+			if model.ValidAlarmRelated(rel) {
 				alarm.Related = rel
 			} else {
 				warns = append(warns, fmt.Sprintf("VALARM TRIGGER RELATED=%s: unsupported value, using START", rel))
@@ -733,12 +729,13 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	if prop := comp.Props.Get(ical.PropDuration); prop != nil {
 		// A malformed DURATION stores without error, but the next push
 		// re-emits it verbatim and a strict CalDAV server rejects the
-		// whole resource with 400. Drop it and warn. Export pairs
-		// DURATION with REPEAT, so the repeat count alone emits nothing.
+		// whole resource with 400. Drop it and warn. Also clear REPEAT:
+		// RFC 5545 §3.8.6.3 requires the pair together.
 		if duration.Validate(prop.Value) == nil {
 			alarm.Duration = prop.Value
 		} else {
-			warns = append(warns, fmt.Sprintf("VALARM DURATION: unparseable value %q; repeat interval dropped", prop.Value))
+			alarm.Repeat = 0
+			warns = append(warns, fmt.Sprintf("VALARM DURATION: unparseable value %q; repeat dropped", prop.Value))
 		}
 	}
 

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -619,22 +619,27 @@ func parseCategories(ve ical.Event) string {
 // parseAlarm extracts a model.Alarm from a VALARM component.
 // The second return value is a warning string (empty if no issues). A VALARM
 // with several problems reports all of them. Each one changes what the alarm
-// does in silence. The user needs to see every reason. The one exception is
-// an unsupported ACTION: it drops the whole alarm at once, so the function
-// reports only that problem.
+// does in silence. The user needs to see every reason. An unsupported ACTION
+// is the one early exit: it drops the whole alarm and stops the parse, and
+// the warnings found before it stay in the report.
 func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	alarm := model.Alarm{Action: "DISPLAY", Related: "START"}
 	var warns []string
 
 	if prop := comp.Props.Get(ical.PropAction); prop != nil {
-		alarm.Action = strings.ToUpper(prop.Value)
 		// Google Calendar emits ACTION:NONE as a "no reminder" sentinel.
 		// An unsupported action must not reach the alarm tables (issue
-		// #575, see model.ValidAlarmAction). The next push then omits the
+		// #575, see model.ValidAlarmAction). Every later push omits the
 		// VALARM, so Google can re-apply its default reminders. That loss
-		// is smaller than a sync that never converges.
-		if !model.ValidAlarmAction(alarm.Action) {
-			return model.Alarm{}, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", alarm.Action)
+		// is smaller than a sync that never converges. An empty value
+		// keeps the DISPLAY default: applyAlarmDefaults rescued it before
+		// this check existed, and a reminder must not vanish over it.
+		if action := strings.ToUpper(strings.TrimSpace(prop.Value)); action != "" {
+			if !model.ValidAlarmAction(action) {
+				warns = append(warns, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", action))
+				return model.Alarm{}, strings.Join(warns, "; ")
+			}
+			alarm.Action = action
 		}
 	}
 	if prop := comp.Props.Get(ical.PropTrigger); prop != nil {
@@ -705,11 +710,10 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 			// Same failure class as an unsupported ACTION (issue #575,
 			// see model.ValidAlarmRelated). Keep the default START and
 			// warn.
-			rel = strings.ToUpper(rel)
-			if model.ValidAlarmRelated(rel) {
-				alarm.Related = rel
+			if up := strings.ToUpper(rel); model.ValidAlarmRelated(up) {
+				alarm.Related = up
 			} else {
-				warns = append(warns, fmt.Sprintf("VALARM TRIGGER RELATED=%s: unsupported value, using START", rel))
+				warns = append(warns, fmt.Sprintf("VALARM TRIGGER RELATED=%q: unsupported value, using START", rel))
 			}
 		}
 	}
@@ -729,14 +733,23 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	if prop := comp.Props.Get(ical.PropDuration); prop != nil {
 		// A malformed DURATION stores without error, but the next push
 		// re-emits it verbatim and a strict CalDAV server rejects the
-		// whole resource with 400. Drop it and warn. Also clear REPEAT:
-		// RFC 5545 §3.8.6.3 requires the pair together.
-		if duration.Validate(prop.Value) == nil {
+		// whole resource with 400. A negative value passes
+		// duration.Validate, and the repeat triggers then walk backwards
+		// from the first trigger. Drop the bad value and warn.
+		if duration.Validate(prop.Value) == nil && !strings.HasPrefix(prop.Value, "-") {
 			alarm.Duration = prop.Value
 		} else {
-			alarm.Repeat = 0
-			warns = append(warns, fmt.Sprintf("VALARM DURATION: unparseable value %q; repeat dropped", prop.Value))
+			warns = append(warns, fmt.Sprintf("VALARM DURATION: invalid value %q; dropped", prop.Value))
 		}
+	}
+	// RFC 5545 §3.8.6.3 requires REPEAT and DURATION together. An unpaired
+	// value cannot round-trip: buildValarm omits it, and the next pull then
+	// deletes and recreates the alarm row, which loses the alarm state.
+	// Clear the incomplete pair and warn.
+	if (alarm.Repeat > 0) != (alarm.Duration != "") {
+		alarm.Repeat = 0
+		alarm.Duration = ""
+		warns = append(warns, "VALARM: REPEAT and DURATION must appear together; repeat dropped")
 	}
 
 	// UID (RFC 9074)

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -627,6 +627,20 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	if prop := comp.Props.Get(ical.PropAction); prop != nil {
 		alarm.Action = strings.ToUpper(prop.Value)
 	}
+	// The alarm tables accept only these three actions (the CHECK constraint
+	// in db/migrations/003 and 006). An unsupported action must not reach
+	// storage: the failed insert rolls back the whole resource transaction,
+	// and sync then retries the resource forever (issue #575). Google
+	// Calendar emits ACTION:NONE as a "no reminder" sentinel. Drop the alarm
+	// and warn. The alarm does nothing, so the other VALARM properties do
+	// not matter and this returns early. The next push omits the VALARM, so
+	// Google can re-apply its default reminders. That loss is smaller than a
+	// wedged sync.
+	switch alarm.Action {
+	case "AUDIO", "DISPLAY", "EMAIL":
+	default:
+		return model.Alarm{}, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", alarm.Action)
+	}
 	if prop := comp.Props.Get(ical.PropTrigger); prop != nil {
 		tv := prop.Value
 		tzid := prop.Params.Get(ical.ParamTimezoneID)

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -621,7 +621,6 @@ func parseCategories(ve ical.Event) string {
 // with several problems reports all of them. Each one changes what the alarm
 // does in silence. The user needs to see every reason. An unsupported ACTION
 // is the one early exit. It drops the whole alarm and stops the parse.
-// Warnings found before it stay in the report.
 func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	alarm := model.Alarm{Action: "DISPLAY", Related: "START"}
 	var warns []string
@@ -730,18 +729,20 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		alarm.Summary = prop.Value
 	}
 	repeatZero := false
+	clampedFrom := 0
 	if prop := comp.Props.Get("REPEAT"); prop != nil {
 		// Clamp: REPEAT expands into per-trigger state in the check loop,
 		// so an absurd imported value must not hang or OOM every check.
-		// Every arm that changes the value warns: the report must name
-		// the cause, and the clamp changes what a later push sends back.
+		// The clamp warning waits until after the pairing rule below.
+		// Without the wait, one report could claim the clamp survived
+		// and the repeat was dropped at the same time.
 		v, err := strconv.Atoi(strings.TrimSpace(prop.Value))
 		switch {
 		case err != nil || v < 0:
 			warns = append(warns, fmt.Sprintf("VALARM REPEAT: invalid value %q; ignored", prop.Value))
 		case v > model.MaxAlarmRepeat:
 			alarm.Repeat = model.MaxAlarmRepeat
-			warns = append(warns, fmt.Sprintf("VALARM REPEAT: value %d clamped to %d", v, model.MaxAlarmRepeat))
+			clampedFrom = v
 		case v > 0:
 			alarm.Repeat = v
 		default:
@@ -756,8 +757,8 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 			alarm.Duration = v
 		} else if alarm.Repeat > 0 {
 			// One defect, one warning: the REPEAT is unusable without
-			// its interval, so name both drops here and keep the
-			// pairing check below quiet.
+			// its interval. Name both drops here, so the pairing check
+			// below finds a complete pair and adds no second warning.
 			alarm.Repeat = 0
 			warns = append(warns, fmt.Sprintf("VALARM DURATION: invalid value %q; dropped with its REPEAT", prop.Value))
 		} else {
@@ -768,9 +769,9 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	// value cannot round-trip: buildValarm omits it, and the next pull then
 	// deletes and recreates the alarm row, which loses the alarm state.
 	// Clear the incomplete pair and name the dropped side. An explicit
-	// REPEAT:0 with a DURATION is legal iCal, but the row cannot store
+	// REPEAT:0 with a DURATION is legal iCal. The row cannot store
 	// "repeats disabled" apart from "REPEAT absent", so that pair cannot
-	// round-trip either; it gets its own accurate message.
+	// round-trip either. It gets its own accurate message.
 	switch {
 	case repeatZero && alarm.Duration != "":
 		alarm.Duration = ""
@@ -783,6 +784,9 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		alarm.Repeat = 0
 		alarm.Duration = ""
 		warns = append(warns, fmt.Sprintf("VALARM: REPEAT and DURATION must appear together; %s dropped", dropped))
+	}
+	if clampedFrom > 0 && alarm.Repeat > 0 {
+		warns = append(warns, fmt.Sprintf("VALARM REPEAT: value %d clamped to %d", clampedFrom, model.MaxAlarmRepeat))
 	}
 
 	// UID (RFC 9074)

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -709,7 +709,7 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		// (push+pull resets it to START) and that silently resurfaces if the
 		// user later switches the trigger to a duration. Keep the default
 		// "START" for absolute triggers.
-		if rel := prop.Params.Get("RELATED"); rel != "" && isDuration {
+		if rel := strings.TrimSpace(prop.Params.Get("RELATED")); rel != "" && isDuration {
 			// Same failure class as an unsupported ACTION (issue #575,
 			// see model.ValidAlarmRelated).
 			if up := strings.ToUpper(rel); model.ValidAlarmRelated(up) {
@@ -729,24 +729,37 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	if prop := comp.Props.Get(ical.PropSummary); prop != nil {
 		alarm.Summary = prop.Value
 	}
+	repeatZero := false
 	if prop := comp.Props.Get("REPEAT"); prop != nil {
 		// Clamp: REPEAT expands into per-trigger state in the check loop,
 		// so an absurd imported value must not hang or OOM every check.
-		// An unreadable value must warn: the pairing rule below drops the
-		// DURATION over it, and the report must name the cause.
+		// Every arm that changes the value warns: the report must name
+		// the cause, and the clamp changes what a later push sends back.
 		v, err := strconv.Atoi(strings.TrimSpace(prop.Value))
-		if err != nil || v < 0 {
+		switch {
+		case err != nil || v < 0:
 			warns = append(warns, fmt.Sprintf("VALARM REPEAT: invalid value %q; ignored", prop.Value))
-		} else if v > 0 { // zero is a valid "no repeats", not a defect
-			alarm.Repeat = min(v, model.MaxAlarmRepeat)
+		case v > model.MaxAlarmRepeat:
+			alarm.Repeat = model.MaxAlarmRepeat
+			warns = append(warns, fmt.Sprintf("VALARM REPEAT: value %d clamped to %d", v, model.MaxAlarmRepeat))
+		case v > 0:
+			alarm.Repeat = v
+		default:
+			repeatZero = true // a valid "no repeats", not a defect
 		}
 	}
 	if prop := comp.Props.Get(ical.PropDuration); prop != nil {
 		// A malformed DURATION pushes verbatim, and a strict CalDAV
 		// server rejects the whole resource with 400. See
 		// model.ValidAlarmDuration for the value rule.
-		if model.ValidAlarmDuration(prop.Value) {
-			alarm.Duration = prop.Value
+		if v := strings.TrimSpace(prop.Value); model.ValidAlarmDuration(v) {
+			alarm.Duration = v
+		} else if alarm.Repeat > 0 {
+			// One defect, one warning: the REPEAT is unusable without
+			// its interval, so name both drops here and keep the
+			// pairing check below quiet.
+			alarm.Repeat = 0
+			warns = append(warns, fmt.Sprintf("VALARM DURATION: invalid value %q; dropped with its REPEAT", prop.Value))
 		} else {
 			warns = append(warns, fmt.Sprintf("VALARM DURATION: invalid value %q; dropped", prop.Value))
 		}
@@ -754,8 +767,15 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	// RFC 5545 §3.8.6.3 requires REPEAT and DURATION together. An unpaired
 	// value cannot round-trip: buildValarm omits it, and the next pull then
 	// deletes and recreates the alarm row, which loses the alarm state.
-	// Clear the incomplete pair and name the dropped side.
-	if !alarm.RepeatPaired() {
+	// Clear the incomplete pair and name the dropped side. An explicit
+	// REPEAT:0 with a DURATION is legal iCal, but the row cannot store
+	// "repeats disabled" apart from "REPEAT absent", so that pair cannot
+	// round-trip either; it gets its own accurate message.
+	switch {
+	case repeatZero && alarm.Duration != "":
+		alarm.Duration = ""
+		warns = append(warns, "VALARM REPEAT:0: repeats disabled; DURATION dropped")
+	case !alarm.RepeatPaired():
 		dropped := "REPEAT"
 		if alarm.Duration != "" {
 			dropped = "DURATION"

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -631,14 +631,16 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		// An unsupported action must not reach the alarm tables (issue
 		// #575, see model.ValidAlarmAction). Every later push omits the
 		// VALARM, so Google can re-apply its default reminders. That loss
-		// is smaller than a sync that never converges. An empty value
-		// keeps the DISPLAY default: applyAlarmDefaults rescued it before
-		// this check existed, and a reminder must not vanish over it.
-		if action := strings.ToUpper(strings.TrimSpace(prop.Value)); action != "" {
-			if !model.ValidAlarmAction(action) {
-				warns = append(warns, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", action))
-				return model.Alarm{}, strings.Join(warns, "; ")
-			}
+		// is smaller than a sync that never converges.
+		switch action := strings.ToUpper(strings.TrimSpace(prop.Value)); {
+		case action == "":
+			// Keep the DISPLAY default: applyAlarmDefaults rescued the
+			// empty value before this check existed, and a reminder
+			// must not vanish over it.
+		case !model.ValidAlarmAction(action):
+			warns = append(warns, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", action))
+			return model.Alarm{}, strings.Join(warns, "; ")
+		default:
 			alarm.Action = action
 		}
 	}
@@ -709,8 +711,7 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		// "START" for absolute triggers.
 		if rel := prop.Params.Get("RELATED"); rel != "" && isDuration {
 			// Same failure class as an unsupported ACTION (issue #575,
-			// see model.ValidAlarmRelated). Keep the default START and
-			// warn.
+			// see model.ValidAlarmRelated).
 			if up := strings.ToUpper(rel); model.ValidAlarmRelated(up) {
 				alarm.Related = up
 			} else {
@@ -734,18 +735,16 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		// An unreadable value must warn: the pairing rule below drops the
 		// DURATION over it, and the report must name the cause.
 		v, err := strconv.Atoi(strings.TrimSpace(prop.Value))
-		switch {
-		case err != nil || v < 0:
+		if err != nil || v < 0 {
 			warns = append(warns, fmt.Sprintf("VALARM REPEAT: invalid value %q; ignored", prop.Value))
-		case v > 0:
+		} else if v > 0 { // zero is a valid "no repeats", not a defect
 			alarm.Repeat = min(v, model.MaxAlarmRepeat)
 		}
 	}
 	if prop := comp.Props.Get(ical.PropDuration); prop != nil {
 		// A malformed DURATION pushes verbatim, and a strict CalDAV
-		// server rejects the whole resource with 400. A negative or zero
-		// value breaks the repeat triggers (see model.ValidAlarmDuration).
-		// Drop the bad value and warn.
+		// server rejects the whole resource with 400. See
+		// model.ValidAlarmDuration for the value rule.
 		if model.ValidAlarmDuration(prop.Value) {
 			alarm.Duration = prop.Value
 		} else {
@@ -756,7 +755,7 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	// value cannot round-trip: buildValarm omits it, and the next pull then
 	// deletes and recreates the alarm row, which loses the alarm state.
 	// Clear the incomplete pair and name the dropped side.
-	if (alarm.Repeat > 0) != (alarm.Duration != "") {
+	if !alarm.RepeatPaired() {
 		dropped := "REPEAT"
 		if alarm.Duration != "" {
 			dropped = "DURATION"

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -156,6 +156,52 @@ func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 	}
 }
 
+// An unsupported TRIGGER RELATED value and a malformed DURATION share the
+// failure class of issue #575: RELATED hits the CHECK constraint and rolls
+// back the resource, DURATION round-trips into a push a strict server
+// rejects. Both must degrade with a warning instead of being stored.
+func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:bad-related-event@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:Event with a bad RELATED and DURATION\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:DISPLAY\r\n" +
+		"TRIGGER;RELATED=STARTS:-PT15M\r\n" +
+		"REPEAT:2\r\n" +
+		"DURATION:5 minutes\r\n" +
+		"END:VALARM\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 1 {
+		t.Fatalf("events/alarms = %d/%v, want 1 event with 1 alarm", len(result.Events), result.Events)
+	}
+	alarm := result.Events[0].Alarms[0]
+	if alarm.Related != "START" {
+		t.Errorf("Related = %q, want the START default", alarm.Related)
+	}
+	if alarm.Duration != "" {
+		t.Errorf("Duration = %q, want empty", alarm.Duration)
+	}
+	if !warningMentions(result.Warnings, `event "bad-related-event@example.com"`, "RELATED", "STARTS") {
+		t.Errorf("no RELATED warning that names the event; warnings = %v", result.Warnings)
+	}
+	if !warningMentions(result.Warnings, `event "bad-related-event@example.com"`, "DURATION", `"5 minutes"`) {
+		t.Errorf("no DURATION warning that names the event; warnings = %v", result.Warnings)
+	}
+}
+
 // parseAlarm reports every problem it finds. A single warning slot meant the
 // ATTACH message overwrote the "will not fire" one. The user then saw a broken
 // sound file and never learned the alarm was dead.

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -146,10 +146,10 @@ func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 	}
 }
 
-// An unsupported TRIGGER RELATED value and a malformed DURATION share the
-// failure class of issue #575: RELATED hits the CHECK constraint and rolls
-// back the resource, DURATION round-trips into a push a strict server
-// rejects. Both must degrade with a warning instead of being stored.
+// An unsupported RELATED value and a malformed DURATION share the failure
+// class of issue #575. RELATED hits the CHECK constraint and rolls back the
+// resource. DURATION round-trips into a push that a strict server rejects.
+// The parser must degrade both with a warning and must not store them.
 func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing.T) {
 	t.Parallel()
 	const ics = "BEGIN:VCALENDAR\r\n" +
@@ -192,6 +192,58 @@ func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing
 	}
 	if !warningMentions(result.Warnings, `event "bad-related-event@example.com"`, "DURATION", `"5 minutes"`) {
 		t.Errorf("no DURATION warning that names the event; warnings = %v", result.Warnings)
+	}
+}
+
+// Three recoverable VALARM defects must degrade without a lost reminder:
+// an empty ACTION keeps the DISPLAY default, a REPEAT with no DURATION is
+// cleared (RFC 5545 pairs them), and a negative DURATION is dropped so the
+// repeat triggers cannot walk backwards in time.
+func TestImport_RecoverableAlarmDefects_KeepAlarm(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:recoverable-alarm-event@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:Event with recoverable alarm defects\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:\r\n" +
+		"TRIGGER:-PT15M\r\n" +
+		"REPEAT:3\r\n" +
+		"END:VALARM\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:DISPLAY\r\n" +
+		"TRIGGER:-PT30M\r\n" +
+		"REPEAT:2\r\n" +
+		"DURATION:-PT5M\r\n" +
+		"END:VALARM\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 2 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 2 alarms", len(result.Events), result.Events)
+	}
+	for i, alarm := range result.Events[0].Alarms {
+		if alarm.Action != "DISPLAY" {
+			t.Errorf("alarm %d: Action = %q, want DISPLAY", i, alarm.Action)
+		}
+		if alarm.Repeat != 0 || alarm.Duration != "" {
+			t.Errorf("alarm %d: Repeat/Duration = %d/%q, want the cleared pair", i, alarm.Repeat, alarm.Duration)
+		}
+	}
+	if !warningMentions(result.Warnings, "REPEAT and DURATION") {
+		t.Errorf("no unpaired REPEAT warning; warnings = %v", result.Warnings)
+	}
+	if !warningMentions(result.Warnings, "DURATION", `"-PT5M"`) {
+		t.Errorf("no negative DURATION warning; warnings = %v", result.Warnings)
 	}
 }
 

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -91,6 +91,71 @@ func TestImport_DroppedAlarmWarning_NamesOwningRecord(t *testing.T) {
 	}
 }
 
+// Regression test for issue #575. Google CalDAV emits VALARM ACTION:NONE as
+// a "no reminder" sentinel. The alarm tables reject that action with a CHECK
+// constraint. The failed insert rolled back the whole resource transaction,
+// so the event never persisted and sync never converged. The parser must
+// drop the unsupported alarm with a warning and keep the parent record and
+// its supported alarms.
+func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:action-none-event@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:Event with a no-op alarm\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:NONE\r\n" +
+		"TRIGGER:-PT15M\r\n" +
+		"END:VALARM\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:DISPLAY\r\n" +
+		"TRIGGER:-PT30M\r\n" +
+		"DESCRIPTION:Real reminder\r\n" +
+		"END:VALARM\r\n" +
+		"END:VEVENT\r\n" +
+		"BEGIN:VTODO\r\n" +
+		"UID:action-proc-todo@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"SUMMARY:Todo with a legacy alarm\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:PROCEDURE\r\n" +
+		"TRIGGER:-PT5M\r\n" +
+		"END:VALARM\r\n" +
+		"END:VTODO\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	if len(result.Events[0].Alarms) != 1 {
+		t.Fatalf("event alarms = %d, want 1; alarms = %+v", len(result.Events[0].Alarms), result.Events[0].Alarms)
+	}
+	if got := result.Events[0].Alarms[0].Action; got != "DISPLAY" {
+		t.Errorf("surviving alarm action = %q, want DISPLAY", got)
+	}
+	if len(result.Todos) != 1 {
+		t.Fatalf("todos = %d, want 1", len(result.Todos))
+	}
+	if len(result.Todos[0].Alarms) != 0 {
+		t.Errorf("todo alarms = %d, want 0", len(result.Todos[0].Alarms))
+	}
+	if !warningMentions(result.Warnings, `event "action-none-event@example.com"`, "ACTION", `"NONE"`) {
+		t.Errorf("no ACTION NONE warning that names the event; warnings = %v", result.Warnings)
+	}
+	if !warningMentions(result.Warnings, `todo "action-proc-todo@example.com"`, "ACTION", `"PROCEDURE"`) {
+		t.Errorf("no ACTION PROCEDURE warning that names the todo; warnings = %v", result.Warnings)
+	}
+}
+
 // parseAlarm reports every problem it finds. A single warning slot meant the
 // ATTACH message overwrote the "will not fire" one. The user then saw a broken
 // sound file and never learned the alarm was dead.

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -91,6 +91,25 @@ func TestImport_DroppedAlarmWarning_NamesOwningRecord(t *testing.T) {
 	}
 }
 
+// eventICS builds a VCALENDAR with one VEVENT and the given VALARM bodies.
+// Each valarm string holds the property lines of one VALARM, with CRLF
+// line ends.
+func eventICS(uid, summary string, valarms ...string) string {
+	s := "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:" + uid + "\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:" + summary + "\r\n"
+	for _, v := range valarms {
+		s += "BEGIN:VALARM\r\n" + v + "END:VALARM\r\n"
+	}
+	return s + "END:VEVENT\r\nEND:VCALENDAR\r\n"
+}
+
 // Regression test for issue #575. Google CalDAV emits VALARM ACTION:NONE as
 // a "no reminder" sentinel. The alarm tables reject that action with a CHECK
 // constraint. The failed insert rolled back the whole resource transaction,
@@ -100,40 +119,18 @@ func TestImport_DroppedAlarmWarning_NamesOwningRecord(t *testing.T) {
 // TestImport_DroppedAlarmWarning_NamesOwningRecord.)
 func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 	t.Parallel()
-	const ics = "BEGIN:VCALENDAR\r\n" +
-		"VERSION:2.0\r\n" +
-		"PRODID:-//test//EN\r\n" +
-		"BEGIN:VEVENT\r\n" +
-		"UID:action-none-event@example.com\r\n" +
-		"DTSTAMP:20260401T100000Z\r\n" +
-		"DTSTART:20260401T140000Z\r\n" +
-		"DTEND:20260401T150000Z\r\n" +
-		"SUMMARY:Event with a no-op alarm\r\n" +
-		"BEGIN:VALARM\r\n" +
-		"ACTION:NONE\r\n" +
-		"TRIGGER:-PT15M\r\n" +
-		"END:VALARM\r\n" +
-		"BEGIN:VALARM\r\n" +
-		"ACTION:PROCEDURE\r\n" +
-		"TRIGGER:-PT5M\r\n" +
-		"END:VALARM\r\n" +
-		"BEGIN:VALARM\r\n" +
-		"ACTION:DISPLAY\r\n" +
-		"TRIGGER:-PT30M\r\n" +
-		"DESCRIPTION:Real reminder\r\n" +
-		"END:VALARM\r\n" +
-		"END:VEVENT\r\n" +
-		"END:VCALENDAR\r\n"
+	ics := eventICS("action-none-event@example.com", "Event with a no-op alarm",
+		"ACTION:NONE\r\nTRIGGER:-PT15M\r\n",
+		"ACTION:PROCEDURE\r\nTRIGGER:-PT5M\r\n",
+		"ACTION:DISPLAY\r\nTRIGGER:-PT30M\r\nDESCRIPTION:Real reminder\r\n",
+	)
 
 	result, err := ImportFile(strings.NewReader(ics))
 	if err != nil {
 		t.Fatalf("ImportFile: %v", err)
 	}
-	if len(result.Events) != 1 {
-		t.Fatalf("events = %d, want 1", len(result.Events))
-	}
-	if len(result.Events[0].Alarms) != 1 {
-		t.Fatalf("event alarms = %d, want 1; alarms = %+v", len(result.Events[0].Alarms), result.Events[0].Alarms)
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 1 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 1 alarm", len(result.Events), result.Events)
 	}
 	if got := result.Events[0].Alarms[0].Action; got != "DISPLAY" {
 		t.Errorf("surviving alarm action = %q, want DISPLAY", got)
@@ -152,23 +149,9 @@ func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 // rejects. The parser must warn about both values and must not store them.
 func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing.T) {
 	t.Parallel()
-	const ics = "BEGIN:VCALENDAR\r\n" +
-		"VERSION:2.0\r\n" +
-		"PRODID:-//test//EN\r\n" +
-		"BEGIN:VEVENT\r\n" +
-		"UID:bad-related-event@example.com\r\n" +
-		"DTSTAMP:20260401T100000Z\r\n" +
-		"DTSTART:20260401T140000Z\r\n" +
-		"DTEND:20260401T150000Z\r\n" +
-		"SUMMARY:Event with a bad RELATED and DURATION\r\n" +
-		"BEGIN:VALARM\r\n" +
-		"ACTION:DISPLAY\r\n" +
-		"TRIGGER;RELATED=STARTS:-PT15M\r\n" +
-		"REPEAT:2\r\n" +
-		"DURATION:5 minutes\r\n" +
-		"END:VALARM\r\n" +
-		"END:VEVENT\r\n" +
-		"END:VCALENDAR\r\n"
+	ics := eventICS("bad-related-event@example.com", "Event with a bad RELATED and DURATION",
+		"ACTION:DISPLAY\r\nTRIGGER;RELATED=STARTS:-PT15M\r\nREPEAT:2\r\nDURATION:5 minutes\r\n",
+	)
 
 	result, err := ImportFile(strings.NewReader(ics))
 	if err != nil {
@@ -201,28 +184,10 @@ func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing
 // the repeat triggers cannot walk backwards in time.
 func TestImport_RecoverableAlarmDefects_KeepAlarm(t *testing.T) {
 	t.Parallel()
-	const ics = "BEGIN:VCALENDAR\r\n" +
-		"VERSION:2.0\r\n" +
-		"PRODID:-//test//EN\r\n" +
-		"BEGIN:VEVENT\r\n" +
-		"UID:recoverable-alarm-event@example.com\r\n" +
-		"DTSTAMP:20260401T100000Z\r\n" +
-		"DTSTART:20260401T140000Z\r\n" +
-		"DTEND:20260401T150000Z\r\n" +
-		"SUMMARY:Event with recoverable alarm defects\r\n" +
-		"BEGIN:VALARM\r\n" +
-		"ACTION:\r\n" +
-		"TRIGGER:-PT15M\r\n" +
-		"REPEAT:3\r\n" +
-		"END:VALARM\r\n" +
-		"BEGIN:VALARM\r\n" +
-		"ACTION:DISPLAY\r\n" +
-		"TRIGGER:-PT30M\r\n" +
-		"REPEAT:2\r\n" +
-		"DURATION:-PT5M\r\n" +
-		"END:VALARM\r\n" +
-		"END:VEVENT\r\n" +
-		"END:VCALENDAR\r\n"
+	ics := eventICS("recoverable-alarm-event@example.com", "Event with recoverable alarm defects",
+		"ACTION:\r\nTRIGGER:-PT15M\r\nREPEAT:3\r\n",
+		"ACTION:DISPLAY\r\nTRIGGER:-PT30M\r\nREPEAT:2\r\nDURATION:-PT5M\r\n",
+	)
 
 	result, err := ImportFile(strings.NewReader(ics))
 	if err != nil {

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -147,9 +147,9 @@ func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 }
 
 // An unsupported RELATED value and a malformed DURATION share the failure
-// class of issue #575. RELATED hits the CHECK constraint and rolls back the
-// resource. DURATION round-trips into a push that a strict server rejects.
-// The parser must degrade both with a warning and must not store them.
+// class of issue #575. RELATED fails the CHECK constraint and rolls back
+// the resource. DURATION round-trips into a push that a strict server
+// rejects. The parser must warn about both values and must not store them.
 func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing.T) {
 	t.Parallel()
 	const ics = "BEGIN:VCALENDAR\r\n" +
@@ -195,10 +195,10 @@ func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing
 	}
 }
 
-// Three recoverable VALARM defects must degrade without a lost reminder:
-// an empty ACTION keeps the DISPLAY default, a REPEAT with no DURATION is
-// cleared (RFC 5545 pairs them), and a negative DURATION is dropped so the
-// repeat triggers cannot walk backwards in time.
+// Three recoverable VALARM defects must not lose the reminder. The parser
+// keeps the DISPLAY default for an empty ACTION. It clears a REPEAT that
+// has no DURATION (RFC 5545 pairs them). It drops a negative DURATION so
+// the repeat triggers cannot walk backwards in time.
 func TestImport_RecoverableAlarmDefects_KeepAlarm(t *testing.T) {
 	t.Parallel()
 	const ics = "BEGIN:VCALENDAR\r\n" +

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -95,8 +95,9 @@ func TestImport_DroppedAlarmWarning_NamesOwningRecord(t *testing.T) {
 // a "no reminder" sentinel. The alarm tables reject that action with a CHECK
 // constraint. The failed insert rolled back the whole resource transaction,
 // so the event never persisted and sync never converged. The parser must
-// drop the unsupported alarm with a warning and keep the parent record and
-// its supported alarms.
+// drop each unsupported alarm with a warning and keep the parent record and
+// its supported alarms. (The todo caller shares the warning wrapper; see
+// TestImport_DroppedAlarmWarning_NamesOwningRecord.)
 func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 	t.Parallel()
 	const ics = "BEGIN:VCALENDAR\r\n" +
@@ -113,20 +114,15 @@ func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 		"TRIGGER:-PT15M\r\n" +
 		"END:VALARM\r\n" +
 		"BEGIN:VALARM\r\n" +
+		"ACTION:PROCEDURE\r\n" +
+		"TRIGGER:-PT5M\r\n" +
+		"END:VALARM\r\n" +
+		"BEGIN:VALARM\r\n" +
 		"ACTION:DISPLAY\r\n" +
 		"TRIGGER:-PT30M\r\n" +
 		"DESCRIPTION:Real reminder\r\n" +
 		"END:VALARM\r\n" +
 		"END:VEVENT\r\n" +
-		"BEGIN:VTODO\r\n" +
-		"UID:action-proc-todo@example.com\r\n" +
-		"DTSTAMP:20260401T100000Z\r\n" +
-		"SUMMARY:Todo with a legacy alarm\r\n" +
-		"BEGIN:VALARM\r\n" +
-		"ACTION:PROCEDURE\r\n" +
-		"TRIGGER:-PT5M\r\n" +
-		"END:VALARM\r\n" +
-		"END:VTODO\r\n" +
 		"END:VCALENDAR\r\n"
 
 	result, err := ImportFile(strings.NewReader(ics))
@@ -142,17 +138,11 @@ func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 	if got := result.Events[0].Alarms[0].Action; got != "DISPLAY" {
 		t.Errorf("surviving alarm action = %q, want DISPLAY", got)
 	}
-	if len(result.Todos) != 1 {
-		t.Fatalf("todos = %d, want 1", len(result.Todos))
-	}
-	if len(result.Todos[0].Alarms) != 0 {
-		t.Errorf("todo alarms = %d, want 0", len(result.Todos[0].Alarms))
-	}
 	if !warningMentions(result.Warnings, `event "action-none-event@example.com"`, "ACTION", `"NONE"`) {
 		t.Errorf("no ACTION NONE warning that names the event; warnings = %v", result.Warnings)
 	}
-	if !warningMentions(result.Warnings, `todo "action-proc-todo@example.com"`, "ACTION", `"PROCEDURE"`) {
-		t.Errorf("no ACTION PROCEDURE warning that names the todo; warnings = %v", result.Warnings)
+	if !warningMentions(result.Warnings, `event "action-none-event@example.com"`, "ACTION", `"PROCEDURE"`) {
+		t.Errorf("no ACTION PROCEDURE warning that names the event; warnings = %v", result.Warnings)
 	}
 }
 
@@ -193,6 +183,9 @@ func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing
 	}
 	if alarm.Duration != "" {
 		t.Errorf("Duration = %q, want empty", alarm.Duration)
+	}
+	if alarm.Repeat != 0 {
+		t.Errorf("Repeat = %d, want 0 (RFC 5545 pairs REPEAT with DURATION)", alarm.Repeat)
 	}
 	if !warningMentions(result.Warnings, `event "bad-related-event@example.com"`, "RELATED", "STARTS") {
 		t.Errorf("no RELATED warning that names the event; warnings = %v", result.Warnings)

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -3,6 +3,8 @@ package ical
 import (
 	"strings"
 	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
 )
 
 // An unparseable DUE or DTSTART on a VTODO is dropped. It cannot be stored.
@@ -178,37 +180,53 @@ func TestImport_UnsupportedAlarmRelatedAndDuration_DegradeWithWarning(t *testing
 	}
 }
 
-// Three recoverable VALARM defects must not lose the reminder. The parser
-// keeps the DISPLAY default for an empty ACTION. It clears a REPEAT that
-// has no DURATION (RFC 5545 pairs them). It drops a negative DURATION so
-// the repeat triggers cannot walk backwards in time.
+// Recoverable VALARM defects must not lose the reminder. The parser keeps
+// the DISPLAY default for an empty ACTION. It clears a REPEAT that has no
+// DURATION (RFC 5545 pairs them). It drops a negative DURATION together
+// with its REPEAT, in one warning. It drops the DURATION of an explicit
+// REPEAT:0 with an accurate message. It clamps an absurd REPEAT and warns.
 func TestImport_RecoverableAlarmDefects_KeepAlarm(t *testing.T) {
 	t.Parallel()
 	ics := eventICS("recoverable-alarm-event@example.com", "Event with recoverable alarm defects",
 		"ACTION:\r\nTRIGGER:-PT15M\r\nREPEAT:3\r\n",
 		"ACTION:DISPLAY\r\nTRIGGER:-PT30M\r\nREPEAT:2\r\nDURATION:-PT5M\r\n",
+		"ACTION:DISPLAY\r\nTRIGGER:-PT45M\r\nREPEAT:0\r\nDURATION:PT5M\r\n",
+		"ACTION:DISPLAY\r\nTRIGGER:-PT1H\r\nREPEAT:5000\r\nDURATION:PT5M\r\n",
 	)
 
 	result, err := ImportFile(strings.NewReader(ics))
 	if err != nil {
 		t.Fatalf("ImportFile: %v", err)
 	}
-	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 2 {
-		t.Fatalf("events/alarms = %d/%+v, want 1 event with 2 alarms", len(result.Events), result.Events)
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 4 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 4 alarms", len(result.Events), result.Events)
 	}
-	for i, alarm := range result.Events[0].Alarms {
+	alarms := result.Events[0].Alarms
+	for i, alarm := range alarms {
 		if alarm.Action != "DISPLAY" {
 			t.Errorf("alarm %d: Action = %q, want DISPLAY", i, alarm.Action)
 		}
+	}
+	for i, alarm := range alarms[:3] {
 		if alarm.Repeat != 0 || alarm.Duration != "" {
 			t.Errorf("alarm %d: Repeat/Duration = %d/%q, want the cleared pair", i, alarm.Repeat, alarm.Duration)
 		}
 	}
-	if !warningMentions(result.Warnings, "REPEAT and DURATION") {
+	if alarms[3].Repeat != model.MaxAlarmRepeat || alarms[3].Duration != "PT5M" {
+		t.Errorf("alarm 3: Repeat/Duration = %d/%q, want the clamp %d with the kept interval",
+			alarms[3].Repeat, alarms[3].Duration, model.MaxAlarmRepeat)
+	}
+	if !warningMentions(result.Warnings, "REPEAT and DURATION", "REPEAT dropped") {
 		t.Errorf("no unpaired REPEAT warning; warnings = %v", result.Warnings)
 	}
-	if !warningMentions(result.Warnings, "DURATION", `"-PT5M"`) {
-		t.Errorf("no negative DURATION warning; warnings = %v", result.Warnings)
+	if !warningMentions(result.Warnings, `"-PT5M"`, "dropped with its REPEAT") {
+		t.Errorf("no combined negative-DURATION warning; warnings = %v", result.Warnings)
+	}
+	if !warningMentions(result.Warnings, "REPEAT:0", "DURATION dropped") {
+		t.Errorf("no REPEAT:0 warning; warnings = %v", result.Warnings)
+	}
+	if !warningMentions(result.Warnings, "clamped") {
+		t.Errorf("no clamp warning; warnings = %v", result.Warnings)
 	}
 }
 

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -156,16 +156,22 @@ func ValidAlarmRelated(related string) bool {
 }
 
 // ValidAlarmDuration returns true if d is a repeat interval the alarm
-// engine can fire: a well-formed, positive RFC 5545 duration. A negative
-// interval walks the repeat triggers backwards in time. A zero interval
-// never advances them. The import parser, the CLI parser, and the
-// exporter share this rule.
+// engine can fire: a well-formed RFC 5545 duration that advances time.
+// A negative interval walks the repeat triggers backwards. A zero
+// interval never advances them. The import parser, the CLI parser, and
+// the exporter share this rule.
 func ValidAlarmDuration(d string) bool {
-	if duration.Validate(d) != nil || strings.HasPrefix(d, "-") {
+	if duration.Validate(d) != nil {
 		return false
 	}
 	var t time.Time
-	return !duration.Add(t, d).Equal(t)
+	return duration.Add(t, d).After(t)
+}
+
+// RepeatPaired reports whether REPEAT and DURATION are both set or both
+// absent. RFC 5545 §3.8.6.3 forbids one without the other.
+func (a Alarm) RepeatPaired() bool {
+	return (a.Repeat > 0) == (a.Duration != "")
 }
 
 // ValidateAcknowledged returns true if v is a valid RFC 9074 ACKNOWLEDGED

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -155,6 +155,19 @@ func ValidAlarmRelated(related string) bool {
 	return related == "START" || related == "END"
 }
 
+// ValidAlarmDuration returns true if d is a repeat interval the alarm
+// engine can fire: a well-formed, positive RFC 5545 duration. A negative
+// interval walks the repeat triggers backwards in time. A zero interval
+// never advances them. The import parser, the CLI parser, and the
+// exporter share this rule.
+func ValidAlarmDuration(d string) bool {
+	if duration.Validate(d) != nil || strings.HasPrefix(d, "-") {
+		return false
+	}
+	var t time.Time
+	return !duration.Add(t, d).Equal(t)
+}
+
 // ValidateAcknowledged returns true if v is a valid RFC 9074 ACKNOWLEDGED
 // value: empty string (clear), iCal UTC datetime, or RFC 3339.
 func ValidateAcknowledged(v string) bool {

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -158,12 +158,15 @@ func ValidAlarmRelated(related string) bool {
 // ValidAlarmDuration returns true if d is a repeat interval the alarm
 // engine can fire: a well-formed RFC 5545 duration that advances time.
 // A negative interval walks the repeat triggers backwards. A zero
-// interval never advances them. The import parser, the CLI parser, and
-// the exporter share this rule.
+// interval never advances them. The import parser, the CLI parser, the
+// exporter, and the repeat fire path share this rule.
+//
+// One duration.Add call answers both "well-formed" and "advances time".
+// Add returns the zero time when d does not parse, and the base here is
+// the zero time, so an unparseable, empty, zero, or negative d all land
+// at or before the base. The predicate runs on the alarm check loop, so
+// it must not parse d twice.
 func ValidAlarmDuration(d string) bool {
-	if duration.Validate(d) != nil {
-		return false
-	}
 	var t time.Time
 	return duration.Add(t, d).After(t)
 }

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -137,7 +137,7 @@ func sortedEmails(atts []AlarmAttendee) []string {
 
 // ValidAlarmAction returns true if action is a value the alarm tables
 // accept. The set mirrors the CHECK constraints in db/migrations/003 and
-// 006. Keep this function and the two constraints in lockstep: a value
+// 006. Keep this function and the two constraints in lockstep. A value
 // that passes here but fails the constraint rolls back the whole resource
 // transaction during sync (issue #575).
 func ValidAlarmAction(action string) bool {

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -148,6 +148,13 @@ func ValidAlarmAction(action string) bool {
 	return false
 }
 
+// ValidAlarmRelated returns true if related is a value the alarm tables
+// accept for the TRIGGER anchor. The set mirrors the same CHECK
+// constraints as ValidAlarmAction, with the same lockstep rule.
+func ValidAlarmRelated(related string) bool {
+	return related == "START" || related == "END"
+}
+
 // ValidateAcknowledged returns true if v is a valid RFC 9074 ACKNOWLEDGED
 // value: empty string (clear), iCal UTC datetime, or RFC 3339.
 func ValidateAcknowledged(v string) bool {

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -135,6 +135,19 @@ func sortedEmails(atts []AlarmAttendee) []string {
 	return emails
 }
 
+// ValidAlarmAction returns true if action is a value the alarm tables
+// accept. The set mirrors the CHECK constraints in db/migrations/003 and
+// 006. Keep this function and the two constraints in lockstep: a value
+// that passes here but fails the constraint rolls back the whole resource
+// transaction during sync (issue #575).
+func ValidAlarmAction(action string) bool {
+	switch action {
+	case "AUDIO", "DISPLAY", "EMAIL":
+		return true
+	}
+	return false
+}
+
 // ValidateAcknowledged returns true if v is a valid RFC 9074 ACKNOWLEDGED
 // value: empty string (clear), iCal UTC datetime, or RFC 3339.
 func ValidateAcknowledged(v string) bool {

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/douglasdemoura/chroncal/db"
 	"github.com/douglasdemoura/chroncal/internal/fileid"
+	"github.com/douglasdemoura/chroncal/internal/model"
 )
 
 func Open(dbPath string) (*sql.DB, *Queries, error) {
@@ -65,6 +66,10 @@ func Open(dbPath string) (*sql.DB, *Queries, error) {
 	if err := purgeLibicalDiagnosticXProps(conn); err != nil {
 		conn.Close()
 		return nil, nil, fmt.Errorf("purge libical diagnostic x-props: %w", err)
+	}
+	if err := normalizeAlarmRepeatPairs(conn); err != nil {
+		conn.Close()
+		return nil, nil, fmt.Errorf("normalize alarm repeat pairs: %w", err)
 	}
 
 	return conn, q, nil
@@ -198,6 +203,64 @@ func purgeLibicalDiagnosticXProps(conn *sql.DB) error {
 	_, err := conn.ExecContext(context.Background(),
 		`DELETE FROM x_properties WHERE name LIKE 'X-LIC-%'`)
 	return err
+}
+
+// normalizeAlarmRepeatPairs heals alarm rows written before the parsers
+// validated REPEAT and DURATION (issue #580). It clamps the repeat count.
+// It clears an interval that fails model.ValidAlarmDuration. It clears an
+// unpaired REPEAT or DURATION. Without this repair, export and the next
+// pull disagree with the stored row: the mismatch deletes and recreates
+// the alarm row, and the cascade discards the alarm state. The function
+// runs on every startup. It changes nothing when all rows are normal.
+func normalizeAlarmRepeatPairs(conn *sql.DB) error {
+	ctx := context.Background()
+	for _, table := range []string{"event_alarms", "todo_alarms"} {
+		type fix struct {
+			id       int64
+			repeat   int
+			duration string
+		}
+		var fixes []fix
+		err := func() error {
+			rows, err := conn.QueryContext(ctx,
+				`SELECT id, repeat, COALESCE(duration, '') FROM `+table+
+					` WHERE repeat > 0 OR COALESCE(duration, '') != ''`)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var id int64
+				var a model.Alarm
+				if err := rows.Scan(&id, &a.Repeat, &a.Duration); err != nil {
+					return err
+				}
+				healed := a
+				healed.Repeat = min(healed.Repeat, model.MaxAlarmRepeat)
+				if !model.ValidAlarmDuration(healed.Duration) {
+					healed.Duration = ""
+				}
+				if !healed.RepeatPaired() {
+					healed.Repeat, healed.Duration = 0, ""
+				}
+				if healed.Repeat != a.Repeat || healed.Duration != a.Duration {
+					fixes = append(fixes, fix{id, healed.Repeat, healed.Duration})
+				}
+			}
+			return rows.Err()
+		}()
+		if err != nil {
+			return fmt.Errorf("scan %s: %w", table, err)
+		}
+		for _, f := range fixes {
+			if _, err := conn.ExecContext(ctx,
+				`UPDATE `+table+` SET repeat = ?, duration = NULLIF(?, '') WHERE id = ?`,
+				f.repeat, f.duration, f.id); err != nil {
+				return fmt.Errorf("heal %s row %d: %w", table, f.id, err)
+			}
+		}
+	}
+	return nil
 }
 
 // backfillAlarmUIDs assigns random UUIDs to alarms that have empty UIDs.

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
 )
 
 func TestOpen_InMemory(t *testing.T) {
@@ -249,5 +251,72 @@ func TestOpen_ForeignKeys(t *testing.T) {
 	}
 	if fk != 1 {
 		t.Errorf("foreign_keys = %d, want 1", fk)
+	}
+}
+
+// normalizeAlarmRepeatPairs must heal rows written before the parsers
+// validated REPEAT and DURATION: clamp the count, clear a bad interval,
+// clear an unpaired value, and leave normal rows alone (issue #580).
+func TestNormalizeAlarmRepeatPairs(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("list calendars: %v", err)
+	}
+	calID := cals[0].ID
+	res, err := db.Exec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time, all_day, status, transp, sequence, priority)
+		 VALUES ('heal-event', ?, 'Test', '2026-04-01T00:00:00Z', '2026-04-01T01:00:00Z', 0, 'CONFIRMED', 'OPAQUE', 0, 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	eventID, _ := res.LastInsertId()
+
+	// Legacy shapes the old importer and CLI could store.
+	rows := []struct {
+		repeat       int
+		duration     string
+		wantRepeat   int
+		wantDuration string
+	}{
+		{3, "-PT5M", 0, ""},                          // negative interval
+		{2, "5 minutes", 0, ""},                      // malformed interval
+		{4, "", 0, ""},                               // unpaired REPEAT
+		{0, "PT5M", 0, ""},                           // unpaired DURATION
+		{5000, "PT5M", model.MaxAlarmRepeat, "PT5M"}, // pre-clamp count
+		{2, "PT10M", 2, "PT10M"},                     // normal row stays
+	}
+	ids := make([]int64, len(rows))
+	for i, r := range rows {
+		res, err := db.Exec(
+			`INSERT INTO event_alarms (event_id, action, trigger_value, repeat, duration) VALUES (?, 'DISPLAY', '-PT15M', ?, NULLIF(?, ''))`,
+			eventID, r.repeat, r.duration)
+		if err != nil {
+			t.Fatalf("insert alarm %d: %v", i, err)
+		}
+		ids[i], _ = res.LastInsertId()
+	}
+
+	if err := normalizeAlarmRepeatPairs(db); err != nil {
+		t.Fatalf("normalizeAlarmRepeatPairs: %v", err)
+	}
+
+	for i, r := range rows {
+		var repeat int
+		var duration string
+		err := db.QueryRow(`SELECT repeat, COALESCE(duration, '') FROM event_alarms WHERE id = ?`, ids[i]).
+			Scan(&repeat, &duration)
+		if err != nil {
+			t.Fatalf("read alarm %d: %v", i, err)
+		}
+		if repeat != r.wantRepeat || duration != r.wantDuration {
+			t.Errorf("row %d (%d/%q): healed to %d/%q, want %d/%q",
+				i, r.repeat, r.duration, repeat, duration, r.wantRepeat, r.wantDuration)
+		}
 	}
 }

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -398,6 +398,9 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 				t.Errorf("%s action %q: insert ok = %v, ValidAlarmAction = %v (err: %v)",
 					ins.table, action, got, want, err)
 			}
+			if err != nil && !strings.Contains(err.Error(), "CHECK constraint failed") {
+				t.Errorf("%s action %q: rejected by %v, not by the CHECK constraint", ins.table, action, err)
+			}
 		}
 		for _, related := range relateds {
 			_, err := db.Exec(
@@ -407,6 +410,9 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 			if got, want := err == nil, model.ValidAlarmRelated(related); got != want {
 				t.Errorf("%s related %q: insert ok = %v, ValidAlarmRelated = %v (err: %v)",
 					ins.table, related, got, want, err)
+			}
+			if err != nil && !strings.Contains(err.Error(), "CHECK constraint failed") {
+				t.Errorf("%s related %q: rejected by %v, not by the CHECK constraint", ins.table, related, err)
 			}
 		}
 	}

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -385,34 +385,29 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 		{"event_alarms", "event_id", eventID},
 		{"todo_alarms", "todo_id", todoID},
 	}
-	actions := []string{"AUDIO", "DISPLAY", "EMAIL", "NONE", "PROCEDURE", "display", ""}
-	relateds := []string{"START", "END", "STARTS", "end", ""}
+	checks := []struct {
+		col    string
+		values []string
+		valid  func(string) bool
+	}{
+		{"action", []string{"AUDIO", "DISPLAY", "EMAIL", "NONE", "PROCEDURE", "display", ""}, model.ValidAlarmAction},
+		{"related", []string{"START", "END", "STARTS", "end", ""}, model.ValidAlarmRelated},
+	}
 
 	for _, ins := range inserts {
-		for _, action := range actions {
-			_, err := db.Exec(
-				`INSERT INTO `+ins.table+` (`+ins.fk+`, action, trigger_value) VALUES (?, ?, '-PT15M')`,
-				ins.id, action,
-			)
-			if got, want := err == nil, model.ValidAlarmAction(action); got != want {
-				t.Errorf("%s action %q: insert ok = %v, ValidAlarmAction = %v (err: %v)",
-					ins.table, action, got, want, err)
-			}
-			if err != nil && !strings.Contains(err.Error(), "CHECK constraint failed") {
-				t.Errorf("%s action %q: rejected by %v, not by the CHECK constraint", ins.table, action, err)
-			}
-		}
-		for _, related := range relateds {
-			_, err := db.Exec(
-				`INSERT INTO `+ins.table+` (`+ins.fk+`, action, trigger_value, related) VALUES (?, 'DISPLAY', '-PT15M', ?)`,
-				ins.id, related,
-			)
-			if got, want := err == nil, model.ValidAlarmRelated(related); got != want {
-				t.Errorf("%s related %q: insert ok = %v, ValidAlarmRelated = %v (err: %v)",
-					ins.table, related, got, want, err)
-			}
-			if err != nil && !strings.Contains(err.Error(), "CHECK constraint failed") {
-				t.Errorf("%s related %q: rejected by %v, not by the CHECK constraint", ins.table, related, err)
+		for _, c := range checks {
+			for _, v := range c.values {
+				_, err := db.Exec(
+					`INSERT INTO `+ins.table+` (`+ins.fk+`, `+c.col+`, trigger_value) VALUES (?, ?, '-PT15M')`,
+					ins.id, v,
+				)
+				if got, want := err == nil, c.valid(v); got != want {
+					t.Errorf("%s %s %q: insert ok = %v, model predicate = %v (err: %v)",
+						ins.table, c.col, v, got, want, err)
+				}
+				if err != nil && !strings.Contains(err.Error(), "CHECK constraint failed") {
+					t.Errorf("%s %s %q: rejected by %v, not by the CHECK constraint", ins.table, c.col, v, err)
+				}
 			}
 		}
 	}

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -344,12 +344,12 @@ func TestCalendarsRejectInvalidRemoteMetadata(t *testing.T) {
 	}
 }
 
-// The alarm CHECK constraints and the model predicates must stay in
-// lockstep (issue #575: a value that passes the Go side but fails the
-// constraint rolls back the whole resource transaction during sync). This
-// test probes both alarm tables with candidate values and requires that
-// the schema and model.ValidAlarmAction / model.ValidAlarmRelated agree
-// on each one.
+// The alarm CHECK constraints and the model predicates must agree. A
+// value that passes the Go side but fails the constraint rolls back the
+// whole resource transaction during sync (issue #575). This test probes
+// both alarm tables with candidate values. The schema and
+// model.ValidAlarmAction / model.ValidAlarmRelated must give the same
+// verdict on each one.
 func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 	db, q, err := Open(":memory:")
 	if err != nil {

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
 )
 
 func TestTodosSchemaRejectsDueDateAndDuration(t *testing.T) {
@@ -339,5 +341,73 @@ func TestCalendarsRejectInvalidRemoteMetadata(t *testing.T) {
 		`INSERT INTO calendars (name, remote_missing) VALUES ('Bad missing flag', 2)`,
 	); err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
 		t.Fatalf("invalid remote missing error = %v, want CHECK constraint failure", err)
+	}
+}
+
+// The alarm CHECK constraints and the model predicates must stay in
+// lockstep (issue #575: a value that passes the Go side but fails the
+// constraint rolls back the whole resource transaction during sync). This
+// test probes both alarm tables with candidate values and requires that
+// the schema and model.ValidAlarmAction / model.ValidAlarmRelated agree
+// on each one.
+func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("list calendars: %v", err)
+	}
+	calID := cals[0].ID
+
+	res, err := db.Exec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time, all_day, status, transp, sequence, priority)
+		 VALUES ('lockstep-event', ?, 'Test', '2026-04-01T00:00:00Z', '2026-04-01T01:00:00Z', 0, 'CONFIRMED', 'OPAQUE', 0, 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	eventID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO todos (uid, calendar_id, summary, status, priority, sequence)
+		 VALUES ('lockstep-todo', ?, 'Test', 'NEEDS-ACTION', 0, 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert todo: %v", err)
+	}
+	todoID, _ := res.LastInsertId()
+
+	inserts := []struct {
+		table string
+		fk    string
+		id    int64
+	}{
+		{"event_alarms", "event_id", eventID},
+		{"todo_alarms", "todo_id", todoID},
+	}
+	actions := []string{"AUDIO", "DISPLAY", "EMAIL", "NONE", "PROCEDURE", "display", ""}
+	relateds := []string{"START", "END", "STARTS", "end", ""}
+
+	for _, ins := range inserts {
+		for _, action := range actions {
+			_, err := db.Exec(
+				`INSERT INTO `+ins.table+` (`+ins.fk+`, action, trigger_value) VALUES (?, ?, '-PT15M')`,
+				ins.id, action,
+			)
+			if got, want := err == nil, model.ValidAlarmAction(action); got != want {
+				t.Errorf("%s action %q: insert ok = %v, ValidAlarmAction = %v (err: %v)",
+					ins.table, action, got, want, err)
+			}
+		}
+		for _, related := range relateds {
+			_, err := db.Exec(
+				`INSERT INTO `+ins.table+` (`+ins.fk+`, action, trigger_value, related) VALUES (?, 'DISPLAY', '-PT15M', ?)`,
+				ins.id, related,
+			)
+			if got, want := err == nil, model.ValidAlarmRelated(related); got != want {
+				t.Errorf("%s related %q: insert ok = %v, ValidAlarmRelated = %v (err: %v)",
+					ins.table, related, got, want, err)
+			}
+		}
 	}
 }

--- a/internal/tui/alarm_editor_test.go
+++ b/internal/tui/alarm_editor_test.go
@@ -349,3 +349,15 @@ func TestAlarmEditor_EditModeMouseClickOnCancelReturnsToList(t *testing.T) {
 	assert.Equal(t, alarmModeList, m.mode, "after clicking cancel, editor must return to list mode")
 	assert.Empty(t, m.Alarms(), "clicking cancel must not save the alarm")
 }
+
+// Every action the dropdown offers must pass model.ValidAlarmAction. The
+// predicate mirrors the storage CHECK constraints, so a drifted option
+// would let the user pick an action the insert rejects — the issue #575
+// rollback class through the TUI.
+func TestAlarmActionOptsMatchModelValidator(t *testing.T) {
+	require.NotEmpty(t, alarmActionOpts)
+	for _, opt := range alarmActionOpts {
+		assert.True(t, model.ValidAlarmAction(opt.Value),
+			"dropdown option %q (%s) fails model.ValidAlarmAction", opt.Value, opt.Label)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #575.

Google CalDAV emits `VALARM ACTION:NONE` as a "no reminder" sentinel. `parseAlarm` accepted any `ACTION` value, but the alarm tables permit only `AUDIO`, `DISPLAY`, and `EMAIL` (the CHECK constraint in migrations 003 and 006). The failed insert rolled back the whole resource transaction in `persistImported`, the resource stayed dirty, the sync-token did not advance, and initial sync against Google never converged.

## Change

- `parseAlarm` now validates the uppercased action against the storage-supported set. An unsupported action drops the alarm and emits a warning that names the owning record — the same contract as an unparseable `TRIGGER`. This generalizes past `NONE`: legacy `PROCEDURE` and `X-` actions hit the same constraint.
- Regression test `TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord`: the parent event and its supported alarms survive, the todo case is covered, and both warnings name their owner.

## Trade-off

The next push omits the dropped VALARM, so Google can re-apply its default reminders. That loss is smaller than a permanently wedged sync. The code comment records this.

## Testing

- `go build ./...` and full `go test ./...` pass.
- `gofmt` and `go vet` clean.