### PR TITLE
fix(duration): reject durations that overflow time.Duration

### DIFF
--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1715,7 +1715,7 @@ func parseOneAlarm(val string) (model.Alarm, error) {
 	}
 	if len(parts) > 3 && parts[3] != "" {
 		if !model.ValidAlarmDuration(parts[3]) {
-			return model.Alarm{}, fmt.Errorf("alarm %q: repeat duration %q must be a positive RFC 5545 duration", val, parts[3])
+			return model.Alarm{}, fmt.Errorf("alarm %q: repeat duration %q must be a positive RFC 5545 duration within the supported range", val, parts[3])
 		}
 		a.Duration = parts[3]
 	}

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1895,16 +1895,27 @@ func validateAlarmTrigger(trigger string) error {
 	if trigger == "" {
 		return errInvalidInputf("alarm trigger must not be empty")
 	}
-	// model.ParseableAlarmTrigger is the one accepted set: the engine,
-	// the exporter, and this flag agree, so the compact iCal layouts
-	// pass here too. The duration error carries the reason: a
-	// well-formed duration can fail the range check, and a generic
-	// message would misdescribe that rejection.
-	if model.ParseableAlarmTrigger(trigger) {
+	// The CLI accepts a strict subset of model.ParseableAlarmTrigger:
+	// durations, compact UTC, and RFC 3339. A compact floating time
+	// (no trailing Z) is excluded. The flag has no TZID context, the
+	// value would store raw, and export would emit invalid iCal
+	// (issue #572 documents that failure). The duration error carries
+	// the reason: a well-formed duration can fail the range check, and
+	// a generic message would misdescribe that rejection.
+	if trigger[0] == '-' || trigger[0] == '+' || trigger[0] == 'P' {
+		if err := duration.Validate(trigger); err != nil {
+			return errInvalidInputf("invalid alarm trigger: %v (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", err)
+		}
 		return nil
 	}
-	if trigger[0] == '-' || trigger[0] == '+' || trigger[0] == 'P' {
-		return errInvalidInputf("invalid alarm trigger: %v (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", duration.Validate(trigger))
+	if _, err := time.Parse("20060102T150405Z", trigger); err == nil {
+		return nil
+	}
+	if _, err := time.Parse(time.RFC3339, trigger); err == nil {
+		return nil
+	}
+	if _, err := time.Parse("20060102T150405", trigger); err == nil {
+		return errInvalidInputf("invalid alarm trigger %q: a floating time has no timezone; add a Z suffix or use an RFC 3339 datetime with an offset", trigger)
 	}
 	return errInvalidInputf("invalid alarm trigger %q (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", trigger)
 }

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1896,25 +1896,26 @@ func validateAlarmTrigger(trigger string) error {
 		return errInvalidInputf("alarm trigger must not be empty")
 	}
 	// The CLI accepts a strict subset of model.ParseableAlarmTrigger:
-	// durations, compact UTC, and RFC 3339. A compact floating time
-	// (no trailing Z) is excluded. The flag has no TZID context, the
-	// value would store raw, and export would emit invalid iCal
-	// (issue #572 documents that failure). The duration error carries
-	// the reason: a well-formed duration can fail the range check, and
-	// a generic message would misdescribe that rejection.
-	if trigger[0] == '-' || trigger[0] == '+' || trigger[0] == 'P' {
+	// durations, compact UTC, and RFC 3339. The CLI does not accept a
+	// compact floating time (no trailing Z). The flag has no TZID
+	// context, the value would store raw, and export would emit
+	// invalid iCal (issue #572 documents that failure). The duration
+	// error carries the reason. A well-formed duration can fail the
+	// range check, and a generic message would misdescribe that
+	// rejection.
+	if model.AlarmTriggerIsDuration(trigger) {
 		if err := duration.Validate(trigger); err != nil {
 			return errInvalidInputf("invalid alarm trigger: %v (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", err)
 		}
 		return nil
 	}
-	if _, err := time.Parse("20060102T150405Z", trigger); err == nil {
+	if _, err := model.ParseAbsoluteTimeUTC(trigger); err == nil {
 		return nil
 	}
-	if _, err := time.Parse(time.RFC3339, trigger); err == nil {
-		return nil
-	}
-	if _, err := time.Parse("20060102T150405", trigger); err == nil {
+	// ParseAbsoluteTime accepts one more layout than the strict parser
+	// above: the compact floating form. A value that reaches here and
+	// parses is therefore floating.
+	if _, err := model.ParseAbsoluteTime(trigger, ""); err == nil {
 		return errInvalidInputf("invalid alarm trigger %q: a floating time has no timezone; add a Z suffix or use an RFC 3339 datetime with an offset", trigger)
 	}
 	return errInvalidInputf("invalid alarm trigger %q (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", trigger)

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1895,15 +1895,16 @@ func validateAlarmTrigger(trigger string) error {
 	if trigger == "" {
 		return errInvalidInputf("alarm trigger must not be empty")
 	}
-	// Try RFC 3339 absolute datetime first.
-	if _, err := time.Parse(time.RFC3339, trigger); err == nil {
+	// model.ParseableAlarmTrigger is the one accepted set: the engine,
+	// the exporter, and this flag agree, so the compact iCal layouts
+	// pass here too. The duration error carries the reason: a
+	// well-formed duration can fail the range check, and a generic
+	// message would misdescribe that rejection.
+	if model.ParseableAlarmTrigger(trigger) {
 		return nil
 	}
-	// Strict RFC 5545 duration validation. Surface the parse error: a
-	// well-formed duration can now fail the range check, and "must be
-	// an ISO 8601 duration" alone would misdescribe that rejection.
-	if err := duration.Validate(trigger); err != nil {
-		return errInvalidInputf("invalid alarm trigger %q: %v (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", trigger, err)
+	if trigger[0] == '-' || trigger[0] == '+' || trigger[0] == 'P' {
+		return errInvalidInputf("invalid alarm trigger: %v (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", duration.Validate(trigger))
 	}
-	return nil
+	return errInvalidInputf("invalid alarm trigger %q (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", trigger)
 }

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1899,9 +1899,11 @@ func validateAlarmTrigger(trigger string) error {
 	if _, err := time.Parse(time.RFC3339, trigger); err == nil {
 		return nil
 	}
-	// Strict RFC 5545 duration validation.
+	// Strict RFC 5545 duration validation. Surface the parse error: a
+	// well-formed duration can now fail the range check, and "must be
+	// an ISO 8601 duration" alone would misdescribe that rejection.
 	if err := duration.Validate(trigger); err != nil {
-		return errInvalidInputf("invalid alarm trigger %q: must be an ISO 8601 duration (e.g. -PT15M) or RFC 3339 datetime", trigger)
+		return errInvalidInputf("invalid alarm trigger %q: %v (use an ISO 8601 duration such as -PT15M, or an RFC 3339 datetime)", trigger, err)
 	}
 	return nil
 }

--- a/cmd/chroncal/event_test.go
+++ b/cmd/chroncal/event_test.go
@@ -179,6 +179,8 @@ func TestValidateAlarmTrigger(t *testing.T) {
 		{"positive duration", "PT15M", false},
 		{"absolute datetime", "2026-05-10T14:00:00Z", false},
 		{"absolute with offset", "2026-05-10T14:00:00-04:00", false},
+		{"compact UTC", "20260510T140000Z", false},
+		{"compact floating has no timezone", "20260510T140000", true},
 		{"empty", "", true},
 		{"garbage", "garbage", true},
 		{"just P", "P", true},

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -374,7 +374,11 @@ and percent-complete to 100.`,
 				if d, err := time.ParseDuration(durationStr); err == nil {
 					durationVal = duration.FromGo(d)
 				} else if strings.HasPrefix(strings.ToUpper(durationStr), "P") {
-					durationVal = durationStr
+					// Store the canonical upper case. The parser is
+					// case-sensitive, so a lowercase value would fail
+					// the span rule with a message that contradicts
+					// what the user typed.
+					durationVal = strings.ToUpper(durationStr)
 				} else {
 					return errInvalidInputf("parse duration: %q (use Go format like 1h30m or RFC 5545 like PT1H30M)", durationStr)
 				}
@@ -676,7 +680,9 @@ a --progress value other than 100.`,
 				} else if d, err := time.ParseDuration(durationStr); err == nil {
 					p.Duration = duration.FromGo(d)
 				} else if strings.HasPrefix(strings.ToUpper(durationStr), "P") {
-					p.Duration = durationStr
+					// Store the canonical upper case; see the create
+					// command for the reason.
+					p.Duration = strings.ToUpper(durationStr)
 				} else {
 					return errInvalidInputf("parse duration: %q (use Go format like 1h30m or RFC 5545 like PT1H30M)", durationStr)
 				}

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -248,12 +248,16 @@ func computeTodoTriggerTimeForInstance(inst recurrence.ExpandedTodo, alarm model
 			base = inst.InstanceTime.Add(due.Sub(start))
 		case !due.IsZero():
 			base = inst.InstanceTime
-		case inst.Duration != "" && duration.Validate(inst.Duration) == nil:
-			// The Validate gate keeps a legacy out-of-range value from
-			// the zero time Add returns. A year-1 trigger would look
-			// stale and would never fire (issue #582 round 2). An
-			// invalid Duration keeps the START anchor instead.
-			base = duration.Add(base, inst.Duration)
+		case inst.Duration != "":
+			// A legacy invalid or out-of-range Duration makes Add return
+			// the zero time. Refuse like the empty-trigger branch below:
+			// a silent START anchor would fire the alarm at the wrong
+			// time, and the callers already skip an alarm on error.
+			t := duration.Add(base, inst.Duration)
+			if t.IsZero() {
+				return time.Time{}, fmt.Errorf("invalid todo duration %q for the END anchor", inst.Duration)
+			}
+			base = t
 		}
 	}
 

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -248,7 +248,11 @@ func computeTodoTriggerTimeForInstance(inst recurrence.ExpandedTodo, alarm model
 			base = inst.InstanceTime.Add(due.Sub(start))
 		case !due.IsZero():
 			base = inst.InstanceTime
-		case inst.Duration != "":
+		case inst.Duration != "" && duration.Validate(inst.Duration) == nil:
+			// The Validate gate keeps a legacy out-of-range value from
+			// the zero time Add returns. A year-1 trigger would look
+			// stale and would never fire (issue #582 round 2). An
+			// invalid Duration keeps the START anchor instead.
 			base = duration.Add(base, inst.Duration)
 		}
 	}

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -105,6 +105,13 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 			for _, a := range alarms {
 				triggerAt, err := computeTodoTriggerTimeForInstance(inst, a)
 				if err != nil {
+					// A refused anchor drops a reminder. Log it like
+					// the stale branch below, so the state-dir log
+					// shows why the alarm never fired.
+					slog.Debug("skipping todo alarm with an unusable trigger",
+						"alarm_id", a.ID,
+						"todo", t.Summary,
+						"error", err)
 					continue
 				}
 
@@ -250,19 +257,18 @@ func computeTodoTriggerTimeForInstance(inst recurrence.ExpandedTodo, alarm model
 			base = inst.InstanceTime
 		case inst.Duration != "":
 			// A legacy invalid, negative, or out-of-range Duration must
-			// not anchor the alarm. Refuse like the empty-trigger branch
-			// below: a silent or backward anchor fires the alarm at the
-			// wrong time, and the callers already skip an alarm on error.
+			// not anchor the alarm. Refuse instead. A backward anchor
+			// fires the alarm at the wrong time, and the callers already
+			// skip an alarm on error.
 			if err := duration.ValidateSpan(inst.Duration); err != nil {
 				return time.Time{}, fmt.Errorf("invalid todo duration for the END anchor: %w", err)
 			}
 			base = duration.Add(base, inst.Duration)
-		default:
-			// No due and no duration: the END anchor has no end to bind
-			// to. Refuse instead of a silent START anchor — the same
-			// defect class as an invalid Duration, with one behavior.
-			return time.Time{}, fmt.Errorf("todo has no due date and no duration for the END anchor")
 		}
+		// A todo with neither an end nor a span keeps the START anchor.
+		// RFC 5545 gives such a VTODO no end, so START is the only time
+		// the alarm can bind to. A refusal here would stop a reminder
+		// that fires correctly today.
 	}
 
 	if alarm.TriggerValue == "" {

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -249,15 +249,19 @@ func computeTodoTriggerTimeForInstance(inst recurrence.ExpandedTodo, alarm model
 		case !due.IsZero():
 			base = inst.InstanceTime
 		case inst.Duration != "":
-			// A legacy invalid or out-of-range Duration makes Add return
-			// the zero time. Refuse like the empty-trigger branch below:
-			// a silent START anchor would fire the alarm at the wrong
-			// time, and the callers already skip an alarm on error.
-			t := duration.Add(base, inst.Duration)
-			if t.IsZero() {
-				return time.Time{}, fmt.Errorf("invalid todo duration %q for the END anchor", inst.Duration)
+			// A legacy invalid, negative, or out-of-range Duration must
+			// not anchor the alarm. Refuse like the empty-trigger branch
+			// below: a silent or backward anchor fires the alarm at the
+			// wrong time, and the callers already skip an alarm on error.
+			if err := duration.ValidateSpan(inst.Duration); err != nil {
+				return time.Time{}, fmt.Errorf("invalid todo duration for the END anchor: %w", err)
 			}
-			base = t
+			base = duration.Add(base, inst.Duration)
+		default:
+			// No due and no duration: the END anchor has no end to bind
+			// to. Refuse instead of a silent START anchor — the same
+			// defect class as an invalid Duration, with one behavior.
+			return time.Time{}, fmt.Errorf("todo has no due date and no duration for the END anchor")
 		}
 	}
 

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -739,3 +739,36 @@ func TestCheckTodos_FiresLongLeadTimeAlarm(t *testing.T) {
 		t.Fatalf("got %d due todo alarms, want 1 (long-lead-time alarm missed)", len(got))
 	}
 }
+
+// A RELATED=END alarm must refuse a legacy negative Duration. A silent
+// backward anchor fires the alarm before the start (issue #582 round 4).
+func TestComputeTodoTrigger_RelatedEnd_NegativeDurationRefused(t *testing.T) {
+	start := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	inst := recurrence.ExpandedTodo{
+		Todo: todo.Todo{
+			StartDate: start.Format(time.RFC3339),
+			Duration:  "-PT2H",
+		},
+		InstanceTime: start,
+	}
+	alarm := model.Alarm{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "END"}
+	if _, err := computeTodoTriggerTimeForInstance(inst, alarm); err == nil {
+		t.Fatal("negative Duration for the END anchor: got nil error, want a refusal")
+	}
+}
+
+// A RELATED=END alarm with no due and no duration has no end to bind
+// to. The function must refuse, not fall back to a silent START anchor.
+func TestComputeTodoTrigger_RelatedEnd_NoAnchorRefused(t *testing.T) {
+	start := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	inst := recurrence.ExpandedTodo{
+		Todo: todo.Todo{
+			StartDate: start.Format(time.RFC3339),
+		},
+		InstanceTime: start,
+	}
+	alarm := model.Alarm{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "END"}
+	if _, err := computeTodoTriggerTimeForInstance(inst, alarm); err == nil {
+		t.Fatal("END anchor with no due and no duration: got nil error, want a refusal")
+	}
+}

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -757,18 +757,58 @@ func TestComputeTodoTrigger_RelatedEnd_NegativeDurationRefused(t *testing.T) {
 	}
 }
 
-// A RELATED=END alarm with no due and no duration has no end to bind
-// to. The function must refuse, not fall back to a silent START anchor.
-func TestComputeTodoTrigger_RelatedEnd_NoAnchorRefused(t *testing.T) {
+// A VTODO with DTSTART, no DUE, and no DURATION has no end. RFC 5545
+// gives such a todo no end time, so a RELATED=END alarm keeps the START
+// anchor. A refusal here would stop a reminder that fires correctly
+// (issue #582 round 5).
+func TestComputeTodoTrigger_RelatedEnd_StartOnlyKeepsStartAnchor(t *testing.T) {
 	start := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+
 	inst := recurrence.ExpandedTodo{
 		Todo: todo.Todo{
 			StartDate: start.Format(time.RFC3339),
+			// No DueDate and no Duration: the todo has no end.
 		},
 		InstanceTime: start,
 	}
-	alarm := model.Alarm{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "END"}
+
+	alarm := model.Alarm{
+		Action:       "DISPLAY",
+		TriggerValue: "-PT15M",
+		Related:      "END",
+	}
+
+	got, err := computeTodoTriggerTimeForInstance(inst, alarm)
+	if err != nil {
+		t.Fatalf("computeTodoTriggerTimeForInstance: %v", err)
+	}
+	want := start.Add(-15 * time.Minute)
+	if !got.Equal(want) {
+		t.Errorf("RELATED=END with a start-only todo: got %v, want %v (the START anchor must stand)", got, want)
+	}
+}
+
+// A present but invalid Duration is a different case. The parser must
+// refuse it, because a backward anchor fires the alarm at the wrong
+// time.
+func TestComputeTodoTrigger_RelatedEnd_InvalidDurationRefused(t *testing.T) {
+	start := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+
+	inst := recurrence.ExpandedTodo{
+		Todo: todo.Todo{
+			StartDate: start.Format(time.RFC3339),
+			Duration:  "-PT2H", // legacy negative span
+		},
+		InstanceTime: start,
+	}
+
+	alarm := model.Alarm{
+		Action:       "DISPLAY",
+		TriggerValue: "-PT15M",
+		Related:      "END",
+	}
+
 	if _, err := computeTodoTriggerTimeForInstance(inst, alarm); err == nil {
-		t.Fatal("END anchor with no due and no duration: got nil error, want a refusal")
+		t.Error("a negative stored Duration must refuse the END anchor, not anchor backwards")
 	}
 }

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -16,13 +16,15 @@ import (
 const maxSeconds = math.MaxInt64 / int64(time.Second)
 
 // maxDays is the largest day total (days plus weeks, as days) that
-// parse accepts: about 1000 years. The bound serves the RFC 3339
-// storage format. Every database time is a 4-digit-year string, and a
-// day total past this cap could push a 4-digit start year into 5
-// digits, which time.Parse rejects and which misorders lexicographic
-// range queries. The cap also keeps the AddDate int conversion safe on
-// a 32-bit build.
-const maxDays = 365242
+// parse accepts. The bound exists for overflow safety alone: Add
+// converts the total to an int for AddDate, which is 32 bits wide on a
+// 32-bit build.
+//
+// The bound is deliberately not a storage rule. Whether a duration
+// carries a time past the storable range depends on the start it
+// applies to, and parse has no start. The callers that add a span to a
+// time own that check (see timeutil.Storable).
+const maxDays = math.MaxInt32
 
 type parsed struct {
 	neg     bool
@@ -36,8 +38,8 @@ type parsed struct {
 // checkRange rejects a duration whose components are out of range. The
 // day total must fit maxDays. The hours, minutes, and seconds total
 // must fit maxSeconds. The per-component guards run before the sum, so
-// the arithmetic itself cannot wrap: each bounded component contributes
-// at most maxSeconds, and three such terms stay far below
+// the arithmetic itself cannot wrap. Each bounded component
+// contributes at most maxSeconds. Three such terms stay far below
 // math.MaxInt64.
 func (p parsed) checkRange(orig string) error {
 	if p.weeks > maxDays/7 || p.days > maxDays-p.weeks*7 {
@@ -63,9 +65,9 @@ func consumeComponent(s string, letter byte, orig string) (string, int64, error)
 		return "", 0, fmt.Errorf("invalid duration %q: %c requires a number", orig, letter)
 	}
 	num := s[:i]
-	// strconv.ParseInt rejects every non-digit except a leading sign, so
-	// a first-byte sign check is all that's needed to forbid
-	// per-component signs (num is non-empty here because i > 0).
+	// strconv.ParseInt rejects every non-digit except a leading sign. A
+	// first-byte sign check therefore forbids the per-component signs.
+	// num is non-empty here, because i > 0.
 	// The 64-bit width keeps the range checks the same on a 32-bit
 	// build. strconv.Atoi is int-sized there. A value at a ceiling
 	// would then fail the parse instead of the range check.
@@ -220,9 +222,9 @@ func FromGo(d time.Duration) string {
 // Validate checks that s is a well-formed RFC 5545 duration string.
 // Format: [+/-]P[nW] or [+/-]P[nD][T[nH][nM][nS]]
 // Returns an error if the string is empty, malformed, or has leftover garbage.
-// Also returns an error when a component is out of range: checkRange
-// caps the time total at maxSeconds (about 292 years) and the day
-// total at maxDays (about 1000 years).
+// Also returns an error when a component is out of range. checkRange
+// caps the time total at maxSeconds (about 292 years). It caps the day
+// total at maxDays. Both bounds exist for overflow safety.
 func Validate(s string) error {
 	_, err := parse(s)
 	return err
@@ -242,6 +244,24 @@ func ValidateSpan(s string) error {
 		return fmt.Errorf("invalid duration %q: a span must be positive", s)
 	}
 	return nil
+}
+
+// ValidateOptionalSpan is ValidateSpan for a field the caller can leave
+// unset. An empty string means "no span" and passes. Every optional
+// span column shares this rule: the event duration, the todo duration,
+// and the two export guards that read them.
+func ValidateOptionalSpan(s string) error {
+	if s == "" {
+		return nil
+	}
+	return ValidateSpan(s)
+}
+
+// UsableSpan reports whether s is a span the caller can emit: present
+// and valid. The two exporters share this rule. It is the opposite test
+// to ValidateOptionalSpan, which passes an absent value.
+func UsableSpan(s string) bool {
+	return s != "" && ValidateSpan(s) == nil
 }
 
 // Add parses an RFC 5545 duration string and adds it to a time.

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -2,10 +2,21 @@ package duration
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// maxSeconds is the largest total, in seconds, that parse accepts. It is
+// the number of whole seconds a time.Duration can hold (math.MaxInt64
+// nanoseconds, about 292 years). Add multiplies hours, minutes, and
+// seconds into a time.Duration. A total above this bound would wrap
+// (issue #581). The bound also applies to the days and weeks components.
+// Add moves days with AddDate, so days do not wrap the same way, but one
+// consistent ceiling keeps the rule simple. For the bound, a day counts
+// as 24 hours and a week counts as 7 days.
+const maxSeconds = math.MaxInt64 / int64(time.Second)
 
 type parsed struct {
 	neg     bool
@@ -14,6 +25,34 @@ type parsed struct {
 	hours   int
 	minutes int
 	seconds int
+}
+
+// checkRange rejects a duration whose total is more than maxSeconds.
+// It guards each multiply before it runs, so the arithmetic itself
+// cannot wrap. All components are non-negative here, so the running
+// total stays far below math.MaxInt64 between checks.
+func (p parsed) checkRange(orig string) error {
+	var total int64
+	for _, c := range []struct {
+		value   int
+		seconds int64
+	}{
+		{p.weeks, 7 * 86400},
+		{p.days, 86400},
+		{p.hours, 3600},
+		{p.minutes, 60},
+		{p.seconds, 1},
+	} {
+		v := int64(c.value)
+		if v > maxSeconds/c.seconds {
+			return fmt.Errorf("invalid duration %q: too large, the total is more than %d seconds", orig, maxSeconds)
+		}
+		total += v * c.seconds
+		if total > maxSeconds {
+			return fmt.Errorf("invalid duration %q: too large, the total is more than %d seconds", orig, maxSeconds)
+		}
+	}
+	return nil
 }
 
 // consumeComponent extracts the unsigned integer before letter in s.
@@ -79,7 +118,7 @@ func parse(s string) (parsed, error) {
 		if r != "" {
 			return parsed{}, fmt.Errorf("invalid duration %q: trailing characters after W", s)
 		}
-		return p, nil
+		return p, p.checkRange(s)
 	}
 
 	r, p.days, err = consumeComponent(r, 'D', s)
@@ -88,7 +127,7 @@ func parse(s string) (parsed, error) {
 	}
 
 	if r == "" {
-		return p, nil
+		return p, p.checkRange(s)
 	}
 
 	if r[0] != 'T' {
@@ -116,7 +155,7 @@ func parse(s string) (parsed, error) {
 	if r != "" {
 		return parsed{}, fmt.Errorf("invalid duration %q: trailing characters %q", s, r)
 	}
-	return p, nil
+	return p, p.checkRange(s)
 }
 
 // FromGo converts a Go time.Duration to an RFC 5545 duration string.
@@ -183,6 +222,7 @@ func FromGo(d time.Duration) string {
 // Validate checks that s is a well-formed RFC 5545 duration string.
 // Format: [+/-]P[nW] or [+/-]P[nD][T[nH][nM][nS]]
 // Returns an error if the string is empty, malformed, or has leftover garbage.
+// Also returns an error if the total is more than maxSeconds (about 292 years).
 func Validate(s string) error {
 	_, err := parse(s)
 	return err
@@ -190,8 +230,8 @@ func Validate(s string) error {
 
 // Add parses an RFC 5545 duration string and adds it to a time.
 // Format: [+/-]P[nW] or [+/-]P[nD][T[nH][nM][nS]]
-// Returns zero time for empty or unparseable input. Callers should
-// validate with Validate() before they call Add().
+// Returns zero time for empty, unparseable, or out-of-range input.
+// Callers should validate with Validate() before they call Add().
 func Add(t time.Time, dur string) time.Time {
 	p, err := parse(dur)
 	if err != nil {

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -16,11 +16,13 @@ import (
 const maxSeconds = math.MaxInt64 / int64(time.Second)
 
 // maxDays is the largest day total (days plus weeks, as days) that
-// parse accepts. Add moves the day total with AddDate, which takes an
-// int day count. This bound keeps that conversion safe on a 32-bit
-// build. Days do not feed the time.Duration sum, so they need no
-// nanosecond ceiling.
-const maxDays = math.MaxInt32
+// parse accepts: about 1000 years. The bound serves the RFC 3339
+// storage format. Every database time is a 4-digit-year string, and a
+// day total past this cap could push a 4-digit start year into 5
+// digits, which time.Parse rejects and which misorders lexicographic
+// range queries. The cap also keeps the AddDate int conversion safe on
+// a 32-bit build.
+const maxDays = 365242
 
 type parsed struct {
 	neg     bool
@@ -33,29 +35,17 @@ type parsed struct {
 
 // checkRange rejects a duration whose components are out of range. The
 // day total must fit maxDays. The hours, minutes, and seconds total
-// must fit maxSeconds. Each multiply has a guard before it runs, so
-// the arithmetic itself cannot wrap. All components are non-negative
-// here, so the sums stay far below math.MaxInt64 between checks.
+// must fit maxSeconds. The per-component guards run before the sum, so
+// the arithmetic itself cannot wrap: each bounded component contributes
+// at most maxSeconds, and three such terms stay far below
+// math.MaxInt64.
 func (p parsed) checkRange(orig string) error {
 	if p.weeks > maxDays/7 || p.days > maxDays-p.weeks*7 {
 		return fmt.Errorf("invalid duration %q: too large, the day total is more than %d days", orig, int64(maxDays))
 	}
-	var total int64
-	for _, c := range []struct {
-		value   int64
-		seconds int64
-	}{
-		{p.hours, 3600},
-		{p.minutes, 60},
-		{p.seconds, 1},
-	} {
-		if c.value > maxSeconds/c.seconds {
-			return fmt.Errorf("invalid duration %q: too large, the time total is more than %d seconds", orig, maxSeconds)
-		}
-		total += c.value * c.seconds
-		if total > maxSeconds {
-			return fmt.Errorf("invalid duration %q: too large, the time total is more than %d seconds", orig, maxSeconds)
-		}
+	if p.hours > maxSeconds/3600 || p.minutes > maxSeconds/60 || p.seconds > maxSeconds ||
+		p.hours*3600+p.minutes*60+p.seconds > maxSeconds {
+		return fmt.Errorf("invalid duration %q: too large, the time total is more than %d seconds", orig, maxSeconds)
 	}
 	return nil
 }
@@ -230,12 +220,28 @@ func FromGo(d time.Duration) string {
 // Validate checks that s is a well-formed RFC 5545 duration string.
 // Format: [+/-]P[nW] or [+/-]P[nD][T[nH][nM][nS]]
 // Returns an error if the string is empty, malformed, or has leftover garbage.
-// Also returns an error when a component is out of range: the time
-// total is capped at maxSeconds (about 292 years) and the day total at
-// maxDays.
+// Also returns an error when a component is out of range: checkRange
+// caps the time total at maxSeconds (about 292 years) and the day
+// total at maxDays (about 1000 years).
 func Validate(s string) error {
 	_, err := parse(s)
 	return err
+}
+
+// ValidateSpan checks that s is a well-formed, positive RFC 5545
+// duration. A DURATION property that expresses a span (a VEVENT end,
+// a VTODO duration) must be positive per RFC 5545 §3.8.2.5. Triggers
+// are different: a VALARM TRIGGER may be negative, so trigger callers
+// use Validate.
+func ValidateSpan(s string) error {
+	p, err := parse(s)
+	if err != nil {
+		return err
+	}
+	if p.neg || (p.weeks|p.days|p.hours|p.minutes|p.seconds) == 0 {
+		return fmt.Errorf("invalid duration %q: a span must be positive", s)
+	}
+	return nil
 }
 
 // Add parses an RFC 5545 duration string and adds it to a time.

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -8,15 +8,19 @@ import (
 	"time"
 )
 
-// maxSeconds is the largest total, in seconds, that parse accepts. It is
-// the number of whole seconds a time.Duration can hold (math.MaxInt64
-// nanoseconds, about 292 years). Add multiplies hours, minutes, and
-// seconds into a time.Duration. A total above this bound would wrap
-// (issue #581). The bound also applies to the days and weeks components.
-// Add moves days with AddDate, so days do not wrap the same way, but one
-// consistent ceiling keeps the rule simple. For the bound, a day counts
-// as 24 hours and a week counts as 7 days.
+// maxSeconds is the largest time total, in seconds, that parse accepts
+// for the hours, minutes, and seconds components. It is the number of
+// whole seconds a time.Duration can hold (math.MaxInt64 nanoseconds,
+// about 292 years). Add multiplies these components into a
+// time.Duration. A total above this bound would wrap (issue #581).
 const maxSeconds = math.MaxInt64 / int64(time.Second)
+
+// maxDays is the largest day total (days plus weeks, as days) that
+// parse accepts. Add moves the day total with AddDate, which takes an
+// int day count. This bound keeps that conversion safe on a 32-bit
+// build. Days do not feed the time.Duration sum, so they need no
+// nanosecond ceiling.
+const maxDays = math.MaxInt32
 
 type parsed struct {
 	neg     bool
@@ -27,29 +31,30 @@ type parsed struct {
 	seconds int64
 }
 
-// checkRange rejects a duration whose total is more than maxSeconds.
-// It guards each multiply before it runs, so the arithmetic itself
-// cannot wrap. All components are non-negative here, so the running
-// total stays far below math.MaxInt64 between checks.
+// checkRange rejects a duration whose components are out of range. The
+// day total must fit maxDays. The hours, minutes, and seconds total
+// must fit maxSeconds. Each multiply has a guard before it runs, so
+// the arithmetic itself cannot wrap. All components are non-negative
+// here, so the sums stay far below math.MaxInt64 between checks.
 func (p parsed) checkRange(orig string) error {
+	if p.weeks > maxDays/7 || p.days > maxDays-p.weeks*7 {
+		return fmt.Errorf("invalid duration %q: too large, the day total is more than %d days", orig, int64(maxDays))
+	}
 	var total int64
 	for _, c := range []struct {
 		value   int64
 		seconds int64
 	}{
-		{p.weeks, 7 * 86400},
-		{p.days, 86400},
 		{p.hours, 3600},
 		{p.minutes, 60},
 		{p.seconds, 1},
 	} {
-		v := c.value
-		if v > maxSeconds/c.seconds {
-			return fmt.Errorf("invalid duration %q: too large, the total is more than %d seconds", orig, maxSeconds)
+		if c.value > maxSeconds/c.seconds {
+			return fmt.Errorf("invalid duration %q: too large, the time total is more than %d seconds", orig, maxSeconds)
 		}
-		total += v * c.seconds
+		total += c.value * c.seconds
 		if total > maxSeconds {
-			return fmt.Errorf("invalid duration %q: too large, the total is more than %d seconds", orig, maxSeconds)
+			return fmt.Errorf("invalid duration %q: too large, the time total is more than %d seconds", orig, maxSeconds)
 		}
 	}
 	return nil
@@ -71,10 +76,9 @@ func consumeComponent(s string, letter byte, orig string) (string, int64, error)
 	// strconv.ParseInt rejects every non-digit except a leading sign, so
 	// a first-byte sign check is all that's needed to forbid
 	// per-component signs (num is non-empty here because i > 0).
-	// The 64-bit width keeps the maxSeconds ceiling the same on a 32-bit
-	// build: strconv.Atoi is int-sized there, and a value at the ceiling
-	// would fail the parse instead of the range check (issue #582
-	// review).
+	// The 64-bit width keeps the range checks the same on a 32-bit
+	// build. strconv.Atoi is int-sized there. A value at a ceiling
+	// would then fail the parse instead of the range check.
 	if num[0] == '+' || num[0] == '-' {
 		return "", 0, fmt.Errorf("invalid duration %q: bad %c value %q", orig, letter, num)
 	}
@@ -226,7 +230,9 @@ func FromGo(d time.Duration) string {
 // Validate checks that s is a well-formed RFC 5545 duration string.
 // Format: [+/-]P[nW] or [+/-]P[nD][T[nH][nM][nS]]
 // Returns an error if the string is empty, malformed, or has leftover garbage.
-// Also returns an error if the total is more than maxSeconds (about 292 years).
+// Also returns an error when a component is out of range: the time
+// total is capped at maxSeconds (about 292 years) and the day total at
+// maxDays.
 func Validate(s string) error {
 	_, err := parse(s)
 	return err

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -20,11 +20,11 @@ const maxSeconds = math.MaxInt64 / int64(time.Second)
 
 type parsed struct {
 	neg     bool
-	weeks   int
-	days    int
-	hours   int
-	minutes int
-	seconds int
+	weeks   int64
+	days    int64
+	hours   int64
+	minutes int64
+	seconds int64
 }
 
 // checkRange rejects a duration whose total is more than maxSeconds.
@@ -34,7 +34,7 @@ type parsed struct {
 func (p parsed) checkRange(orig string) error {
 	var total int64
 	for _, c := range []struct {
-		value   int
+		value   int64
 		seconds int64
 	}{
 		{p.weeks, 7 * 86400},
@@ -43,7 +43,7 @@ func (p parsed) checkRange(orig string) error {
 		{p.minutes, 60},
 		{p.seconds, 1},
 	} {
-		v := int64(c.value)
+		v := c.value
 		if v > maxSeconds/c.seconds {
 			return fmt.Errorf("invalid duration %q: too large, the total is more than %d seconds", orig, maxSeconds)
 		}
@@ -59,7 +59,7 @@ func (p parsed) checkRange(orig string) error {
 // If letter is absent, returns (s, 0, nil). Per RFC 5545 a component
 // value is one or more DIGITs with no embedded sign. The whole-duration
 // sign is handled once in parse, so "PT-1H" and "PT+1H" are rejected.
-func consumeComponent(s string, letter byte, orig string) (string, int, error) {
+func consumeComponent(s string, letter byte, orig string) (string, int64, error) {
 	i := strings.IndexByte(s, letter)
 	if i < 0 {
 		return s, 0, nil
@@ -68,13 +68,17 @@ func consumeComponent(s string, letter byte, orig string) (string, int, error) {
 		return "", 0, fmt.Errorf("invalid duration %q: %c requires a number", orig, letter)
 	}
 	num := s[:i]
-	// strconv.Atoi rejects every non-digit except a leading sign, so a
-	// first-byte sign check is all that's needed to forbid per-component
-	// signs (num is non-empty here because i > 0).
+	// strconv.ParseInt rejects every non-digit except a leading sign, so
+	// a first-byte sign check is all that's needed to forbid
+	// per-component signs (num is non-empty here because i > 0).
+	// The 64-bit width keeps the maxSeconds ceiling the same on a 32-bit
+	// build: strconv.Atoi is int-sized there, and a value at the ceiling
+	// would fail the parse instead of the range check (issue #582
+	// review).
 	if num[0] == '+' || num[0] == '-' {
 		return "", 0, fmt.Errorf("invalid duration %q: bad %c value %q", orig, letter, num)
 	}
-	v, err := strconv.Atoi(num)
+	v, err := strconv.ParseInt(num, 10, 64)
 	if err != nil {
 		return "", 0, fmt.Errorf("invalid duration %q: bad %c value %q", orig, letter, num)
 	}
@@ -238,7 +242,9 @@ func Add(t time.Time, dur string) time.Time {
 		return time.Time{}
 	}
 
-	days := p.days + p.weeks*7
+	// checkRange bounds the components, so the day total fits an int32
+	// and the AddDate conversion is safe on a 32-bit build.
+	days := int(p.days + p.weeks*7)
 	d := time.Duration(p.hours)*time.Hour +
 		time.Duration(p.minutes)*time.Minute +
 		time.Duration(p.seconds)*time.Second

--- a/internal/duration/duration_test.go
+++ b/internal/duration/duration_test.go
@@ -26,6 +26,9 @@ func TestAdd(t *testing.T) {
 		// range check (issue #581). Add now returns the zero time.
 		{"overflow returns zero", "PT5124096H", time.Time{}},
 		{"negative overflow returns zero", "PT3000000H", time.Time{}},
+		// A large day count moves through AddDate and never touches the
+		// time.Duration sum, so it stays exact (issue #582 round 2).
+		{"large day count stays exact", "P200000D", base.AddDate(0, 0, 200000)},
 	}
 
 	for _, tt := range tests {
@@ -83,8 +86,9 @@ func TestValidate(t *testing.T) {
 		{"plus signed minutes", "PT+15M", true},
 		{"signed trailing component", "PT1H-30M", true},
 
-		// Range check (issue #581): the total must not be more than
-		// maxSeconds (math.MaxInt64 nanoseconds, about 292 years).
+		// Range check (issue #581): the hours, minutes, and seconds
+		// total must not be more than maxSeconds (math.MaxInt64
+		// nanoseconds, about 292 years).
 		// PT5124096H wrapped to about +25 minutes before the check.
 		{"hours wrap positive", "PT5124096H", true},
 		// PT3000000H wrapped to a negative offset before the check.
@@ -94,12 +98,20 @@ func TestValidate(t *testing.T) {
 		{"seconds above the ceiling", "PT9223372037S", true},
 		{"hours just under the ceiling", "PT2562047H", false},
 		{"hours just above the ceiling", "PT2562048H", true},
-		{"weeks just under the ceiling", "P15250W", false},
-		{"huge weeks", "P15251W", true},
-		{"days just under the ceiling", "P106751D", false},
-		{"huge days", "P106752D", true},
-		// The components pass alone but the sum crosses the ceiling.
-		{"component sum crosses the ceiling", "P106751DT24H", true},
+		// The time components pass alone but their sum crosses the
+		// ceiling.
+		{"time sum crosses the ceiling", "PT2562047H60M", true},
+		// The day total has its own bound (maxDays, an int32). Days
+		// move through AddDate, not the time.Duration sum, so a large
+		// day count is valid (issue #582 round 2 restored this).
+		{"large day count", "P200000D", false},
+		{"large week count", "P15251W", false},
+		{"days at the day bound", "P2147483647D", false},
+		{"days above the day bound", "P2147483648D", true},
+		{"weeks at the day bound", "P306783378W", false},
+		{"weeks above the day bound", "P306783379W", true},
+		// Days above the bound with a valid time part still fail.
+		{"day bound with time part", "P2147483648DT1H", true},
 		// A component too large for int64 fails in strconv, not in the
 		// range check. It must still report an error.
 		{"component beyond int64", "PT99999999999999999999H", true},

--- a/internal/duration/duration_test.go
+++ b/internal/duration/duration_test.go
@@ -22,6 +22,10 @@ func TestAdd(t *testing.T) {
 		{"positive prefix", "+PT10M", time.Date(2026, 4, 1, 14, 10, 0, 0, time.UTC)},
 		{"hours minutes seconds", "-PT1H30M45S", time.Date(2026, 4, 1, 12, 29, 15, 0, time.UTC)},
 		{"empty returns zero", "", time.Time{}},
+		// A total above maxSeconds wrapped int64 nanoseconds before the
+		// range check (issue #581). Add now returns the zero time.
+		{"overflow returns zero", "PT5124096H", time.Time{}},
+		{"negative overflow returns zero", "PT3000000H", time.Time{}},
 	}
 
 	for _, tt := range tests {
@@ -78,6 +82,27 @@ func TestValidate(t *testing.T) {
 		{"signed seconds", "PT-30S", true},
 		{"plus signed minutes", "PT+15M", true},
 		{"signed trailing component", "PT1H-30M", true},
+
+		// Range check (issue #581): the total must not be more than
+		// maxSeconds (math.MaxInt64 nanoseconds, about 292 years).
+		// PT5124096H wrapped to about +25 minutes before the check.
+		{"hours wrap positive", "PT5124096H", true},
+		// PT3000000H wrapped to a negative offset before the check.
+		{"hours wrap negative", "PT3000000H", true},
+		{"negative hours wrap", "-PT5124096H", true},
+		{"seconds at the ceiling", "PT9223372036S", false},
+		{"seconds above the ceiling", "PT9223372037S", true},
+		{"hours just under the ceiling", "PT2562047H", false},
+		{"hours just above the ceiling", "PT2562048H", true},
+		{"weeks just under the ceiling", "P15250W", false},
+		{"huge weeks", "P15251W", true},
+		{"days just under the ceiling", "P106751D", false},
+		{"huge days", "P106752D", true},
+		// The components pass alone but the sum crosses the ceiling.
+		{"component sum crosses the ceiling", "P106751DT24H", true},
+		// A component too large for int64 fails in strconv, not in the
+		// range check. It must still report an error.
+		{"component beyond int64", "PT99999999999999999999H", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/duration/duration_test.go
+++ b/internal/duration/duration_test.go
@@ -101,18 +101,20 @@ func TestValidate(t *testing.T) {
 		// The time components pass alone but their sum crosses the
 		// ceiling.
 		{"time sum crosses the ceiling", "PT2562047H60M", true},
-		// The day total has its own bound (maxDays, about 1000 years).
-		// Days move through AddDate, not the time.Duration sum, so a
-		// large day count is valid up to the storage-format cap: a
-		// 4-digit start year must stay 4-digit (issue #582 round 3).
+		// The day total has its own bound (maxDays). Days move through
+		// AddDate, not the time.Duration sum, so the bound exists only
+		// to keep the int conversion safe on a 32-bit build. Whether a
+		// span carries a time past the storable range depends on the
+		// start, so the callers own that check (issue #582 round 5).
 		{"large day count", "P200000D", false},
 		{"large week count", "P15251W", false},
-		{"days at the day bound", "P365242D", false},
-		{"days above the day bound", "P365243D", true},
-		{"weeks at the day bound", "P52177W", false},
-		{"weeks above the day bound", "P52178W", true},
+		{"day count past the old storage cap", "P400000D", false},
+		{"days at the day bound", "P2147483647D", false},
+		{"days above the day bound", "P2147483648D", true},
+		{"weeks at the day bound", "P306783378W", false},
+		{"weeks above the day bound", "P306783379W", true},
 		// Days above the bound with a valid time part still fail.
-		{"day bound with time part", "P365243DT1H", true},
+		{"day bound with time part", "P2147483648DT1H", true},
 		// A component too large for int64 fails in strconv, not in the
 		// range check. It must still report an error.
 		{"component beyond int64", "PT99999999999999999999H", true},
@@ -144,7 +146,10 @@ func TestValidateSpan(t *testing.T) {
 		{"zero day span", "P0D", true},
 		{"malformed span", "5 minutes", true},
 		{"empty span", "", true},
-		{"span above the day bound", "P365243D", true},
+		{"span above the day bound", "P2147483648D", true},
+		// A span past the old 1000-year cap is valid again. Whether it
+		// is storable depends on the start (issue #582 round 5).
+		{"span past the old storage cap", "P400000D", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/duration/duration_test.go
+++ b/internal/duration/duration_test.go
@@ -101,17 +101,18 @@ func TestValidate(t *testing.T) {
 		// The time components pass alone but their sum crosses the
 		// ceiling.
 		{"time sum crosses the ceiling", "PT2562047H60M", true},
-		// The day total has its own bound (maxDays, an int32). Days
-		// move through AddDate, not the time.Duration sum, so a large
-		// day count is valid (issue #582 round 2 restored this).
+		// The day total has its own bound (maxDays, about 1000 years).
+		// Days move through AddDate, not the time.Duration sum, so a
+		// large day count is valid up to the storage-format cap: a
+		// 4-digit start year must stay 4-digit (issue #582 round 3).
 		{"large day count", "P200000D", false},
 		{"large week count", "P15251W", false},
-		{"days at the day bound", "P2147483647D", false},
-		{"days above the day bound", "P2147483648D", true},
-		{"weeks at the day bound", "P306783378W", false},
-		{"weeks above the day bound", "P306783379W", true},
+		{"days at the day bound", "P365242D", false},
+		{"days above the day bound", "P365243D", true},
+		{"weeks at the day bound", "P52177W", false},
+		{"weeks above the day bound", "P52178W", true},
 		// Days above the bound with a valid time part still fail.
-		{"day bound with time part", "P2147483648DT1H", true},
+		{"day bound with time part", "P365243DT1H", true},
 		// A component too large for int64 fails in strconv, not in the
 		// range check. It must still report an error.
 		{"component beyond int64", "PT99999999999999999999H", true},
@@ -122,6 +123,35 @@ func TestValidate(t *testing.T) {
 			err := Validate(tt.dur)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate(%q) error = %v, wantErr %v", tt.dur, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// A span (a VEVENT end, a VTODO duration) must be a well-formed,
+// positive duration. Triggers stay on Validate, which accepts a sign.
+func TestValidateSpan(t *testing.T) {
+	tests := []struct {
+		name    string
+		dur     string
+		wantErr bool
+	}{
+		{"positive time span", "PT1H30M", false},
+		{"positive day span", "P200000D", false},
+		{"negative span", "-PT1H", true},
+		{"signed positive span", "+PT1H", false},
+		{"zero span", "PT0S", true},
+		{"zero day span", "P0D", true},
+		{"malformed span", "5 minutes", true},
+		{"empty span", "", true},
+		{"span above the day bound", "P365243D", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSpan(tt.dur)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSpan(%q) error = %v, wantErr %v", tt.dur, err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/douglasdemoura/chroncal/internal/calendaraccess"
+	"github.com/douglasdemoura/chroncal/internal/duration"
 	"github.com/douglasdemoura/chroncal/internal/hydrate"
 	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/storage"
@@ -389,9 +390,22 @@ func (s *Service) ensureSeriesWritable(ctx context.Context, uid string) error {
 	return nil
 }
 
+// validateDurationValue mirrors the todo-side span rule (validateTiming
+// in the todo service). The import path drops a bad value with a
+// warning instead, so sync never reaches this error.
+func validateDurationValue(v string) error {
+	if v == "" {
+		return nil
+	}
+	return duration.ValidateSpan(v)
+}
+
 func (s *Service) Create(ctx context.Context, p CreateParams) (Event, error) {
 	p.applyDefaults()
 
+	if err := validateDurationValue(p.DurationValue); err != nil {
+		return Event{}, err
+	}
 	if err := calendaraccess.EnsureWritable(ctx, s.q, p.CalendarID, "VEVENT"); err != nil {
 		return Event{}, err
 	}
@@ -479,6 +493,9 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, 
 // plus ReplaceAttendees/ReplaceAlarms in separate transactions. Those separate
 // writes could leave a half-updated row when a later child write failed.
 func (s *Service) UpdateWithRelations(ctx context.Context, id int64, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
+	if err := validateDurationValue(p.DurationValue); err != nil {
+		return Event{}, err
+	}
 	p.applyDefaults()
 
 	if err := s.ensureEventWritable(ctx, id, p.CalendarID); err != nil {
@@ -551,6 +568,9 @@ func updateEventTx(ctx context.Context, qtx *storage.Queries, id int64, p Update
 }
 
 func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Event, error) {
+	if err := validateDurationValue(p.DurationValue); err != nil {
+		return Event{}, err
+	}
 	p.applyDefaults()
 
 	qtx, commit, rollback, err := s.txscope(ctx)
@@ -971,6 +991,9 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 // the same transaction, so the override row and its children commit atomically
 // (issue #87).
 func (s *Service) UpdateInstanceWithRelations(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
+	if err := validateDurationValue(p.DurationValue); err != nil {
+		return Event{}, err
+	}
 	p.applyDefaults()
 
 	// Reject a bad alarm before the transaction opens. See
@@ -1176,6 +1199,9 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 // write on the new split series in the same transaction. The truncation, the
 // new master, and its children then commit atomically (issue #87).
 func (s *Service) UpdateFromInstanceWithRelations(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
+	if err := validateDurationValue(p.DurationValue); err != nil {
+		return Event{}, err
+	}
 	p.applyDefaults()
 
 	// Reject a bad alarm before the transaction opens. See

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -390,22 +390,31 @@ func (s *Service) ensureSeriesWritable(ctx context.Context, uid string) error {
 	return nil
 }
 
-// validateDurationValue mirrors the todo-side span rule (validateTiming
-// in the todo service). The import path drops a bad value with a
-// warning instead, so sync never reaches this error.
-func validateDurationValue(v string) error {
-	if v == "" {
+// validateDurationValue applies the span rule that the todo service
+// applies in validateTiming. The import path drops a bad value with a
+// warning instead, so sync never reaches this error. The start time
+// anchors the storability check. A span that carries the end past the
+// storable range would write a time the database cannot read back
+// (see timeutil.Storable).
+func validateDurationValue(start time.Time, v string) error {
+	if err := duration.ValidateOptionalSpan(v); err != nil {
+		return err
+	}
+	if v == "" || start.IsZero() {
 		return nil
 	}
-	return duration.ValidateSpan(v)
+	if end := duration.Add(start, v); !timeutil.Storable(end) {
+		return fmt.Errorf("invalid duration %q: the end time is past year %d", v, timeutil.MaxStorableYear)
+	}
+	return nil
 }
 
 func (s *Service) Create(ctx context.Context, p CreateParams) (Event, error) {
-	p.applyDefaults()
-
-	if err := validateDurationValue(p.DurationValue); err != nil {
+	if err := validateDurationValue(p.StartTime, p.DurationValue); err != nil {
 		return Event{}, err
 	}
+	p.applyDefaults()
+
 	if err := calendaraccess.EnsureWritable(ctx, s.q, p.CalendarID, "VEVENT"); err != nil {
 		return Event{}, err
 	}
@@ -493,9 +502,6 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, 
 // plus ReplaceAttendees/ReplaceAlarms in separate transactions. Those separate
 // writes could leave a half-updated row when a later child write failed.
 func (s *Service) UpdateWithRelations(ctx context.Context, id int64, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
-	if err := validateDurationValue(p.DurationValue); err != nil {
-		return Event{}, err
-	}
 	p.applyDefaults()
 
 	if err := s.ensureEventWritable(ctx, id, p.CalendarID); err != nil {
@@ -533,6 +539,11 @@ func (s *Service) UpdateWithRelations(ctx context.Context, id int64, p UpdatePar
 // dirty, so callers can compose it with attendee/alarm writes inside one
 // transaction.
 func updateEventTx(ctx context.Context, qtx *storage.Queries, id int64, p UpdateParams) (Event, error) {
+	// Every update entry point reaches this function, so the span rule
+	// lives here rather than at each caller.
+	if err := validateDurationValue(p.StartTime, p.DurationValue); err != nil {
+		return Event{}, err
+	}
 	r, err := qtx.UpdateEvent(ctx, storage.UpdateEventParams{
 		ID:             id,
 		Title:          p.Title,
@@ -568,7 +579,7 @@ func updateEventTx(ctx context.Context, qtx *storage.Queries, id int64, p Update
 }
 
 func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Event, error) {
-	if err := validateDurationValue(p.DurationValue); err != nil {
+	if err := validateDurationValue(p.StartTime, p.DurationValue); err != nil {
 		return Event{}, err
 	}
 	p.applyDefaults()
@@ -991,9 +1002,6 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 // the same transaction, so the override row and its children commit atomically
 // (issue #87).
 func (s *Service) UpdateInstanceWithRelations(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
-	if err := validateDurationValue(p.DurationValue); err != nil {
-		return Event{}, err
-	}
 	p.applyDefaults()
 
 	// Reject a bad alarm before the transaction opens. See
@@ -1028,6 +1036,11 @@ func (s *Service) UpdateInstanceWithRelations(ctx context.Context, uid string, i
 // calendar ID (for a dirty mark after commit). It opens no transaction, so
 // callers can compose it with attendee/alarm writes.
 func updateInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, instanceTime time.Time, p UpdateParams) (Event, int64, error) {
+	// Every update entry point reaches this function, so the span rule
+	// lives here rather than at each caller.
+	if err := validateDurationValue(p.StartTime, p.DurationValue); err != nil {
+		return Event{}, 0, err
+	}
 	master, err := qtx.GetEventByUID(ctx, uid)
 	if err != nil {
 		return Event{}, 0, fmt.Errorf("get master: %w", err)
@@ -1199,9 +1212,6 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 // write on the new split series in the same transaction. The truncation, the
 // new master, and its children then commit atomically (issue #87).
 func (s *Service) UpdateFromInstanceWithRelations(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
-	if err := validateDurationValue(p.DurationValue); err != nil {
-		return Event{}, err
-	}
 	p.applyDefaults()
 
 	// Reject a bad alarm before the transaction opens. See
@@ -1238,6 +1248,11 @@ func (s *Service) UpdateFromInstanceWithRelations(ctx context.Context, uid strin
 // Queries. It returns the new event and the master's calendar ID. It opens
 // no transaction. Callers can then compose it with attendee/alarm writes.
 func updateFromInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, instanceTime time.Time, p UpdateParams) (Event, int64, error) {
+	// Every update entry point reaches this function, so the span rule
+	// lives here rather than at each caller.
+	if err := validateDurationValue(p.StartTime, p.DurationValue); err != nil {
+		return Event{}, 0, err
+	}
 	master, err := qtx.GetEventByUID(ctx, uid)
 	if err != nil {
 		return Event{}, 0, fmt.Errorf("get master: %w", err)

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -1112,3 +1112,25 @@ func TestEventService_ReplaceAlarms_CrossEventUIDCollision(t *testing.T) {
 		t.Errorf("e2 alarm UID = %q, want a freshly minted non-empty UID", alarms[0].UID)
 	}
 }
+
+// validateDurationValue must reject a span that carries the end past
+// the storable range, and it must accept the same span on a normal
+// start (issue #582 round 5).
+func TestValidateDurationValue_StorableEnd(t *testing.T) {
+	unstorable := time.Date(9999, 12, 1, 0, 0, 0, 0, time.UTC)
+	if err := validateDurationValue(unstorable, "P365D"); err == nil {
+		t.Error("a span whose end passes the storable range must fail")
+	}
+	normal := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	if err := validateDurationValue(normal, "P365D"); err != nil {
+		t.Errorf("a storable span must pass: %v", err)
+	}
+	// An empty span and a zero start stay valid: there is nothing to
+	// anchor the check on.
+	if err := validateDurationValue(normal, ""); err != nil {
+		t.Errorf("an empty span must pass: %v", err)
+	}
+	if err := validateDurationValue(time.Time{}, "P365D"); err != nil {
+		t.Errorf("a zero start must skip the storability check: %v", err)
+	}
+}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -237,11 +237,11 @@ func setPropFloating(vevent *ical.Event, propName string, t time.Time) {
 func setEventTimes(vevent *ical.Event, e event.Event) {
 	// RFC 5545 forbids both DTEND and DURATION on the same VEVENT.
 	// When DurationValue is set (imported from .ics), emit DURATION instead of DTEND.
-	// The Validate guard exists for DB rows written before import
+	// The ValidateSpan guard exists for DB rows written before import
 	// validated DURATION (the same reason as the alarm-path guard in
-	// buildValarm). A stored bad value must not reach the server; the
-	// stored end time takes over as DTEND.
-	useDuration := e.DurationValue != "" && duration.Validate(e.DurationValue) == nil
+	// buildValarm). A stored bad or negative value must not reach the
+	// server; the stored end time takes over as DTEND.
+	useDuration := e.DurationValue != "" && duration.ValidateSpan(e.DurationValue) == nil
 
 	if e.AllDay {
 		vevent.Props.SetDate(ical.PropDateTimeStart, allDayExportDate(e.StartTime, e.Timezone))
@@ -401,10 +401,10 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 		// (import enforces no mutual exclusion), and a single bad component makes
 		// enc.Encode reject the whole calendar, dropping every todo. Drop the
 		// conflicting DURATION instead so the rest of the batch still exports.
-		// The Validate guard covers DB rows written before import
-		// validated the todo DURATION; a stored bad value must not
-		// reach the server.
-		if t.Duration != "" && duration.Validate(t.Duration) == nil &&
+		// The ValidateSpan guard covers DB rows written before import
+		// validated the todo DURATION; a stored bad or negative value
+		// must not reach the server.
+		if t.Duration != "" && duration.ValidateSpan(t.Duration) == nil &&
 			vtodo.Props.Get(ical.PropDue) == nil &&
 			vtodo.Props.Get(ical.PropDateTimeStart) != nil {
 			p := &ical.Prop{Name: ical.PropDuration}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -237,7 +237,11 @@ func setPropFloating(vevent *ical.Event, propName string, t time.Time) {
 func setEventTimes(vevent *ical.Event, e event.Event) {
 	// RFC 5545 forbids both DTEND and DURATION on the same VEVENT.
 	// When DurationValue is set (imported from .ics), emit DURATION instead of DTEND.
-	useDuration := e.DurationValue != ""
+	// The Validate guard exists for DB rows written before import
+	// validated DURATION (the same reason as the alarm-path guard in
+	// buildValarm). A stored bad value must not reach the server; the
+	// stored end time takes over as DTEND.
+	useDuration := e.DurationValue != "" && duration.Validate(e.DurationValue) == nil
 
 	if e.AllDay {
 		vevent.Props.SetDate(ical.PropDateTimeStart, allDayExportDate(e.StartTime, e.Timezone))
@@ -397,7 +401,10 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 		// (import enforces no mutual exclusion), and a single bad component makes
 		// enc.Encode reject the whole calendar, dropping every todo. Drop the
 		// conflicting DURATION instead so the rest of the batch still exports.
-		if t.Duration != "" &&
+		// The Validate guard covers DB rows written before import
+		// validated the todo DURATION; a stored bad value must not
+		// reach the server.
+		if t.Duration != "" && duration.Validate(t.Duration) == nil &&
 			vtodo.Props.Get(ical.PropDue) == nil &&
 			vtodo.Props.Get(ical.PropDateTimeStart) != nil {
 			p := &ical.Prop{Name: ical.PropDuration}
@@ -728,18 +735,7 @@ func emitRecurrenceID(props ical.Props, recurrenceID string, allDay, floating bo
 // was reverted. It read floating values as UTC while the alarm engine reads
 // them in the record's timezone. That moved reminders by the zone offset.
 func exportableTrigger(v string) bool {
-	if v == "" {
-		return false
-	}
-	if v[0] == '-' || v[0] == '+' || v[0] == 'P' {
-		return duration.Validate(v) == nil
-	}
-	for _, layout := range []string{"20060102T150405Z", "20060102T150405", time.RFC3339} {
-		if _, err := time.Parse(layout, v); err == nil {
-			return true
-		}
-	}
-	return false
+	return model.ParseableAlarmTrigger(v)
 }
 
 // buildValarm renders an alarm as a VALARM component, or nil when the alarm

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -237,18 +237,33 @@ func setPropFloating(vevent *ical.Event, propName string, t time.Time) {
 func setEventTimes(vevent *ical.Event, e event.Event) {
 	// RFC 5545 forbids both DTEND and DURATION on the same VEVENT.
 	// When DurationValue is set (imported from .ics), emit DURATION instead of DTEND.
-	// The ValidateSpan guard exists for DB rows written before import
+	// The UsableSpan guard exists for DB rows written before import
 	// validated DURATION (the same reason as the alarm-path guard in
 	// buildValarm). A stored bad or negative value must not reach the
 	// server; the stored end time takes over as DTEND.
-	useDuration := e.DurationValue != "" && duration.ValidateSpan(e.DurationValue) == nil
+	useDuration := duration.UsableSpan(e.DurationValue)
+
+	// A legacy row whose span failed the guard above also holds an end
+	// time that the same bad span produced, so the end can precede the
+	// start. An inverted interval is invalid iCal. That is the defect
+	// the guard prevents, in another shape. Fall back to the span the
+	// importer gives a broken value. An end equal to the start stays:
+	// RFC 5545 allows a zero-length event.
+	endTime := e.EndTime
+	if !useDuration && endTime.Before(e.StartTime) {
+		if e.AllDay {
+			endTime = e.StartTime.AddDate(0, 0, 1)
+		} else {
+			endTime = e.StartTime.Add(time.Hour)
+		}
+	}
 
 	if e.AllDay {
 		vevent.Props.SetDate(ical.PropDateTimeStart, allDayExportDate(e.StartTime, e.Timezone))
 		if useDuration {
 			setPropDuration(vevent, e.DurationValue)
 		} else {
-			vevent.Props.SetDate(ical.PropDateTimeEnd, allDayExportDate(e.EndTime, e.Timezone))
+			vevent.Props.SetDate(ical.PropDateTimeEnd, allDayExportDate(endTime, e.Timezone))
 		}
 	} else if e.Timezone == "FLOATING" {
 		// Floating times are host-independent wall clocks. Import interprets
@@ -258,7 +273,7 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 		if useDuration {
 			setPropDuration(vevent, e.DurationValue)
 		} else {
-			setPropFloating(vevent, ical.PropDateTimeEnd, e.EndTime.UTC())
+			setPropFloating(vevent, ical.PropDateTimeEnd, endTime.UTC())
 		}
 	} else if e.Timezone != "" {
 		loc, err := time.LoadLocation(e.Timezone)
@@ -270,7 +285,7 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 			if useDuration {
 				setPropDuration(vevent, e.DurationValue)
 			} else {
-				vevent.Props.SetDateTime(ical.PropDateTimeEnd, e.EndTime.In(loc))
+				vevent.Props.SetDateTime(ical.PropDateTimeEnd, endTime.In(loc))
 				if prop := vevent.Props.Get(ical.PropDateTimeEnd); prop != nil {
 					prop.Params.Set(ical.ParamTimezoneID, e.Timezone)
 				}
@@ -280,7 +295,7 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 			if useDuration {
 				setPropDuration(vevent, e.DurationValue)
 			} else {
-				vevent.Props.SetDateTime(ical.PropDateTimeEnd, e.EndTime.UTC())
+				vevent.Props.SetDateTime(ical.PropDateTimeEnd, endTime.UTC())
 			}
 		}
 	} else {
@@ -288,7 +303,7 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 		if useDuration {
 			setPropDuration(vevent, e.DurationValue)
 		} else {
-			vevent.Props.SetDateTime(ical.PropDateTimeEnd, e.EndTime.UTC())
+			vevent.Props.SetDateTime(ical.PropDateTimeEnd, endTime.UTC())
 		}
 	}
 }
@@ -401,10 +416,10 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 		// (import enforces no mutual exclusion), and a single bad component makes
 		// enc.Encode reject the whole calendar, dropping every todo. Drop the
 		// conflicting DURATION instead so the rest of the batch still exports.
-		// The ValidateSpan guard covers DB rows written before import
+		// The UsableSpan guard covers DB rows written before import
 		// validated the todo DURATION; a stored bad or negative value
 		// must not reach the server.
-		if t.Duration != "" && duration.ValidateSpan(t.Duration) == nil &&
+		if duration.UsableSpan(t.Duration) &&
 			vtodo.Props.Get(ical.PropDue) == nil &&
 			vtodo.Props.Get(ical.PropDateTimeStart) != nil {
 			p := &ical.Prop{Name: ical.PropDuration}

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -44,13 +44,18 @@ func TestExport_SingleEvent(t *testing.T) {
 // falls back to the stored end time as DTEND (issue #582 round 4). The
 // startup heal clears such values, so this guard covers only a row the
 // heal has not seen yet.
-func TestExport_NegativeStoredDurationFallsBackToDTEND(t *testing.T) {
+// A legacy row holds the end time that its bad span produced, so the
+// end can precede the start. Export must emit neither the invalid
+// DURATION nor an inverted interval (issue #582 round 4).
+func TestExport_NegativeStoredDurationFallsBackToPositiveSpan(t *testing.T) {
 	t.Parallel()
+	start := time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC)
 	events := []event.Event{{
-		UID:           "export-neg-duration",
-		Title:         "Legacy negative span",
-		StartTime:     time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
-		EndTime:       time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		UID:   "export-neg-duration",
+		Title: "Legacy negative span",
+		// The real legacy shape: end = start + (-PT1H).
+		StartTime:     start,
+		EndTime:       start.Add(-time.Hour),
 		DurationValue: "-PT1H",
 		Status:        "CONFIRMED",
 		Transp:        "OPAQUE",
@@ -66,8 +71,11 @@ func TestExport_NegativeStoredDurationFallsBackToDTEND(t *testing.T) {
 	if strings.Contains(ics, "DURATION:") {
 		t.Errorf("output carries the invalid DURATION; want the DTEND fallback:\n%s", ics)
 	}
-	if !strings.Contains(ics, "DTEND:") {
-		t.Errorf("output missing the DTEND fallback:\n%s", ics)
+	if !strings.Contains(ics, "DTEND:20260401T150000Z") {
+		t.Errorf("output missing the 1h fallback DTEND; an inverted interval is invalid iCal:\n%s", ics)
+	}
+	if strings.Contains(ics, "DTEND:20260401T130000Z") {
+		t.Errorf("output carries an inverted DTEND before the DTSTART:\n%s", ics)
 	}
 }
 

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -40,6 +40,37 @@ func TestExport_SingleEvent(t *testing.T) {
 	}
 }
 
+// A legacy stored negative DURATION must not reach the server. Export
+// falls back to the stored end time as DTEND (issue #582 round 4). The
+// startup heal clears such values, so this guard covers only a row the
+// heal has not seen yet.
+func TestExport_NegativeStoredDurationFallsBackToDTEND(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{{
+		UID:           "export-neg-duration",
+		Title:         "Legacy negative span",
+		StartTime:     time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:       time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		DurationValue: "-PT1H",
+		Status:        "CONFIRMED",
+		Transp:        "OPAQUE",
+		Class:         "PUBLIC",
+	}}
+
+	data, err := ExportEvents(events, "Test")
+	if err != nil {
+		t.Fatalf("ExportEvents error: %v", err)
+	}
+	ics := string(data)
+
+	if strings.Contains(ics, "DURATION:") {
+		t.Errorf("output carries the invalid DURATION; want the DTEND fallback:\n%s", ics)
+	}
+	if !strings.Contains(ics, "DTEND:") {
+		t.Errorf("output missing the DTEND fallback:\n%s", ics)
+	}
+}
+
 func TestExport_EventAllFields(t *testing.T) {
 	t.Parallel()
 	events := []event.Event{{

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -201,9 +201,16 @@ func todoFromVTodo(comp *ical.Component) (todo.Todo, []string, error) {
 		todoWarnings = append(todoWarnings, w)
 	}
 
-	var duration string
+	// Validate like the VEVENT path. A malformed value would persist,
+	// re-export verbatim, and poison a RELATED=END alarm anchor.
+	var durationValue string
 	if prop := props.Get(ical.PropDuration); prop != nil {
-		duration = prop.Value
+		if duration.Validate(prop.Value) == nil {
+			durationValue = prop.Value
+		} else {
+			todoWarnings = append(todoWarnings, fmt.Sprintf(
+				"todo %q: invalid DURATION %q; dropped", uid, prop.Value))
+		}
 	}
 
 	var completedAt string
@@ -320,7 +327,7 @@ func todoFromVTodo(comp *ical.Component) (todo.Todo, []string, error) {
 		Location:        location,
 		DueDate:         dueDate,
 		StartDate:       startDate,
-		Duration:        duration,
+		Duration:        durationValue,
 		CompletedAt:     completedAt,
 		PercentComplete: percentComplete,
 		Status:          strings.ToUpper(status),
@@ -429,10 +436,12 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 			endTime = addDuration(startTime, prop.Value)
 			explicitEnd = true
 		} else if prop != nil {
-			// Malformed DURATION (go-ical stores the raw value without validating).
-			// Fall back to a 1h span and drop the bad value so it is neither
-			// persisted nor re-exported.
+			// Malformed DURATION (go-ical stores the raw value with no
+			// validation). Fall back to a 1h span, warn, and drop the bad
+			// value so it does not persist and does not re-export.
 			endTime = startTime.Add(time.Hour)
+			dtendWarnings = append(dtendWarnings, fmt.Sprintf(
+				"event %q: invalid DURATION %q; dropped, the event gets a 1h span", uid, prop.Value))
 		} else if badDTEND {
 			// DTEND was present but unusable and there is no DURATION to fall
 			// back on. A timed event gets the same 1h default as a malformed

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -436,10 +436,11 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		prop := ve.Props.Get(ical.PropDuration)
 		spanOK := false
 		if prop != nil && duration.ValidateSpan(prop.Value) == nil {
-			// The end must stay a 4-digit year. The RFC 3339 storage
-			// format cannot represent year 10000, and a 5-digit-year
-			// string misorders the lexicographic range queries.
-			if end := addDuration(startTime, prop.Value); end.Year() <= 9999 {
+			// The end must stay a 4-digit year in the stored UTC form.
+			// The RFC 3339 storage format cannot represent year 10000,
+			// and a 5-digit-year string misorders the lexicographic
+			// range queries.
+			if end := addDuration(startTime, prop.Value); end.UTC().Year() <= 9999 {
 				durationValue = prop.Value
 				endTime = end
 				explicitEnd = true
@@ -448,8 +449,16 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		}
 		if spanOK {
 			// The DURATION above is the span.
+		} else if prop != nil && duration.Validate(prop.Value) == nil &&
+			addDuration(startTime, prop.Value).Equal(startTime) {
+			// An exact zero span (DURATION:PT0S). RFC 5545 §3.6.1 gives
+			// the same meaning to a VEVENT with no DTEND and no
+			// DURATION, so store the equivalent zero-length event. Drop
+			// the value; DTEND=DTSTART carries the semantics on export.
+			endTime = startTime
+			explicitEnd = true
 		} else if prop != nil {
-			// Malformed, negative, zero, or unstorable DURATION (go-ical
+			// Malformed, negative, or unstorable DURATION (go-ical
 			// stores the raw value with no validation). Fall back to a 1h
 			// span, warn, and drop the bad value so it does not persist
 			// and does not re-export.

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -201,15 +201,17 @@ func todoFromVTodo(comp *ical.Component) (todo.Todo, []string, error) {
 		todoWarnings = append(todoWarnings, w)
 	}
 
-	// Validate like the VEVENT path. A malformed value would persist,
-	// re-export verbatim, and poison a RELATED=END alarm anchor.
+	// Validate like the VEVENT path, with the span rule: a DURATION
+	// must be positive (RFC 5545 §3.8.2.5). A malformed or negative
+	// value would persist, re-export verbatim, and poison a
+	// RELATED=END alarm anchor.
 	var durationValue string
 	if prop := props.Get(ical.PropDuration); prop != nil {
-		if duration.Validate(prop.Value) == nil {
+		if duration.ValidateSpan(prop.Value) == nil {
 			durationValue = prop.Value
 		} else {
 			todoWarnings = append(todoWarnings, fmt.Sprintf(
-				"todo %q: invalid DURATION %q; dropped", uid, prop.Value))
+				"todo %q: unusable DURATION %q; dropped", uid, prop.Value))
 		}
 	}
 
@@ -431,17 +433,29 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		}
 	}
 	if endTime.IsZero() {
-		if prop := ve.Props.Get(ical.PropDuration); prop != nil && duration.Validate(prop.Value) == nil {
-			durationValue = prop.Value
-			endTime = addDuration(startTime, prop.Value)
-			explicitEnd = true
+		prop := ve.Props.Get(ical.PropDuration)
+		spanOK := false
+		if prop != nil && duration.ValidateSpan(prop.Value) == nil {
+			// The end must stay a 4-digit year. The RFC 3339 storage
+			// format cannot represent year 10000, and a 5-digit-year
+			// string misorders the lexicographic range queries.
+			if end := addDuration(startTime, prop.Value); end.Year() <= 9999 {
+				durationValue = prop.Value
+				endTime = end
+				explicitEnd = true
+				spanOK = true
+			}
+		}
+		if spanOK {
+			// The DURATION above is the span.
 		} else if prop != nil {
-			// Malformed DURATION (go-ical stores the raw value with no
-			// validation). Fall back to a 1h span, warn, and drop the bad
-			// value so it does not persist and does not re-export.
+			// Malformed, negative, zero, or unstorable DURATION (go-ical
+			// stores the raw value with no validation). Fall back to a 1h
+			// span, warn, and drop the bad value so it does not persist
+			// and does not re-export.
 			endTime = startTime.Add(time.Hour)
 			dtendWarnings = append(dtendWarnings, fmt.Sprintf(
-				"event %q: invalid DURATION %q; dropped, the event gets a 1h span", uid, prop.Value))
+				"event %q: unusable DURATION %q; dropped, the event gets a 1h span", uid, prop.Value))
 		} else if badDTEND {
 			// DTEND was present but unusable and there is no DURATION to fall
 			// back on. A timed event gets the same 1h default as a malformed

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -201,17 +201,30 @@ func todoFromVTodo(comp *ical.Component) (todo.Todo, []string, error) {
 		todoWarnings = append(todoWarnings, w)
 	}
 
-	// Validate like the VEVENT path, with the span rule: a DURATION
-	// must be positive (RFC 5545 §3.8.2.5). A malformed or negative
-	// value would persist, re-export verbatim, and poison a
-	// RELATED=END alarm anchor.
+	// Screen the DURATION on the same three rules the todo service
+	// applies. The value must be a positive span (RFC 5545 §3.8.2.5).
+	// DUE and DURATION are mutually exclusive, and a DURATION needs a
+	// DTSTART (§3.6.2).
+	//
+	// Drop the DURATION and warn when a rule fails. A stored bad value
+	// would re-export verbatim and would poison a RELATED=END alarm
+	// anchor. A rejected shape would fail the whole calendar pull on
+	// every run, because the sync engine stops at the first resource
+	// error.
 	var durationValue string
 	if prop := props.Get(ical.PropDuration); prop != nil {
-		if duration.ValidateSpan(prop.Value) == nil {
-			durationValue = prop.Value
-		} else {
+		switch {
+		case duration.ValidateSpan(prop.Value) != nil:
 			todoWarnings = append(todoWarnings, fmt.Sprintf(
 				"todo %q: unusable DURATION %q; dropped", uid, prop.Value))
+		case dueDate != "":
+			todoWarnings = append(todoWarnings, fmt.Sprintf(
+				"todo %q: DUE and DURATION are mutually exclusive; DURATION %q dropped", uid, prop.Value))
+		case startDate == "":
+			todoWarnings = append(todoWarnings, fmt.Sprintf(
+				"todo %q: DURATION %q needs a DTSTART; dropped", uid, prop.Value))
+		default:
+			durationValue = prop.Value
 		}
 	}
 
@@ -436,11 +449,9 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		prop := ve.Props.Get(ical.PropDuration)
 		spanOK := false
 		if prop != nil && duration.ValidateSpan(prop.Value) == nil {
-			// The end must stay a 4-digit year in the stored UTC form.
-			// The RFC 3339 storage format cannot represent year 10000,
-			// and a 5-digit-year string misorders the lexicographic
-			// range queries.
-			if end := addDuration(startTime, prop.Value); end.UTC().Year() <= 9999 {
+			// The end must land on a time the database can hold. See
+			// timeutil.Storable for that rule.
+			if end := addDuration(startTime, prop.Value); timeutil.Storable(end) {
 				durationValue = prop.Value
 				endTime = end
 				explicitEnd = true
@@ -459,9 +470,9 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 			explicitEnd = true
 		} else if prop != nil {
 			// Malformed, negative, or unstorable DURATION (go-ical
-			// stores the raw value with no validation). Fall back to a 1h
-			// span, warn, and drop the bad value so it does not persist
-			// and does not re-export.
+			// stores the raw value with no validation). Fall back to a
+			// 1h span. Warn the user. Drop the bad value, so it does
+			// not persist and does not re-export.
 			endTime = startTime.Add(time.Hour)
 			dtendWarnings = append(dtendWarnings, fmt.Sprintf(
 				"event %q: unusable DURATION %q; dropped, the event gets a 1h span", uid, prop.Value))

--- a/internal/ical/import_dtend_regression_test.go
+++ b/internal/ical/import_dtend_regression_test.go
@@ -113,3 +113,40 @@ func TestImport_MalformedDTEND_TimedFallsBackToOneHour(t *testing.T) {
 		t.Errorf("EndTime = %v, want %v (1h default)", e.EndTime, want)
 	}
 }
+
+// DURATION:PT0S is a zero-length event, the same meaning RFC 5545
+// §3.6.1 gives a VEVENT with no DTEND and no DURATION. Import must
+// store end = start with no warning and no fabricated 1h span
+// (issue #582 round 4).
+func TestImport_ZeroDuration_StoresZeroLengthEvent(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:zero-duration@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T100000Z\r\n" +
+		"DURATION:PT0S\r\n" +
+		"SUMMARY:Zero-length marker\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	e := result.Events[0]
+	if !e.EndTime.Equal(e.StartTime) {
+		t.Errorf("EndTime = %v, want the start %v (zero-length event)", e.EndTime, e.StartTime)
+	}
+	if e.DurationValue != "" {
+		t.Errorf("DurationValue = %q, want empty (DTEND=DTSTART carries the meaning)", e.DurationValue)
+	}
+	if len(result.Warnings) != 0 {
+		t.Errorf("warnings = %v, want none for a zero span", result.Warnings)
+	}
+}

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -860,11 +860,10 @@ END:VCALENDAR`
 }
 
 // A DURATION property is a span and must be positive (RFC 5545
-// §3.8.2.5). A negative value must not persist: it would store an end
-// before the start and re-export a value strict servers reject. A
-// valid huge value whose end passes year 9999 must also drop: the RFC
-// 3339 storage format cannot represent a 5-digit year, and the string
-// misorders the lexicographic range queries (issue #582 round 3).
+// §3.8.2.5). A negative value must not persist. It would store an end
+// before the start. It would also re-export a value that strict
+// servers reject. A value whose end passes the storable range must
+// drop as well. See timeutil.Storable for that rule.
 func TestImport_SpanDuration_RejectsNegativeAndUnstorable(t *testing.T) {
 	t.Parallel()
 	ics := `BEGIN:VCALENDAR
@@ -1434,5 +1433,81 @@ func TestImport_CustomVTimezone_PreservesZoneLabel(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("VTIMEZONE Custom/Office not captured in result.Timezones")
+	}
+}
+
+// A large day span is valid when the end still lands in the storable
+// range. The day cap in internal/duration exists for overflow safety
+// alone, so it must not replace such a span with the 1h fallback and
+// push that value back over the server copy (issue #582 round 5).
+func TestImport_LargeDaySpan_KeepsTheDuration(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:large-day-span
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T140000Z
+DURATION:P400000D
+SUMMARY:Long Span Event
+END:VEVENT
+END:VCALENDAR`
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile error: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	e := result.Events[0]
+	if e.DurationValue != "P400000D" {
+		t.Errorf("DurationValue = %q, want P400000D kept", e.DurationValue)
+	}
+	if want := e.StartTime.AddDate(0, 0, 400000); !e.EndTime.Equal(want) {
+		t.Errorf("EndTime = %s, want %s", e.EndTime, want)
+	}
+}
+
+// RFC 5545 §3.6.2 makes DUE and DURATION mutually exclusive and needs a
+// DTSTART beside a DURATION. The todo service rejects both shapes, so
+// import must drop the DURATION and warn. A stored shape would fail the
+// whole calendar pull on every run (issue #582 round 5).
+func TestImport_TodoStructuralDuration_DroppedWithWarning(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:due-plus-duration
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T140000Z
+DUE:20260402T140000Z
+DURATION:PT1H
+SUMMARY:Due And Duration
+END:VTODO
+BEGIN:VTODO
+UID:duration-without-start
+DTSTAMP:20260401T100000Z
+DURATION:PT1H
+SUMMARY:Duration Without Start
+END:VTODO
+END:VCALENDAR`
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile error: %v", err)
+	}
+	if len(result.Todos) != 2 {
+		t.Fatalf("todos = %d, want 2", len(result.Todos))
+	}
+	for _, td := range result.Todos {
+		if td.Duration != "" {
+			t.Errorf("todo %q: Duration = %q, want it dropped", td.UID, td.Duration)
+		}
+	}
+	joined := strings.Join(result.Warnings, " | ")
+	if !strings.Contains(joined, "mutually exclusive") {
+		t.Errorf("no DUE+DURATION warning; warnings = %v", result.Warnings)
+	}
+	if !strings.Contains(joined, "needs a DTSTART") {
+		t.Errorf("no DURATION-without-DTSTART warning; warnings = %v", result.Warnings)
 	}
 }

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -859,6 +859,67 @@ END:VCALENDAR`
 	}
 }
 
+// A DURATION property is a span and must be positive (RFC 5545
+// §3.8.2.5). A negative value must not persist: it would store an end
+// before the start and re-export a value strict servers reject. A
+// valid huge value whose end passes year 9999 must also drop: the RFC
+// 3339 storage format cannot represent a 5-digit year, and the string
+// misorders the lexicographic range queries (issue #582 round 3).
+func TestImport_SpanDuration_RejectsNegativeAndUnstorable(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:neg-dur-event
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T140000Z
+DURATION:-PT1H
+SUMMARY:Negative Duration Event
+END:VEVENT
+BEGIN:VEVENT
+UID:huge-dur-event
+DTSTAMP:20260401T100000Z
+DTSTART:99990401T140000Z
+DURATION:P365D
+SUMMARY:Unstorable Duration Event
+END:VEVENT
+BEGIN:VTODO
+UID:neg-dur-todo
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T140000Z
+DURATION:-PT1H
+SUMMARY:Negative Duration Todo
+END:VTODO
+END:VCALENDAR`
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile error: %v", err)
+	}
+	if len(result.Events) != 2 || len(result.Todos) != 1 {
+		t.Fatalf("events/todos = %d/%d, want 2/1", len(result.Events), len(result.Todos))
+	}
+	for _, e := range result.Events {
+		if e.DurationValue != "" {
+			t.Errorf("event %q: DurationValue = %q, want empty", e.UID, e.DurationValue)
+		}
+		if want := e.StartTime.Add(time.Hour); !e.EndTime.Equal(want) {
+			t.Errorf("event %q: EndTime = %s, want the 1h fallback %s",
+				e.UID, e.EndTime.Format(time.RFC3339), want.Format(time.RFC3339))
+		}
+	}
+	if got := result.Todos[0].Duration; got != "" {
+		t.Errorf("todo Duration = %q, want empty", got)
+	}
+	for _, uid := range []string{"neg-dur-event", "huge-dur-event", "neg-dur-todo"} {
+		hasWarning := slices.ContainsFunc(result.Warnings, func(w string) bool {
+			return strings.Contains(w, uid) && strings.Contains(w, "DURATION")
+		})
+		if !hasWarning {
+			t.Errorf("no DURATION warning for %q; warnings = %v", uid, result.Warnings)
+		}
+	}
+}
+
 // A malformed DTEND (go-ical stores the raw value with no validate) must not
 // collapse the event to zero duration in silence. The old code did that
 // (endTime, _ = Props.DateTime). Mirror the malformed-DURATION treatment

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -269,9 +269,11 @@ func (a Alarm) RepeatPaired() bool {
 
 // ParseableAlarmTrigger returns true if v is a trigger value the alarm
 // engine and the exporter can read: a valid RFC 5545 duration, or an
-// absolute time in one of the three accepted layouts. The exporter and
-// the startup heal in the storage package share this rule. A row that
-// fails it can never fire, and export omits its VALARM.
+// absolute time that ParseAbsoluteTime accepts. The exporter and the
+// CLI share this rule. A row that fails it can never fire, and export
+// omits its VALARM. The absolute branch delegates to ParseAbsoluteTime
+// so the accepted layouts have one owner and cannot drift from the
+// fire path.
 func ParseableAlarmTrigger(v string) bool {
 	if v == "" {
 		return false
@@ -279,12 +281,8 @@ func ParseableAlarmTrigger(v string) bool {
 	if v[0] == '-' || v[0] == '+' || v[0] == 'P' {
 		return duration.Validate(v) == nil
 	}
-	for _, layout := range []string{"20060102T150405Z", "20060102T150405", time.RFC3339} {
-		if _, err := time.Parse(layout, v); err == nil {
-			return true
-		}
-	}
-	return false
+	_, err := ParseAbsoluteTime(v, "")
+	return err == nil
 }
 
 // ValidateAcknowledged returns true if v is a valid RFC 9074 ACKNOWLEDGED

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -246,19 +246,15 @@ func prepareAlarmForWrite(a *Alarm) error {
 }
 
 // ValidAlarmDuration returns true if d is a repeat interval the alarm
-// engine can fire: a well-formed RFC 5545 duration that advances time.
-// A negative interval walks the repeat triggers backwards. A zero
+// engine can fire: a well-formed, positive RFC 5545 duration. A
+// negative interval walks the repeat triggers backwards. A zero
 // interval never advances them. The import parser, the CLI parser, the
 // exporter, and the repeat fire path share this rule.
 //
-// One duration.Add call answers both "well-formed" and "advances time".
-// Add returns the zero time when d does not parse, and the base here is
-// the zero time, so an unparseable, empty, zero, or negative d all land
-// at or before the base. The predicate runs on the alarm check loop, so
-// it must not parse d twice.
+// The predicate delegates to duration.ValidateSpan, the one positivity
+// rule over the parser, with a single parse per call.
 func ValidAlarmDuration(d string) bool {
-	var t time.Time
-	return duration.Add(t, d).After(t)
+	return duration.ValidateSpan(d) == nil
 }
 
 // RepeatPaired reports whether REPEAT and DURATION are both set or both

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -92,23 +92,51 @@ func parseTriggerTime(s string) (time.Time, bool) {
 	return t, err == nil
 }
 
+// The iCal datetime layouts. The compact floating layout carries no
+// zone, so only the callers that can resolve one accept it.
+const (
+	icalUTCLayout      = "20060102T150405Z"
+	icalFloatingLayout = "20060102T150405"
+)
+
+// AlarmTriggerIsDuration reports whether v has the shape of a duration
+// trigger. RFC 5545 durations start with P, and a trigger may carry a
+// sign. The exporter, the CLI, and ParseableAlarmTrigger share the
+// test, so the accepted shapes cannot drift.
+func AlarmTriggerIsDuration(v string) bool {
+	return v != "" && (v[0] == '-' || v[0] == '+' || v[0] == 'P')
+}
+
+// ParseAbsoluteTimeUTC parses an absolute iCal datetime that carries its
+// own zone: iCal UTC (20060102T150405Z) or RFC 3339. It refuses the
+// compact floating form. Use it where the caller has no timezone to
+// resolve a floating value with, such as the CLI trigger flag.
+func ParseAbsoluteTimeUTC(value string) (time.Time, error) {
+	if t, err := time.Parse(icalUTCLayout, value); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("invalid trigger format: %q", value)
+}
+
 // ParseAbsoluteTime parses an absolute iCal datetime value in any of the three
 // recognized forms: iCal UTC (20060102T150405Z), iCal floating (20060102T150405),
 // or RFC 3339. A floating value is interpreted in timezone (a tz database name)
 // when non-empty and loadable; otherwise it is returned with its zero offset.
+// The three layouts are mutually exclusive, so the zone-bearing forms can
+// resolve first through ParseAbsoluteTimeUTC.
 func ParseAbsoluteTime(value, timezone string) (time.Time, error) {
-	if t, err := time.Parse("20060102T150405Z", value); err == nil {
+	if t, err := ParseAbsoluteTimeUTC(value); err == nil {
 		return t, nil
 	}
-	if t, err := time.Parse("20060102T150405", value); err == nil {
+	if t, err := time.Parse(icalFloatingLayout, value); err == nil {
 		if timezone != "" {
 			if loc, lerr := time.LoadLocation(timezone); lerr == nil {
 				return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, loc), nil
 			}
 		}
-		return t, nil
-	}
-	if t, err := time.Parse(time.RFC3339, value); err == nil {
 		return t, nil
 	}
 	return time.Time{}, fmt.Errorf("invalid trigger format: %q", value)
@@ -264,17 +292,16 @@ func (a Alarm) RepeatPaired() bool {
 }
 
 // ParseableAlarmTrigger returns true if v is a trigger value the alarm
-// engine and the exporter can read: a valid RFC 5545 duration, or an
-// absolute time that ParseAbsoluteTime accepts. The exporter and the
-// CLI share this rule. A row that fails it can never fire, and export
-// omits its VALARM. The absolute branch delegates to ParseAbsoluteTime
-// so the accepted layouts have one owner and cannot drift from the
-// fire path.
+// engine and the exporter can read. It accepts a valid RFC 5545
+// duration, or an absolute time that ParseAbsoluteTime accepts. A row
+// that fails the test can never fire, and export omits its VALARM.
+// The absolute branch delegates to ParseAbsoluteTime, so the accepted
+// layouts have one owner.
 func ParseableAlarmTrigger(v string) bool {
 	if v == "" {
 		return false
 	}
-	if v[0] == '-' || v[0] == '+' || v[0] == 'P' {
+	if AlarmTriggerIsDuration(v) {
 		return duration.Validate(v) == nil
 	}
 	_, err := ParseAbsoluteTime(v, "")

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -267,6 +267,26 @@ func (a Alarm) RepeatPaired() bool {
 	return (a.Repeat > 0) == (a.Duration != "")
 }
 
+// ParseableAlarmTrigger returns true if v is a trigger value the alarm
+// engine and the exporter can read: a valid RFC 5545 duration, or an
+// absolute time in one of the three accepted layouts. The exporter and
+// the startup heal in the storage package share this rule. A row that
+// fails it can never fire, and export omits its VALARM.
+func ParseableAlarmTrigger(v string) bool {
+	if v == "" {
+		return false
+	}
+	if v[0] == '-' || v[0] == '+' || v[0] == 'P' {
+		return duration.Validate(v) == nil
+	}
+	for _, layout := range []string{"20060102T150405Z", "20060102T150405", time.RFC3339} {
+		if _, err := time.Parse(layout, v); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateAcknowledged returns true if v is a valid RFC 9074 ACKNOWLEDGED
 // value: empty string (clear), iCal UTC datetime, or RFC 3339.
 func ValidateAcknowledged(v string) bool {

--- a/internal/model/alarm_parse_test.go
+++ b/internal/model/alarm_parse_test.go
@@ -82,3 +82,26 @@ func TestContentEqual_RelatedIgnoredOnAbsoluteTriggers(t *testing.T) {
 		t.Error("duration-trigger alarms anchored to different ends fire at different times and must NOT match")
 	}
 }
+
+// TestValidAlarmDuration_RejectsOverflow guards the range check in
+// internal/duration (issue #581). PT5124096H once wrapped int64
+// nanoseconds to about +25 minutes, so buildRepeatTriggers set repeats
+// about 25 minutes apart instead of centuries apart. The parse-level
+// bound must make ValidAlarmDuration reject it. Normal intervals must
+// still pass.
+func TestValidAlarmDuration_RejectsOverflow(t *testing.T) {
+	tests := []struct {
+		dur  string
+		want bool
+	}{
+		{"PT5124096H", false}, // wrapped positive before the range check
+		{"PT3000000H", false}, // wrapped negative before the range check
+		{"PT5M", true},
+		{"P1D", true},
+	}
+	for _, tt := range tests {
+		if got := ValidAlarmDuration(tt.dur); got != tt.want {
+			t.Errorf("ValidAlarmDuration(%q) = %v, want %v", tt.dur, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -67,9 +67,9 @@ func Open(dbPath string) (*sql.DB, *Queries, error) {
 		conn.Close()
 		return nil, nil, fmt.Errorf("purge libical diagnostic x-props: %w", err)
 	}
-	if err := healAlarmRows(conn); err != nil {
+	if err := normalizeAlarmRepeatPairs(conn); err != nil {
 		conn.Close()
-		return nil, nil, fmt.Errorf("heal alarm rows: %w", err)
+		return nil, nil, fmt.Errorf("normalize alarm repeat pairs: %w", err)
 	}
 
 	return conn, q, nil
@@ -205,24 +205,25 @@ func purgeLibicalDiagnosticXProps(conn *sql.DB) error {
 	return err
 }
 
-// healAlarmRows repairs alarm rows written before the parsers validated
-// them, in one scan per table (issues #580 and #581). Two jobs:
+// normalizeAlarmRepeatPairs heals alarm rows written before the parsers
+// validated REPEAT and DURATION (issues #580 and #581). It clamps the
+// repeat count, clears an interval that fails model.ValidAlarmDuration,
+// and clears an unpaired value. Without this repair, export and the
+// next pull disagree with the stored row. The mismatch deletes and
+// recreates the alarm row, and the cascade discards the alarm state.
 //
-//   - It heals REPEAT and DURATION. It clamps the repeat count, clears
-//     an interval that fails model.ValidAlarmDuration, and clears an
-//     unpaired value. Without this repair, export and the next pull
-//     disagree with the stored row. The mismatch deletes and recreates
-//     the alarm row, and the cascade discards the alarm state.
-//   - It deletes a row whose trigger_value fails
-//     model.ParseableAlarmTrigger. Such a row is dead weight: the fire
-//     path cannot read it and export already omits its VALARM, so it
-//     only makes the push and the local store disagree in silence.
+// The pass does not delete a row whose trigger_value fails
+// model.ParseableAlarmTrigger. Such a row is inert: the fire path
+// cannot read it and export omits its VALARM. A delete would cascade
+// away the alarm state. It could not reach the server, because nothing
+// marks the resource dirty. It would also destroy an RFC-valid trigger
+// from another client that only this build cannot represent.
 //
 // The writes for each table run in one transaction, like
 // backfillAlarmUIDs, and a failure is fatal to Open, like every startup
 // pass here. The function runs on every startup. It changes nothing
 // when all rows are healthy.
-func healAlarmRows(conn *sql.DB) error {
+func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 	ctx := context.Background()
 	for _, table := range []string{"event_alarms", "todo_alarms"} {
 		type fix struct {
@@ -231,10 +232,10 @@ func healAlarmRows(conn *sql.DB) error {
 			duration string
 		}
 		var fixes []fix
-		var dead []int64
 		err := func() error {
 			rows, err := conn.QueryContext(ctx,
-				`SELECT id, repeat, COALESCE(duration, ''), trigger_value FROM `+table)
+				`SELECT id, repeat, COALESCE(duration, '') FROM `+table+
+					` WHERE repeat > 0 OR COALESCE(duration, '') != ''`)
 			if err != nil {
 				return err
 			}
@@ -242,12 +243,8 @@ func healAlarmRows(conn *sql.DB) error {
 			for rows.Next() {
 				var id int64
 				var a model.Alarm
-				if err := rows.Scan(&id, &a.Repeat, &a.Duration, &a.TriggerValue); err != nil {
+				if err := rows.Scan(&id, &a.Repeat, &a.Duration); err != nil {
 					return err
-				}
-				if !model.ParseableAlarmTrigger(a.TriggerValue) {
-					dead = append(dead, id)
-					continue
 				}
 				healed := a
 				healed.Repeat = min(healed.Repeat, model.MaxAlarmRepeat)
@@ -266,7 +263,7 @@ func healAlarmRows(conn *sql.DB) error {
 		if err != nil {
 			return fmt.Errorf("scan %s: %w", table, err)
 		}
-		if len(fixes) == 0 && len(dead) == 0 {
+		if len(fixes) == 0 {
 			continue
 		}
 		tx, err := conn.BeginTx(ctx, nil)
@@ -279,13 +276,6 @@ func healAlarmRows(conn *sql.DB) error {
 				f.repeat, f.duration, f.id); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("heal %s row %d: %w", table, f.id, err)
-			}
-		}
-		for _, id := range dead {
-			if _, err := tx.ExecContext(ctx,
-				`DELETE FROM `+table+` WHERE id = ?`, id); err != nil {
-				tx.Rollback()
-				return fmt.Errorf("purge %s row %d: %w", table, id, err)
 			}
 		}
 		if err := tx.Commit(); err != nil {

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -12,7 +12,6 @@ import (
 	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
 
 	"github.com/douglasdemoura/chroncal/db"
-	"github.com/douglasdemoura/chroncal/internal/duration"
 	"github.com/douglasdemoura/chroncal/internal/fileid"
 	"github.com/douglasdemoura/chroncal/internal/model"
 )
@@ -68,13 +67,9 @@ func Open(dbPath string) (*sql.DB, *Queries, error) {
 		conn.Close()
 		return nil, nil, fmt.Errorf("purge libical diagnostic x-props: %w", err)
 	}
-	if err := normalizeAlarmRepeatPairs(conn); err != nil {
+	if err := healAlarmRows(conn); err != nil {
 		conn.Close()
-		return nil, nil, fmt.Errorf("normalize alarm repeat pairs: %w", err)
-	}
-	if err := purgeInvalidAlarmTriggers(conn); err != nil {
-		conn.Close()
-		return nil, nil, fmt.Errorf("purge invalid alarm triggers: %w", err)
+		return nil, nil, fmt.Errorf("heal alarm rows: %w", err)
 	}
 
 	return conn, q, nil
@@ -210,14 +205,24 @@ func purgeLibicalDiagnosticXProps(conn *sql.DB) error {
 	return err
 }
 
-// normalizeAlarmRepeatPairs heals alarm rows written before the parsers
-// validated REPEAT and DURATION (issue #580). It clamps the repeat count.
-// It clears an interval that fails model.ValidAlarmDuration. It clears an
-// unpaired REPEAT or DURATION. Without this repair, export and the next
-// pull disagree with the stored row: the mismatch deletes and recreates
-// the alarm row, and the cascade discards the alarm state. The function
-// runs on every startup. It changes nothing when all rows are normal.
-func normalizeAlarmRepeatPairs(conn *sql.DB) error {
+// healAlarmRows repairs alarm rows written before the parsers validated
+// them, in one scan per table (issues #580 and #581). Two jobs:
+//
+//   - It heals REPEAT and DURATION. It clamps the repeat count, clears
+//     an interval that fails model.ValidAlarmDuration, and clears an
+//     unpaired value. Without this repair, export and the next pull
+//     disagree with the stored row. The mismatch deletes and recreates
+//     the alarm row, and the cascade discards the alarm state.
+//   - It deletes a row whose trigger_value fails
+//     model.ParseableAlarmTrigger. Such a row is dead weight: the fire
+//     path cannot read it and export already omits its VALARM, so it
+//     only makes the push and the local store disagree in silence.
+//
+// The writes for each table run in one transaction, like
+// backfillAlarmUIDs, and a failure is fatal to Open, like every startup
+// pass here. The function runs on every startup. It changes nothing
+// when all rows are healthy.
+func healAlarmRows(conn *sql.DB) error {
 	ctx := context.Background()
 	for _, table := range []string{"event_alarms", "todo_alarms"} {
 		type fix struct {
@@ -226,10 +231,10 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 			duration string
 		}
 		var fixes []fix
+		var dead []int64
 		err := func() error {
 			rows, err := conn.QueryContext(ctx,
-				`SELECT id, repeat, COALESCE(duration, '') FROM `+table+
-					` WHERE repeat > 0 OR COALESCE(duration, '') != ''`)
+				`SELECT id, repeat, COALESCE(duration, ''), trigger_value FROM `+table)
 			if err != nil {
 				return err
 			}
@@ -237,12 +242,16 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 			for rows.Next() {
 				var id int64
 				var a model.Alarm
-				if err := rows.Scan(&id, &a.Repeat, &a.Duration); err != nil {
+				if err := rows.Scan(&id, &a.Repeat, &a.Duration, &a.TriggerValue); err != nil {
 					return err
+				}
+				if !model.ParseableAlarmTrigger(a.TriggerValue) {
+					dead = append(dead, id)
+					continue
 				}
 				healed := a
 				healed.Repeat = min(healed.Repeat, model.MaxAlarmRepeat)
-				if !model.ValidAlarmDuration(healed.Duration) {
+				if healed.Duration != "" && !model.ValidAlarmDuration(healed.Duration) {
 					healed.Duration = ""
 				}
 				if !healed.RepeatPaired() {
@@ -257,58 +266,30 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 		if err != nil {
 			return fmt.Errorf("scan %s: %w", table, err)
 		}
+		if len(fixes) == 0 && len(dead) == 0 {
+			continue
+		}
+		tx, err := conn.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("heal %s: %w", table, err)
+		}
 		for _, f := range fixes {
-			if _, err := conn.ExecContext(ctx,
+			if _, err := tx.ExecContext(ctx,
 				`UPDATE `+table+` SET repeat = ?, duration = NULLIF(?, '') WHERE id = ?`,
 				f.repeat, f.duration, f.id); err != nil {
+				tx.Rollback()
 				return fmt.Errorf("heal %s row %d: %w", table, f.id, err)
 			}
 		}
-	}
-	return nil
-}
-
-// purgeInvalidAlarmTriggers deletes alarm rows with a duration-shaped
-// trigger_value that fails duration.Validate (issue #581). Validate
-// accepted an out-of-range duration before it had a range check, so old
-// rows can hold one. The alarm engine cannot fire such a row, and
-// buildValarm refuses to export it. The dead row would make the push
-// and the local store disagree in silence. An absolute trigger does not
-// start with '-', '+', or 'P', so this pass never touches it. The
-// function runs on every startup. It changes nothing when all rows are
-// valid.
-func purgeInvalidAlarmTriggers(conn *sql.DB) error {
-	ctx := context.Background()
-	for _, table := range []string{"event_alarms", "todo_alarms"} {
-		var dead []int64
-		err := func() error {
-			rows, err := conn.QueryContext(ctx,
-				`SELECT id, trigger_value FROM `+table+
-					` WHERE substr(trigger_value, 1, 1) IN ('-', '+', 'P')`)
-			if err != nil {
-				return err
-			}
-			defer rows.Close()
-			for rows.Next() {
-				var id int64
-				var trigger string
-				if err := rows.Scan(&id, &trigger); err != nil {
-					return err
-				}
-				if duration.Validate(trigger) != nil {
-					dead = append(dead, id)
-				}
-			}
-			return rows.Err()
-		}()
-		if err != nil {
-			return fmt.Errorf("scan %s: %w", table, err)
-		}
 		for _, id := range dead {
-			if _, err := conn.ExecContext(ctx,
+			if _, err := tx.ExecContext(ctx,
 				`DELETE FROM `+table+` WHERE id = ?`, id); err != nil {
+				tx.Rollback()
 				return fmt.Errorf("purge %s row %d: %w", table, id, err)
 			}
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("heal %s: %w", table, err)
 		}
 	}
 	return nil

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -12,7 +12,6 @@ import (
 	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
 
 	"github.com/douglasdemoura/chroncal/db"
-	"github.com/douglasdemoura/chroncal/internal/duration"
 	"github.com/douglasdemoura/chroncal/internal/fileid"
 	"github.com/douglasdemoura/chroncal/internal/model"
 )
@@ -72,11 +71,6 @@ func Open(dbPath string) (*sql.DB, *Queries, error) {
 		conn.Close()
 		return nil, nil, fmt.Errorf("normalize alarm repeat pairs: %w", err)
 	}
-	if err := clearInvalidSpanColumns(conn); err != nil {
-		conn.Close()
-		return nil, nil, fmt.Errorf("clear invalid span columns: %w", err)
-	}
-
 	return conn, q, nil
 }
 
@@ -255,7 +249,7 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 				}
 				healed := a
 				healed.Repeat = min(healed.Repeat, model.MaxAlarmRepeat)
-				if healed.Duration != "" && !model.ValidAlarmDuration(healed.Duration) {
+				if !model.ValidAlarmDuration(healed.Duration) {
 					healed.Duration = ""
 				}
 				if !healed.RepeatPaired() {
@@ -287,70 +281,6 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 		}
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("heal %s: %w", table, err)
-		}
-	}
-	return nil
-}
-
-// clearInvalidSpanColumns heals span columns written before the parsers
-// validated them with duration.ValidateSpan (issue #581). It clears an
-// events.duration or a todos.duration that fails the span rule.
-// The clear is safe: end_time and due stay authoritative, and an
-// invalid span never had a usable meaning. Without this repair, a
-// legacy negative or malformed value blocks every later edit at the
-// service boundary and can reach the server on a push. The function
-// runs on every startup. It changes nothing when all rows are healthy.
-func clearInvalidSpanColumns(conn *sql.DB) error {
-	ctx := context.Background()
-	specs := []struct {
-		table  string
-		column string
-	}{
-		{"events", "duration"},
-		{"todos", "duration"},
-	}
-	for _, spec := range specs {
-		var ids []int64
-		err := func() error {
-			rows, err := conn.QueryContext(ctx,
-				`SELECT id, `+spec.column+` FROM `+spec.table+
-					` WHERE COALESCE(`+spec.column+`, '') != ''`)
-			if err != nil {
-				return err
-			}
-			defer rows.Close()
-			for rows.Next() {
-				var id int64
-				var span string
-				if err := rows.Scan(&id, &span); err != nil {
-					return err
-				}
-				if duration.ValidateSpan(span) != nil {
-					ids = append(ids, id)
-				}
-			}
-			return rows.Err()
-		}()
-		if err != nil {
-			return fmt.Errorf("scan %s: %w", spec.table, err)
-		}
-		if len(ids) == 0 {
-			continue
-		}
-		tx, err := conn.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("heal %s: %w", spec.table, err)
-		}
-		for _, id := range ids {
-			if _, err := tx.ExecContext(ctx,
-				`UPDATE `+spec.table+` SET `+spec.column+` = NULL WHERE id = ?`,
-				id); err != nil {
-				tx.Rollback()
-				return fmt.Errorf("heal %s row %d: %w", spec.table, id, err)
-			}
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("heal %s: %w", spec.table, err)
 		}
 	}
 	return nil
@@ -403,17 +333,29 @@ func backfillAlarmUIDs(conn *sql.DB, q *Queries) error {
 	return nil
 }
 
-func runMigrations(conn *sql.DB) error {
+// NewMigrationProvider builds the goose provider over the embedded SQL
+// migrations plus every Go migration. Production and the tests share it,
+// so a provider cannot miss a Go migration and then report an applied
+// version it does not know.
+func NewMigrationProvider(conn *sql.DB) (*goose.Provider, error) {
 	migrationsFS, err := fs.Sub(db.Migrations, "migrations")
 	if err != nil {
-		return fmt.Errorf("sub migrations fs: %w", err)
+		return nil, fmt.Errorf("sub migrations fs: %w", err)
 	}
-	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS)
+	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS,
+		goose.WithGoMigrations(newSpanColumnMigration()))
 	if err != nil {
-		return fmt.Errorf("create goose provider: %w", err)
+		return nil, fmt.Errorf("create goose provider: %w", err)
 	}
-	_, err = provider.Up(context.Background())
+	return provider, nil
+}
+
+func runMigrations(conn *sql.DB) error {
+	provider, err := NewMigrationProvider(conn)
 	if err != nil {
+		return err
+	}
+	if _, err := provider.Up(context.Background()); err != nil {
 		return fmt.Errorf("apply migrations: %w", err)
 	}
 	return nil

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -12,6 +12,7 @@ import (
 	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
 
 	"github.com/douglasdemoura/chroncal/db"
+	"github.com/douglasdemoura/chroncal/internal/duration"
 	"github.com/douglasdemoura/chroncal/internal/fileid"
 	"github.com/douglasdemoura/chroncal/internal/model"
 )
@@ -70,6 +71,10 @@ func Open(dbPath string) (*sql.DB, *Queries, error) {
 	if err := normalizeAlarmRepeatPairs(conn); err != nil {
 		conn.Close()
 		return nil, nil, fmt.Errorf("normalize alarm repeat pairs: %w", err)
+	}
+	if err := purgeInvalidAlarmTriggers(conn); err != nil {
+		conn.Close()
+		return nil, nil, fmt.Errorf("purge invalid alarm triggers: %w", err)
 	}
 
 	return conn, q, nil
@@ -257,6 +262,52 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 				`UPDATE `+table+` SET repeat = ?, duration = NULLIF(?, '') WHERE id = ?`,
 				f.repeat, f.duration, f.id); err != nil {
 				return fmt.Errorf("heal %s row %d: %w", table, f.id, err)
+			}
+		}
+	}
+	return nil
+}
+
+// purgeInvalidAlarmTriggers deletes alarm rows with a duration-shaped
+// trigger_value that fails duration.Validate (issue #581). Validate
+// accepted an out-of-range duration before it had a range check, so old
+// rows can hold one. The alarm engine cannot fire such a row, and
+// buildValarm refuses to export it. The dead row would make the push
+// and the local store disagree in silence. An absolute trigger does not
+// start with '-', '+', or 'P', so this pass never touches it. The
+// function runs on every startup. It changes nothing when all rows are
+// valid.
+func purgeInvalidAlarmTriggers(conn *sql.DB) error {
+	ctx := context.Background()
+	for _, table := range []string{"event_alarms", "todo_alarms"} {
+		var dead []int64
+		err := func() error {
+			rows, err := conn.QueryContext(ctx,
+				`SELECT id, trigger_value FROM `+table+
+					` WHERE substr(trigger_value, 1, 1) IN ('-', '+', 'P')`)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var id int64
+				var trigger string
+				if err := rows.Scan(&id, &trigger); err != nil {
+					return err
+				}
+				if duration.Validate(trigger) != nil {
+					dead = append(dead, id)
+				}
+			}
+			return rows.Err()
+		}()
+		if err != nil {
+			return fmt.Errorf("scan %s: %w", table, err)
+		}
+		for _, id := range dead {
+			if _, err := conn.ExecContext(ctx,
+				`DELETE FROM `+table+` WHERE id = ?`, id); err != nil {
+				return fmt.Errorf("purge %s row %d: %w", table, id, err)
 			}
 		}
 	}

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -12,6 +12,7 @@ import (
 	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
 
 	"github.com/douglasdemoura/chroncal/db"
+	"github.com/douglasdemoura/chroncal/internal/duration"
 	"github.com/douglasdemoura/chroncal/internal/fileid"
 	"github.com/douglasdemoura/chroncal/internal/model"
 )
@@ -70,6 +71,10 @@ func Open(dbPath string) (*sql.DB, *Queries, error) {
 	if err := normalizeAlarmRepeatPairs(conn); err != nil {
 		conn.Close()
 		return nil, nil, fmt.Errorf("normalize alarm repeat pairs: %w", err)
+	}
+	if err := clearInvalidSpanColumns(conn); err != nil {
+		conn.Close()
+		return nil, nil, fmt.Errorf("clear invalid span columns: %w", err)
 	}
 
 	return conn, q, nil
@@ -215,9 +220,11 @@ func purgeLibicalDiagnosticXProps(conn *sql.DB) error {
 // The pass does not delete a row whose trigger_value fails
 // model.ParseableAlarmTrigger. Such a row is inert: the fire path
 // cannot read it and export omits its VALARM. A delete would cascade
-// away the alarm state. It could not reach the server, because nothing
-// marks the resource dirty. It would also destroy an RFC-valid trigger
-// from another client that only this build cannot represent.
+// away the alarm state. It would also destroy an RFC-valid trigger
+// from another client that only this build cannot represent. The keep
+// decision protects only the local row and its state. The next push of
+// that resource still omits the VALARM, so the server copy can lose
+// the alarm through an ordinary edit.
 //
 // The writes for each table run in one transaction, like
 // backfillAlarmUIDs, and a failure is fatal to Open, like every startup
@@ -280,6 +287,70 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 		}
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("heal %s: %w", table, err)
+		}
+	}
+	return nil
+}
+
+// clearInvalidSpanColumns heals span columns written before the parsers
+// validated them with duration.ValidateSpan (issue #581). It clears an
+// events.duration or a todos.duration that fails the span rule.
+// The clear is safe: end_time and due stay authoritative, and an
+// invalid span never had a usable meaning. Without this repair, a
+// legacy negative or malformed value blocks every later edit at the
+// service boundary and can reach the server on a push. The function
+// runs on every startup. It changes nothing when all rows are healthy.
+func clearInvalidSpanColumns(conn *sql.DB) error {
+	ctx := context.Background()
+	specs := []struct {
+		table  string
+		column string
+	}{
+		{"events", "duration"},
+		{"todos", "duration"},
+	}
+	for _, spec := range specs {
+		var ids []int64
+		err := func() error {
+			rows, err := conn.QueryContext(ctx,
+				`SELECT id, `+spec.column+` FROM `+spec.table+
+					` WHERE COALESCE(`+spec.column+`, '') != ''`)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var id int64
+				var span string
+				if err := rows.Scan(&id, &span); err != nil {
+					return err
+				}
+				if duration.ValidateSpan(span) != nil {
+					ids = append(ids, id)
+				}
+			}
+			return rows.Err()
+		}()
+		if err != nil {
+			return fmt.Errorf("scan %s: %w", spec.table, err)
+		}
+		if len(ids) == 0 {
+			continue
+		}
+		tx, err := conn.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("heal %s: %w", spec.table, err)
+		}
+		for _, id := range ids {
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE `+spec.table+` SET `+spec.column+` = NULL WHERE id = ?`,
+				id); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("heal %s row %d: %w", spec.table, id, err)
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("heal %s: %w", spec.table, err)
 		}
 	}
 	return nil

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -254,10 +254,10 @@ func TestOpen_ForeignKeys(t *testing.T) {
 	}
 }
 
-// normalizeAlarmRepeatPairs must heal rows written before the parsers
-// validated REPEAT and DURATION: clamp the count, clear a bad interval,
-// clear an unpaired value, and leave normal rows alone (issue #580).
-func TestNormalizeAlarmRepeatPairs(t *testing.T) {
+// healAlarmRows must heal rows written before the parsers validated
+// REPEAT and DURATION: clamp the count, clear a bad interval, clear an
+// unpaired value, and leave normal rows alone (issue #580).
+func TestHealAlarmRows_NormalizesRepeatPairs(t *testing.T) {
 	db, q, err := Open(":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -302,8 +302,8 @@ func TestNormalizeAlarmRepeatPairs(t *testing.T) {
 		ids[i], _ = res.LastInsertId()
 	}
 
-	if err := normalizeAlarmRepeatPairs(db); err != nil {
-		t.Fatalf("normalizeAlarmRepeatPairs: %v", err)
+	if err := healAlarmRows(db); err != nil {
+		t.Fatalf("healAlarmRows: %v", err)
 	}
 
 	for i, r := range rows {
@@ -321,10 +321,11 @@ func TestNormalizeAlarmRepeatPairs(t *testing.T) {
 	}
 }
 
-// purgeInvalidAlarmTriggers must delete an alarm row with an out-of-range
-// duration trigger_value. It must keep a valid duration trigger. It must
-// never touch an absolute trigger (issue #581).
-func TestPurgeInvalidAlarmTriggers(t *testing.T) {
+// healAlarmRows must delete an alarm row whose trigger_value fails
+// model.ParseableAlarmTrigger: an out-of-range duration, a malformed
+// duration, a bare number, an empty value, or an invalid absolute time.
+// It must keep every readable trigger (issues #581 and #582 round 2).
+func TestHealAlarmRows_PurgesDeadTriggers(t *testing.T) {
 	db, q, err := Open(":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -348,10 +349,14 @@ func TestPurgeInvalidAlarmTriggers(t *testing.T) {
 		trigger  string
 		survives bool
 	}{
-		{"PT5124096H", false},      // over the ceiling; Validate accepted it before the range check
-		{"-PT15M", true},           // valid duration
-		{"20260401T100000Z", true}, // absolute trigger, not duration-shaped
-		{"P", false},               // malformed duration shape
+		{"PT5124096H", false},       // over the ceiling; Validate accepted it before the range check
+		{"-PT15M", true},            // valid duration
+		{"20260401T100000Z", true},  // absolute compact UTC trigger
+		{"20260401T100000", true},   // absolute compact floating trigger
+		{"P", false},                // malformed duration shape
+		{"15M", false},              // legacy raw value; export omits it, the engine cannot read it
+		{"", false},                 // empty; the alarm could never fire
+		{"20261301T250000Z", false}, // absolute shape that fails every layout
 	}
 	ids := make([]int64, len(rows))
 	for i, r := range rows {
@@ -364,8 +369,8 @@ func TestPurgeInvalidAlarmTriggers(t *testing.T) {
 		ids[i], _ = res.LastInsertId()
 	}
 
-	if err := purgeInvalidAlarmTriggers(db); err != nil {
-		t.Fatalf("purgeInvalidAlarmTriggers: %v", err)
+	if err := healAlarmRows(db); err != nil {
+		t.Fatalf("healAlarmRows: %v", err)
 	}
 
 	for i, r := range rows {

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -382,10 +382,12 @@ func TestNormalizeAlarmRepeatPairs_KeepsUnreadableTriggers(t *testing.T) {
 	}
 }
 
-// clearInvalidSpanColumns must clear a legacy events.duration or
+// The span-column migration must clear a legacy events.duration or
 // todos.duration that fails the span rule, and keep valid values. The
 // clear unblocks every later edit of the row (issue #582 round 4).
-func TestClearInvalidSpanColumns(t *testing.T) {
+// The test drives the migration function directly, because Open runs
+// it once per database and a fresh database holds no legacy row.
+func TestHealSpanColumns(t *testing.T) {
 	db, q, err := Open(":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -430,8 +432,16 @@ func TestClearInvalidSpanColumns(t *testing.T) {
 		todoIDs[i], _ = res.LastInsertId()
 	}
 
-	if err := clearInvalidSpanColumns(db); err != nil {
-		t.Fatalf("clearInvalidSpanColumns: %v", err)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := healSpanColumnsTx(ctx, tx); err != nil {
+		tx.Rollback()
+		t.Fatalf("healSpanColumnsTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
 	}
 
 	for i, r := range rows {

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -377,6 +378,75 @@ func TestNormalizeAlarmRepeatPairs_KeepsUnreadableTriggers(t *testing.T) {
 		}
 		if n != 1 {
 			t.Errorf("row %d (%q): deleted; every row must survive", i, trigger)
+		}
+	}
+}
+
+// clearInvalidSpanColumns must clear a legacy events.duration or
+// todos.duration that fails the span rule, and keep valid values. The
+// clear unblocks every later edit of the row (issue #582 round 4).
+func TestClearInvalidSpanColumns(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("list calendars: %v", err)
+	}
+	calID := cals[0].ID
+
+	rows := []struct {
+		span string
+		want string // "" = cleared
+	}{
+		{"-PT1H", ""},      // negative span
+		{"PT0S", ""},       // zero span
+		{"5 minutes", ""},  // malformed
+		{"PT5124096H", ""}, // over the range ceiling
+		{"PT1H", "PT1H"},   // valid span stays
+	}
+
+	eventIDs := make([]int64, len(rows))
+	todoIDs := make([]int64, len(rows))
+	for i, r := range rows {
+		res, err := db.Exec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time, all_day, status, transp, sequence, priority, duration)
+			 VALUES (?, ?, 'Test', '2026-04-01T00:00:00Z', '2026-04-01T01:00:00Z', 0, 'CONFIRMED', 'OPAQUE', 0, 0, ?)`,
+			fmt.Sprintf("span-event-%d", i), calID, r.span)
+		if err != nil {
+			t.Fatalf("insert event %d: %v", i, err)
+		}
+		eventIDs[i], _ = res.LastInsertId()
+
+		res, err = db.Exec(`INSERT INTO todos (uid, calendar_id, summary, status, priority, sequence, start_date, duration)
+			 VALUES (?, ?, 'Test', 'NEEDS-ACTION', 0, 0, '2026-04-01T00:00:00Z', ?)`,
+			fmt.Sprintf("span-todo-%d", i), calID, r.span)
+		if err != nil {
+			t.Fatalf("insert todo %d: %v", i, err)
+		}
+		todoIDs[i], _ = res.LastInsertId()
+	}
+
+	if err := clearInvalidSpanColumns(db); err != nil {
+		t.Fatalf("clearInvalidSpanColumns: %v", err)
+	}
+
+	for i, r := range rows {
+		var eventSpan, todoSpan string
+		if err := db.QueryRow(`SELECT COALESCE(duration, '') FROM events WHERE id = ?`, eventIDs[i]).Scan(&eventSpan); err != nil {
+			t.Fatalf("read event %d: %v", i, err)
+		}
+		if err := db.QueryRow(`SELECT COALESCE(duration, '') FROM todos WHERE id = ?`, todoIDs[i]).Scan(&todoSpan); err != nil {
+			t.Fatalf("read todo %d: %v", i, err)
+		}
+		if eventSpan != r.want {
+			t.Errorf("event %d (%q): duration = %q, want %q", i, r.span, eventSpan, r.want)
+		}
+		if todoSpan != r.want {
+			t.Errorf("todo %d (%q): duration = %q, want %q", i, r.span, todoSpan, r.want)
 		}
 	}
 }

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -254,10 +254,10 @@ func TestOpen_ForeignKeys(t *testing.T) {
 	}
 }
 
-// healAlarmRows must heal rows written before the parsers validated
-// REPEAT and DURATION: clamp the count, clear a bad interval, clear an
-// unpaired value, and leave normal rows alone (issue #580).
-func TestHealAlarmRows_NormalizesRepeatPairs(t *testing.T) {
+// normalizeAlarmRepeatPairs must heal rows written before the parsers
+// validated REPEAT and DURATION: clamp the count, clear a bad interval,
+// clear an unpaired value, and leave normal rows alone (issue #580).
+func TestNormalizeAlarmRepeatPairs(t *testing.T) {
 	db, q, err := Open(":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -302,8 +302,8 @@ func TestHealAlarmRows_NormalizesRepeatPairs(t *testing.T) {
 		ids[i], _ = res.LastInsertId()
 	}
 
-	if err := healAlarmRows(db); err != nil {
-		t.Fatalf("healAlarmRows: %v", err)
+	if err := normalizeAlarmRepeatPairs(db); err != nil {
+		t.Fatalf("normalizeAlarmRepeatPairs: %v", err)
 	}
 
 	for i, r := range rows {
@@ -321,11 +321,12 @@ func TestHealAlarmRows_NormalizesRepeatPairs(t *testing.T) {
 	}
 }
 
-// healAlarmRows must delete an alarm row whose trigger_value fails
-// model.ParseableAlarmTrigger: an out-of-range duration, a malformed
-// duration, a bare number, an empty value, or an invalid absolute time.
-// It must keep every readable trigger (issues #581 and #582 round 2).
-func TestHealAlarmRows_PurgesDeadTriggers(t *testing.T) {
+// normalizeAlarmRepeatPairs must not delete an alarm row, whatever its
+// trigger_value holds. An unreadable trigger is inert: the fire path
+// skips it and export omits its VALARM. A delete would cascade away the
+// alarm state and destroy an RFC-valid trigger from another client.
+// This test pins the deliberate keep decision (issue #582 round 3).
+func TestNormalizeAlarmRepeatPairs_KeepsUnreadableTriggers(t *testing.T) {
 	db, q, err := Open(":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -345,41 +346,37 @@ func TestHealAlarmRows_PurgesDeadTriggers(t *testing.T) {
 	}
 	eventID, _ := res.LastInsertId()
 
-	rows := []struct {
-		trigger  string
-		survives bool
-	}{
-		{"PT5124096H", false},       // over the ceiling; Validate accepted it before the range check
-		{"-PT15M", true},            // valid duration
-		{"20260401T100000Z", true},  // absolute compact UTC trigger
-		{"20260401T100000", true},   // absolute compact floating trigger
-		{"P", false},                // malformed duration shape
-		{"15M", false},              // legacy raw value; export omits it, the engine cannot read it
-		{"", false},                 // empty; the alarm could never fire
-		{"20261301T250000Z", false}, // absolute shape that fails every layout
+	triggers := []string{
+		"PT5124096H",       // over the ceiling; Validate accepted it before the range check
+		"-PT15M",           // valid duration
+		"20260401T100000Z", // absolute compact UTC trigger
+		"P",                // malformed duration shape
+		"15M",              // legacy raw value
+		"",                 // empty
+		"20261301T250000Z", // absolute shape that fails every layout
 	}
-	ids := make([]int64, len(rows))
-	for i, r := range rows {
+	ids := make([]int64, len(triggers))
+	for i, trigger := range triggers {
 		res, err := db.Exec(
 			`INSERT INTO event_alarms (event_id, action, trigger_value) VALUES (?, 'DISPLAY', ?)`,
-			eventID, r.trigger)
+			eventID, trigger)
 		if err != nil {
 			t.Fatalf("insert alarm %d: %v", i, err)
 		}
 		ids[i], _ = res.LastInsertId()
 	}
 
-	if err := healAlarmRows(db); err != nil {
-		t.Fatalf("healAlarmRows: %v", err)
+	if err := normalizeAlarmRepeatPairs(db); err != nil {
+		t.Fatalf("normalizeAlarmRepeatPairs: %v", err)
 	}
 
-	for i, r := range rows {
+	for i, trigger := range triggers {
 		var n int
 		if err := db.QueryRow(`SELECT COUNT(*) FROM event_alarms WHERE id = ?`, ids[i]).Scan(&n); err != nil {
 			t.Fatalf("count alarm %d: %v", i, err)
 		}
-		if got, want := n == 1, r.survives; got != want {
-			t.Errorf("row %d (%q): survives = %v, want %v", i, r.trigger, got, want)
+		if n != 1 {
+			t.Errorf("row %d (%q): deleted; every row must survive", i, trigger)
 		}
 	}
 }

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -320,3 +320,61 @@ func TestNormalizeAlarmRepeatPairs(t *testing.T) {
 		}
 	}
 }
+
+// purgeInvalidAlarmTriggers must delete an alarm row with an out-of-range
+// duration trigger_value. It must keep a valid duration trigger. It must
+// never touch an absolute trigger (issue #581).
+func TestPurgeInvalidAlarmTriggers(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("list calendars: %v", err)
+	}
+	calID := cals[0].ID
+	res, err := db.Exec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time, all_day, status, transp, sequence, priority)
+		 VALUES ('purge-trigger-event', ?, 'Test', '2026-04-01T00:00:00Z', '2026-04-01T01:00:00Z', 0, 'CONFIRMED', 'OPAQUE', 0, 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	eventID, _ := res.LastInsertId()
+
+	rows := []struct {
+		trigger  string
+		survives bool
+	}{
+		{"PT5124096H", false},      // over the ceiling; Validate accepted it before the range check
+		{"-PT15M", true},           // valid duration
+		{"20260401T100000Z", true}, // absolute trigger, not duration-shaped
+		{"P", false},               // malformed duration shape
+	}
+	ids := make([]int64, len(rows))
+	for i, r := range rows {
+		res, err := db.Exec(
+			`INSERT INTO event_alarms (event_id, action, trigger_value) VALUES (?, 'DISPLAY', ?)`,
+			eventID, r.trigger)
+		if err != nil {
+			t.Fatalf("insert alarm %d: %v", i, err)
+		}
+		ids[i], _ = res.LastInsertId()
+	}
+
+	if err := purgeInvalidAlarmTriggers(db); err != nil {
+		t.Fatalf("purgeInvalidAlarmTriggers: %v", err)
+	}
+
+	for i, r := range rows {
+		var n int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM event_alarms WHERE id = ?`, ids[i]).Scan(&n); err != nil {
+			t.Fatalf("count alarm %d: %v", i, err)
+		}
+		if got, want := n == 1, r.survives; got != want {
+			t.Errorf("row %d (%q): survives = %v, want %v", i, r.trigger, got, want)
+		}
+	}
+}

--- a/internal/storage/migration_043_span_columns.go
+++ b/internal/storage/migration_043_span_columns.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/douglasdemoura/chroncal/internal/duration"
+)
+
+// migration043Version matches the file name a SQL migration would carry.
+// The heal needs the Go span parser, so it is a Go migration instead of a
+// file in db/migrations.
+const migration043Version = 43
+
+// newSpanColumnMigration heals the span columns that the parsers wrote
+// before they validated a span with duration.ValidateSpan (issue #581).
+// It clears an events.duration or a todos.duration that fails the span
+// rule.
+//
+// The clear is safe. end_time and due stay authoritative, and an
+// invalid span never had a usable meaning. Without the repair, a legacy
+// negative or malformed value blocks every later edit at the service
+// boundary, and it can reach the server on a push.
+//
+// The migration runs once per database, so no startup pays for the two
+// table scans. An older binary can still write a bad span after the
+// migration runs. That window is small: the service boundary now
+// validates every write path, so only a downgrade re-opens it.
+func newSpanColumnMigration() *goose.Migration {
+	return goose.NewGoMigration(
+		migration043Version,
+		&goose.GoFunc{RunTx: healSpanColumnsTx},
+		// The Down direction restores nothing. The migration deletes no
+		// row and no column, and the cleared values were unusable.
+		&goose.GoFunc{RunTx: func(context.Context, *sql.Tx) error { return nil }},
+	)
+}
+
+func healSpanColumnsTx(ctx context.Context, tx *sql.Tx) error {
+	for _, table := range []string{"events", "todos"} {
+		var ids []int64
+		err := func() error {
+			rows, err := tx.QueryContext(ctx,
+				`SELECT id, duration FROM `+table+` WHERE COALESCE(duration, '') != ''`)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var id int64
+				var span string
+				if err := rows.Scan(&id, &span); err != nil {
+					return err
+				}
+				if duration.ValidateSpan(span) != nil {
+					ids = append(ids, id)
+				}
+			}
+			return rows.Err()
+		}()
+		if err != nil {
+			return fmt.Errorf("scan %s: %w", table, err)
+		}
+		for _, id := range ids {
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE `+table+` SET duration = NULL WHERE id = ?`, id); err != nil {
+				return fmt.Errorf("heal %s row %d: %w", table, id, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -2,12 +2,7 @@ package storage
 
 import (
 	"context"
-	"io/fs"
 	"testing"
-
-	"github.com/pressly/goose/v3"
-
-	dbembed "github.com/douglasdemoura/chroncal/db"
 )
 
 // Verifies migration 031 rolls back and re-applies cleanly (table rebuild +
@@ -44,11 +39,7 @@ func TestMigration031UpDown(t *testing.T) {
 		t.Fatalf("query seeded prop: %v", err)
 	}
 
-	migrationsFS, err := fs.Sub(dbembed.Migrations, "migrations")
-	if err != nil {
-		t.Fatalf("sub fs: %v", err)
-	}
-	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS)
+	provider, err := NewMigrationProvider(conn)
 	if err != nil {
 		t.Fatalf("provider: %v", err)
 	}
@@ -177,11 +168,7 @@ func TestMigration040UpDown(t *testing.T) {
 		t.Error("calendars.name UNIQUE constraint not enforced after Up")
 	}
 
-	migrationsFS, err := fs.Sub(dbembed.Migrations, "migrations")
-	if err != nil {
-		t.Fatalf("sub fs: %v", err)
-	}
-	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS)
+	provider, err := NewMigrationProvider(conn)
 	if err != nil {
 		t.Fatalf("provider: %v", err)
 	}
@@ -239,5 +226,54 @@ func TestMigration040UpDown(t *testing.T) {
 	}
 	if gotEventID != eventID {
 		t.Errorf("event id drifted after re-Up = %d, want %d", gotEventID, eventID)
+	}
+}
+
+// The span-column heal is a Go migration, so goose runs it once per
+// database and no startup pays for the two table scans. The test pins
+// the once-per-database contract: the version is recorded after Open,
+// and a legacy row written afterwards stays untouched by a second Up
+// (issue #582 round 5).
+func TestMigration043RunsOncePerDatabase(t *testing.T) {
+	conn, _, err := Open(t.TempDir() + "/mig043.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer conn.Close()
+	ctx := context.Background()
+
+	var applied int
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM goose_db_version WHERE version_id = ?`,
+		migration043Version).Scan(&applied); err != nil {
+		t.Fatalf("read goose version: %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("migration %d applied %d times, want 1", migration043Version, applied)
+	}
+
+	// A bad span written after the migration (an older binary could do
+	// this) must survive a second Up, which is a no-op.
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO events (uid, calendar_id, title, start_time, end_time, duration)
+		 VALUES ('post-migration', 1, 'Later', '2026-01-01T10:00:00Z', '2026-01-01T09:00:00Z', '-PT1H')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	provider, err := NewMigrationProvider(conn)
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if _, err := provider.Up(ctx); err != nil {
+		t.Fatalf("second up: %v", err)
+	}
+
+	var span string
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COALESCE(duration, '') FROM events WHERE uid = 'post-migration'`).Scan(&span); err != nil {
+		t.Fatalf("read span: %v", err)
+	}
+	if span != "-PT1H" {
+		t.Errorf("duration = %q, want the row untouched by a second Up", span)
 	}
 }

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -30,6 +30,19 @@ func AsDateOnly(t time.Time) time.Time {
 // numeric offset, since all stored times are UTC.
 const StorageTimeFormat = "2006-01-02T15:04:05Z"
 
+// MaxStorableYear is the largest year StorageTimeFormat can hold. The
+// layout writes exactly four year digits.
+const MaxStorableYear = 9999
+
+// Storable reports whether the database can hold t. The check uses the
+// UTC calendar year, because every stored time is UTC. A year outside
+// the range breaks two contracts. time.Parse rejects the string on
+// read. The value also misorders the lexicographic range queries.
+func Storable(t time.Time) bool {
+	y := t.UTC().Year()
+	return y >= 1 && y <= MaxStorableYear
+}
+
 // IsDateOnlyTime reports whether t carries the all-day (date-only) marker
 // location set by ParseTimeList and AsDateOnly, i.e. it round-trips as a
 // VALUE=DATE rather than a DATE-TIME.

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -137,3 +137,39 @@ func TestRemoveTimeFromList(t *testing.T) {
 		})
 	}
 }
+
+// The storage layout writes four year digits. Storable must reject a
+// time the database cannot read back (issue #582 round 5).
+func TestStorable(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Time
+		want bool
+	}{
+		{"a normal time", time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC), true},
+		{"the last storable year", time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC), true},
+		{"the first year past the range", time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC), false},
+		{"a year before the range", time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Storable(tt.in); got != tt.want {
+				t.Errorf("Storable(%s) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// The check must use the UTC year, because every stored time is UTC. A
+// zone west of UTC can hold a 4-digit local year whose UTC form rolls
+// into the next year.
+func TestStorable_UsesTheUTCYear(t *testing.T) {
+	loc := time.FixedZone("west", -12*3600)
+	local := time.Date(9999, 12, 31, 20, 0, 0, 0, loc) // 10000-01-01T08:00Z
+	if local.UTC().Year() != 10000 {
+		t.Fatalf("fixture UTC year = %d, want 10000", local.UTC().Year())
+	}
+	if Storable(local) {
+		t.Error("a local 4-digit year whose UTC form is 5-digit must not be storable")
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/douglasdemoura/chroncal/internal/calendaraccess"
+	"github.com/douglasdemoura/chroncal/internal/duration"
 	"github.com/douglasdemoura/chroncal/internal/hydrate"
 	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/storage"
@@ -188,6 +189,12 @@ func completedAtFor(status, completedAt string) string {
 func validateTiming(dueDate, startDate, dur string) error {
 	if dur == "" {
 		return nil
+	}
+	// The span rule closes every CLI and TUI write path at once (issue
+	// #582 round 3). The import path drops a bad value with a warning
+	// instead, so sync never reaches this error.
+	if err := duration.ValidateSpan(dur); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidTiming, err)
 	}
 	if startDate == "" {
 		return fmt.Errorf("%w: duration requires start date", ErrInvalidTiming)

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -191,8 +191,9 @@ func validateTiming(dueDate, startDate, dur string) error {
 		return nil
 	}
 	// The span rule closes every CLI and TUI write path at once (issue
-	// #582 round 3). The import path drops a bad value with a warning
-	// instead, so sync never reaches this error.
+	// #582 round 3). The import path screens the same three rules and
+	// drops the DURATION with a warning, so a server cannot fail a
+	// sync pull here (issue #582 round 5).
 	if err := duration.ValidateSpan(dur); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidTiming, err)
 	}
@@ -201,6 +202,13 @@ func validateTiming(dueDate, startDate, dur string) error {
 	}
 	if dueDate != "" {
 		return fmt.Errorf("%w: due date and duration are mutually exclusive", ErrInvalidTiming)
+	}
+	// The span must also land on a time the database can hold. See
+	// timeutil.Storable.
+	if start := timeutil.ParseDate(startDate); !start.IsZero() {
+		if end := duration.Add(start, dur); !timeutil.Storable(end) {
+			return fmt.Errorf("%w: the end time is past year %d", ErrInvalidTiming, timeutil.MaxStorableYear)
+		}
 	}
 	return nil
 }

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -195,7 +195,7 @@ func validateTiming(dueDate, startDate, dur string) error {
 	// drops the DURATION with a warning, so a server cannot fail a
 	// sync pull here (issue #582 round 5).
 	if err := duration.ValidateSpan(dur); err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidTiming, err)
+		return fmt.Errorf("%w: %w", ErrInvalidTiming, err)
 	}
 	if startDate == "" {
 		return fmt.Errorf("%w: duration requires start date", ErrInvalidTiming)

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -733,3 +733,16 @@ func TestTodoService_ReplaceAlarms_XPropertiesRoundTrip(t *testing.T) {
 		t.Fatalf("empty XProperties must clear stored rows; got %+v", alarms[0].XProperties)
 	}
 }
+
+// A span that carries the end past the storable range must fail at the
+// service boundary. The database cannot read such a time back, and the
+// value misorders the range queries (issue #582 round 5).
+func TestValidateTiming_RejectsAnUnstorableEnd(t *testing.T) {
+	if err := validateTiming("", "9999-12-01T00:00:00Z", "P365D"); err == nil {
+		t.Error("a span whose end passes the storable range must fail")
+	}
+	// The same span on a normal start stays valid.
+	if err := validateTiming("", "2026-04-01T00:00:00Z", "P365D"); err != nil {
+		t.Errorf("a storable span must pass: %v", err)
+	}
+}

--- a/internal/todo/validation_test.go
+++ b/internal/todo/validation_test.go
@@ -36,6 +36,26 @@ func TestTodoServiceUpdateRejectsDurationWithoutStartDate(t *testing.T) {
 	}
 }
 
+// The service boundary owns the span rule, so every CLI and TUI write
+// path rejects a malformed or negative duration in one place (issue
+// #582 round 3). The import path drops such a value with a warning
+// before it reaches this boundary.
+func TestTodoServiceCreateRejectsInvalidDuration(t *testing.T) {
+	svc := newTestService(t)
+
+	for _, dur := range []string{"Pjunk", "-PT1H", "PT0S", "PT5124096H"} {
+		_, err := svc.Create(context.Background(), CreateParams{
+			CalendarID: 1,
+			Summary:    "Invalid duration",
+			StartDate:  "2026-04-01",
+			Duration:   dur,
+		})
+		if !errors.Is(err, ErrInvalidTiming) {
+			t.Errorf("duration %q: expected ErrInvalidTiming, got %v", dur, err)
+		}
+	}
+}
+
 func TestTodoServiceUpsertRejectsDurationWithoutStartDate(t *testing.T) {
 	svc := newTestService(t)
 


### PR DESCRIPTION
## Summary

`internal/duration/parse` accepted unbounded component values, and `Add` multiplied hours, minutes, and seconds into `int64` nanoseconds with no overflow guard (issue #581):

- `DURATION:PT5124096H` wrapped to about +25 minutes. `model.ValidAlarmDuration` accepted it, and `buildRepeatTriggers` set repeats about 25 minutes apart instead of centuries apart.
- `PT3000000H` wrapped negative. Import dropped it, and the CLI described the well-formed positive value as not positive.

## The rule

`parse` now rejects a duration whose total is more than the `time.Duration` ceiling: `math.MaxInt64` nanoseconds (9,223,372,036 whole seconds, about 292 years). The check guards each multiply before it runs, so the arithmetic itself cannot wrap. One consistent ceiling also applies to the days and weeks components, even though `Add` moves days with `AddDate`. For the bound, a day counts as 24 hours and a week counts as 7 days. The rationale lives in the `maxSeconds` doc comment.

Every consumer of `Validate` and `Add` inherits the bound: trigger validation in `internal/ical/import.go`, `model.ValidAlarmDuration`, the alarm engine, and freebusy. `Add` keeps its contract and returns the zero time for any parse error, so `ValidAlarmDuration` is unchanged.

The parse error names the reason: `invalid duration %q: too large, the total is more than %d seconds`. The CLI repeat-duration message in `cmd/chroncal/event.go` now says "within the supported range", because a too-large value is positive and the old text misdescribed it.

## Tests

- `internal/duration`: `PT5124096H` and `PT3000000H` rejected; values at and just under the ceiling accepted (`PT9223372036S`, `PT2562047H`, `P15250W`, `P106751D`); values just above rejected; a mixed-component sum that crosses the ceiling rejected; `Add` returns the zero time for out-of-range input; all pre-existing valid values still pass.
- `internal/model`: regression test that `ValidAlarmDuration` rejects `PT5124096H` and `PT3000000H`.

No existing test used a now-rejected duration, so no test needed an update.

## Verification

- `gofmt` clean on the touched files
- `go build ./...`
- `go vet ./...`
- `go test ./...` fully green

Fixes #581
