### PR TITLE
fix(ical): preserve VALARMs with unsupported ACTION values across sync

### DIFF
--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,7 +17,6 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/alarm"
 	"github.com/douglasdemoura/chroncal/internal/app"
 	"github.com/douglasdemoura/chroncal/internal/event"
-	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/notify"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
@@ -111,12 +111,6 @@ type fireResult struct {
 // snoozed_to first affects a row and wins the claim. The loser sees claimed
 // == false. That is likewise a non-fired, non-error result.
 func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) fireResult {
-	// Refuse a preserved sync-only action (issue #579) before the claim.
-	// A claim would consume the state and record a false "fired" entry
-	// for a notification that never appears.
-	if !model.FireableAlarmAction(da.Alarm.Action) {
-		return fireResult{}
-	}
 	stateID := da.StateID
 	var markErr error
 	op := "mark-fired"
@@ -136,6 +130,9 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 		if isAlarmAlreadyClaimed(markErr) {
 			return fireResult{} // another checker already fired this alarm
 		}
+		if errors.Is(markErr, alarm.ErrNotFireable) {
+			return fireResult{} // a sync pull disabled this alarm (issue #579)
+		}
 		fmt.Fprintf(os.Stderr, "chroncal: %s error: event=%q: %v\n", op, safeText(da.Event.Title), markErr)
 		return fireResult{StateID: stateID, MarkErr: markErr}
 	}
@@ -150,11 +147,6 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 
 // markAndFireTodoAlarm is the todo counterpart of markAndFireEventAlarm.
 func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlarm, policy alarmExecutionPolicy) fireResult {
-	// Same sync-only refusal as markAndFireEventAlarm; see the comment
-	// there.
-	if !model.FireableAlarmAction(tda.Alarm.Action) {
-		return fireResult{}
-	}
 	stateID := tda.StateID
 	var markErr error
 	op := "mark-fired"
@@ -173,6 +165,9 @@ func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlar
 	if markErr != nil {
 		if isAlarmAlreadyClaimed(markErr) {
 			return fireResult{} // another checker already fired this alarm
+		}
+		if errors.Is(markErr, alarm.ErrNotFireable) {
+			return fireResult{} // a sync pull disabled this alarm (issue #579)
 		}
 		fmt.Fprintf(os.Stderr, "chroncal: %s error: todo=%q: %v\n", op, safeText(tda.Todo.Summary), markErr)
 		return fireResult{StateID: stateID, MarkErr: markErr}

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/alarm"
 	"github.com/douglasdemoura/chroncal/internal/app"
 	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/notify"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
@@ -50,6 +51,14 @@ var fireAlarmFn = fireAlarm
 // post-trigger notifications. The alarm check loop generates separate
 // trigger times for each repeat, each tracked independently via alarm state.
 func fireAlarm(da alarm.DueAlarm, policy alarmExecutionPolicy) error {
+	// Defense in depth for a preserved sync-only action (issue #579):
+	// Check already skips it, so this arm is normally dead. Dispatch
+	// nothing and report no error. A DISPLAY fallback here would show a
+	// reminder the user disabled (ACTION:NONE) or one that belongs to
+	// another client.
+	if !model.FireableAlarmAction(da.Alarm.Action) {
+		return nil
+	}
 	switch da.Alarm.Action {
 	case "AUDIO":
 		if err := notify.Audio(da, policy.notifyPolicy()); err != nil {

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -62,12 +62,11 @@ func fireAlarm(da alarm.DueAlarm, policy alarmExecutionPolicy) error {
 			return notify.Display(da)
 		}
 		return nil
-	case "DISPLAY":
-		return notify.Display(da)
 	}
-	// A preserved sync-only action (issue #579): dispatch nothing. The
-	// callers refuse the claim first, so this arm is defense in depth.
-	return nil
+	// DISPLAY, and the safety net: a fireable action with no dispatch arm
+	// still shows a notification. A sync-only action cannot reach this
+	// function — the mark helpers refuse it before the claim.
+	return notify.Display(da)
 }
 
 // isAlarmAlreadyClaimed reports whether err is the SQLite UNIQUE-constraint
@@ -151,9 +150,8 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 
 // markAndFireTodoAlarm is the todo counterpart of markAndFireEventAlarm.
 func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlarm, policy alarmExecutionPolicy) fireResult {
-	// Refuse a preserved sync-only action (issue #579) before the claim.
-	// A claim would consume the state and record a false "fired" entry
-	// for a notification that never appears.
+	// Same sync-only refusal as markAndFireEventAlarm; see the comment
+	// there.
 	if !model.FireableAlarmAction(tda.Alarm.Action) {
 		return fireResult{}
 	}

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -63,7 +63,7 @@ func fireAlarm(da alarm.DueAlarm, policy alarmExecutionPolicy) error {
 		}
 		return nil
 	}
-	// DISPLAY, and the safety net: a fireable action with no dispatch arm
+	// DISPLAY, and the fallback: a fireable action with no dispatch arm
 	// still shows a notification. A sync-only action cannot reach this
 	// function — the mark helpers refuse it before the claim.
 	return notify.Display(da)

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -51,14 +51,6 @@ var fireAlarmFn = fireAlarm
 // post-trigger notifications. The alarm check loop generates separate
 // trigger times for each repeat, each tracked independently via alarm state.
 func fireAlarm(da alarm.DueAlarm, policy alarmExecutionPolicy) error {
-	// Defense in depth for a preserved sync-only action (issue #579):
-	// Check already skips it, so this arm is normally dead. Dispatch
-	// nothing and report no error. A DISPLAY fallback here would show a
-	// reminder the user disabled (ACTION:NONE) or one that belongs to
-	// another client.
-	if !model.FireableAlarmAction(da.Alarm.Action) {
-		return nil
-	}
 	switch da.Alarm.Action {
 	case "AUDIO":
 		if err := notify.Audio(da, policy.notifyPolicy()); err != nil {
@@ -70,9 +62,12 @@ func fireAlarm(da alarm.DueAlarm, policy alarmExecutionPolicy) error {
 			return notify.Display(da)
 		}
 		return nil
-	default: // DISPLAY and unknown
+	case "DISPLAY":
 		return notify.Display(da)
 	}
+	// A preserved sync-only action (issue #579): dispatch nothing. The
+	// callers refuse the claim first, so this arm is defense in depth.
+	return nil
 }
 
 // isAlarmAlreadyClaimed reports whether err is the SQLite UNIQUE-constraint
@@ -117,6 +112,12 @@ type fireResult struct {
 // snoozed_to first affects a row and wins the claim. The loser sees claimed
 // == false. That is likewise a non-fired, non-error result.
 func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) fireResult {
+	// Refuse a preserved sync-only action (issue #579) before the claim.
+	// A claim would consume the state and record a false "fired" entry
+	// for a notification that never appears.
+	if !model.FireableAlarmAction(da.Alarm.Action) {
+		return fireResult{}
+	}
 	stateID := da.StateID
 	var markErr error
 	op := "mark-fired"
@@ -150,6 +151,12 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 
 // markAndFireTodoAlarm is the todo counterpart of markAndFireEventAlarm.
 func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlarm, policy alarmExecutionPolicy) fireResult {
+	// Refuse a preserved sync-only action (issue #579) before the claim.
+	// A claim would consume the state and record a false "fired" entry
+	// for a notification that never appears.
+	if !model.FireableAlarmAction(tda.Alarm.Action) {
+		return fireResult{}
+	}
 	stateID := tda.StateID
 	var markErr error
 	op := "mark-fired"

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1204,7 +1204,11 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 			}
 
 			if cmd.Flags().Changed("alarm") {
-				if err := a.Events.ReplaceAlarms(ctx, e.ID, alarms); err != nil {
+				stored, err := a.Events.ListAlarms(ctx, e.ID)
+				if err != nil {
+					return fmt.Errorf("load alarms: %w", err)
+				}
+				if err := a.Events.ReplaceAlarms(ctx, e.ID, keepSyncOnlyAlarms(stored, alarms)); err != nil {
 					return fmt.Errorf("update alarms: %w", err)
 				}
 			}
@@ -1623,6 +1627,20 @@ func mergeAttendeeUpdate(existing []model.Attendee, attendeeChanged bool, newAtt
 //
 // Extended format is only available for duration triggers (prefix -, +, or P).
 // Absolute RFC 3339 triggers do not support additional fields.
+// keepSyncOnlyAlarms appends the stored sync-only alarms to a replacement
+// list. The --alarm flag syntax cannot state a preserved non-fireable
+// action (issue #579). A full replacement must carry those rows forward.
+// Without the carry-over, ReplaceAlarms deletes them and the next push
+// deletes the VALARM of another client from the server.
+func keepSyncOnlyAlarms(stored, replacement []model.Alarm) []model.Alarm {
+	for _, a := range stored {
+		if !model.FireableAlarmAction(a.Action) {
+			replacement = append(replacement, a)
+		}
+	}
+	return replacement
+}
+
 func parseAlarmFlags(flags []string) ([]model.Alarm, error) {
 	var out []model.Alarm
 	warnedMissingSMTP := false

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1659,7 +1659,11 @@ func parseOneAlarm(val string) (model.Alarm, error) {
 	// Check for ACTION: prefix
 	if idx := strings.Index(val, ":"); idx > 0 {
 		prefix := strings.ToUpper(val[:idx])
-		if model.ValidAlarmAction(prefix) {
+		// Only a fireable action is a valid prefix. The CLI creates local
+		// alarms, and a local alarm must be one the engine can fire. A
+		// sync-only action (issue #579) enters the database from import
+		// alone.
+		if model.FireableAlarmAction(prefix) {
 			action = prefix
 			rest = val[idx+1:]
 		}

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -1204,11 +1204,7 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 			}
 
 			if cmd.Flags().Changed("alarm") {
-				stored, err := a.Events.ListAlarms(ctx, e.ID)
-				if err != nil {
-					return fmt.Errorf("load alarms: %w", err)
-				}
-				if err := a.Events.ReplaceAlarms(ctx, e.ID, keepSyncOnlyAlarms(stored, alarms)); err != nil {
+				if err := a.Events.ReplaceFireableAlarms(ctx, e.ID, alarms); err != nil {
 					return fmt.Errorf("update alarms: %w", err)
 				}
 			}
@@ -1627,20 +1623,6 @@ func mergeAttendeeUpdate(existing []model.Attendee, attendeeChanged bool, newAtt
 //
 // Extended format is only available for duration triggers (prefix -, +, or P).
 // Absolute RFC 3339 triggers do not support additional fields.
-// keepSyncOnlyAlarms appends the stored sync-only alarms to a replacement
-// list. The --alarm flag syntax cannot state a preserved non-fireable
-// action (issue #579). A full replacement must carry those rows forward.
-// Without the carry-over, ReplaceAlarms deletes them and the next push
-// deletes the VALARM of another client from the server.
-func keepSyncOnlyAlarms(stored, replacement []model.Alarm) []model.Alarm {
-	for _, a := range stored {
-		if !model.FireableAlarmAction(a.Action) {
-			replacement = append(replacement, a)
-		}
-	}
-	return replacement
-}
-
 func parseAlarmFlags(flags []string) ([]model.Alarm, error) {
 	var out []model.Alarm
 	warnedMissingSMTP := false

--- a/cmd/chroncal/event_alarm_preserve_cli_test.go
+++ b/cmd/chroncal/event_alarm_preserve_cli_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+// TestEventUpdateAlarmKeepsSyncOnlyRows guards the issue #579 CLI gap.
+// The --alarm flag replaces the full alarm set, and its syntax cannot
+// state a preserved non-fireable action. The update command must carry
+// the stored sync-only rows forward. Without the carry-over, the next
+// push deletes the VALARM of another client from the server.
+func TestEventUpdateAlarmKeepsSyncOnlyRows(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Synced meeting",
+		"--calendar", "Work",
+		"--date", "2026-04-21",
+		"--time", "09:00",
+		"--duration", "30m",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	// Seed a preserved sync-only alarm the way a sync pull does. The CLI
+	// parser cannot state this action, so the seed goes through the
+	// service.
+	seed, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (seed): %v", err)
+	}
+	if err := seed.Events.ReplaceAlarms(ctx, 1, []model.Alarm{
+		{Action: "NONE", TriggerValue: "19760401T005545Z", UID: "google-none@test"},
+	}); err != nil {
+		seed.Close()
+		t.Fatalf("seed sync-only alarm: %v", err)
+	}
+	seed.Close()
+
+	if _, _, err := runChroncalCommand(t,
+		"event", "update", "1", "--alarm", "-PT30M",
+	); err != nil {
+		t.Fatalf("event update --alarm: %v", err)
+	}
+
+	check, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (check): %v", err)
+	}
+	defer check.Close()
+	alarms, err := check.Events.ListAlarms(ctx, 1)
+	if err != nil {
+		t.Fatalf("list alarms: %v", err)
+	}
+	if len(alarms) != 2 {
+		t.Fatalf("alarms = %d, want 2 (the new DISPLAY and the preserved NONE); got %+v", len(alarms), alarms)
+	}
+	var sawNone, sawDisplay bool
+	for _, a := range alarms {
+		switch a.Action {
+		case "NONE":
+			sawNone = true
+		case "DISPLAY":
+			sawDisplay = true
+		}
+	}
+	if !sawNone {
+		t.Errorf("the preserved NONE alarm is gone; alarms = %+v", alarms)
+	}
+	if !sawDisplay {
+		t.Errorf("the new DISPLAY alarm is missing; alarms = %+v", alarms)
+	}
+}

--- a/cmd/chroncal/ical_import_test.go
+++ b/cmd/chroncal/ical_import_test.go
@@ -116,13 +116,15 @@ func TestImportComponentsSurfacesChildFieldFailure(t *testing.T) {
 		Title:     "Has bad alarm",
 		StartTime: start,
 		EndTime:   start.Add(time.Hour),
-		// The service boundary rejects an ACTION outside model.AlarmActions
-		// with model.ErrInvalidAlarm (issue #578), so this alarm fails to
-		// attach even though the event itself is valid.
+		// The service boundary rejects a RELATED outside
+		// model.AlarmRelatedValues with model.ErrInvalidAlarm (issue
+		// #578), so this alarm fails to attach even though the event
+		// itself is valid. The action no longer forces the failure:
+		// since issue #579 the tables accept any non-empty action.
 		Alarms: []model.Alarm{{
-			Action:       "BOGUS",
+			Action:       "DISPLAY",
 			TriggerValue: "-PT15M",
-			Related:      "START",
+			Related:      "BOGUS",
 		}},
 	}
 

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -807,7 +807,11 @@ a --progress value other than 100.`,
 				}
 			}
 			if cmd.Flags().Changed("alarm") {
-				if err := a.Todos.ReplaceAlarms(ctx, t.ID, alarms); err != nil {
+				stored, err := a.Todos.ListAlarms(ctx, t.ID)
+				if err != nil {
+					return fmt.Errorf("load alarms: %w", err)
+				}
+				if err := a.Todos.ReplaceAlarms(ctx, t.ID, keepSyncOnlyAlarms(stored, alarms)); err != nil {
 					return fmt.Errorf("update alarms: %w", err)
 				}
 			}

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -807,11 +807,7 @@ a --progress value other than 100.`,
 				}
 			}
 			if cmd.Flags().Changed("alarm") {
-				stored, err := a.Todos.ListAlarms(ctx, t.ID)
-				if err != nil {
-					return fmt.Errorf("load alarms: %w", err)
-				}
-				if err := a.Todos.ReplaceAlarms(ctx, t.ID, keepSyncOnlyAlarms(stored, alarms)); err != nil {
+				if err := a.Todos.ReplaceFireableAlarms(ctx, t.ID, alarms); err != nil {
 					return fmt.Errorf("update alarms: %w", err)
 				}
 			}

--- a/db/migrations/043_alarm_action_preserve.sql
+++ b/db/migrations/043_alarm_action_preserve.sql
@@ -1,0 +1,279 @@
+-- +goose Up
+
+-- Widen the action CHECK on event_alarms and todo_alarms to any non-empty
+-- value (issue #579). The old constraint permitted only AUDIO, DISPLAY, and
+-- EMAIL. Import then dropped a VALARM with an RFC 5545 x-name or iana-token
+-- action (for example X-APPLE-SOUND) or with the Google ACTION:NONE
+-- sentinel. Every later push deleted that VALARM from the server copy. The
+-- alarm engine still fires only the three actions in
+-- model.FireableAlarmAction. The wide constraint mirrors
+-- model.StorableAlarmAction.
+--
+-- SQLite cannot alter a CHECK constraint, so rebuild both tables (the
+-- migration 031 pattern). Two extra hazards apply here:
+--
+-- 1. Foreign keys are ON. DROP TABLE performs an implicit DELETE, and the
+--    ON DELETE CASCADE clauses in alarm_state, todo_alarm_state,
+--    event_alarm_attendees, and todo_alarm_attendees then erase those
+--    rows. Back up each child table first. Restore it after the rebuild.
+--    The implicit DELETE fires no SQL triggers, so the alarm-owned
+--    x_properties rows survive in place.
+-- 2. The x_properties owner-exists triggers reference the alarm tables by
+--    name. The rename reparses the schema and would choke on a trigger
+--    that points at a missing table. Drop those triggers first. Recreate
+--    them after. The AFTER DELETE cleanup triggers live on the alarm
+--    tables and die with the DROP; recreate them too.
+DROP TRIGGER IF EXISTS x_properties_event_alarm_owner_exists;
+DROP TRIGGER IF EXISTS x_properties_todo_alarm_owner_exists;
+
+CREATE TABLE alarm_state_backup AS SELECT * FROM alarm_state;
+CREATE TABLE event_alarm_attendees_backup AS SELECT * FROM event_alarm_attendees;
+CREATE TABLE todo_alarm_state_backup AS SELECT * FROM todo_alarm_state;
+CREATE TABLE todo_alarm_attendees_backup AS SELECT * FROM todo_alarm_attendees;
+
+CREATE TABLE event_alarms_new (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id       INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    action         TEXT    NOT NULL DEFAULT 'DISPLAY'
+        CHECK(action <> ''),
+    trigger_value  TEXT    NOT NULL,
+    description    TEXT,
+    repeat         INTEGER NOT NULL DEFAULT 0,
+    duration       TEXT,
+    related        TEXT    NOT NULL DEFAULT 'START'
+        CHECK(related IN ('START','END')),
+    summary        TEXT,
+    uid            TEXT,
+    acknowledged   TEXT,
+    attach_uri     TEXT,
+    attach_fmttype TEXT,
+    attach_binary  BLOB
+);
+
+INSERT INTO event_alarms_new (id, event_id, action, trigger_value, description,
+    repeat, duration, related, summary, uid, acknowledged, attach_uri,
+    attach_fmttype, attach_binary)
+SELECT id, event_id, action, trigger_value, description,
+    repeat, duration, related, summary, uid, acknowledged, attach_uri,
+    attach_fmttype, attach_binary
+FROM event_alarms;
+
+DROP TABLE event_alarms;
+ALTER TABLE event_alarms_new RENAME TO event_alarms;
+
+CREATE INDEX idx_event_alarms_event_id ON event_alarms(event_id);
+CREATE UNIQUE INDEX idx_event_alarms_uid ON event_alarms(uid) WHERE uid IS NOT NULL;
+
+CREATE TABLE todo_alarms_new (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    todo_id        INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
+    action         TEXT    NOT NULL DEFAULT 'DISPLAY'
+        CHECK(action <> ''),
+    trigger_value  TEXT    NOT NULL,
+    description    TEXT,
+    repeat         INTEGER NOT NULL DEFAULT 0,
+    duration       TEXT,
+    related        TEXT    NOT NULL DEFAULT 'START'
+        CHECK(related IN ('START','END')),
+    summary        TEXT,
+    uid            TEXT,
+    acknowledged   TEXT,
+    attach_uri     TEXT,
+    attach_fmttype TEXT,
+    attach_binary  BLOB
+);
+
+INSERT INTO todo_alarms_new (id, todo_id, action, trigger_value, description,
+    repeat, duration, related, summary, uid, acknowledged, attach_uri,
+    attach_fmttype, attach_binary)
+SELECT id, todo_id, action, trigger_value, description,
+    repeat, duration, related, summary, uid, acknowledged, attach_uri,
+    attach_fmttype, attach_binary
+FROM todo_alarms;
+
+DROP TABLE todo_alarms;
+ALTER TABLE todo_alarms_new RENAME TO todo_alarms;
+
+CREATE INDEX idx_todo_alarms_todo_id ON todo_alarms(todo_id);
+CREATE UNIQUE INDEX idx_todo_alarms_uid ON todo_alarms(uid) WHERE uid IS NOT NULL;
+
+-- Restore the child rows the implicit DELETE cascaded away. The DELETE
+-- before each restore makes the step idempotent when no cascade ran.
+DELETE FROM alarm_state;
+INSERT INTO alarm_state SELECT * FROM alarm_state_backup;
+DROP TABLE alarm_state_backup;
+
+DELETE FROM event_alarm_attendees;
+INSERT INTO event_alarm_attendees SELECT * FROM event_alarm_attendees_backup;
+DROP TABLE event_alarm_attendees_backup;
+
+DELETE FROM todo_alarm_state;
+INSERT INTO todo_alarm_state SELECT * FROM todo_alarm_state_backup;
+DROP TABLE todo_alarm_state_backup;
+
+DELETE FROM todo_alarm_attendees;
+INSERT INTO todo_alarm_attendees SELECT * FROM todo_alarm_attendees_backup;
+DROP TABLE todo_alarm_attendees_backup;
+
+-- +goose StatementBegin
+CREATE TRIGGER x_properties_event_alarm_owner_exists
+BEFORE INSERT ON x_properties
+WHEN NEW.owner_type = 'event_alarm'
+ AND NOT EXISTS (SELECT 1 FROM event_alarms WHERE id = NEW.owner_id) BEGIN
+    SELECT RAISE(ABORT, 'x_properties owner does not exist');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER x_properties_todo_alarm_owner_exists
+BEFORE INSERT ON x_properties
+WHEN NEW.owner_type = 'todo_alarm'
+ AND NOT EXISTS (SELECT 1 FROM todo_alarms WHERE id = NEW.owner_id) BEGIN
+    SELECT RAISE(ABORT, 'x_properties owner does not exist');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER event_alarms_x_properties_ad
+AFTER DELETE ON event_alarms BEGIN
+    DELETE FROM x_properties WHERE owner_type = 'event_alarm' AND owner_id = OLD.id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER todo_alarms_x_properties_ad
+AFTER DELETE ON todo_alarms BEGIN
+    DELETE FROM x_properties WHERE owner_type = 'todo_alarm' AND owner_id = OLD.id;
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- Intentional, unrecoverable data loss: the narrow CHECK cannot hold an
+-- alarm with an action outside AUDIO, DISPLAY, and EMAIL. Delete those
+-- alarms first. The DELETE cascades their state and attendee rows and the
+-- AFTER DELETE trigger removes their x_properties rows.
+DELETE FROM event_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL');
+DELETE FROM todo_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL');
+
+DROP TRIGGER IF EXISTS x_properties_event_alarm_owner_exists;
+DROP TRIGGER IF EXISTS x_properties_todo_alarm_owner_exists;
+
+CREATE TABLE alarm_state_backup AS SELECT * FROM alarm_state;
+CREATE TABLE event_alarm_attendees_backup AS SELECT * FROM event_alarm_attendees;
+CREATE TABLE todo_alarm_state_backup AS SELECT * FROM todo_alarm_state;
+CREATE TABLE todo_alarm_attendees_backup AS SELECT * FROM todo_alarm_attendees;
+
+CREATE TABLE event_alarms_old (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id       INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    action         TEXT    NOT NULL DEFAULT 'DISPLAY'
+        CHECK(action IN ('AUDIO','DISPLAY','EMAIL')),
+    trigger_value  TEXT    NOT NULL,
+    description    TEXT,
+    repeat         INTEGER NOT NULL DEFAULT 0,
+    duration       TEXT,
+    related        TEXT    NOT NULL DEFAULT 'START'
+        CHECK(related IN ('START','END')),
+    summary        TEXT,
+    uid            TEXT,
+    acknowledged   TEXT,
+    attach_uri     TEXT,
+    attach_fmttype TEXT,
+    attach_binary  BLOB
+);
+
+INSERT INTO event_alarms_old (id, event_id, action, trigger_value, description,
+    repeat, duration, related, summary, uid, acknowledged, attach_uri,
+    attach_fmttype, attach_binary)
+SELECT id, event_id, action, trigger_value, description,
+    repeat, duration, related, summary, uid, acknowledged, attach_uri,
+    attach_fmttype, attach_binary
+FROM event_alarms;
+
+DROP TABLE event_alarms;
+ALTER TABLE event_alarms_old RENAME TO event_alarms;
+
+CREATE INDEX idx_event_alarms_event_id ON event_alarms(event_id);
+CREATE UNIQUE INDEX idx_event_alarms_uid ON event_alarms(uid) WHERE uid IS NOT NULL;
+
+CREATE TABLE todo_alarms_old (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    todo_id        INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
+    action         TEXT    NOT NULL DEFAULT 'DISPLAY'
+        CHECK(action IN ('AUDIO','DISPLAY','EMAIL')),
+    trigger_value  TEXT    NOT NULL,
+    description    TEXT,
+    repeat         INTEGER NOT NULL DEFAULT 0,
+    duration       TEXT,
+    related        TEXT    NOT NULL DEFAULT 'START'
+        CHECK(related IN ('START','END')),
+    summary        TEXT,
+    uid            TEXT,
+    acknowledged   TEXT,
+    attach_uri     TEXT,
+    attach_fmttype TEXT,
+    attach_binary  BLOB
+);
+
+INSERT INTO todo_alarms_old (id, todo_id, action, trigger_value, description,
+    repeat, duration, related, summary, uid, acknowledged, attach_uri,
+    attach_fmttype, attach_binary)
+SELECT id, todo_id, action, trigger_value, description,
+    repeat, duration, related, summary, uid, acknowledged, attach_uri,
+    attach_fmttype, attach_binary
+FROM todo_alarms;
+
+DROP TABLE todo_alarms;
+ALTER TABLE todo_alarms_old RENAME TO todo_alarms;
+
+CREATE INDEX idx_todo_alarms_todo_id ON todo_alarms(todo_id);
+CREATE UNIQUE INDEX idx_todo_alarms_uid ON todo_alarms(uid) WHERE uid IS NOT NULL;
+
+DELETE FROM alarm_state;
+INSERT INTO alarm_state SELECT * FROM alarm_state_backup;
+DROP TABLE alarm_state_backup;
+
+DELETE FROM event_alarm_attendees;
+INSERT INTO event_alarm_attendees SELECT * FROM event_alarm_attendees_backup;
+DROP TABLE event_alarm_attendees_backup;
+
+DELETE FROM todo_alarm_state;
+INSERT INTO todo_alarm_state SELECT * FROM todo_alarm_state_backup;
+DROP TABLE todo_alarm_state_backup;
+
+DELETE FROM todo_alarm_attendees;
+INSERT INTO todo_alarm_attendees SELECT * FROM todo_alarm_attendees_backup;
+DROP TABLE todo_alarm_attendees_backup;
+
+-- +goose StatementBegin
+CREATE TRIGGER x_properties_event_alarm_owner_exists
+BEFORE INSERT ON x_properties
+WHEN NEW.owner_type = 'event_alarm'
+ AND NOT EXISTS (SELECT 1 FROM event_alarms WHERE id = NEW.owner_id) BEGIN
+    SELECT RAISE(ABORT, 'x_properties owner does not exist');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER x_properties_todo_alarm_owner_exists
+BEFORE INSERT ON x_properties
+WHEN NEW.owner_type = 'todo_alarm'
+ AND NOT EXISTS (SELECT 1 FROM todo_alarms WHERE id = NEW.owner_id) BEGIN
+    SELECT RAISE(ABORT, 'x_properties owner does not exist');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER event_alarms_x_properties_ad
+AFTER DELETE ON event_alarms BEGIN
+    DELETE FROM x_properties WHERE owner_type = 'event_alarm' AND owner_id = OLD.id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER todo_alarms_x_properties_ad
+AFTER DELETE ON todo_alarms BEGIN
+    DELETE FROM x_properties WHERE owner_type = 'todo_alarm' AND owner_id = OLD.id;
+END;
+-- +goose StatementEnd

--- a/db/migrations/044_alarm_action_preserve.sql
+++ b/db/migrations/044_alarm_action_preserve.sql
@@ -158,6 +158,20 @@ END;
 -- local only. The next push omits the deleted VALARMs, so the server copy
 -- loses them too, and Google re-applies the default reminders that its
 -- ACTION:NONE sentinel turned off.
+--
+-- Delete the dependent rows explicitly before the alarm rows. The
+-- cascade removes them when foreign keys are ON, but an external goose
+-- run without the DSN pragmas has them OFF. Without this insurance the
+-- backup tables below would capture orphan state and attendee rows and
+-- the restore would re-insert them.
+DELETE FROM alarm_state WHERE alarm_id IN
+    (SELECT id FROM event_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL'));
+DELETE FROM event_alarm_attendees WHERE alarm_id IN
+    (SELECT id FROM event_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL'));
+DELETE FROM todo_alarm_state WHERE alarm_id IN
+    (SELECT id FROM todo_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL'));
+DELETE FROM todo_alarm_attendees WHERE alarm_id IN
+    (SELECT id FROM todo_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL'));
 DELETE FROM event_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL');
 DELETE FROM todo_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL');
 

--- a/db/migrations/044_alarm_action_preserve.sql
+++ b/db/migrations/044_alarm_action_preserve.sql
@@ -19,10 +19,10 @@
 --    The implicit DELETE fires no SQL triggers, so the alarm-owned
 --    x_properties rows survive in place.
 -- 2. The x_properties owner-exists triggers reference the alarm tables by
---    name. The rename reparses the schema and would choke on a trigger
---    that points at a missing table. Drop those triggers first. Recreate
---    them after. The AFTER DELETE cleanup triggers live on the alarm
---    tables and die with the DROP; recreate them too.
+--    name. The rename reparses the schema and fails on a trigger that
+--    points at a missing table. Drop those triggers first. Recreate
+--    them after. The DROP also removes the AFTER DELETE cleanup triggers
+--    on the alarm tables; recreate them too.
 DROP TRIGGER IF EXISTS x_properties_event_alarm_owner_exists;
 DROP TRIGGER IF EXISTS x_properties_todo_alarm_owner_exists;
 
@@ -152,7 +152,10 @@ END;
 -- Intentional, unrecoverable data loss: the narrow CHECK cannot hold an
 -- alarm with an action outside AUDIO, DISPLAY, and EMAIL. Delete those
 -- alarms first. The DELETE cascades their state and attendee rows and the
--- AFTER DELETE trigger removes their x_properties rows.
+-- AFTER DELETE trigger removes their x_properties rows. The loss is not
+-- local only. The next push omits the deleted VALARMs, so the server copy
+-- loses them too, and Google re-applies the default reminders that its
+-- ACTION:NONE sentinel turned off.
 DELETE FROM event_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL');
 DELETE FROM todo_alarms WHERE action NOT IN ('AUDIO','DISPLAY','EMAIL');
 

--- a/db/migrations/044_alarm_action_preserve.sql
+++ b/db/migrations/044_alarm_action_preserve.sql
@@ -97,8 +97,10 @@ ALTER TABLE todo_alarms_new RENAME TO todo_alarms;
 CREATE INDEX idx_todo_alarms_todo_id ON todo_alarms(todo_id);
 CREATE UNIQUE INDEX idx_todo_alarms_uid ON todo_alarms(uid) WHERE uid IS NOT NULL;
 
--- Restore the child rows the implicit DELETE cascaded away. The DELETE
--- before each restore makes the step idempotent when no cascade ran.
+-- Restore the child rows the implicit DELETE cascaded away. On every
+-- normal path the cascade runs: the DSN pragmas set foreign_keys ON for
+-- each connection. The DELETE before each restore is insurance for an
+-- external goose run on a connection without those pragmas.
 DELETE FROM alarm_state;
 INSERT INTO alarm_state SELECT * FROM alarm_state_backup;
 DROP TABLE alarm_state_backup;

--- a/db/queries/alarm_state.sql
+++ b/db/queries/alarm_state.sql
@@ -1,35 +1,53 @@
 -- name: GetAlarmState :one
 SELECT * FROM alarm_state WHERE alarm_id = ? AND trigger_at = ?;
 
+-- Claim a fire slot for one alarm. The EXISTS arm reads the action in the
+-- same statement as the insert, so a sync pull that rewrites the alarm to
+-- a sync-only action between the check and the claim cannot leave a fired
+-- state for an alarm the user disabled (issue #579). Zero rows means the
+-- claim failed, and the caller reports sql.ErrNoRows.
+-- Keep the action list in lockstep with model.FireableAlarmAction.
 -- name: CreateAlarmState :one
 INSERT INTO alarm_state (alarm_id, event_id, trigger_at, fired_at)
-VALUES (?, ?, ?, ?) RETURNING *;
+SELECT sqlc.arg(alarm_id), sqlc.arg(event_id), sqlc.arg(trigger_at), sqlc.arg(fired_at)
+WHERE EXISTS (
+    SELECT 1 FROM event_alarms
+    WHERE id = sqlc.arg(alarm_id) AND action IN ('AUDIO','DISPLAY','EMAIL')
+)
+RETURNING *;
 
 -- name: AcknowledgeAlarmState :exec
 UPDATE alarm_state SET acked_at = ? WHERE id = ?;
 
--- Retire the live state of one alarm. A sync pull can rewrite an alarm
--- to a sync-only action in place. The check loop never fires that alarm
--- again, so an open state row would stay pending forever.
--- name: AcknowledgeAlarmStatesByAlarmID :exec
-UPDATE alarm_state SET acked_at = ? WHERE alarm_id = ? AND acked_at IS NULL;
-
 -- name: SnoozeAlarmState :exec
 UPDATE alarm_state SET snoozed_to = ? WHERE id = ?;
 
+-- Hide the state of an alarm a sync pull rewrote to a sync-only action.
+-- The filter reads the current action, so the row comes back when a later
+-- pull restores a fireable action (issue #579). A retirement that wrote
+-- acked_at instead would consume the snooze of the user for good.
+-- Keep the action list in lockstep with model.FireableAlarmAction.
 -- name: ListPendingAlarmStates :many
-SELECT * FROM alarm_state WHERE acked_at IS NULL AND fired_at IS NOT NULL ORDER BY trigger_at;
+SELECT s.* FROM alarm_state s
+JOIN event_alarms a ON a.id = s.alarm_id
+WHERE s.acked_at IS NULL AND s.fired_at IS NOT NULL
+  AND a.action IN ('AUDIO','DISPLAY','EMAIL')
+ORDER BY s.trigger_at;
 
 -- name: GetAlarmStateByID :one
 SELECT * FROM alarm_state WHERE id = ?;
 
+-- The same sync-only filter as ListPendingAlarmStates, for the re-fire path.
+-- Keep the action list in lockstep with model.FireableAlarmAction.
 -- name: ListExpiredSnoozedAlarmStates :many
-SELECT * FROM alarm_state
-WHERE fired_at IS NOT NULL
-  AND acked_at IS NULL
-  AND snoozed_to IS NOT NULL
-  AND snoozed_to <= ?
-ORDER BY snoozed_to;
+SELECT s.* FROM alarm_state s
+JOIN event_alarms a ON a.id = s.alarm_id
+WHERE s.fired_at IS NOT NULL
+  AND s.acked_at IS NULL
+  AND s.snoozed_to IS NOT NULL
+  AND s.snoozed_to <= ?
+  AND a.action IN ('AUDIO','DISPLAY','EMAIL')
+ORDER BY s.snoozed_to;
 
 -- name: RefireAlarmState :execrows
 UPDATE alarm_state SET fired_at = ?, snoozed_to = NULL

--- a/db/queries/alarm_state.sql
+++ b/db/queries/alarm_state.sql
@@ -8,6 +8,12 @@ VALUES (?, ?, ?, ?) RETURNING *;
 -- name: AcknowledgeAlarmState :exec
 UPDATE alarm_state SET acked_at = ? WHERE id = ?;
 
+-- Retire the live state of one alarm. A sync pull can rewrite an alarm
+-- to a sync-only action in place. The check loop never fires that alarm
+-- again, so an open state row would stay pending forever.
+-- name: AcknowledgeAlarmStatesByAlarmID :exec
+UPDATE alarm_state SET acked_at = ? WHERE alarm_id = ? AND acked_at IS NULL;
+
 -- name: SnoozeAlarmState :exec
 UPDATE alarm_state SET snoozed_to = ? WHERE id = ?;
 

--- a/db/queries/alarms.sql
+++ b/db/queries/alarms.sql
@@ -12,8 +12,14 @@ SELECT * FROM event_alarms WHERE event_id = ? ORDER BY id;
 SELECT DISTINCT trigger_value FROM event_alarms
 WHERE action IN ('AUDIO', 'DISPLAY', 'EMAIL');
 
--- name: ListAlarmsByEventIDs :many
-SELECT * FROM event_alarms WHERE event_id IN (sqlc.slice(event_ids)) ORDER BY event_id, id;
+-- name: ListFireableAlarmsByEventIDs :many
+-- The action list mirrors model.FireableAlarmAction. Keep the two in
+-- lockstep. The alarm check loop is the only caller, and a preserved
+-- sync-only action must not reach it.
+SELECT * FROM event_alarms
+WHERE event_id IN (sqlc.slice(event_ids))
+  AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
+ORDER BY event_id, id;
 
 -- name: DeleteAlarmsByEventID :exec
 DELETE FROM event_alarms WHERE event_id = ?;

--- a/db/queries/alarms.sql
+++ b/db/queries/alarms.sql
@@ -6,7 +6,11 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 SELECT * FROM event_alarms WHERE event_id = ? ORDER BY id;
 
 -- name: ListDistinctAlarmTriggers :many
-SELECT DISTINCT trigger_value FROM event_alarms;
+-- The action list mirrors model.FireableAlarmAction. Keep the two in
+-- lockstep. A preserved sync-only action never fires, so its trigger
+-- must not size the alarm check window.
+SELECT DISTINCT trigger_value FROM event_alarms
+WHERE action IN ('AUDIO', 'DISPLAY', 'EMAIL');
 
 -- name: ListAlarmsByEventIDs :many
 SELECT * FROM event_alarms WHERE event_id IN (sqlc.slice(event_ids)) ORDER BY event_id, id;

--- a/db/queries/todo_alarm_state.sql
+++ b/db/queries/todo_alarm_state.sql
@@ -10,6 +10,12 @@ RETURNING *;
 -- name: AcknowledgeTodoAlarmState :exec
 UPDATE todo_alarm_state SET acked_at = ? WHERE id = ?;
 
+-- Retire the live state of one alarm. A sync pull can rewrite an alarm
+-- to a sync-only action in place. The check loop never fires that alarm
+-- again, so an open state row would stay pending forever.
+-- name: AcknowledgeTodoAlarmStatesByAlarmID :exec
+UPDATE todo_alarm_state SET acked_at = ? WHERE alarm_id = ? AND acked_at IS NULL;
+
 -- name: SnoozeTodoAlarmState :exec
 UPDATE todo_alarm_state SET snoozed_to = ? WHERE id = ?;
 

--- a/db/queries/todo_alarm_state.sql
+++ b/db/queries/todo_alarm_state.sql
@@ -2,19 +2,23 @@
 SELECT * FROM todo_alarm_state 
 WHERE alarm_id = ? AND trigger_at = ?;
 
+-- Claim a fire slot for one todo alarm. The EXISTS arm reads the action in
+-- the same statement as the insert, so a sync pull that rewrites the alarm
+-- to a sync-only action between the check and the claim cannot leave a
+-- fired state for an alarm the user disabled (issue #579).
+-- Keep the action list in lockstep with model.FireableAlarmAction.
 -- name: InsertTodoAlarmState :one
 INSERT INTO todo_alarm_state (alarm_id, todo_id, trigger_at, fired_at, acked_at, snoozed_to)
-VALUES (?, ?, ?, ?, ?, ?)
+SELECT sqlc.arg(alarm_id), sqlc.arg(todo_id), sqlc.arg(trigger_at),
+       sqlc.arg(fired_at), sqlc.arg(acked_at), sqlc.arg(snoozed_to)
+WHERE EXISTS (
+    SELECT 1 FROM todo_alarms
+    WHERE id = sqlc.arg(alarm_id) AND action IN ('AUDIO','DISPLAY','EMAIL')
+)
 RETURNING *;
 
 -- name: AcknowledgeTodoAlarmState :exec
 UPDATE todo_alarm_state SET acked_at = ? WHERE id = ?;
-
--- Retire the live state of one alarm. A sync pull can rewrite an alarm
--- to a sync-only action in place. The check loop never fires that alarm
--- again, so an open state row would stay pending forever.
--- name: AcknowledgeTodoAlarmStatesByAlarmID :exec
-UPDATE todo_alarm_state SET acked_at = ? WHERE alarm_id = ? AND acked_at IS NULL;
 
 -- name: SnoozeTodoAlarmState :exec
 UPDATE todo_alarm_state SET snoozed_to = ? WHERE id = ?;
@@ -29,13 +33,17 @@ SELECT * FROM todo_alarm_state
 WHERE todo_id = ? AND fired_at IS NOT NULL AND acked_at IS NULL AND snoozed_to IS NULL
 ORDER BY fired_at DESC;
 
+-- The same sync-only filter as ListPendingTodoAlarmStates, for the re-fire
+-- path. Keep the action list in lockstep with model.FireableAlarmAction.
 -- name: ListExpiredTodoSnoozed :many
-SELECT * FROM todo_alarm_state
-WHERE fired_at IS NOT NULL
-  AND acked_at IS NULL
-  AND snoozed_to IS NOT NULL
-  AND snoozed_to <= ?
-ORDER BY snoozed_to;
+SELECT s.* FROM todo_alarm_state s
+JOIN todo_alarms a ON a.id = s.alarm_id
+WHERE s.fired_at IS NOT NULL
+  AND s.acked_at IS NULL
+  AND s.snoozed_to IS NOT NULL
+  AND s.snoozed_to <= ?
+  AND a.action IN ('AUDIO','DISPLAY','EMAIL')
+ORDER BY s.snoozed_to;
 
 -- name: RefireTodoAlarmState :execrows
 UPDATE todo_alarm_state SET fired_at = ?, snoozed_to = NULL
@@ -47,10 +55,16 @@ DELETE FROM todo_alarm_state WHERE id = ?;
 -- name: CountTodoAlarmStates :one
 SELECT COUNT(*) FROM todo_alarm_state WHERE todo_id = ?;
 
+-- Hide the state of an alarm a sync pull rewrote to a sync-only action.
+-- The filter reads the current action, so the row comes back when a later
+-- pull restores a fireable action (issue #579).
+-- Keep the action list in lockstep with model.FireableAlarmAction.
 -- name: ListPendingTodoAlarmStates :many
-SELECT * FROM todo_alarm_state
-WHERE acked_at IS NULL AND (fired_at IS NOT NULL OR snoozed_to IS NOT NULL)
-ORDER BY trigger_at;
+SELECT s.* FROM todo_alarm_state s
+JOIN todo_alarms a ON a.id = s.alarm_id
+WHERE s.acked_at IS NULL AND (s.fired_at IS NOT NULL OR s.snoozed_to IS NOT NULL)
+  AND a.action IN ('AUDIO','DISPLAY','EMAIL')
+ORDER BY s.trigger_at;
 
 -- name: GetTodoAlarmStateByID :one
 SELECT * FROM todo_alarm_state WHERE id = ?;

--- a/db/queries/todo_alarms.sql
+++ b/db/queries/todo_alarms.sql
@@ -5,6 +5,15 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 -- name: ListTodoAlarmsByTodoID :many
 SELECT * FROM todo_alarms WHERE todo_id = ? ORDER BY id;
 
+-- name: ListFireableTodoAlarmsByTodoID :many
+-- The action list mirrors model.FireableAlarmAction. Keep the two in
+-- lockstep. The alarm check loop is the only caller, and a preserved
+-- sync-only action must not reach it.
+SELECT * FROM todo_alarms
+WHERE todo_id = ?
+  AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
+ORDER BY id;
+
 -- name: ListDistinctTodoAlarmTriggers :many
 -- The action list mirrors model.FireableAlarmAction. Keep the two in
 -- lockstep. A preserved sync-only action never fires, so its trigger

--- a/db/queries/todo_alarms.sql
+++ b/db/queries/todo_alarms.sql
@@ -6,7 +6,11 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 SELECT * FROM todo_alarms WHERE todo_id = ? ORDER BY id;
 
 -- name: ListDistinctTodoAlarmTriggers :many
-SELECT DISTINCT trigger_value FROM todo_alarms;
+-- The action list mirrors model.FireableAlarmAction. Keep the two in
+-- lockstep. A preserved sync-only action never fires, so its trigger
+-- must not size the alarm check window.
+SELECT DISTINCT trigger_value FROM todo_alarms
+WHERE action IN ('AUDIO', 'DISPLAY', 'EMAIL');
 
 -- name: DeleteTodoAlarmsByTodoID :exec
 DELETE FROM todo_alarms WHERE todo_id = ?;

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -141,6 +141,10 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 	var missed []MissedAlarm
 	for _, expEvt := range expanded {
 		for _, a := range alarmMap[expEvt.ID] {
+			// A sync-only action never fires, so it is never missed.
+			if !model.FireableAlarmAction(a.Action) {
+				continue
+			}
 			triggerAt, err := computeTriggerTimeForInstance(expEvt, a)
 			if err != nil {
 				continue
@@ -194,6 +198,10 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			}
 			for _, inst := range instances {
 				for _, a := range alarms {
+					// A sync-only action never fires, so it is never missed.
+					if !model.FireableAlarmAction(a.Action) {
+						continue
+					}
 					triggerAt, err := computeTodoTriggerTimeForInstance(inst, a)
 					if err != nil {
 						continue
@@ -311,6 +319,11 @@ func (s *Service) checkEventAlarms(ctx context.Context, now time.Time) ([]DueAla
 		alarms := alarmMap[expEvt.ID] // nil if no alarms for this event
 
 		for _, a := range alarms {
+			// A preserved sync-only action (issue #579) never fires.
+			// Skip it in silence: the row is healthy, not a defect.
+			if !model.FireableAlarmAction(a.Action) {
+				continue
+			}
 			triggerAt, err := computeTriggerTimeForInstance(expEvt, a)
 			if err != nil {
 				continue

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -176,10 +176,7 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			}
 
 			alarms, err := s.todos.ListFireableAlarmsLean(ctx, td.ID)
-			if err != nil {
-				continue
-			}
-			if len(alarms) == 0 {
+			if err != nil || len(alarms) == 0 {
 				continue
 			}
 
@@ -519,15 +516,11 @@ func (s *Service) ListExpiredSnoozed(ctx context.Context, now time.Time) ([]DueA
 		}
 		// A sync pull can rewrite a snoozed alarm to a sync-only action
 		// in place (same row ID, matched by UID). The re-fire must not
-		// happen. Acknowledge the state row: an unconsumed snooze would
+		// happen. Dismiss the state row: an unconsumed snooze would
 		// stay pending in `alarm list` forever, and every check tick
-		// would resolve it again for nothing.
+		// would resolve it again with no effect.
 		if !model.FireableAlarmAction(matched.Action) {
-			ackAt := now.UTC().Format(time.RFC3339)
-			_ = s.q.AcknowledgeAlarmState(ctx, storage.AcknowledgeAlarmStateParams{
-				AckedAt: &ackAt,
-				ID:      st.ID,
-			})
+			_ = s.Dismiss(ctx, st.ID)
 			continue
 		}
 
@@ -719,14 +712,73 @@ func (s *Service) Snooze(ctx context.Context, stateID int64, until time.Time) er
 	})
 }
 
-// ListPending returns all fired alarms that are not acknowledged.
+// ListPending returns all fired alarms that are not acknowledged. A sync
+// pull can rewrite a fired alarm to a sync-only action in place before
+// the user dismisses it. That alarm can never re-fire. Retire its state
+// row with the same dismiss treatment as the expired-snooze path, so
+// `alarm list` does not show it forever.
 func (s *Service) ListPending(ctx context.Context) ([]storage.AlarmState, error) {
-	return s.q.ListPendingAlarmStates(ctx)
+	states, err := s.q.ListPendingAlarmStates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	kept := make([]storage.AlarmState, 0, len(states))
+	for _, st := range states {
+		if s.pendingStateIsSyncOnly(ctx, st) {
+			_ = s.Dismiss(ctx, st.ID)
+			continue
+		}
+		kept = append(kept, st)
+	}
+	return kept, nil
 }
 
-// ListPendingTodoAlarms returns all fired-but-not-acknowledged todo alarms.
+// pendingStateIsSyncOnly reports whether the state row points at an alarm
+// whose action the engine cannot fire.
+func (s *Service) pendingStateIsSyncOnly(ctx context.Context, st storage.AlarmState) bool {
+	alarms, err := s.events.ListAlarms(ctx, st.EventID)
+	if err != nil {
+		return false
+	}
+	for _, a := range alarms {
+		if a.ID == st.AlarmID {
+			return !model.FireableAlarmAction(a.Action)
+		}
+	}
+	return false
+}
+
+// ListPendingTodoAlarms returns all fired-but-not-acknowledged todo
+// alarms, with the same sync-only retirement as ListPending.
 func (s *Service) ListPendingTodoAlarms(ctx context.Context) ([]storage.TodoAlarmState, error) {
-	return s.q.ListPendingTodoAlarmStates(ctx)
+	states, err := s.q.ListPendingTodoAlarmStates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	kept := make([]storage.TodoAlarmState, 0, len(states))
+	for _, st := range states {
+		if s.pendingTodoStateIsSyncOnly(ctx, st) {
+			_ = s.DismissTodoAlarm(ctx, st.ID)
+			continue
+		}
+		kept = append(kept, st)
+	}
+	return kept, nil
+}
+
+// pendingTodoStateIsSyncOnly reports whether the todo state row points at
+// an alarm whose action the engine cannot fire.
+func (s *Service) pendingTodoStateIsSyncOnly(ctx context.Context, st storage.TodoAlarmState) bool {
+	alarms, err := s.todos.ListAlarmsLean(ctx, st.TodoID)
+	if err != nil {
+		return false
+	}
+	for _, a := range alarms {
+		if a.ID == st.AlarmID {
+			return !model.FireableAlarmAction(a.Action)
+		}
+	}
+	return false
 }
 
 // DismissTodoAlarm acknowledges a fired todo alarm so it will not show as pending.

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -48,21 +48,6 @@ func maxLeadTime(triggers []string) time.Duration {
 	return longest
 }
 
-// fireable returns only the alarms the engine can dispatch. A preserved
-// sync-only action (issue #579) never fires. The row is healthy, not a
-// defect, so the filter is silent. Apply this filter to every alarm fetch
-// on the check paths. A new loop over a filtered fetch then cannot fire a
-// sync-only alarm.
-func fireable(alarms []model.Alarm) []model.Alarm {
-	kept := make([]model.Alarm, 0, len(alarms))
-	for _, a := range alarms {
-		if model.FireableAlarmAction(a.Action) {
-			kept = append(kept, a)
-		}
-	}
-	return kept
-}
-
 // DueAlarm represents an alarm that should fire now.
 type DueAlarm struct {
 	Event     event.Event
@@ -148,12 +133,9 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			uniqueIDs = append(uniqueIDs, expEvt.ID)
 		}
 	}
-	alarmMap, err := s.events.ListAlarmsByEventIDs(ctx, uniqueIDs)
+	alarmMap, err := s.events.ListFireableAlarmsByEventIDs(ctx, uniqueIDs)
 	if err != nil {
 		return nil, nil, err
-	}
-	for id, as := range alarmMap {
-		alarmMap[id] = fireable(as)
 	}
 
 	var missed []MissedAlarm
@@ -193,11 +175,10 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 				continue
 			}
 
-			alarms, err := s.todos.ListAlarmsLean(ctx, td.ID)
+			alarms, err := s.todos.ListFireableAlarmsLean(ctx, td.ID)
 			if err != nil {
 				continue
 			}
-			alarms = fireable(alarms)
 			if len(alarms) == 0 {
 				continue
 			}
@@ -322,12 +303,9 @@ func (s *Service) checkEventAlarms(ctx context.Context, now time.Time) ([]DueAla
 			uniqueParentIDs = append(uniqueParentIDs, expEvt.ID)
 		}
 	}
-	alarmMap, err := s.events.ListAlarmsByEventIDs(ctx, uniqueParentIDs)
+	alarmMap, err := s.events.ListFireableAlarmsByEventIDs(ctx, uniqueParentIDs)
 	if err != nil {
 		return nil, fmt.Errorf("fetch alarms: %w", err)
-	}
-	for id, as := range alarmMap {
-		alarmMap[id] = fireable(as)
 	}
 
 	var due []DueAlarm
@@ -541,8 +519,15 @@ func (s *Service) ListExpiredSnoozed(ctx context.Context, now time.Time) ([]DueA
 		}
 		// A sync pull can rewrite a snoozed alarm to a sync-only action
 		// in place (same row ID, matched by UID). The re-fire must not
-		// happen and the snooze state must stay unconsumed.
+		// happen. Acknowledge the state row: an unconsumed snooze would
+		// stay pending in `alarm list` forever, and every check tick
+		// would resolve it again for nothing.
 		if !model.FireableAlarmAction(matched.Action) {
+			ackAt := now.UTC().Format(time.RFC3339)
+			_ = s.q.AcknowledgeAlarmState(ctx, storage.AcknowledgeAlarmStateParams{
+				AckedAt: &ackAt,
+				ID:      st.ID,
+			})
 			continue
 		}
 

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -48,6 +48,21 @@ func maxLeadTime(triggers []string) time.Duration {
 	return longest
 }
 
+// fireable returns only the alarms the engine can dispatch. A preserved
+// sync-only action (issue #579) never fires. The row is healthy, not a
+// defect, so the filter is silent. Apply this filter to every alarm fetch
+// on the check paths. A new loop over a filtered fetch then cannot fire a
+// sync-only alarm.
+func fireable(alarms []model.Alarm) []model.Alarm {
+	kept := make([]model.Alarm, 0, len(alarms))
+	for _, a := range alarms {
+		if model.FireableAlarmAction(a.Action) {
+			kept = append(kept, a)
+		}
+	}
+	return kept
+}
+
 // DueAlarm represents an alarm that should fire now.
 type DueAlarm struct {
 	Event     event.Event
@@ -137,14 +152,13 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 	if err != nil {
 		return nil, nil, err
 	}
+	for id, as := range alarmMap {
+		alarmMap[id] = fireable(as)
+	}
 
 	var missed []MissedAlarm
 	for _, expEvt := range expanded {
 		for _, a := range alarmMap[expEvt.ID] {
-			// A sync-only action never fires, so it is never missed.
-			if !model.FireableAlarmAction(a.Action) {
-				continue
-			}
 			triggerAt, err := computeTriggerTimeForInstance(expEvt, a)
 			if err != nil {
 				continue
@@ -180,7 +194,11 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			}
 
 			alarms, err := s.todos.ListAlarmsLean(ctx, td.ID)
-			if err != nil || len(alarms) == 0 {
+			if err != nil {
+				continue
+			}
+			alarms = fireable(alarms)
+			if len(alarms) == 0 {
 				continue
 			}
 
@@ -198,10 +216,6 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			}
 			for _, inst := range instances {
 				for _, a := range alarms {
-					// A sync-only action never fires, so it is never missed.
-					if !model.FireableAlarmAction(a.Action) {
-						continue
-					}
 					triggerAt, err := computeTodoTriggerTimeForInstance(inst, a)
 					if err != nil {
 						continue
@@ -312,6 +326,9 @@ func (s *Service) checkEventAlarms(ctx context.Context, now time.Time) ([]DueAla
 	if err != nil {
 		return nil, fmt.Errorf("fetch alarms: %w", err)
 	}
+	for id, as := range alarmMap {
+		alarmMap[id] = fireable(as)
+	}
 
 	var due []DueAlarm
 
@@ -319,11 +336,6 @@ func (s *Service) checkEventAlarms(ctx context.Context, now time.Time) ([]DueAla
 		alarms := alarmMap[expEvt.ID] // nil if no alarms for this event
 
 		for _, a := range alarms {
-			// A preserved sync-only action (issue #579) never fires.
-			// Skip it in silence: the row is healthy, not a defect.
-			if !model.FireableAlarmAction(a.Action) {
-				continue
-			}
 			triggerAt, err := computeTriggerTimeForInstance(expEvt, a)
 			if err != nil {
 				continue
@@ -526,6 +538,12 @@ func (s *Service) ListExpiredSnoozed(ctx context.Context, now time.Time) ([]DueA
 		}
 		if matched.ID == 0 {
 			continue // alarm definition was removed
+		}
+		// A sync pull can rewrite a snoozed alarm to a sync-only action
+		// in place (same row ID, matched by UID). The re-fire must not
+		// happen and the snooze state must stay unconsumed.
+		if !model.FireableAlarmAction(matched.Action) {
+			continue
 		}
 
 		triggerAt, _ := time.Parse(time.RFC3339, storage.NullableToString(st.SnoozedTo))

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -514,15 +514,9 @@ func (s *Service) ListExpiredSnoozed(ctx context.Context, now time.Time) ([]DueA
 		if matched.ID == 0 {
 			continue // alarm definition was removed
 		}
-		// A sync pull can rewrite a snoozed alarm to a sync-only action
-		// in place (same row ID, matched by UID). The re-fire must not
-		// happen. Dismiss the state row: an unconsumed snooze would
-		// stay pending in `alarm list` forever, and every check tick
-		// would resolve it again with no effect.
-		if !model.FireableAlarmAction(matched.Action) {
-			_ = s.Dismiss(ctx, st.ID)
-			continue
-		}
+		// A rewrite to a sync-only action retires the state row at the
+		// write point (updateAlarmInPlace), so this list never returns
+		// such a row.
 
 		triggerAt, _ := time.Parse(time.RFC3339, storage.NullableToString(st.SnoozedTo))
 
@@ -712,73 +706,17 @@ func (s *Service) Snooze(ctx context.Context, stateID int64, until time.Time) er
 	})
 }
 
-// ListPending returns all fired alarms that are not acknowledged. A sync
-// pull can rewrite a fired alarm to a sync-only action in place before
-// the user dismisses it. That alarm can never re-fire. Retire its state
-// row with the same dismiss treatment as the expired-snooze path, so
-// `alarm list` does not show it forever.
+// ListPending returns all fired alarms that are not acknowledged. A
+// rewrite to a sync-only action retires the alarm's state at the write
+// point (updateAlarmInPlace), so this list never returns such a row.
 func (s *Service) ListPending(ctx context.Context) ([]storage.AlarmState, error) {
-	states, err := s.q.ListPendingAlarmStates(ctx)
-	if err != nil {
-		return nil, err
-	}
-	kept := make([]storage.AlarmState, 0, len(states))
-	for _, st := range states {
-		if s.pendingStateIsSyncOnly(ctx, st) {
-			_ = s.Dismiss(ctx, st.ID)
-			continue
-		}
-		kept = append(kept, st)
-	}
-	return kept, nil
+	return s.q.ListPendingAlarmStates(ctx)
 }
 
-// pendingStateIsSyncOnly reports whether the state row points at an alarm
-// whose action the engine cannot fire.
-func (s *Service) pendingStateIsSyncOnly(ctx context.Context, st storage.AlarmState) bool {
-	alarms, err := s.events.ListAlarms(ctx, st.EventID)
-	if err != nil {
-		return false
-	}
-	for _, a := range alarms {
-		if a.ID == st.AlarmID {
-			return !model.FireableAlarmAction(a.Action)
-		}
-	}
-	return false
-}
-
-// ListPendingTodoAlarms returns all fired-but-not-acknowledged todo
-// alarms, with the same sync-only retirement as ListPending.
+// ListPendingTodoAlarms returns all fired todo alarms that are not
+// acknowledged, with the same write-point retirement as ListPending.
 func (s *Service) ListPendingTodoAlarms(ctx context.Context) ([]storage.TodoAlarmState, error) {
-	states, err := s.q.ListPendingTodoAlarmStates(ctx)
-	if err != nil {
-		return nil, err
-	}
-	kept := make([]storage.TodoAlarmState, 0, len(states))
-	for _, st := range states {
-		if s.pendingTodoStateIsSyncOnly(ctx, st) {
-			_ = s.DismissTodoAlarm(ctx, st.ID)
-			continue
-		}
-		kept = append(kept, st)
-	}
-	return kept, nil
-}
-
-// pendingTodoStateIsSyncOnly reports whether the todo state row points at
-// an alarm whose action the engine cannot fire.
-func (s *Service) pendingTodoStateIsSyncOnly(ctx context.Context, st storage.TodoAlarmState) bool {
-	alarms, err := s.todos.ListAlarmsLean(ctx, st.TodoID)
-	if err != nil {
-		return false
-	}
-	for _, a := range alarms {
-		if a.ID == st.AlarmID {
-			return !model.FireableAlarmAction(a.Action)
-		}
-	}
-	return false
+	return s.q.ListPendingTodoAlarmStates(ctx)
 }
 
 // DismissTodoAlarm acknowledges a fired todo alarm so it will not show as pending.

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -18,6 +18,11 @@ import (
 // StaleThreshold is the maximum age of an unfired alarm before it is skipped.
 const StaleThreshold = 24 * time.Hour
 
+// ErrNotFireable reports that the stored action of an alarm is sync-only.
+// The alarm engine preserves such an alarm for the round trip, but it never
+// dispatches a notification for it (issue #579).
+var ErrNotFireable = errors.New("alarm action is not fireable")
+
 // baseForwardWindow is the minimum distance past `now` that the expansion
 // window reaches, before configured alarm lead times are added. It covers
 // the common short reminders (-PT15M, -P1D, …) without a DB scan. It also
@@ -531,6 +536,9 @@ func (s *Service) ListExpiredSnoozed(ctx context.Context, now time.Time) ([]DueA
 }
 
 // MarkFired records that an alarm has been fired and returns the new state ID.
+// It returns ErrNotFireable when the stored action is sync-only. The insert
+// reads the action in the same statement, so a sync pull that disables the
+// alarm after the check loop reads it cannot leave a fired state behind.
 func (s *Service) MarkFired(ctx context.Context, da DueAlarm) (int64, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	st, err := s.q.CreateAlarmState(ctx, storage.CreateAlarmStateParams{
@@ -539,6 +547,9 @@ func (s *Service) MarkFired(ctx context.Context, da DueAlarm) (int64, error) {
 		TriggerAt: da.TriggerAt.UTC().Format(time.RFC3339),
 		FiredAt:   &now,
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFireable
+	}
 	if err != nil {
 		return 0, err
 	}

--- a/internal/alarm/service_integration_test.go
+++ b/internal/alarm/service_integration_test.go
@@ -32,13 +32,7 @@ func (m *mockAlarmLister) ListFireableAlarmsLean(ctx context.Context, todoID int
 	if err != nil {
 		return nil, err
 	}
-	kept := make([]model.Alarm, 0, len(alarms))
-	for _, a := range alarms {
-		if model.FireableAlarmAction(a.Action) {
-			kept = append(kept, a)
-		}
-	}
-	return kept, nil
+	return filterFireable(alarms), nil
 }
 
 func TestService_Check_BothEventAndTodoAlarms(t *testing.T) {

--- a/internal/alarm/service_integration_test.go
+++ b/internal/alarm/service_integration_test.go
@@ -27,6 +27,20 @@ func (m *mockAlarmLister) ListAlarmsLean(ctx context.Context, todoID int64) ([]m
 	return m.ListAlarms(ctx, todoID)
 }
 
+func (m *mockAlarmLister) ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error) {
+	alarms, err := m.ListAlarmsLean(ctx, todoID)
+	if err != nil {
+		return nil, err
+	}
+	kept := make([]model.Alarm, 0, len(alarms))
+	for _, a := range alarms {
+		if model.FireableAlarmAction(a.Action) {
+			kept = append(kept, a)
+		}
+	}
+	return kept, nil
+}
+
 func TestService_Check_BothEventAndTodoAlarms(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -298,7 +298,7 @@ func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 	}
 	// The lister retires the state row. An unconsumed snooze would stay
 	// pending in `alarm list` forever, and every check tick would resolve
-	// it again for nothing.
+	// it again with no effect.
 	var ackedAt sql.NullString
 	if err := db.QueryRowContext(ctx,
 		`SELECT acked_at FROM alarm_state WHERE id = ?`, stateID).Scan(&ackedAt); err != nil {
@@ -306,6 +306,68 @@ func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 	}
 	if !ackedAt.Valid || ackedAt.String == "" {
 		t.Errorf("state row not acknowledged; the dead snooze must be retired")
+	}
+}
+
+// A fired-but-undismissed alarm can also be rewritten in place to a
+// sync-only action before the user dismisses it. ListPending must retire
+// that state row with the same dismiss treatment, so `alarm list` does
+// not show a pending entry that can never re-fire.
+func TestListPending_RetiresRewrittenSyncOnlyState(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	evtSvc := event.NewService(db, q)
+	svc := NewService(db, q, evtSvc, nil)
+	ctx := context.Background()
+
+	start := time.Now().Add(10 * time.Minute)
+	e, err := evtSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Fired then disabled",
+		StartTime:  start,
+		EndTime:    start.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	due, _, err := svc.Check(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("due = %d, want 1", len(due))
+	}
+	stateID, err := svc.MarkFired(ctx, due[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite the alarm row in place, like updateAlarmInPlace does on a
+	// sync pull.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE event_alarms SET action = 'NONE' WHERE id = ?`, due[0].Alarm.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := svc.ListPending(ctx)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("pending = %d, want 0 (a sync-only alarm must not stay pending)", len(pending))
+	}
+	var ackedAt sql.NullString
+	if err := db.QueryRowContext(ctx,
+		`SELECT acked_at FROM alarm_state WHERE id = ?`, stateID).Scan(&ackedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !ackedAt.Valid || ackedAt.String == "" {
+		t.Errorf("state row not acknowledged; the dead pending entry must be retired")
 	}
 }
 

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -296,13 +296,16 @@ func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 	if len(due) != 0 {
 		t.Errorf("due after rewrite = %d, want 0 (a sync-only action must not re-fire)", len(due))
 	}
-	var snoozedTo sql.NullString
+	// The lister retires the state row. An unconsumed snooze would stay
+	// pending in `alarm list` forever, and every check tick would resolve
+	// it again for nothing.
+	var ackedAt sql.NullString
 	if err := db.QueryRowContext(ctx,
-		`SELECT snoozed_to FROM alarm_state WHERE id = ?`, stateID).Scan(&snoozedTo); err != nil {
+		`SELECT acked_at FROM alarm_state WHERE id = ?`, stateID).Scan(&ackedAt); err != nil {
 		t.Fatal(err)
 	}
-	if !snoozedTo.Valid || snoozedTo.String == "" {
-		t.Errorf("snoozed_to was cleared; the snooze state must stay unconsumed")
+	if !ackedAt.Valid || ackedAt.String == "" {
+		t.Errorf("state row not acknowledged; the dead snooze must be retired")
 	}
 }
 

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -242,9 +242,10 @@ func TestCheck_SkipsSyncOnlyAction(t *testing.T) {
 }
 
 // A sync pull can rewrite a snoozed alarm to a sync-only action in place
-// (same row ID, matched by UID). The write point retires the snooze state
-// in the same transaction, so the expired snooze does not re-fire and
-// `alarm list` does not show it forever.
+// (same row ID, matched by UID). The snooze must not re-fire while the
+// action stays sync-only. The state row must survive, because a later pull
+// can restore a fireable action. A retirement that wrote acked_at would
+// consume the snooze of the user for good (issue #579).
 func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 	evtSvc := event.NewService(db, q)
@@ -283,8 +284,7 @@ func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 	}
 
 	// Rewrite the alarm through ReplaceAlarms with the same UID. The UID
-	// match routes to updateAlarmInPlace: the row ID survives, and the
-	// write point retires the snooze state in the same transaction.
+	// match routes to updateAlarmInPlace, so the row ID survives.
 	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
 		{Action: "NONE", TriggerValue: "-PT15M", UID: "snooze-rewrite@test"},
 	}); err != nil {
@@ -303,16 +303,34 @@ func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 		`SELECT acked_at FROM alarm_state WHERE id = ?`, stateID).Scan(&ackedAt); err != nil {
 		t.Fatal(err)
 	}
-	if !ackedAt.Valid || ackedAt.String == "" {
-		t.Errorf("state row not acknowledged; the write point must retire the dead snooze")
+	if ackedAt.Valid && ackedAt.String != "" {
+		t.Errorf("state row acknowledged; a sync-only rewrite must not consume the snooze")
+	}
+
+	// A later pull restores the fireable action. The snooze must come back,
+	// because nothing consumed it.
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M", UID: "snooze-rewrite@test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	due, _, err = svc.Check(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("check after restore: %v", err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("due after restore = %d, want 1 (the restored alarm must fire again)", len(due))
+	}
+	if due[0].StateID != stateID {
+		t.Errorf("state id = %d, want the original %d", due[0].StateID, stateID)
 	}
 }
 
 // A fired-but-undismissed alarm can also be rewritten in place to a
-// sync-only action before the user dismisses it. The write point retires
-// that state row, so `alarm list` does not show a pending entry that can
-// never re-fire.
-func TestListPending_RetiresRewrittenSyncOnlyState(t *testing.T) {
+// sync-only action before the user dismisses it. `alarm list` must hide
+// that entry, because the alarm cannot fire. The row must survive, so the
+// entry comes back when a later pull restores a fireable action.
+func TestListPending_HidesRewrittenSyncOnlyState(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 	evtSvc := event.NewService(db, q)
 	svc := NewService(db, q, evtSvc, nil)
@@ -347,7 +365,7 @@ func TestListPending_RetiresRewrittenSyncOnlyState(t *testing.T) {
 	}
 
 	// Rewrite the alarm through ReplaceAlarms with the same UID. The UID
-	// match routes to updateAlarmInPlace, which retires the state row.
+	// match routes to updateAlarmInPlace, so the row ID survives.
 	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
 		{Action: "NONE", TriggerValue: "-PT15M", UID: "pending-rewrite@test"},
 	}); err != nil {
@@ -366,8 +384,23 @@ func TestListPending_RetiresRewrittenSyncOnlyState(t *testing.T) {
 		`SELECT acked_at FROM alarm_state WHERE id = ?`, stateID).Scan(&ackedAt); err != nil {
 		t.Fatal(err)
 	}
-	if !ackedAt.Valid || ackedAt.String == "" {
-		t.Errorf("state row not acknowledged; the dead pending entry must be retired")
+	if ackedAt.Valid && ackedAt.String != "" {
+		t.Errorf("state row acknowledged; the hide must not dismiss the alarm of the user")
+	}
+
+	// A later pull restores the fireable action. The pending entry must
+	// come back, because nothing dismissed it.
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M", UID: "pending-rewrite@test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pending, err = svc.ListPending(ctx)
+	if err != nil {
+		t.Fatalf("list pending after restore: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending after restore = %d, want 1 (the entry must come back)", len(pending))
 	}
 }
 

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -213,33 +213,96 @@ func TestCheck_SkipsSyncOnlyAction(t *testing.T) {
 		t.Errorf("todo alarms = %d, want 0 (a sync-only action never fires)", len(dueTodos))
 	}
 
-	// CheckMissed must not report a sync-only action either: it never
-	// fires, so it is never missed.
+	// CheckMissed must not report a sync-only action: it never fires, so
+	// it is never missed. The exact counts also fail on an over-broad
+	// skip that drops the DISPLAY alarm.
 	missed, missedTodos, err := svc.CheckMissed(ctx, time.Now().Add(48*time.Hour), 72*time.Hour)
 	if err != nil {
 		t.Fatalf("check missed: %v", err)
 	}
-	for _, m := range missed {
-		alarms, err := evtSvc.ListAlarms(ctx, e.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, a := range alarms {
-			if a.ID == m.AlarmID && !model.FireableAlarmAction(a.Action) {
-				t.Errorf("missed report includes sync-only alarm %d (%s)", a.ID, a.Action)
-			}
+	alarms, err := evtSvc.ListAlarms(ctx, e.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncOnlyIDs := make(map[int64]bool)
+	for _, a := range alarms {
+		if !model.FireableAlarmAction(a.Action) {
+			syncOnlyIDs[a.ID] = true
 		}
 	}
-	for _, m := range missedTodos {
-		alarms, err := todoSvc.ListAlarms(ctx, td.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, a := range alarms {
-			if a.ID == m.AlarmID && !model.FireableAlarmAction(a.Action) {
-				t.Errorf("missed report includes sync-only todo alarm %d (%s)", a.ID, a.Action)
-			}
-		}
+	if len(missed) != 1 {
+		t.Fatalf("missed = %d, want exactly 1 (the DISPLAY alarm)", len(missed))
+	}
+	if syncOnlyIDs[missed[0].AlarmID] {
+		t.Errorf("missed report includes a sync-only alarm (id %d)", missed[0].AlarmID)
+	}
+	if len(missedTodos) != 0 {
+		t.Errorf("missed todos = %d, want 0 (the only todo alarm is sync-only)", len(missedTodos))
+	}
+}
+
+// A sync pull can rewrite a snoozed alarm to a sync-only action in place
+// (same row ID, matched by UID). The expired snooze must not re-fire, and
+// the snooze state must stay unconsumed.
+func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	evtSvc := event.NewService(db, q)
+	svc := NewService(db, q, evtSvc, nil)
+	ctx := context.Background()
+
+	start := time.Now().Add(10 * time.Minute)
+	e, err := evtSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Snoozed then disabled",
+		StartTime:  start,
+		EndTime:    start.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	due, _, err := svc.Check(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("due = %d, want 1", len(due))
+	}
+	stateID, err := svc.MarkFired(ctx, due[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Snooze(ctx, stateID, time.Now().Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite the alarm row in place, like updateAlarmInPlace does on a
+	// sync pull. ReplaceAlarms would delete and recreate the row, and the
+	// cascade would remove the snooze state this test must observe.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE event_alarms SET action = 'NONE' WHERE id = ?`, due[0].Alarm.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	due, _, err = svc.Check(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("check after rewrite: %v", err)
+	}
+	if len(due) != 0 {
+		t.Errorf("due after rewrite = %d, want 0 (a sync-only action must not re-fire)", len(due))
+	}
+	var snoozedTo sql.NullString
+	if err := db.QueryRowContext(ctx,
+		`SELECT snoozed_to FROM alarm_state WHERE id = ?`, stateID).Scan(&snoozedTo); err != nil {
+		t.Fatal(err)
+	}
+	if !snoozedTo.Valid || snoozedTo.String == "" {
+		t.Errorf("snoozed_to was cleared; the snooze state must stay unconsumed")
 	}
 }
 

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -242,8 +242,9 @@ func TestCheck_SkipsSyncOnlyAction(t *testing.T) {
 }
 
 // A sync pull can rewrite a snoozed alarm to a sync-only action in place
-// (same row ID, matched by UID). The expired snooze must not re-fire, and
-// the snooze state must stay unconsumed.
+// (same row ID, matched by UID). The write point retires the snooze state
+// in the same transaction, so the expired snooze does not re-fire and
+// `alarm list` does not show it forever.
 func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 	evtSvc := event.NewService(db, q)
@@ -261,7 +262,7 @@ func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
-		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M", UID: "snooze-rewrite@test"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -281,11 +282,12 @@ func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Rewrite the alarm row in place, like updateAlarmInPlace does on a
-	// sync pull. ReplaceAlarms would delete and recreate the row, and the
-	// cascade would remove the snooze state this test must observe.
-	if _, err := db.ExecContext(ctx,
-		`UPDATE event_alarms SET action = 'NONE' WHERE id = ?`, due[0].Alarm.ID); err != nil {
+	// Rewrite the alarm through ReplaceAlarms with the same UID. The UID
+	// match routes to updateAlarmInPlace: the row ID survives, and the
+	// write point retires the snooze state in the same transaction.
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "NONE", TriggerValue: "-PT15M", UID: "snooze-rewrite@test"},
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -296,23 +298,20 @@ func TestCheck_SnoozedAlarmRewrittenSyncOnly_DoesNotRefire(t *testing.T) {
 	if len(due) != 0 {
 		t.Errorf("due after rewrite = %d, want 0 (a sync-only action must not re-fire)", len(due))
 	}
-	// The lister retires the state row. An unconsumed snooze would stay
-	// pending in `alarm list` forever, and every check tick would resolve
-	// it again with no effect.
 	var ackedAt sql.NullString
 	if err := db.QueryRowContext(ctx,
 		`SELECT acked_at FROM alarm_state WHERE id = ?`, stateID).Scan(&ackedAt); err != nil {
 		t.Fatal(err)
 	}
 	if !ackedAt.Valid || ackedAt.String == "" {
-		t.Errorf("state row not acknowledged; the dead snooze must be retired")
+		t.Errorf("state row not acknowledged; the write point must retire the dead snooze")
 	}
 }
 
 // A fired-but-undismissed alarm can also be rewritten in place to a
-// sync-only action before the user dismisses it. ListPending must retire
-// that state row with the same dismiss treatment, so `alarm list` does
-// not show a pending entry that can never re-fire.
+// sync-only action before the user dismisses it. The write point retires
+// that state row, so `alarm list` does not show a pending entry that can
+// never re-fire.
 func TestListPending_RetiresRewrittenSyncOnlyState(t *testing.T) {
 	db, q := testutil.NewTestDB(t)
 	evtSvc := event.NewService(db, q)
@@ -330,7 +329,7 @@ func TestListPending_RetiresRewrittenSyncOnlyState(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
-		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M", UID: "pending-rewrite@test"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -347,10 +346,11 @@ func TestListPending_RetiresRewrittenSyncOnlyState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Rewrite the alarm row in place, like updateAlarmInPlace does on a
-	// sync pull.
-	if _, err := db.ExecContext(ctx,
-		`UPDATE event_alarms SET action = 'NONE' WHERE id = ?`, due[0].Alarm.ID); err != nil {
+	// Rewrite the alarm through ReplaceAlarms with the same UID. The UID
+	// match routes to updateAlarmInPlace, which retires the state row.
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "NONE", TriggerValue: "-PT15M", UID: "pending-rewrite@test"},
+	}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -158,6 +158,91 @@ func TestCheck_GarbageTrigger_NeverFires(t *testing.T) {
 	}
 }
 
+// Regression test for issue #579. Import preserves a VALARM action outside
+// model.FireableAlarmAction (for example the Google ACTION:NONE sentinel or
+// an x-name action from another client). Check must skip such an alarm in
+// silence, on both the event path and the todo path, while a fireable alarm
+// on the same record still fires.
+func TestCheck_SkipsSyncOnlyAction(t *testing.T) {
+	svc, evtSvc, todoSvc := newTestServicesWithTodos(t)
+	ctx := context.Background()
+
+	start := time.Now().Add(10 * time.Minute)
+	e, err := evtSvc.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Foreign alarms",
+		StartTime:  start,
+		EndTime:    start.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "NONE", TriggerValue: "-PT15M"},
+		{Action: "X-APPLE-SOUND", TriggerValue: "-PT15M"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M", Description: "real reminder"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	td, err := todoSvc.Create(ctx, todo.CreateParams{
+		CalendarID: 1,
+		Summary:    "Foreign todo alarm",
+		DueDate:    start.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := todoSvc.ReplaceAlarms(ctx, td.ID, []model.Alarm{
+		{Action: "NONE", TriggerValue: "-PT15M"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	dueEvents, dueTodos, err := svc.Check(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if len(dueEvents) != 1 {
+		t.Fatalf("event alarms = %d, want 1 (only the DISPLAY alarm fires)", len(dueEvents))
+	}
+	if got := dueEvents[0].Alarm.Action; got != "DISPLAY" {
+		t.Errorf("fired action = %q, want DISPLAY", got)
+	}
+	if len(dueTodos) != 0 {
+		t.Errorf("todo alarms = %d, want 0 (a sync-only action never fires)", len(dueTodos))
+	}
+
+	// CheckMissed must not report a sync-only action either: it never
+	// fires, so it is never missed.
+	missed, missedTodos, err := svc.CheckMissed(ctx, time.Now().Add(48*time.Hour), 72*time.Hour)
+	if err != nil {
+		t.Fatalf("check missed: %v", err)
+	}
+	for _, m := range missed {
+		alarms, err := evtSvc.ListAlarms(ctx, e.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, a := range alarms {
+			if a.ID == m.AlarmID && !model.FireableAlarmAction(a.Action) {
+				t.Errorf("missed report includes sync-only alarm %d (%s)", a.ID, a.Action)
+			}
+		}
+	}
+	for _, m := range missedTodos {
+		alarms, err := todoSvc.ListAlarms(ctx, td.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, a := range alarms {
+			if a.ID == m.AlarmID && !model.FireableAlarmAction(a.Action) {
+				t.Errorf("missed report includes sync-only todo alarm %d (%s)", a.ID, a.Action)
+			}
+		}
+	}
+}
+
 func TestCheck_SkipsAlreadyFired(t *testing.T) {
 	svc, evtSvc := newTestServices(t)
 	ctx := context.Background()

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -103,6 +103,11 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 
 		for _, inst := range instances {
 			for _, a := range alarms {
+				// A preserved sync-only action (issue #579) never fires.
+				// Skip it in silence: the row is healthy, not a defect.
+				if !model.FireableAlarmAction(a.Action) {
+					continue
+				}
 				triggerAt, err := computeTodoTriggerTimeForInstance(inst, a)
 				if err != nil {
 					// A refused anchor drops a reminder. Log it like

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -24,12 +24,16 @@ type TodoDueAlarm struct {
 	StateID   int64
 }
 
-// TodoAlarmLister defines the interface for a list of todo alarms.
-// ListAlarmsLean omits X-properties (round-trip-only metadata) — the check
-// loop calls it per todo every tick and never reads them.
+// TodoAlarmLister defines the interface for a list of todo alarms. The
+// Lean variants omit X-properties (round-trip-only metadata) — the check
+// loop calls them per todo every tick and never reads them. The Fireable
+// variant also excludes preserved sync-only actions in SQL; the snooze
+// lister needs the unfiltered list to detect and retire a rewritten
+// alarm's state.
 type TodoAlarmLister interface {
 	ListAlarms(ctx context.Context, todoID int64) ([]model.Alarm, error)
 	ListAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error)
+	ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error)
 }
 
 // TodoService handles alarm operations for todos
@@ -78,11 +82,10 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 			continue
 		}
 
-		alarms, err := s.todos.ListAlarmsLean(ctx, t.ID)
+		alarms, err := s.todos.ListFireableAlarmsLean(ctx, t.ID)
 		if err != nil {
 			continue
 		}
-		alarms = fireable(alarms)
 		if len(alarms) == 0 {
 			continue
 		}
@@ -367,8 +370,15 @@ func (s *TodoService) ListExpiredTodoSnoozed(ctx context.Context, now time.Time)
 		}
 		// A sync pull can rewrite a snoozed alarm to a sync-only action
 		// in place (same row ID, matched by UID). The re-fire must not
-		// happen and the snooze state must stay unconsumed.
+		// happen. Acknowledge the state row: an unconsumed snooze would
+		// stay pending in `alarm list` forever, and every check tick
+		// would resolve it again for nothing.
 		if !model.FireableAlarmAction(matched.Action) {
+			ackAt := now.UTC().Format(time.RFC3339)
+			_ = s.q.AcknowledgeTodoAlarmState(ctx, storage.AcknowledgeTodoAlarmStateParams{
+				AckedAt: &ackAt,
+				ID:      st.ID,
+			})
 			continue
 		}
 

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -27,9 +27,9 @@ type TodoDueAlarm struct {
 // TodoAlarmLister defines the interface for a list of todo alarms. The
 // Lean variants omit X-properties (round-trip-only metadata) — the check
 // loop calls them per todo every tick and never reads them. The Fireable
-// variant also excludes preserved sync-only actions in SQL; the snooze
-// lister needs the unfiltered list to detect and retire a rewritten
-// alarm's state.
+// variant also excludes preserved sync-only actions in SQL. The snooze
+// lister uses the unfiltered list: the write point retires the state of
+// a rewritten alarm, so every snoozed state it matches is fireable.
 type TodoAlarmLister interface {
 	ListAlarms(ctx context.Context, todoID int64) ([]model.Alarm, error)
 	ListAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error)
@@ -365,15 +365,9 @@ func (s *TodoService) ListExpiredTodoSnoozed(ctx context.Context, now time.Time)
 		if matched.ID == 0 {
 			continue
 		}
-		// A sync pull can rewrite a snoozed alarm to a sync-only action
-		// in place (same row ID, matched by UID). The re-fire must not
-		// happen. Dismiss the state row: an unconsumed snooze would
-		// stay pending in `alarm list` forever, and every check tick
-		// would resolve it again with no effect.
-		if !model.FireableAlarmAction(matched.Action) {
-			_ = s.DismissTodoAlarm(ctx, st.ID)
-			continue
-		}
+		// A rewrite to a sync-only action retires the state row at the
+		// write point (updateTodoAlarmInPlace), so this list never
+		// returns such a row.
 
 		triggerAt, _ := time.Parse(time.RFC3339, storage.NullableToString(st.SnoozedTo))
 

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -83,10 +83,7 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 		}
 
 		alarms, err := s.todos.ListFireableAlarmsLean(ctx, t.ID)
-		if err != nil {
-			continue
-		}
-		if len(alarms) == 0 {
+		if err != nil || len(alarms) == 0 {
 			continue
 		}
 
@@ -370,15 +367,11 @@ func (s *TodoService) ListExpiredTodoSnoozed(ctx context.Context, now time.Time)
 		}
 		// A sync pull can rewrite a snoozed alarm to a sync-only action
 		// in place (same row ID, matched by UID). The re-fire must not
-		// happen. Acknowledge the state row: an unconsumed snooze would
+		// happen. Dismiss the state row: an unconsumed snooze would
 		// stay pending in `alarm list` forever, and every check tick
-		// would resolve it again for nothing.
+		// would resolve it again with no effect.
 		if !model.FireableAlarmAction(matched.Action) {
-			ackAt := now.UTC().Format(time.RFC3339)
-			_ = s.q.AcknowledgeTodoAlarmState(ctx, storage.AcknowledgeTodoAlarmStateParams{
-				AckedAt: &ackAt,
-				ID:      st.ID,
-			})
+			_ = s.DismissTodoAlarm(ctx, st.ID)
 			continue
 		}
 

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -298,7 +298,10 @@ func computeTodoTriggerTimeForInstance(inst recurrence.ExpandedTodo, alarm model
 	return model.ParseAbsoluteTime(alarm.TriggerValue, inst.Timezone)
 }
 
-// MarkTodoAlarmFired records that a todo alarm has fired
+// MarkTodoAlarmFired records that a todo alarm has fired. It returns
+// ErrNotFireable when the stored action is sync-only. The insert reads the
+// action in the same statement, so a sync pull that disables the alarm
+// after the check loop reads it cannot leave a fired state behind.
 func (s *TodoService) MarkTodoAlarmFired(ctx context.Context, alarmID, todoID int64, triggerAt time.Time) (int64, error) {
 	triggerKey := triggerAt.UTC().Format(time.RFC3339)
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -309,6 +312,9 @@ func (s *TodoService) MarkTodoAlarmFired(ctx context.Context, alarmID, todoID in
 		TriggerAt: triggerKey,
 		FiredAt:   &now,
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFireable
+	}
 	if err != nil {
 		return 0, fmt.Errorf("insert todo alarm state: %w", err)
 	}

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -79,7 +79,11 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 		}
 
 		alarms, err := s.todos.ListAlarmsLean(ctx, t.ID)
-		if err != nil || len(alarms) == 0 {
+		if err != nil {
+			continue
+		}
+		alarms = fireable(alarms)
+		if len(alarms) == 0 {
 			continue
 		}
 
@@ -103,11 +107,6 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 
 		for _, inst := range instances {
 			for _, a := range alarms {
-				// A preserved sync-only action (issue #579) never fires.
-				// Skip it in silence: the row is healthy, not a defect.
-				if !model.FireableAlarmAction(a.Action) {
-					continue
-				}
 				triggerAt, err := computeTodoTriggerTimeForInstance(inst, a)
 				if err != nil {
 					// A refused anchor drops a reminder. Log it like
@@ -364,6 +363,12 @@ func (s *TodoService) ListExpiredTodoSnoozed(ctx context.Context, now time.Time)
 			}
 		}
 		if matched.ID == 0 {
+			continue
+		}
+		// A sync pull can rewrite a snoozed alarm to a sync-only action
+		// in place (same row ID, matched by UID). The re-fire must not
+		// happen and the snooze state must stay unconsumed.
+		if !model.FireableAlarmAction(matched.Action) {
 			continue
 		}
 

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -24,6 +24,20 @@ func (m *mockTodoAlarmLister) ListAlarmsLean(ctx context.Context, todoID int64) 
 	return m.ListAlarms(ctx, todoID)
 }
 
+func (m *mockTodoAlarmLister) ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error) {
+	alarms, err := m.ListAlarmsLean(ctx, todoID)
+	if err != nil {
+		return nil, err
+	}
+	kept := make([]model.Alarm, 0, len(alarms))
+	for _, a := range alarms {
+		if model.FireableAlarmAction(a.Action) {
+			kept = append(kept, a)
+		}
+	}
+	return kept, nil
+}
+
 // TestComputeTodoTrigger_RelatedEnd_DtStartPlusDue guards issue #367: a VTODO
 // with DTSTART + DUE (no explicit DURATION) must anchor a RELATED=END trigger
 // at DUE, not at DTSTART. The bug fires the alarm (DUE−DTSTART) too early.

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -29,13 +29,19 @@ func (m *mockTodoAlarmLister) ListFireableAlarmsLean(ctx context.Context, todoID
 	if err != nil {
 		return nil, err
 	}
+	return filterFireable(alarms), nil
+}
+
+// filterFireable keeps the alarms the engine can fire. Both lister mocks
+// in this package share it, so the two cannot drift.
+func filterFireable(alarms []model.Alarm) []model.Alarm {
 	kept := make([]model.Alarm, 0, len(alarms))
 	for _, a := range alarms {
 		if model.FireableAlarmAction(a.Action) {
 			kept = append(kept, a)
 		}
 	}
-	return kept, nil
+	return kept
 }
 
 // TestComputeTodoTrigger_RelatedEnd_DtStartPlusDue guards issue #367: a VTODO

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1513,6 +1513,12 @@ func matchAlarmByUID(existing []model.Alarm, matched []bool, a model.Alarm) (int
 // updateAlarmInPlace rewrites a UID-matched alarm's content on its stored
 // row. The row ID stays so alarm_state entries keyed to it survive.
 func updateAlarmInPlace(ctx context.Context, qtx *storage.Queries, eventID int64, a model.Alarm, ex model.Alarm) error {
+	// Reject an unstorable action in Go, with a named error. The raw
+	// CHECK constraint would roll back the whole resource transaction
+	// during sync (issue #575).
+	if !model.StorableAlarmAction(a.Action) {
+		return fmt.Errorf("update alarm: action %q is not storable", a.Action)
+	}
 	// Same ACKNOWLEDGED policy as syncMatchedAlarm: a malformed incoming
 	// value must not clobber valid stored state.
 	ack := a.Acknowledged
@@ -1601,6 +1607,12 @@ func isUniqueUIDViolation(err error) bool {
 // both copies), which would otherwise fail this event's sync forever. On
 // collision, mint a fresh local UID instead.
 func createNewAlarm(ctx context.Context, qtx *storage.Queries, eventID int64, a model.Alarm) error {
+	// Reject an unstorable action in Go, with a named error. The raw
+	// CHECK constraint would roll back the whole resource transaction
+	// during sync (issue #575).
+	if !model.StorableAlarmAction(a.Action) {
+		return fmt.Errorf("create alarm: action %q is not storable", a.Action)
+	}
 	params := storage.CreateAlarmParams{
 		EventID:       eventID,
 		Uid:           storage.StringToNullable(alarmUID(a)),

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1660,6 +1660,19 @@ func deleteUnmatchedAlarms(ctx context.Context, qtx *storage.Queries, existing [
 	return nil
 }
 
+// ReplaceFireableAlarms replaces the fireable alarms of an event and
+// carries the stored sync-only rows forward. A caller that cannot state a
+// preserved action — the CLI --alarm flag — uses this method, so a
+// routine edit does not delete the VALARM of another client (issue #579).
+// A caller that must delete such a row calls ReplaceAlarms instead.
+func (s *Service) ReplaceFireableAlarms(ctx context.Context, eventID int64, alarms []model.Alarm) error {
+	stored, err := s.ListAlarms(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("list stored alarms: %w", err)
+	}
+	return s.ReplaceAlarms(ctx, eventID, model.KeepSyncOnlyAlarms(stored, alarms))
+}
+
 func (s *Service) ReplaceAlarms(ctx context.Context, eventID int64, alarms []model.Alarm) error {
 	// Prepare before the transaction opens. A standalone call then
 	// rejects a bad alarm without a write lock. A sync caller already

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1430,13 +1430,16 @@ func (s *Service) ListAlarms(ctx context.Context, eventID int64) ([]model.Alarm,
 	return buildAlarmsWithAttendees(ctx, s.q, rows)
 }
 
-// ListAlarmsByEventIDs fetches alarms for multiple event IDs in a single batch query.
-// Returns a map of event ID to its list of alarms.
-func (s *Service) ListAlarmsByEventIDs(ctx context.Context, eventIDs []int64) (map[int64][]model.Alarm, error) {
+// ListFireableAlarmsByEventIDs fetches the fireable alarms for multiple
+// event IDs in a single batch query. Returns a map of event ID to its list
+// of alarms. The query excludes preserved sync-only actions (issue #579):
+// the alarm check loop is the only caller, and a sync-only alarm must not
+// reach it.
+func (s *Service) ListFireableAlarmsByEventIDs(ctx context.Context, eventIDs []int64) (map[int64][]model.Alarm, error) {
 	if len(eventIDs) == 0 {
 		return nil, nil
 	}
-	alarmRows, err := s.q.ListAlarmsByEventIDs(ctx, eventIDs)
+	alarmRows, err := s.q.ListFireableAlarmsByEventIDs(ctx, eventIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1513,11 +1516,8 @@ func matchAlarmByUID(existing []model.Alarm, matched []bool, a model.Alarm) (int
 // updateAlarmInPlace rewrites a UID-matched alarm's content on its stored
 // row. The row ID stays so alarm_state entries keyed to it survive.
 func updateAlarmInPlace(ctx context.Context, qtx *storage.Queries, eventID int64, a model.Alarm, ex model.Alarm) error {
-	// Reject an unstorable action in Go, with a named error. The raw
-	// CHECK constraint would roll back the whole resource transaction
-	// during sync (issue #575).
-	if !model.StorableAlarmAction(a.Action) {
-		return fmt.Errorf("update alarm: action %q is not storable", a.Action)
+	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
+		return fmt.Errorf("update alarm: %w", err)
 	}
 	// Same ACKNOWLEDGED policy as syncMatchedAlarm: a malformed incoming
 	// value must not clobber valid stored state.
@@ -1607,11 +1607,8 @@ func isUniqueUIDViolation(err error) bool {
 // both copies), which would otherwise fail this event's sync forever. On
 // collision, mint a fresh local UID instead.
 func createNewAlarm(ctx context.Context, qtx *storage.Queries, eventID int64, a model.Alarm) error {
-	// Reject an unstorable action in Go, with a named error. The raw
-	// CHECK constraint would roll back the whole resource transaction
-	// during sync (issue #575).
-	if !model.StorableAlarmAction(a.Action) {
-		return fmt.Errorf("create alarm: action %q is not storable", a.Action)
+	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
+		return fmt.Errorf("create alarm: %w", err)
 	}
 	params := storage.CreateAlarmParams{
 		EventID:       eventID,

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1516,29 +1516,13 @@ func matchAlarmByUID(existing []model.Alarm, matched []bool, a model.Alarm) (int
 // updateAlarmInPlace rewrites a UID-matched alarm's content on its stored
 // row. The row ID stays so alarm_state entries keyed to it survive.
 func updateAlarmInPlace(ctx context.Context, qtx *storage.Queries, eventID int64, a model.Alarm, ex model.Alarm) error {
-	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
-		return fmt.Errorf("update alarm: %w", err)
-	}
-	// A rewrite to a sync-only action disables the alarm. Retire its
-	// live state in the same transaction: the check loop never fires
-	// this alarm again, so an open state row would stay pending in
-	// `alarm list` forever (issue #579). This write point is the only
-	// place a stored action can change, so the read paths need no
-	// retirement of their own.
-	if !model.FireableAlarmAction(a.Action) {
-		acked := time.Now().UTC().Format(time.RFC3339)
-		if err := qtx.AcknowledgeAlarmStatesByAlarmID(ctx, storage.AcknowledgeAlarmStatesByAlarmIDParams{
-			AckedAt: &acked,
-			AlarmID: ex.ID,
-		}); err != nil {
-			return fmt.Errorf("retire alarm state: %w", err)
-		}
-	}
-	// Same ACKNOWLEDGED policy as syncMatchedAlarm: a malformed incoming
-	// value must not clobber valid stored state.
-	ack := a.Acknowledged
-	if !model.ValidateAcknowledged(ack) {
-		ack = ex.Acknowledged
+	// A rewrite to a sync-only action disables the alarm, but this code
+	// leaves alarm_state alone. The pending and snooze queries filter on
+	// the current action, so the state of the alarm comes back when a
+	// later pull restores a fireable action (issue #579).
+	ack, err := model.PrepareAlarmUpdate(a, ex)
+	if err != nil {
+		return err
 	}
 	if err := qtx.UpdateAlarmContentByID(ctx, storage.UpdateAlarmContentByIDParams{
 		Action:        a.Action,

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1519,6 +1519,21 @@ func updateAlarmInPlace(ctx context.Context, qtx *storage.Queries, eventID int64
 	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
 		return fmt.Errorf("update alarm: %w", err)
 	}
+	// A rewrite to a sync-only action disables the alarm. Retire its
+	// live state in the same transaction: the check loop never fires
+	// this alarm again, so an open state row would stay pending in
+	// `alarm list` forever (issue #579). This write point is the only
+	// place a stored action can change, so the read paths need no
+	// retirement of their own.
+	if !model.FireableAlarmAction(a.Action) {
+		acked := time.Now().UTC().Format(time.RFC3339)
+		if err := qtx.AcknowledgeAlarmStatesByAlarmID(ctx, storage.AcknowledgeAlarmStatesByAlarmIDParams{
+			AckedAt: &acked,
+			AlarmID: ex.ID,
+		}); err != nil {
+			return fmt.Errorf("retire alarm state: %w", err)
+		}
+	}
 	// Same ACKNOWLEDGED policy as syncMatchedAlarm: a malformed incoming
 	// value must not clobber valid stored state.
 	ack := a.Acknowledged

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -948,9 +948,9 @@ func TestEventService_ListAlarmsByEventIDs_Correctness(t *testing.T) {
 
 	// Fetch alarms in batch (new optimized pattern)
 	eventIDs := []int64{events[0].ID, events[1].ID, events[2].ID}
-	batchMap, err := svc.ListAlarmsByEventIDs(ctx, eventIDs)
+	batchMap, err := svc.ListFireableAlarmsByEventIDs(ctx, eventIDs)
 	if err != nil {
-		t.Fatalf("ListAlarmsByEventIDs: %v", err)
+		t.Fatalf("ListFireableAlarmsByEventIDs: %v", err)
 	}
 
 	// Verify results are identical
@@ -985,7 +985,7 @@ func TestEventService_ListAlarmsByEventIDs_Correctness(t *testing.T) {
 	}
 
 	// Test empty input
-	emptyMap, err := svc.ListAlarmsByEventIDs(ctx, []int64{})
+	emptyMap, err := svc.ListFireableAlarmsByEventIDs(ctx, []int64{})
 	if err != nil {
 		t.Errorf("empty eventIDs: got error %v", err)
 	}
@@ -995,7 +995,7 @@ func TestEventService_ListAlarmsByEventIDs_Correctness(t *testing.T) {
 
 	// Test non-existent event IDs
 	nonExistent := []int64{9999, 9998}
-	nonExistentMap, err := svc.ListAlarmsByEventIDs(ctx, nonExistent)
+	nonExistentMap, err := svc.ListFireableAlarmsByEventIDs(ctx, nonExistent)
 	if err != nil {
 		t.Errorf("non-existent eventIDs: got error %v", err)
 	}

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -346,14 +346,6 @@ func TestEventService_ReplaceAlarms_RejectsInvalidAlarm(t *testing.T) {
 	e := createEvent(t, svc)
 
 	err := svc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
-		{Action: "DISPLAY", TriggerValue: "-PT15M"},
-		{Action: "PROCEDURE", TriggerValue: "-PT5M"},
-	})
-	if !errors.Is(err, model.ErrInvalidAlarm) {
-		t.Fatalf("invalid action: err = %v, want model.ErrInvalidAlarm", err)
-	}
-
-	err = svc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
 		{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "MIDDLE"},
 	})
 	if !errors.Is(err, model.ErrInvalidAlarm) {
@@ -366,6 +358,14 @@ func TestEventService_ReplaceAlarms_RejectsInvalidAlarm(t *testing.T) {
 	}
 	if len(alarms) != 0 {
 		t.Errorf("alarms = %d, want 0 (a rejected write must store no row)", len(alarms))
+	}
+
+	// A preserved foreign action passes. Migration 043 widened the action
+	// constraint, so the boundary accepts it (issue #579).
+	if err := svc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "NONE", TriggerValue: "-PT5M"},
+	}); err != nil {
+		t.Fatalf("preserved action: err = %v, want nil", err)
 	}
 }
 

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -843,9 +843,11 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	// DISPLAY alarms carry no ATTACH, so drop it for that one action. An
 	// empty action means DISPLAY everywhere else, so drop it there too:
 	// an "ACTION:" line plus ATTACH is invalid iCal that a strict server
-	// rejects. A preserved sync-only action (issue #579) keeps its
-	// ATTACH. The RFC leaves the property set of an x-name or iana-token
-	// action open. The VALARM of another client must round-trip verbatim.
+	// rejects.
+	//
+	// A preserved sync-only action (issue #579) keeps its ATTACH. The
+	// RFC leaves the property set of an x-name or iana-token action
+	// open. The VALARM of another client must round-trip verbatim.
 	if alarm.Action != "DISPLAY" && alarm.Action != "" && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
 		p := &ical.Prop{Name: ical.PropAttach, Params: make(ical.Params)}
 		if len(alarm.AttachBinary) > 0 {

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -764,7 +764,15 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	if alarm.UID != "" {
 		valarm.Props.SetText(ical.PropUID, alarm.UID)
 	}
-	valarm.Props.SetText(ical.PropAction, alarm.Action)
+	// Normalize the action once. An empty action means DISPLAY everywhere
+	// else, and a bare "ACTION:" line is invalid iCal that a strict server
+	// rejects. The write paths default the empty value, so this arm covers
+	// an in-memory alarm that skipped them.
+	action := alarm.Action
+	if action == "" {
+		action = "DISPLAY"
+	}
+	valarm.Props.SetText(ical.PropAction, action)
 
 	// exportableTrigger above guarantees a non-empty value that is either a
 	// duration or a date-time, so the VALUE parameter is never a guess.
@@ -840,15 +848,14 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 
 	// ATTACH: a sound for AUDIO alarms or a document for EMAIL alarms
 	// (RFC 5545 §3.6.6). Emitted as an inline BASE64 blob or a URI.
-	// DISPLAY alarms carry no ATTACH, so drop it for that one action. An
-	// empty action means DISPLAY everywhere else, so drop it there too:
-	// an "ACTION:" line plus ATTACH is invalid iCal that a strict server
-	// rejects.
+	// DISPLAY alarms carry no ATTACH, so drop it for that one action.
+	// The fold covers a legacy lowercase "display" row: the wide CHECK
+	// stores it, and it is semantically a DISPLAY alarm.
 	//
 	// A preserved sync-only action (issue #579) keeps its ATTACH. The
 	// RFC leaves the property set of an x-name or iana-token action
 	// open. The VALARM of another client must round-trip verbatim.
-	if alarm.Action != "DISPLAY" && alarm.Action != "" && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
+	if !strings.EqualFold(action, "DISPLAY") && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
 		p := &ical.Prop{Name: ical.PropAttach, Params: make(ical.Params)}
 		if len(alarm.AttachBinary) > 0 {
 			p.Value = base64.StdEncoding.EncodeToString(alarm.AttachBinary)

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -822,8 +822,14 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 		valarm.Props.Set(p)
 		p2 := &ical.Prop{Name: "REPEAT"}
 		// Clamp like import does. A pre-clamp DB row must not push a
-		// count the next pull would rewrite.
-		p2.Value = strconv.Itoa(min(alarm.Repeat, model.MaxAlarmRepeat))
+		// count the next pull would rewrite. A preserved sync-only alarm
+		// keeps its count, because it must round-trip verbatim and it
+		// never expands into trigger state (issue #579).
+		repeat := alarm.Repeat
+		if model.FireableAlarmAction(action) {
+			repeat = min(repeat, model.MaxAlarmRepeat)
+		}
+		p2.Value = strconv.Itoa(repeat)
 		valarm.Props.Set(p2)
 	}
 	// ACKNOWLEDGED (RFC 9074) — round-trip only.

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -839,12 +839,14 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	}
 
 	// ATTACH: a sound for AUDIO alarms or a document for EMAIL alarms
-	// (RFC 5545 §3.6.6). Emitted as an inline BASE64 blob or a URI. DISPLAY
-	// alarms carry no ATTACH, so drop it for that one action. A preserved
-	// sync-only action (issue #579) keeps its ATTACH: the RFC leaves the
-	// property set of an x-name or iana-token action open, and the VALARM
-	// of another client must round-trip verbatim.
-	if alarm.Action != "DISPLAY" && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
+	// (RFC 5545 §3.6.6). Emitted as an inline BASE64 blob or a URI.
+	// DISPLAY alarms carry no ATTACH, so drop it for that one action. An
+	// empty action means DISPLAY everywhere else, so drop it there too:
+	// an "ACTION:" line plus ATTACH is invalid iCal that a strict server
+	// rejects. A preserved sync-only action (issue #579) keeps its
+	// ATTACH. The RFC leaves the property set of an x-name or iana-token
+	// action open. The VALARM of another client must round-trip verbatim.
+	if alarm.Action != "DISPLAY" && alarm.Action != "" && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
 		p := &ical.Prop{Name: ical.PropAttach, Params: make(ical.Params)}
 		if len(alarm.AttachBinary) > 0 {
 			p.Value = base64.StdEncoding.EncodeToString(alarm.AttachBinary)

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -840,8 +840,11 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 
 	// ATTACH: a sound for AUDIO alarms or a document for EMAIL alarms
 	// (RFC 5545 §3.6.6). Emitted as an inline BASE64 blob or a URI. DISPLAY
-	// alarms carry no ATTACH, so only re-emit for the two actions that do.
-	if (alarm.Action == "AUDIO" || alarm.Action == "EMAIL") && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
+	// alarms carry no ATTACH, so drop it for that one action. A preserved
+	// sync-only action (issue #579) keeps its ATTACH: the RFC leaves the
+	// property set of an x-name or iana-token action open, and the VALARM
+	// of another client must round-trip verbatim.
+	if alarm.Action != "DISPLAY" && (len(alarm.AttachBinary) > 0 || alarm.AttachURI != "") {
 		p := &ical.Prop{Name: ical.PropAttach, Params: make(ical.Params)}
 		if len(alarm.AttachBinary) > 0 {
 			p.Value = base64.StdEncoding.EncodeToString(alarm.AttachBinary)

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -662,29 +662,28 @@ func parseCategories(ve ical.Event) string {
 // parseAlarm extracts a model.Alarm from a VALARM component.
 // The second return value is a warning string (empty if no issues). A VALARM
 // with several problems reports all of them. Each one changes what the alarm
-// does in silence. The user needs to see every reason. An unsupported ACTION
-// is the one early exit. It drops the whole alarm and stops the parse.
+// does in silence. The user needs to see every reason.
 func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	alarm := model.Alarm{Action: model.DefaultAlarmAction, Related: model.DefaultAlarmRelated}
 	var warns []string
 
 	if prop := comp.Props.Get(ical.PropAction); prop != nil {
-		// Google Calendar emits ACTION:NONE as a "no reminder" sentinel.
-		// An unsupported action must not reach the alarm tables (issue
-		// #575, see model.ValidAlarmAction). Every later push omits the
-		// VALARM, so Google can re-apply its default reminders. That loss
-		// is smaller than a sync that never converges.
-		switch action := strings.ToUpper(strings.TrimSpace(prop.Value)); {
-		case action == "":
-			// Keep the DISPLAY default. The service write boundary
-			// (model.PrepareAlarmsForWrite) fills the same default, and
-			// a reminder must not vanish over an empty value.
-		case !model.ValidAlarmAction(action):
-			warns = append(warns, fmt.Sprintf("VALARM ACTION %q: unsupported action; alarm dropped", action))
-			return model.Alarm{}, strings.Join(warns, "; ")
-		default:
+		// Keep an action outside model.FireableAlarmAction verbatim
+		// (issue #579). RFC 5545 permits an x-name or iana-token action
+		// (for example X-APPLE-SOUND), and Google Calendar emits
+		// ACTION:NONE as a "reminder disabled" sentinel. A drop here
+		// makes every later push delete the VALARM of the other client.
+		// It also lets Google re-apply the default reminders the user
+		// turned off. The alarm tables accept any non-empty action (see
+		// model.StorableAlarmAction), export re-emits it verbatim, and
+		// the alarm check loop skips it. The alarm round-trips and never
+		// fires locally, so this path needs no warning.
+		if action := strings.ToUpper(strings.TrimSpace(prop.Value)); action != "" {
 			alarm.Action = action
 		}
+		// An empty value keeps the default action. The service write
+		// boundary (model.PrepareAlarmsForWrite) fills the same default,
+		// and a reminder must not vanish over an empty value.
 	}
 	if prop := comp.Props.Get(ical.PropTrigger); prop != nil {
 		tv := prop.Value

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -659,6 +659,21 @@ func parseCategories(ve ical.Event) string {
 	return timeutil.JoinCategoryList(cats)
 }
 
+// validActionToken reports whether s is an RFC 5545 iana-token or x-name:
+// one or more ALPHA, DIGIT, or "-" characters. Any other byte would make
+// export emit an invalid ACTION line that a strict server rejects.
+func validActionToken(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-':
+		default:
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
 // parseAlarm extracts a model.Alarm from a VALARM component.
 // The second return value is a warning string (empty if no issues). A VALARM
 // with several problems reports all of them. Each one changes what the alarm
@@ -675,16 +690,23 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		// so the foreign VALARM round-trips verbatim. A fireable action
 		// stays canonical uppercase.
 		raw := strings.TrimSpace(prop.Value)
-		if up := strings.ToUpper(raw); up != "" {
-			if model.FireableAlarmAction(up) {
-				alarm.Action = up
-			} else {
-				alarm.Action = raw
-			}
+		switch up := strings.ToUpper(raw); {
+		case up == "":
+			// An empty value keeps the default action. The service
+			// write boundary (model.PrepareAlarmsForWrite) fills the
+			// same default, and a reminder must not vanish over an
+			// empty value.
+		case model.FireableAlarmAction(up):
+			alarm.Action = up
+		case validActionToken(raw):
+			alarm.Action = raw
+		default:
+			// A malformed action cannot round-trip: export would emit
+			// an invalid ACTION line, and a strict server rejects the
+			// whole resource with 400. Drop the alarm and warn.
+			warns = append(warns, fmt.Sprintf("VALARM ACTION %q: not an RFC 5545 token; alarm dropped", raw))
+			return model.Alarm{}, strings.Join(warns, "; ")
 		}
-		// An empty value keeps the default action. The service write
-		// boundary (model.PrepareAlarmsForWrite) fills the same default,
-		// and a reminder must not vanish over an empty value.
 	}
 	if prop := comp.Props.Get(ical.PropTrigger); prop != nil {
 		tv := prop.Value

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -668,23 +668,18 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	var warns []string
 
 	if prop := comp.Props.Get(ical.PropAction); prop != nil {
-		// Keep an action outside model.FireableAlarmAction verbatim
-		// (issue #579). RFC 5545 permits an x-name or iana-token action
-		// (for example X-APPLE-SOUND), and Google Calendar emits
-		// ACTION:NONE as a "reminder disabled" sentinel. A drop here
-		// makes every later push delete the VALARM of the other client.
-		// For ACTION:NONE, a drop lets Google re-apply the reminders the
-		// user turned off. The alarm tables accept any non-empty action
-		// (see model.StorableAlarmAction). Export re-emits it verbatim.
-		// The alarm check loop skips it, so it never fires locally. The
-		// warning tells the user that: a legacy ACTION:PROCEDURE or a
-		// typo would otherwise look like an armed reminder with no
-		// diagnostic anywhere. Sync re-imports a resource only when it
-		// changes, so the warning does not repeat on every pull.
-		if action := strings.ToUpper(strings.TrimSpace(prop.Value)); action != "" {
-			alarm.Action = action
-			if !model.FireableAlarmAction(action) {
-				warns = append(warns, fmt.Sprintf("VALARM ACTION %q: preserved for sync; it never fires locally", action))
+		// The parser preserves an action outside model.FireableAlarmAction
+		// (issue #579; that predicate's doc comment holds the shared
+		// rationale). A drop makes every later push delete the VALARM of
+		// the other client. The parser stores the trimmed original case,
+		// so the foreign VALARM round-trips verbatim. A fireable action
+		// stays canonical uppercase.
+		raw := strings.TrimSpace(prop.Value)
+		if up := strings.ToUpper(raw); up != "" {
+			if model.FireableAlarmAction(up) {
+				alarm.Action = up
+			} else {
+				alarm.Action = raw
 			}
 		}
 		// An empty value keeps the default action. The service write
@@ -883,6 +878,16 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	alarm.XProperties = extractXPropertiesWithSet(comp.Props, nil)
 	if alarm.XProperties == nil {
 		alarm.XProperties = []model.XProperty{}
+	}
+
+	// A preserved sync-only action needs a diagnostic: a legacy
+	// ACTION:PROCEDURE or a typo would otherwise look like an armed
+	// reminder. Warn only when the alarm survives the TRIGGER gate. The
+	// report must not say "preserved" and "dropped" for one alarm. Sync
+	// re-imports a resource only when it changes, so the warning does
+	// not repeat on every pull.
+	if alarm.TriggerValue != "" && !model.FireableAlarmAction(alarm.Action) {
+		warns = append(warns, fmt.Sprintf("VALARM ACTION %q: preserved for sync; it never fires locally", alarm.Action))
 	}
 
 	return alarm, strings.Join(warns, "; ")

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -673,13 +673,19 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		// (for example X-APPLE-SOUND), and Google Calendar emits
 		// ACTION:NONE as a "reminder disabled" sentinel. A drop here
 		// makes every later push delete the VALARM of the other client.
-		// It also lets Google re-apply the default reminders the user
-		// turned off. The alarm tables accept any non-empty action (see
-		// model.StorableAlarmAction), export re-emits it verbatim, and
-		// the alarm check loop skips it. The alarm round-trips and never
-		// fires locally, so this path needs no warning.
+		// For ACTION:NONE, a drop lets Google re-apply the reminders the
+		// user turned off. The alarm tables accept any non-empty action
+		// (see model.StorableAlarmAction). Export re-emits it verbatim.
+		// The alarm check loop skips it, so it never fires locally. The
+		// warning tells the user that: a legacy ACTION:PROCEDURE or a
+		// typo would otherwise look like an armed reminder with no
+		// diagnostic anywhere. Sync re-imports a resource only when it
+		// changes, so the warning does not repeat on every pull.
 		if action := strings.ToUpper(strings.TrimSpace(prop.Value)); action != "" {
 			alarm.Action = action
+			if !model.FireableAlarmAction(action) {
+				warns = append(warns, fmt.Sprintf("VALARM ACTION %q: preserved for sync; it never fires locally", action))
+			}
 		}
 		// An empty value keeps the default action. The service write
 		// boundary (model.PrepareAlarmsForWrite) fills the same default,

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -805,6 +805,11 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		switch {
 		case err != nil || v < 0:
 			warns = append(warns, fmt.Sprintf("VALARM REPEAT: invalid value %q; ignored", prop.Value))
+		case v > model.MaxAlarmRepeat && !model.FireableAlarmAction(alarm.Action):
+			// A preserved sync-only alarm never expands into trigger
+			// state, so the clamp guards nothing. A clamp here would
+			// rewrite the VALARM of another client on the next push.
+			alarm.Repeat = v
 		case v > model.MaxAlarmRepeat:
 			alarm.Repeat = model.MaxAlarmRepeat
 			clampedFrom = v

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -147,6 +147,31 @@ func TestImport_UnsupportedAlarmAction_PreservesAlarm(t *testing.T) {
 	}
 }
 
+// A sync-only alarm with an unparseable TRIGGER is dropped by the caller's
+// TriggerValue gate. The report must then carry only the dropped warning.
+// A "preserved" warning next to a "dropped" warning for one alarm would
+// contradict itself.
+func TestImport_SyncOnlyAlarmWithBadTrigger_OneCoherentWarning(t *testing.T) {
+	t.Parallel()
+	ics := eventICS("sync-only-bad-trigger@example.com", "Event with a broken foreign alarm",
+		"ACTION:X-APPLE-SOUND\r\nTRIGGER:soon\r\n",
+	)
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 0 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 0 alarms", len(result.Events), result.Events)
+	}
+	if !warningMentions(result.Warnings, "TRIGGER", `"soon"`, "alarm dropped") {
+		t.Errorf("no dropped-trigger warning; warnings = %v", result.Warnings)
+	}
+	if warningMentions(result.Warnings, "preserved for sync") {
+		t.Errorf("contradictory preserved warning for a dropped alarm; warnings = %v", result.Warnings)
+	}
+}
+
 // An unsupported RELATED value and a malformed DURATION share the failure
 // class of issue #575. RELATED fails the CHECK constraint and rolls back
 // the resource. DURATION round-trips into a push that a strict server

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -112,18 +112,17 @@ func eventICS(uid, summary string, valarms ...string) string {
 	return s + "END:VEVENT\r\nEND:VCALENDAR\r\n"
 }
 
-// Regression test for issue #575. Google CalDAV emits VALARM ACTION:NONE as
-// a "no reminder" sentinel. The alarm tables reject that action with a CHECK
-// constraint. The failed insert rolled back the whole resource transaction,
-// so the event never persisted and sync never converged. The parser must
-// drop each unsupported alarm with a warning and keep the parent record and
-// its supported alarms. (The todo caller shares the warning wrapper; see
-// TestImport_DroppedAlarmWarning_NamesOwningRecord.)
-func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
+// Regression test for issue #579 (follow-up to issue #575). PR #577
+// dropped a VALARM with an action outside the fireable set. Every later
+// push then deleted the VALARM of another client from the server copy —
+// or let Google re-apply the default reminders that its ACTION:NONE
+// sentinel had disabled. The parser must now keep such an alarm verbatim.
+// The preserved alarm round-trips faithfully, so no warning applies.
+func TestImport_UnsupportedAlarmAction_PreservesAlarm(t *testing.T) {
 	t.Parallel()
-	ics := eventICS("action-none-event@example.com", "Event with a no-op alarm",
+	ics := eventICS("action-none-event@example.com", "Event with a sync-only alarm",
 		"ACTION:NONE\r\nTRIGGER:-PT15M\r\n",
-		"ACTION:PROCEDURE\r\nTRIGGER:-PT5M\r\n",
+		"ACTION:X-APPLE-SOUND\r\nTRIGGER:-PT5M\r\n",
 		"ACTION:DISPLAY\r\nTRIGGER:-PT30M\r\nDESCRIPTION:Real reminder\r\n",
 	)
 
@@ -131,17 +130,17 @@ func TestImport_UnsupportedAlarmAction_DropsAlarmKeepsRecord(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ImportFile: %v", err)
 	}
-	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 1 {
-		t.Fatalf("events/alarms = %d/%+v, want 1 event with 1 alarm", len(result.Events), result.Events)
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 3 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 3 alarms", len(result.Events), result.Events)
 	}
-	if got := result.Events[0].Alarms[0].Action; got != "DISPLAY" {
-		t.Errorf("surviving alarm action = %q, want DISPLAY", got)
+	wantActions := []string{"NONE", "X-APPLE-SOUND", "DISPLAY"}
+	for i, want := range wantActions {
+		if got := result.Events[0].Alarms[i].Action; got != want {
+			t.Errorf("alarm %d action = %q, want %q (preserved verbatim)", i, got, want)
+		}
 	}
-	if !warningMentions(result.Warnings, `event "action-none-event@example.com"`, "ACTION", `"NONE"`) {
-		t.Errorf("no ACTION NONE warning that names the event; warnings = %v", result.Warnings)
-	}
-	if !warningMentions(result.Warnings, `event "action-none-event@example.com"`, "ACTION", `"PROCEDURE"`) {
-		t.Errorf("no ACTION PROCEDURE warning that names the event; warnings = %v", result.Warnings)
+	if warningMentions(result.Warnings, "ACTION") {
+		t.Errorf("preserved actions must not warn (they round-trip faithfully); warnings = %v", result.Warnings)
 	}
 }
 

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -147,8 +147,8 @@ func TestImport_UnsupportedAlarmAction_PreservesAlarm(t *testing.T) {
 	}
 }
 
-// A sync-only alarm with an unparseable TRIGGER is dropped by the caller's
-// TriggerValue gate. The report must then carry only the dropped warning.
+// The caller's TriggerValue gate drops a sync-only alarm with an
+// unparseable TRIGGER. The report must then carry only the dropped warning.
 // A "preserved" warning next to a "dropped" warning for one alarm would
 // contradict itself.
 func TestImport_SyncOnlyAlarmWithBadTrigger_OneCoherentWarning(t *testing.T) {

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -291,3 +291,29 @@ func TestImport_AlarmWithTwoProblems_ReportsBoth(t *testing.T) {
 		t.Errorf("ATTACH warning lost; warnings = %v", result.Warnings)
 	}
 }
+
+// The parser preserves only an ACTION that is an RFC 5545 iana-token or
+// x-name. A malformed value cannot round-trip: export would emit an
+// invalid ACTION line, and a strict server rejects the whole resource.
+// The parser drops that alarm and warns. A well-formed x-name survives.
+func TestImport_MalformedActionToken_DropsAlarm(t *testing.T) {
+	t.Parallel()
+	ics := eventICS("bad-action-token@example.com", "Event with a malformed action",
+		"ACTION:NO NE\r\nTRIGGER:-PT15M\r\n",
+		"ACTION:X-APPLE-SOUND\r\nTRIGGER:-PT5M\r\n",
+	)
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 1 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 1 alarm", len(result.Events), result.Events)
+	}
+	if got := result.Events[0].Alarms[0].Action; got != "X-APPLE-SOUND" {
+		t.Errorf("surviving alarm action = %q, want X-APPLE-SOUND", got)
+	}
+	if !warningMentions(result.Warnings, `"NO NE"`, "dropped") {
+		t.Errorf("no malformed-ACTION warning; warnings = %v", result.Warnings)
+	}
+}

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -114,10 +114,10 @@ func eventICS(uid, summary string, valarms ...string) string {
 
 // Regression test for issue #579 (follow-up to issue #575). PR #577
 // dropped a VALARM with an action outside the fireable set. Every later
-// push then deleted the VALARM of another client from the server copy —
-// or let Google re-apply the default reminders that its ACTION:NONE
-// sentinel had disabled. The parser must now keep such an alarm verbatim.
-// The preserved alarm round-trips faithfully, so no warning applies.
+// push then deleted the VALARM of another client from the server copy.
+// For ACTION:NONE, the drop let Google re-apply the reminders the user
+// turned off. The parser must now keep such an alarm verbatim, and the
+// warning must tell the user the alarm never fires locally.
 func TestImport_UnsupportedAlarmAction_PreservesAlarm(t *testing.T) {
 	t.Parallel()
 	ics := eventICS("action-none-event@example.com", "Event with a sync-only alarm",
@@ -139,8 +139,11 @@ func TestImport_UnsupportedAlarmAction_PreservesAlarm(t *testing.T) {
 			t.Errorf("alarm %d action = %q, want %q (preserved verbatim)", i, got, want)
 		}
 	}
-	if warningMentions(result.Warnings, "ACTION") {
-		t.Errorf("preserved actions must not warn (they round-trip faithfully); warnings = %v", result.Warnings)
+	if !warningMentions(result.Warnings, `event "action-none-event@example.com"`, "ACTION", `"NONE"`, "never fires locally") {
+		t.Errorf("no preserved-action warning for NONE; warnings = %v", result.Warnings)
+	}
+	if !warningMentions(result.Warnings, `"X-APPLE-SOUND"`, "never fires locally") {
+		t.Errorf("no preserved-action warning for X-APPLE-SOUND; warnings = %v", result.Warnings)
 	}
 }
 

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -2439,7 +2439,7 @@ func TestRoundtrip_UnsupportedAlarmActionsSurvive(t *testing.T) {
 		"TRIGGER;VALUE=DATE-TIME:19760401T005545Z\r\n" +
 		"END:VALARM\r\n" +
 		"BEGIN:VALARM\r\n" +
-		"ACTION:X-APPLE-SOUND\r\n" +
+		"ACTION:X-Apple-Sound\r\n" +
 		"TRIGGER:-PT9M\r\n" +
 		"ATTACH:Chord\r\n" +
 		"END:VALARM\r\n" +
@@ -2462,7 +2462,7 @@ func TestRoundtrip_UnsupportedAlarmActionsSurvive(t *testing.T) {
 	for _, want := range []string{
 		"ACTION:NONE",
 		"TRIGGER;VALUE=DATE-TIME:19760401T005545Z",
-		"ACTION:X-APPLE-SOUND",
+		"ACTION:X-Apple-Sound",
 		"TRIGGER;VALUE=DURATION:-PT9M",
 		"ATTACH:Chord",
 	} {
@@ -2481,8 +2481,11 @@ func TestRoundtrip_UnsupportedAlarmActionsSurvive(t *testing.T) {
 		t.Fatalf("reimported events/alarms = %d/%+v, want 1 event with 2 alarms",
 			len(reimported.Events), reimported.Events)
 	}
+	// The mixed-case x-name action must keep its original case: an
+	// uppercased copy would rewrite the VALARM of the other client on
+	// the next push.
 	gotActions := []string{reimported.Events[0].Alarms[0].Action, reimported.Events[0].Alarms[1].Action}
-	if gotActions[0] != "NONE" || gotActions[1] != "X-APPLE-SOUND" {
-		t.Errorf("reimported actions = %v, want [NONE X-APPLE-SOUND]", gotActions)
+	if gotActions[0] != "NONE" || gotActions[1] != "X-Apple-Sound" {
+		t.Errorf("reimported actions = %v, want [NONE X-Apple-Sound]", gotActions)
 	}
 }

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -2417,3 +2417,72 @@ END:VCALENDAR`
 		t.Fatalf("round-tripped categories = %v, want [\"Foo, Bar\" \"Baz\"]", got)
 	}
 }
+
+// Regression test for issue #579. A VALARM with an action outside the
+// fireable set must survive an import → export round trip verbatim. That
+// covers the Google ACTION:NONE sentinel and an RFC 5545 x-name action
+// from another client. A drop would make the next push delete the alarm
+// server-side. The ATTACH of an x-name action must survive too.
+func TestRoundtrip_UnsupportedAlarmActionsSurvive(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:sync-only-alarms@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:Event with foreign alarms\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:NONE\r\n" +
+		"TRIGGER;VALUE=DATE-TIME:19760401T005545Z\r\n" +
+		"END:VALARM\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:X-APPLE-SOUND\r\n" +
+		"TRIGGER:-PT9M\r\n" +
+		"ATTACH:Chord\r\n" +
+		"END:VALARM\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 2 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 2 alarms", len(result.Events), result.Events)
+	}
+
+	data, err := ExportEvents(result.Events, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	out := string(data)
+	for _, want := range []string{
+		"ACTION:NONE",
+		"TRIGGER;VALUE=DATE-TIME:19760401T005545Z",
+		"ACTION:X-APPLE-SOUND",
+		"TRIGGER;VALUE=DURATION:-PT9M",
+		"ATTACH:Chord",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("export lacks %q; output:\n%s", want, out)
+		}
+	}
+
+	// The second pass must parse the same two alarms again: the loop must
+	// be stable, not merely one-shot.
+	reimported, err := ImportFile(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("reimport: %v", err)
+	}
+	if len(reimported.Events) != 1 || len(reimported.Events[0].Alarms) != 2 {
+		t.Fatalf("reimported events/alarms = %d/%+v, want 1 event with 2 alarms",
+			len(reimported.Events), reimported.Events)
+	}
+	gotActions := []string{reimported.Events[0].Alarms[0].Action, reimported.Events[0].Alarms[1].Action}
+	if gotActions[0] != "NONE" || gotActions[1] != "X-APPLE-SOUND" {
+		t.Errorf("reimported actions = %v, want [NONE X-APPLE-SOUND]", gotActions)
+	}
+}

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -2,6 +2,7 @@ package ical
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2442,6 +2443,8 @@ func TestRoundtrip_UnsupportedAlarmActionsSurvive(t *testing.T) {
 		"ACTION:X-Apple-Sound\r\n" +
 		"TRIGGER:-PT9M\r\n" +
 		"ATTACH:Chord\r\n" +
+		"REPEAT:5000\r\n" +
+		"DURATION:PT5M\r\n" +
 		"END:VALARM\r\n" +
 		"END:VEVENT\r\n" +
 		"END:VCALENDAR\r\n"
@@ -2465,6 +2468,10 @@ func TestRoundtrip_UnsupportedAlarmActionsSurvive(t *testing.T) {
 		"ACTION:X-Apple-Sound",
 		"TRIGGER;VALUE=DURATION:-PT9M",
 		"ATTACH:Chord",
+		// The clamp guards the check loop, which never expands a
+		// sync-only alarm. A clamp here would rewrite the count of
+		// another client on the next push.
+		"REPEAT:5000",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("export lacks %q; output:\n%s", want, out)
@@ -2487,5 +2494,52 @@ func TestRoundtrip_UnsupportedAlarmActionsSurvive(t *testing.T) {
 	gotActions := []string{reimported.Events[0].Alarms[0].Action, reimported.Events[0].Alarms[1].Action}
 	if gotActions[0] != "NONE" || gotActions[1] != "X-Apple-Sound" {
 		t.Errorf("reimported actions = %v, want [NONE X-Apple-Sound]", gotActions)
+	}
+	if got := reimported.Events[0].Alarms[1].Repeat; got != 5000 {
+		t.Errorf("reimported repeat = %d, want 5000 (a preserved alarm keeps its count)", got)
+	}
+}
+
+// The REPEAT clamp still applies to a fireable alarm. That alarm expands
+// into per-trigger state in the check loop, so an absurd count must not
+// reach the engine. This is the counterpart of the exemption that
+// TestRoundtrip_UnsupportedAlarmActionsSurvive pins.
+func TestRoundtrip_FireableAlarmRepeatStillClamps(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:clamped-alarm@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:Event with an absurd repeat\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:DISPLAY\r\n" +
+		"TRIGGER:-PT9M\r\n" +
+		"REPEAT:5000\r\n" +
+		"DURATION:PT5M\r\n" +
+		"END:VALARM\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 1 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 1 alarm", len(result.Events), result.Events)
+	}
+	if got := result.Events[0].Alarms[0].Repeat; got != model.MaxAlarmRepeat {
+		t.Errorf("imported repeat = %d, want the clamp %d", got, model.MaxAlarmRepeat)
+	}
+
+	data, err := ExportEvents(result.Events, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if want := "REPEAT:" + strconv.Itoa(model.MaxAlarmRepeat); !strings.Contains(string(data), want) {
+		t.Errorf("export lacks %q; output:\n%s", want, string(data))
 	}
 }

--- a/internal/icaltransfer/transfer_test.go
+++ b/internal/icaltransfer/transfer_test.go
@@ -229,10 +229,12 @@ func TestImport_ChildFieldFailureIsWarningNotFailed(t *testing.T) {
 	evt := event.Event{
 		UID: "evt-bad-alarm", Title: "Has bad alarm",
 		StartTime: start, EndTime: start.Add(time.Hour),
-		// The service boundary rejects an ACTION outside model.AlarmActions
-		// with model.ErrInvalidAlarm (issue #578), so this alarm fails to
-		// attach even though the event itself is valid.
-		Alarms: []model.Alarm{{Action: "BOGUS", TriggerValue: "-PT15M", Related: "START"}},
+		// The service boundary rejects a RELATED outside
+		// model.AlarmRelatedValues with model.ErrInvalidAlarm (issue
+		// #578), so this alarm fails to attach even though the event
+		// itself is valid. The action no longer forces the failure:
+		// since issue #579 the tables accept any non-empty action.
+		Alarms: []model.Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "BOGUS"}},
 	}
 	result := &ical.ImportResult{Events: []event.Event{evt}}
 	summary := icaltransfer.Import(ctx, a, cal.ID, result)

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -173,7 +173,7 @@ func sortedEmails(atts []AlarmAttendee) []string {
 // against those queries. The match is case-sensitive. The slice is
 // unexported so no other package can change the set at run time.
 //
-// The storage rule is wider: see StorableAlarmAction. Migration 043
+// The storage rule is wider: see StorableAlarmAction. Migration 044
 // widened the CHECK constraints, so the tables also hold a preserved
 // foreign action (issue #579).
 var alarmActions = []string{"AUDIO", "DISPLAY", "EMAIL"}
@@ -215,15 +215,15 @@ func AlarmRelatedValuesList() string {
 //
 // The storage rule is wider: see StorableAlarmAction. Import preserves an
 // RFC 5545 x-name or iana-token action (for example X-APPLE-SOUND) and
-// the Google ACTION:NONE sentinel, so a push does not delete the alarm of
-// another client (issue #579).
+// the Google ACTION:NONE sentinel (issue #579). A push then does not
+// delete the alarm of another client.
 func FireableAlarmAction(action string) bool {
 	return slices.Contains(alarmActions, action)
 }
 
 // StorableAlarmAction returns true if action is a value the alarm tables
 // accept: any non-empty string. The rule mirrors the CHECK constraints in
-// db/migrations/043. Keep this function and the two constraints in
+// db/migrations/044. Keep this function and the two constraints in
 // lockstep. A value that passes here but fails the constraint rolls back
 // the whole resource transaction during sync (issue #575).
 func StorableAlarmAction(action string) bool {
@@ -305,7 +305,7 @@ func PrepareAlarmsForWrite(alarms []Alarm) ([]Alarm, error) {
 // prepareAlarmForWrite fills the defaults and validates one alarm.
 //
 // The action rule is StorableAlarmAction, not the fireable set. Migration
-// 043 widened the CHECK constraint, because import preserves the action
+// 044 widened the CHECK constraint, because import preserves the action
 // of another client (issue #579). A check against the fireable set here
 // would reject every preserved alarm at the write boundary.
 func prepareAlarmForWrite(a *Alarm) error {

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -230,9 +230,10 @@ func StorableAlarmAction(action string) bool {
 	return action != ""
 }
 
-// CheckStorableAlarmAction reports an action the alarm tables reject. It
-// names the value, so the error beats a raw CHECK failure. The write
-// still rolls back the enclosing transaction.
+// CheckStorableAlarmAction returns a named error for an action the alarm
+// tables reject. It converts an opaque CHECK failure into a named error.
+// The enclosing transaction still rolls back on it. The alarm write
+// helpers in the event and todo services share this check.
 func CheckStorableAlarmAction(action string) error {
 	if !StorableAlarmAction(action) {
 		return fmt.Errorf("action %q is not storable", action)
@@ -257,6 +258,7 @@ func PrepareAlarmUpdate(a, ex Alarm) (string, error) {
 
 // ValidAlarmRelated returns true if related is an accepted RELATED
 // value.
+
 func ValidAlarmRelated(related string) bool {
 	return slices.Contains(alarmRelatedValues, related)
 }

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -261,9 +261,10 @@ func PrepareAlarmUpdate(a, ex Alarm) (string, error) {
 	return ex.Acknowledged, nil
 }
 
-// ValidAlarmRelated returns true if related is an accepted RELATED
-// value.
-
+// ValidAlarmRelated returns true if related is a value the alarm tables
+// accept for the TRIGGER anchor. The set mirrors the related CHECK
+// constraints in db/migrations/003 and 006, with the same lockstep rule
+// as StorableAlarmAction.
 func ValidAlarmRelated(related string) bool {
 	return slices.Contains(alarmRelatedValues, related)
 }

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -43,7 +43,12 @@ type Alarm struct {
 // does not break the match and lose alarm state. Matched alarms get their
 // X-properties rewritten unconditionally instead.
 func (a Alarm) ContentEqual(b Alarm) bool {
-	if !strings.EqualFold(a.Action, b.Action) {
+	// Exact case: the parser canonicalizes fireable actions to uppercase,
+	// so a case fold gains nothing there. A preserved foreign action
+	// keeps its original case (issue #579), and a case-only remote change
+	// must land locally — a fold would skip the update and the next push
+	// would write the stale case back over the other client's VALARM.
+	if a.Action != b.Action {
 		return false
 	}
 	if !triggerValuesEqual(a.TriggerValue, b.TriggerValue) {

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -246,6 +246,24 @@ func CheckStorableAlarmAction(action string) error {
 	return nil
 }
 
+// KeepSyncOnlyAlarms appends every stored alarm the engine cannot fire to
+// a replacement list. A caller that can only state a fireable alarm — the
+// --alarm flag has no syntax for a preserved action — must carry those
+// rows forward. Without the carry-over the replacement deletes them, and
+// the next push deletes the VALARM of another client (issue #579).
+//
+// A caller that must remove a preserved alarm skips this function and
+// calls ReplaceAlarms with the exact list instead. The TUI alarm editor
+// works that way, so a local calendar keeps a way to delete such a row.
+func KeepSyncOnlyAlarms(stored, replacement []Alarm) []Alarm {
+	for _, a := range stored {
+		if !FireableAlarmAction(a.Action) {
+			replacement = append(replacement, a)
+		}
+	}
+	return replacement
+}
+
 // PrepareAlarmUpdate checks an alarm that a caller writes over the stored
 // row ex. It returns the ACKNOWLEDGED value for the update. A malformed
 // value that arrives must not clobber valid stored state, so the function

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -165,22 +165,26 @@ func sortedEmails(atts []AlarmAttendee) []string {
 	return emails
 }
 
-// alarmActions lists the ACTION values the alarm tables accept, in a
-// fixed order. The set mirrors the CHECK constraints in db/migrations/003
-// and 006. Keep this slice and the two constraints in lockstep. A value
-// outside this set fails the constraint and rolls back the whole resource
-// transaction during sync (issue #575). The match is case-sensitive, the
-// same as the constraints. The slice is unexported so no other package
-// can change the accepted set at run time.
+// alarmActions lists the ACTION values the alarm engine can fire, in a
+// fixed order. The TUI dropdown and the CLI --alarm parser offer only
+// this set for a new alarm. The SQL queries that filter on the action
+// copy this list, so the storage test
+// TestFireableAlarmQueriesMatchModelPredicate probes every value here
+// against those queries. The match is case-sensitive. The slice is
+// unexported so no other package can change the set at run time.
+//
+// The storage rule is wider: see StorableAlarmAction. Migration 043
+// widened the CHECK constraints, so the tables also hold a preserved
+// foreign action (issue #579).
 var alarmActions = []string{"AUDIO", "DISPLAY", "EMAIL"}
 
 // alarmRelatedValues lists the RELATED values the alarm tables accept
 // for the TRIGGER anchor, with the same lockstep rule as alarmActions.
 var alarmRelatedValues = []string{"START", "END"}
 
-// AlarmActions returns the accepted ACTION values as a fresh slice.
-// A caller can keep or change the returned slice. The accepted set
-// does not change.
+// AlarmActions returns the fireable ACTION values as a fresh slice.
+// A caller can keep or change the returned slice. The set does not
+// change.
 func AlarmActions() []string {
 	return slices.Clone(alarmActions)
 }
@@ -191,7 +195,7 @@ func AlarmRelatedValues() []string {
 	return slices.Clone(alarmRelatedValues)
 }
 
-// AlarmActionsList returns the accepted ACTION values as one joined
+// AlarmActionsList returns the fireable ACTION values as one joined
 // string, for error messages and help text. The list renders once at
 // package load, so every consumer stays in lockstep with the set.
 func AlarmActionsList() string {
@@ -204,9 +208,51 @@ func AlarmRelatedValuesList() string {
 	return alarmRelatedValuesList
 }
 
-// ValidAlarmAction returns true if action is an accepted ACTION value.
-func ValidAlarmAction(action string) bool {
+// FireableAlarmAction returns true if action is a value the alarm engine
+// can fire. The alarm check loop skips every other action. The TUI
+// dropdown and the CLI --alarm parser offer only this set for a new
+// alarm.
+//
+// The storage rule is wider: see StorableAlarmAction. Import preserves an
+// RFC 5545 x-name or iana-token action (for example X-APPLE-SOUND) and
+// the Google ACTION:NONE sentinel, so a push does not delete the alarm of
+// another client (issue #579).
+func FireableAlarmAction(action string) bool {
 	return slices.Contains(alarmActions, action)
+}
+
+// StorableAlarmAction returns true if action is a value the alarm tables
+// accept: any non-empty string. The rule mirrors the CHECK constraints in
+// db/migrations/043. Keep this function and the two constraints in
+// lockstep. A value that passes here but fails the constraint rolls back
+// the whole resource transaction during sync (issue #575).
+func StorableAlarmAction(action string) bool {
+	return action != ""
+}
+
+// CheckStorableAlarmAction reports an action the alarm tables reject. It
+// names the value, so the error beats a raw CHECK failure. The write
+// still rolls back the enclosing transaction.
+func CheckStorableAlarmAction(action string) error {
+	if !StorableAlarmAction(action) {
+		return fmt.Errorf("action %q is not storable", action)
+	}
+	return nil
+}
+
+// PrepareAlarmUpdate checks an alarm that a caller writes over the stored
+// row ex. It returns the ACKNOWLEDGED value for the update. A malformed
+// value that arrives must not clobber valid stored state, so the function
+// keeps the stored value instead. The event service and the todo service
+// share this rule.
+func PrepareAlarmUpdate(a, ex Alarm) (string, error) {
+	if err := CheckStorableAlarmAction(a.Action); err != nil {
+		return "", fmt.Errorf("update alarm: %w", err)
+	}
+	if ValidateAcknowledged(a.Acknowledged) {
+		return a.Acknowledged, nil
+	}
+	return ex.Acknowledged, nil
 }
 
 // ValidAlarmRelated returns true if related is an accepted RELATED
@@ -236,7 +282,7 @@ var ErrInvalidAlarm = errors.New("invalid alarm")
 // PrepareAlarmsForWrite returns a prepared copy of alarms. For each
 // element it fills an empty Action with DefaultAlarmAction and an
 // empty Related with DefaultAlarmRelated. It then validates the two
-// fields against the sets the alarm tables accept. Those are the two
+// fields against the rules the alarm tables enforce. Those are the two
 // alarm columns with a CHECK constraint. For a bad value it returns an
 // error that wraps ErrInvalidAlarm and names the index, the field, and
 // the value. The caller's slice does not change.
@@ -257,6 +303,11 @@ func PrepareAlarmsForWrite(alarms []Alarm) ([]Alarm, error) {
 }
 
 // prepareAlarmForWrite fills the defaults and validates one alarm.
+//
+// The action rule is StorableAlarmAction, not the fireable set. Migration
+// 043 widened the CHECK constraint, because import preserves the action
+// of another client (issue #579). A check against the fireable set here
+// would reject every preserved alarm at the write boundary.
 func prepareAlarmForWrite(a *Alarm) error {
 	if a.Action == "" {
 		a.Action = DefaultAlarmAction
@@ -264,8 +315,8 @@ func prepareAlarmForWrite(a *Alarm) error {
 	if a.Related == "" {
 		a.Related = DefaultAlarmRelated
 	}
-	if !ValidAlarmAction(a.Action) {
-		return fmt.Errorf("%w: action %q is not one of %s", ErrInvalidAlarm, a.Action, alarmActionsList)
+	if !StorableAlarmAction(a.Action) {
+		return fmt.Errorf("%w: action %q is empty", ErrInvalidAlarm, a.Action)
 	}
 	if !ValidAlarmRelated(a.Related) {
 		return fmt.Errorf("%w: related %q is not one of %s", ErrInvalidAlarm, a.Related, alarmRelatedValuesList)

--- a/internal/model/alarm_validate_test.go
+++ b/internal/model/alarm_validate_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 // TestAlarmActionsMatchPredicate guards AlarmActions and
-// ValidAlarmAction together. The predicate must accept every listed
+// FireableAlarmAction together. The predicate must accept every listed
 // value and only those. AlarmActions must also return a fresh slice:
-// a caller-side change must not widen the accepted set.
+// a caller-side change must not widen the set.
 func TestAlarmActionsMatchPredicate(t *testing.T) {
 	for _, a := range AlarmActions() {
-		if !ValidAlarmAction(a) {
-			t.Errorf("ValidAlarmAction(%q) = false, want true", a)
+		if !FireableAlarmAction(a) {
+			t.Errorf("FireableAlarmAction(%q) = false, want true", a)
 		}
 	}
 	for _, a := range AlarmRelatedValues() {
@@ -21,15 +21,16 @@ func TestAlarmActionsMatchPredicate(t *testing.T) {
 			t.Errorf("ValidAlarmRelated(%q) = false, want true", a)
 		}
 	}
+	// A preserved foreign action is storable but never fireable.
 	for _, a := range []string{"", "NONE", "PROCEDURE", "display", "audio"} {
-		if ValidAlarmAction(a) {
-			t.Errorf("ValidAlarmAction(%q) = true, want false", a)
+		if FireableAlarmAction(a) {
+			t.Errorf("FireableAlarmAction(%q) = true, want false", a)
 		}
 	}
 	leaked := AlarmActions()
 	leaked[0] = "PROCEDURE"
-	if ValidAlarmAction("PROCEDURE") {
-		t.Error("a change to the returned slice widened the accepted set")
+	if FireableAlarmAction("PROCEDURE") {
+		t.Error("a change to the returned slice widened the set")
 	}
 }
 
@@ -60,16 +61,35 @@ func TestPrepareAlarmsForWrite_KeepsValidValues(t *testing.T) {
 	}
 }
 
-func TestPrepareAlarmsForWrite_RejectsInvalidAction(t *testing.T) {
+// Migration 043 widened the action constraint, so the write boundary
+// accepts a preserved foreign action (issue #579). Only an empty action
+// fails, and prepareAlarmForWrite fills that with the default first, so
+// the reject path needs a caller that clears the field after the fill.
+func TestPrepareAlarmsForWrite_KeepsPreservedAction(t *testing.T) {
+	out, err := PrepareAlarmsForWrite([]Alarm{
+		{Action: "NONE", TriggerValue: "-PT30M"},
+		{Action: "X-Apple-Sound", TriggerValue: "-PT15M"},
+	})
+	if err != nil {
+		t.Fatalf("PrepareAlarmsForWrite error: %v", err)
+	}
+	if out[0].Action != "NONE" || out[1].Action != "X-Apple-Sound" {
+		t.Errorf("actions = %q/%q, want the preserved values", out[0].Action, out[1].Action)
+	}
+}
+
+// The related field keeps the narrow rule, so it still reports the index,
+// the field, and the value.
+func TestPrepareAlarmsForWrite_ReportsTheAlarmPosition(t *testing.T) {
 	_, err := PrepareAlarmsForWrite([]Alarm{
 		{TriggerValue: "-PT30M"},
-		{Action: "PROCEDURE", TriggerValue: "-PT15M"},
+		{Action: "DISPLAY", Related: "MIDDLE", TriggerValue: "-PT15M"},
 	})
 	if !errors.Is(err, ErrInvalidAlarm) {
 		t.Fatalf("err = %v, want ErrInvalidAlarm", err)
 	}
 	// The position is 1-based: the second element is "alarm 2".
-	for _, want := range []string{"PROCEDURE", "action", "alarm 2"} {
+	for _, want := range []string{"MIDDLE", "related", "alarm 2"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("err = %q, want it to contain %q", err, want)
 		}

--- a/internal/storage/alarm_state.sql.go
+++ b/internal/storage/alarm_state.sql.go
@@ -23,26 +23,14 @@ func (q *Queries) AcknowledgeAlarmState(ctx context.Context, arg AcknowledgeAlar
 	return err
 }
 
-const acknowledgeAlarmStatesByAlarmID = `-- name: AcknowledgeAlarmStatesByAlarmID :exec
-UPDATE alarm_state SET acked_at = ? WHERE alarm_id = ? AND acked_at IS NULL
-`
-
-type AcknowledgeAlarmStatesByAlarmIDParams struct {
-	AckedAt *string
-	AlarmID int64
-}
-
-// Retire the live state of one alarm. A sync pull can rewrite an alarm
-// to a sync-only action in place. The check loop never fires that alarm
-// again, so an open state row would stay pending forever.
-func (q *Queries) AcknowledgeAlarmStatesByAlarmID(ctx context.Context, arg AcknowledgeAlarmStatesByAlarmIDParams) error {
-	_, err := q.db.ExecContext(ctx, acknowledgeAlarmStatesByAlarmID, arg.AckedAt, arg.AlarmID)
-	return err
-}
-
 const createAlarmState = `-- name: CreateAlarmState :one
 INSERT INTO alarm_state (alarm_id, event_id, trigger_at, fired_at)
-VALUES (?, ?, ?, ?) RETURNING id, alarm_id, event_id, trigger_at, fired_at, acked_at, snoozed_to
+SELECT ?1, ?2, ?3, ?4
+WHERE EXISTS (
+    SELECT 1 FROM event_alarms
+    WHERE id = ?1 AND action IN ('AUDIO','DISPLAY','EMAIL')
+)
+RETURNING id, alarm_id, event_id, trigger_at, fired_at, acked_at, snoozed_to
 `
 
 type CreateAlarmStateParams struct {
@@ -52,6 +40,12 @@ type CreateAlarmStateParams struct {
 	FiredAt   *string
 }
 
+// Claim a fire slot for one alarm. The EXISTS arm reads the action in the
+// same statement as the insert, so a sync pull that rewrites the alarm to
+// a sync-only action between the check and the claim cannot leave a fired
+// state for an alarm the user disabled (issue #579). Zero rows means the
+// claim failed, and the caller reports sql.ErrNoRows.
+// Keep the action list in lockstep with model.FireableAlarmAction.
 func (q *Queries) CreateAlarmState(ctx context.Context, arg CreateAlarmStateParams) (AlarmState, error) {
 	row := q.db.QueryRowContext(ctx, createAlarmState,
 		arg.AlarmID,
@@ -160,14 +154,18 @@ func (q *Queries) ListAlarmStatesByEventID(ctx context.Context, eventID int64) (
 }
 
 const listExpiredSnoozedAlarmStates = `-- name: ListExpiredSnoozedAlarmStates :many
-SELECT id, alarm_id, event_id, trigger_at, fired_at, acked_at, snoozed_to FROM alarm_state
-WHERE fired_at IS NOT NULL
-  AND acked_at IS NULL
-  AND snoozed_to IS NOT NULL
-  AND snoozed_to <= ?
-ORDER BY snoozed_to
+SELECT s.id, s.alarm_id, s.event_id, s.trigger_at, s.fired_at, s.acked_at, s.snoozed_to FROM alarm_state s
+JOIN event_alarms a ON a.id = s.alarm_id
+WHERE s.fired_at IS NOT NULL
+  AND s.acked_at IS NULL
+  AND s.snoozed_to IS NOT NULL
+  AND s.snoozed_to <= ?
+  AND a.action IN ('AUDIO','DISPLAY','EMAIL')
+ORDER BY s.snoozed_to
 `
 
+// The same sync-only filter as ListPendingAlarmStates, for the re-fire path.
+// Keep the action list in lockstep with model.FireableAlarmAction.
 func (q *Queries) ListExpiredSnoozedAlarmStates(ctx context.Context, snoozedTo *string) ([]AlarmState, error) {
 	rows, err := q.db.QueryContext(ctx, listExpiredSnoozedAlarmStates, snoozedTo)
 	if err != nil {
@@ -200,9 +198,18 @@ func (q *Queries) ListExpiredSnoozedAlarmStates(ctx context.Context, snoozedTo *
 }
 
 const listPendingAlarmStates = `-- name: ListPendingAlarmStates :many
-SELECT id, alarm_id, event_id, trigger_at, fired_at, acked_at, snoozed_to FROM alarm_state WHERE acked_at IS NULL AND fired_at IS NOT NULL ORDER BY trigger_at
+SELECT s.id, s.alarm_id, s.event_id, s.trigger_at, s.fired_at, s.acked_at, s.snoozed_to FROM alarm_state s
+JOIN event_alarms a ON a.id = s.alarm_id
+WHERE s.acked_at IS NULL AND s.fired_at IS NOT NULL
+  AND a.action IN ('AUDIO','DISPLAY','EMAIL')
+ORDER BY s.trigger_at
 `
 
+// Hide the state of an alarm a sync pull rewrote to a sync-only action.
+// The filter reads the current action, so the row comes back when a later
+// pull restores a fireable action (issue #579). A retirement that wrote
+// acked_at instead would consume the snooze of the user for good.
+// Keep the action list in lockstep with model.FireableAlarmAction.
 func (q *Queries) ListPendingAlarmStates(ctx context.Context) ([]AlarmState, error) {
 	rows, err := q.db.QueryContext(ctx, listPendingAlarmStates)
 	if err != nil {

--- a/internal/storage/alarm_state.sql.go
+++ b/internal/storage/alarm_state.sql.go
@@ -23,6 +23,23 @@ func (q *Queries) AcknowledgeAlarmState(ctx context.Context, arg AcknowledgeAlar
 	return err
 }
 
+const acknowledgeAlarmStatesByAlarmID = `-- name: AcknowledgeAlarmStatesByAlarmID :exec
+UPDATE alarm_state SET acked_at = ? WHERE alarm_id = ? AND acked_at IS NULL
+`
+
+type AcknowledgeAlarmStatesByAlarmIDParams struct {
+	AckedAt *string
+	AlarmID int64
+}
+
+// Retire the live state of one alarm. A sync pull can rewrite an alarm
+// to a sync-only action in place. The check loop never fires that alarm
+// again, so an open state row would stay pending forever.
+func (q *Queries) AcknowledgeAlarmStatesByAlarmID(ctx context.Context, arg AcknowledgeAlarmStatesByAlarmIDParams) error {
+	_, err := q.db.ExecContext(ctx, acknowledgeAlarmStatesByAlarmID, arg.AckedAt, arg.AlarmID)
+	return err
+}
+
 const createAlarmState = `-- name: CreateAlarmState :one
 INSERT INTO alarm_state (alarm_id, event_id, trigger_at, fired_at)
 VALUES (?, ?, ?, ?) RETURNING id, alarm_id, event_id, trigger_at, fired_at, acked_at, snoozed_to

--- a/internal/storage/alarms.sql.go
+++ b/internal/storage/alarms.sql.go
@@ -223,8 +223,12 @@ func (q *Queries) ListAlarmsWithEmptyUID(ctx context.Context) ([]EventAlarm, err
 
 const listDistinctAlarmTriggers = `-- name: ListDistinctAlarmTriggers :many
 SELECT DISTINCT trigger_value FROM event_alarms
+WHERE action IN ('AUDIO', 'DISPLAY', 'EMAIL')
 `
 
+// The action list mirrors model.FireableAlarmAction. Keep the two in
+// lockstep. A preserved sync-only action never fires, so its trigger
+// must not size the alarm check window.
 func (q *Queries) ListDistinctAlarmTriggers(ctx context.Context) ([]string, error) {
 	rows, err := q.db.QueryContext(ctx, listDistinctAlarmTriggers)
 	if err != nil {

--- a/internal/storage/alarms.sql.go
+++ b/internal/storage/alarms.sql.go
@@ -127,58 +127,6 @@ func (q *Queries) ListAlarmsByEventID(ctx context.Context, eventID int64) ([]Eve
 	return items, nil
 }
 
-const listAlarmsByEventIDs = `-- name: ListAlarmsByEventIDs :many
-SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM event_alarms WHERE event_id IN (/*SLICE:event_ids*/?) ORDER BY event_id, id
-`
-
-func (q *Queries) ListAlarmsByEventIDs(ctx context.Context, eventIds []int64) ([]EventAlarm, error) {
-	query := listAlarmsByEventIDs
-	var queryParams []interface{}
-	if len(eventIds) > 0 {
-		for _, v := range eventIds {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:event_ids*/?", strings.Repeat(",?", len(eventIds))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:event_ids*/?", "NULL", 1)
-	}
-	rows, err := q.db.QueryContext(ctx, query, queryParams...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []EventAlarm
-	for rows.Next() {
-		var i EventAlarm
-		if err := rows.Scan(
-			&i.ID,
-			&i.EventID,
-			&i.Action,
-			&i.TriggerValue,
-			&i.Description,
-			&i.Repeat,
-			&i.Duration,
-			&i.Related,
-			&i.Summary,
-			&i.Uid,
-			&i.Acknowledged,
-			&i.AttachUri,
-			&i.AttachFmttype,
-			&i.AttachBinary,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listAlarmsWithEmptyUID = `-- name: ListAlarmsWithEmptyUID :many
 SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM event_alarms WHERE uid IS NULL
 `
@@ -242,6 +190,64 @@ func (q *Queries) ListDistinctAlarmTriggers(ctx context.Context) ([]string, erro
 			return nil, err
 		}
 		items = append(items, trigger_value)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listFireableAlarmsByEventIDs = `-- name: ListFireableAlarmsByEventIDs :many
+SELECT id, event_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM event_alarms
+WHERE event_id IN (/*SLICE:event_ids*/?)
+  AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
+ORDER BY event_id, id
+`
+
+// The action list mirrors model.FireableAlarmAction. Keep the two in
+// lockstep. The alarm check loop is the only caller, and a preserved
+// sync-only action must not reach it.
+func (q *Queries) ListFireableAlarmsByEventIDs(ctx context.Context, eventIds []int64) ([]EventAlarm, error) {
+	query := listFireableAlarmsByEventIDs
+	var queryParams []interface{}
+	if len(eventIds) > 0 {
+		for _, v := range eventIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:event_ids*/?", strings.Repeat(",?", len(eventIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:event_ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []EventAlarm
+	for rows.Next() {
+		var i EventAlarm
+		if err := rows.Scan(
+			&i.ID,
+			&i.EventID,
+			&i.Action,
+			&i.TriggerValue,
+			&i.Description,
+			&i.Repeat,
+			&i.Duration,
+			&i.Related,
+			&i.Summary,
+			&i.Uid,
+			&i.Acknowledged,
+			&i.AttachUri,
+			&i.AttachFmttype,
+			&i.AttachBinary,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -234,8 +234,12 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 		}
 		var fixes []fix
 		err := func() error {
+			// Read the action so the heal can skip a preserved sync-only
+			// alarm. The repeat and the duration of such an alarm are
+			// round-trip data, not fire-path data, so a repair here would
+			// rewrite the VALARM of another client (issue #579).
 			rows, err := conn.QueryContext(ctx,
-				`SELECT id, repeat, COALESCE(duration, '') FROM `+table+
+				`SELECT id, action, repeat, COALESCE(duration, '') FROM `+table+
 					` WHERE repeat > 0 OR COALESCE(duration, '') != ''`)
 			if err != nil {
 				return err
@@ -244,8 +248,11 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 			for rows.Next() {
 				var id int64
 				var a model.Alarm
-				if err := rows.Scan(&id, &a.Repeat, &a.Duration); err != nil {
+				if err := rows.Scan(&id, &a.Action, &a.Repeat, &a.Duration); err != nil {
 					return err
+				}
+				if !model.FireableAlarmAction(a.Action) {
+					continue
 				}
 				healed := a
 				healed.Repeat = min(healed.Repeat, model.MaxAlarmRepeat)

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+
+	"github.com/pressly/goose/v3"
 )
 
 // migHelpers returns exec and count helpers bound to conn. The migration

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -80,6 +80,112 @@ func TestMigration031UpDown(t *testing.T) {
 		VALUES ('event_alarm', 1, 'X-ALARM-PROP', 'works-again')`)
 }
 
+// Verifies migration 043 (the wide alarm action CHECK) rolls back and
+// re-applies cleanly with live rows. The rebuild runs with foreign keys ON,
+// so DROP TABLE performs an implicit DELETE that cascades into alarm_state
+// and event_alarm_attendees; the migration must restore those rows
+// id-intact. The alarm-owned x_properties rows must survive in place. On
+// Down, an alarm with a sync-only action is intentionally deleted together
+// with its dependent rows.
+func TestMigration043UpDown(t *testing.T) {
+	conn, _, err := Open(t.TempDir() + "/mig043.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := context.Background()
+	mustExec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := conn.ExecContext(ctx, query, args...); err != nil {
+			t.Fatalf("exec %q: %v", query, err)
+		}
+	}
+	count := func(query string, args ...any) int {
+		t.Helper()
+		var n int
+		if err := conn.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+			t.Fatalf("count %q: %v", query, err)
+		}
+		return n
+	}
+
+	// Seed: one event with a fireable alarm (state + attendee + x-prop) and
+	// one sync-only NONE alarm (x-prop only).
+	mustExec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time)
+		VALUES ('mig043-evt', 1, 'Mig', '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z')`)
+	mustExec(`INSERT INTO event_alarms (id, event_id, action, trigger_value) VALUES (1, 1, 'EMAIL', '-PT15M')`)
+	mustExec(`INSERT INTO event_alarms (id, event_id, action, trigger_value) VALUES (2, 1, 'NONE', '-PT5M')`)
+	mustExec(`INSERT INTO alarm_state (id, alarm_id, event_id, trigger_at, fired_at)
+		VALUES (7, 1, 1, '2026-01-01T09:45:00Z', '2026-01-01T09:45:01Z')`)
+	mustExec(`INSERT INTO event_alarm_attendees (alarm_id, email) VALUES (1, 'a@example.com')`)
+	mustExec(`INSERT INTO x_properties (owner_type, owner_id, name, value)
+		VALUES ('event_alarm', 1, 'X-KEEP', 'yes')`)
+	mustExec(`INSERT INTO x_properties (owner_type, owner_id, name, value)
+		VALUES ('event_alarm', 2, 'X-GONE-ON-DOWN', 'yes')`)
+
+	migrationsFS, err := fs.Sub(dbembed.Migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS)
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if _, err := provider.DownTo(ctx, 42); err != nil {
+		t.Fatalf("down to 42: %v", err)
+	}
+
+	if n := count(`SELECT COUNT(*) FROM event_alarms`); n != 1 {
+		t.Errorf("alarms after Down = %d, want 1 (the NONE alarm is dropped)", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM alarm_state WHERE id = 7 AND alarm_id = 1
+		AND trigger_at = '2026-01-01T09:45:00Z'`); n != 1 {
+		t.Errorf("alarm_state row after Down = %d, want 1 (id-intact restore)", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM event_alarm_attendees WHERE alarm_id = 1
+		AND email = 'a@example.com'`); n != 1 {
+		t.Errorf("attendee row after Down = %d, want 1", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM x_properties WHERE owner_type = 'event_alarm'`); n != 1 {
+		t.Errorf("alarm x_properties after Down = %d, want 1 (the NONE alarm's rows go with it)", n)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO event_alarms (event_id, action, trigger_value) VALUES (1, 'NONE', '-PT5M')`,
+	); err == nil {
+		t.Errorf("narrow CHECK accepted action NONE after Down")
+	}
+
+	if _, err := provider.Up(ctx); err != nil {
+		t.Fatalf("re-up: %v", err)
+	}
+
+	if n := count(`SELECT COUNT(*) FROM alarm_state WHERE id = 7 AND alarm_id = 1`); n != 1 {
+		t.Errorf("alarm_state row after re-Up = %d, want 1 (id-intact restore)", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM event_alarm_attendees WHERE alarm_id = 1`); n != 1 {
+		t.Errorf("attendee row after re-Up = %d, want 1", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM x_properties WHERE owner_type = 'event_alarm'
+		AND owner_id = 1 AND name = 'X-KEEP'`); n != 1 {
+		t.Errorf("alarm x_properties after re-Up = %d, want 1", n)
+	}
+	// The wide CHECK accepts a sync-only action again, and the recreated
+	// AFTER DELETE trigger still cleans its x_properties.
+	mustExec(`INSERT INTO event_alarms (id, event_id, action, trigger_value) VALUES (9, 1, 'X-APPLE-SOUND', '-PT9M')`)
+	mustExec(`INSERT INTO x_properties (owner_type, owner_id, name, value)
+		VALUES ('event_alarm', 9, 'X-TMP', 'yes')`)
+	mustExec(`DELETE FROM event_alarms WHERE id = 9`)
+	if n := count(`SELECT COUNT(*) FROM x_properties WHERE owner_type = 'event_alarm' AND owner_id = 9`); n != 0 {
+		t.Errorf("x_properties for the deleted alarm = %d, want 0 (cleanup trigger recreated)", n)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO event_alarms (event_id, action, trigger_value) VALUES (1, '', '-PT5M')`,
+	); err == nil {
+		t.Errorf("wide CHECK accepted an empty action")
+	}
+}
+
 // Verifies migration 040 (transactional ALTER TABLE ADD COLUMN) round-trips
 // cleanly with live data. The four remote_* mirror columns and the partial
 // uniqueness index appear on Up and disappear on Down. The calendars.name

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -2,8 +2,41 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 )
+
+// migHelpers returns exec and count helpers bound to conn. The migration
+// UpDown tests share them.
+func migHelpers(t *testing.T, ctx context.Context, conn *sql.DB) (func(string, ...any), func(string, ...any) int) {
+	mustExec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := conn.ExecContext(ctx, query, args...); err != nil {
+			t.Fatalf("exec %q: %v", query, err)
+		}
+	}
+	count := func(query string, args ...any) int {
+		t.Helper()
+		var n int
+		if err := conn.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+			t.Fatalf("count %q: %v", query, err)
+		}
+		return n
+	}
+	return mustExec, count
+}
+
+// migProvider opens the embedded migrations as a goose provider.
+func migProvider(t *testing.T, conn *sql.DB) *goose.Provider {
+	t.Helper()
+	// Build through the production constructor, so a test provider and
+	// the one Open uses cannot register different migration sets.
+	provider, err := NewMigrationProvider(conn)
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	return provider
+}
 
 // Verifies migration 031 rolls back and re-applies cleanly (table rebuild +
 // trigger recreation in both directions) with live rows. Non-alarm-owned
@@ -17,12 +50,7 @@ func TestMigration031UpDown(t *testing.T) {
 	defer conn.Close()
 
 	ctx := context.Background()
-	mustExec := func(query string, args ...any) {
-		t.Helper()
-		if _, err := conn.ExecContext(ctx, query, args...); err != nil {
-			t.Fatalf("exec %q: %v", query, err)
-		}
-	}
+	mustExec, _ := migHelpers(t, ctx, conn)
 
 	// Seed an event, an alarm on it, and X-properties for both owner kinds.
 	mustExec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time)
@@ -39,10 +67,7 @@ func TestMigration031UpDown(t *testing.T) {
 		t.Fatalf("query seeded prop: %v", err)
 	}
 
-	provider, err := NewMigrationProvider(conn)
-	if err != nil {
-		t.Fatalf("provider: %v", err)
-	}
+	provider := migProvider(t, conn)
 	if _, err := provider.DownTo(ctx, 30); err != nil {
 		t.Fatalf("down to 30: %v", err)
 	}
@@ -80,40 +105,27 @@ func TestMigration031UpDown(t *testing.T) {
 		VALUES ('event_alarm', 1, 'X-ALARM-PROP', 'works-again')`)
 }
 
-// Verifies migration 043 (the wide alarm action CHECK) rolls back and
+// Verifies migration 044 (the wide alarm action CHECK) rolls back and
 // re-applies cleanly with live rows. The rebuild runs with foreign keys ON,
 // so DROP TABLE performs an implicit DELETE that cascades into alarm_state
 // and event_alarm_attendees; the migration must restore those rows
 // id-intact. The alarm-owned x_properties rows must survive in place. On
-// Down, an alarm with a sync-only action is intentionally deleted together
-// with its dependent rows.
-func TestMigration043UpDown(t *testing.T) {
-	conn, _, err := Open(t.TempDir() + "/mig043.db")
+// Down, the migration intentionally deletes an alarm with a sync-only
+// action together with its dependent rows.
+func TestMigration044UpDown(t *testing.T) {
+	conn, _, err := Open(t.TempDir() + "/mig044.db")
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	defer conn.Close()
 
 	ctx := context.Background()
-	mustExec := func(query string, args ...any) {
-		t.Helper()
-		if _, err := conn.ExecContext(ctx, query, args...); err != nil {
-			t.Fatalf("exec %q: %v", query, err)
-		}
-	}
-	count := func(query string, args ...any) int {
-		t.Helper()
-		var n int
-		if err := conn.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
-			t.Fatalf("count %q: %v", query, err)
-		}
-		return n
-	}
+	mustExec, count := migHelpers(t, ctx, conn)
 
 	// Seed: one event with a fireable alarm (state + attendee + x-prop) and
 	// one sync-only NONE alarm (x-prop only).
 	mustExec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time)
-		VALUES ('mig043-evt', 1, 'Mig', '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z')`)
+		VALUES ('mig044-evt', 1, 'Mig', '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z')`)
 	mustExec(`INSERT INTO event_alarms (id, event_id, action, trigger_value) VALUES (1, 1, 'EMAIL', '-PT15M')`)
 	mustExec(`INSERT INTO event_alarms (id, event_id, action, trigger_value) VALUES (2, 1, 'NONE', '-PT5M')`)
 	mustExec(`INSERT INTO alarm_state (id, alarm_id, event_id, trigger_at, fired_at)
@@ -123,15 +135,16 @@ func TestMigration043UpDown(t *testing.T) {
 		VALUES ('event_alarm', 1, 'X-KEEP', 'yes')`)
 	mustExec(`INSERT INTO x_properties (owner_type, owner_id, name, value)
 		VALUES ('event_alarm', 2, 'X-GONE-ON-DOWN', 'yes')`)
+	// Seed the todo half with the same shape, so the todo rebuild and the
+	// todo child-table backup blocks run against live rows too.
+	mustExec(`INSERT INTO todos (uid, calendar_id, summary) VALUES ('mig044-todo', 1, 'Mig')`)
+	mustExec(`INSERT INTO todo_alarms (id, todo_id, action, trigger_value) VALUES (1, 1, 'DISPLAY', '-PT15M')`)
+	mustExec(`INSERT INTO todo_alarms (id, todo_id, action, trigger_value) VALUES (2, 1, 'NONE', '-PT5M')`)
+	mustExec(`INSERT INTO todo_alarm_state (id, alarm_id, todo_id, trigger_at, fired_at)
+		VALUES (8, 1, 1, '2026-01-01T09:45:00Z', '2026-01-01T09:45:01Z')`)
+	mustExec(`INSERT INTO todo_alarm_attendees (alarm_id, email) VALUES (1, 'b@example.com')`)
 
-	migrationsFS, err := fs.Sub(dbembed.Migrations, "migrations")
-	if err != nil {
-		t.Fatalf("sub fs: %v", err)
-	}
-	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS)
-	if err != nil {
-		t.Fatalf("provider: %v", err)
-	}
+	provider := migProvider(t, conn)
 	if _, err := provider.DownTo(ctx, 42); err != nil {
 		t.Fatalf("down to 42: %v", err)
 	}
@@ -155,9 +168,27 @@ func TestMigration043UpDown(t *testing.T) {
 	); err == nil {
 		t.Errorf("narrow CHECK accepted action NONE after Down")
 	}
+	if n := count(`SELECT COUNT(*) FROM todo_alarms`); n != 1 {
+		t.Errorf("todo alarms after Down = %d, want 1 (the NONE alarm is dropped)", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM todo_alarm_state WHERE id = 8 AND alarm_id = 1
+		AND trigger_at = '2026-01-01T09:45:00Z'`); n != 1 {
+		t.Errorf("todo_alarm_state row after Down = %d, want 1 (id-intact restore)", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM todo_alarm_attendees WHERE alarm_id = 1
+		AND email = 'b@example.com'`); n != 1 {
+		t.Errorf("todo attendee row after Down = %d, want 1", n)
+	}
 
 	if _, err := provider.Up(ctx); err != nil {
 		t.Fatalf("re-up: %v", err)
+	}
+
+	if n := count(`SELECT COUNT(*) FROM todo_alarm_state WHERE id = 8 AND alarm_id = 1`); n != 1 {
+		t.Errorf("todo_alarm_state row after re-Up = %d, want 1 (id-intact restore)", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM todo_alarm_attendees WHERE alarm_id = 1`); n != 1 {
+		t.Errorf("todo attendee row after re-Up = %d, want 1", n)
 	}
 
 	if n := count(`SELECT COUNT(*) FROM alarm_state WHERE id = 7 AND alarm_id = 1`); n != 1 {
@@ -201,12 +232,7 @@ func TestMigration040UpDown(t *testing.T) {
 	defer conn.Close()
 
 	ctx := context.Background()
-	mustExec := func(query string, args ...any) {
-		t.Helper()
-		if _, err := conn.ExecContext(ctx, query, args...); err != nil {
-			t.Fatalf("exec %q: %v", query, err)
-		}
-	}
+	mustExec, _ := migHelpers(t, ctx, conn)
 
 	// Calendar id 1 ('Personal') is seeded by migration 001. Hang dependent
 	// rows off it so we can prove foreign keys survive the column rebuild.
@@ -274,10 +300,7 @@ func TestMigration040UpDown(t *testing.T) {
 		t.Error("calendars.name UNIQUE constraint not enforced after Up")
 	}
 
-	provider, err := NewMigrationProvider(conn)
-	if err != nil {
-		t.Fatalf("provider: %v", err)
-	}
+	provider := migProvider(t, conn)
 
 	if _, err := provider.DownTo(ctx, 39); err != nil {
 		t.Fatalf("down to 39: %v", err)

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -451,15 +452,18 @@ func TestFireableAlarmQueriesMatchModelPredicate(t *testing.T) {
 	}
 	todoID, _ := res.LastInsertId()
 
-	// One candidate per action, each with a unique trigger. The trigger
-	// then identifies the action in the distinct-trigger results.
-	candidates := map[string]string{
-		"AUDIO":         "-PT1M",
-		"DISPLAY":       "-PT2M",
-		"EMAIL":         "-PT3M",
-		"NONE":          "-PT4M",
-		"X-APPLE-SOUND": "-PT5M",
-		"display":       "-PT6M",
+	// Derive the fireable candidates from the model set itself, so a value
+	// added there gets a probe row without an edit here. A hardcoded list
+	// would pass without covering the new value, and the drift it must
+	// catch is exactly "the Go set grew, the SQL lists did not".
+	// The non-fireable probes stay fixed: they cover the preserved actions
+	// (issue #579) and a lowercase near-miss.
+	candidates := map[string]string{}
+	for i, action := range model.FireableAlarmActions() {
+		candidates[action] = fmt.Sprintf("-PT%dM", i+1)
+	}
+	for i, action := range []string{"NONE", "X-APPLE-SOUND", "display"} {
+		candidates[action] = fmt.Sprintf("-PT%dH", i+1)
 	}
 	for action, trigger := range candidates {
 		if _, err := db.Exec(
@@ -530,4 +534,40 @@ func TestFireableAlarmQueriesMatchModelPredicate(t *testing.T) {
 		tdGot[i] = r.TriggerValue
 	}
 	check("ListFireableTodoAlarmsByTodoID", tdGot)
+
+	// The state queries filter on the same action list. Give every alarm a
+	// fired state row, then check that only the fireable actions surface.
+	fired := "2026-04-01T00:00:00Z"
+	if _, err := db.Exec(
+		`INSERT INTO alarm_state (alarm_id, event_id, trigger_at, fired_at)
+		 SELECT id, ?, trigger_value, ? FROM event_alarms WHERE event_id = ?`,
+		eventID, fired, eventID); err != nil {
+		t.Fatalf("insert alarm states: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO todo_alarm_state (alarm_id, todo_id, trigger_at, fired_at)
+		 SELECT id, ?, trigger_value, ? FROM todo_alarms WHERE todo_id = ?`,
+		todoID, fired, todoID); err != nil {
+		t.Fatalf("insert todo alarm states: %v", err)
+	}
+
+	evStates, err := q.ListPendingAlarmStates(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingAlarmStates: %v", err)
+	}
+	evStateTrigs := make([]string, len(evStates))
+	for i, s := range evStates {
+		evStateTrigs[i] = s.TriggerAt
+	}
+	check("ListPendingAlarmStates", evStateTrigs)
+
+	tdStates, err := q.ListPendingTodoAlarmStates(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingTodoAlarmStates: %v", err)
+	}
+	tdStateTrigs := make([]string, len(tdStates))
+	for i, s := range tdStates {
+		tdStateTrigs[i] = s.TriggerAt
+	}
+	check("ListPendingTodoAlarmStates", tdStateTrigs)
 }

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -395,7 +395,7 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 		// The valid candidates come from the model sets. The test then
 		// probes a value added to the model but not to a migration
 		// against the CHECK constraint, and the value fails here.
-		// Migration 043 widened the action constraint, so the action rule
+		// Migration 044 widened the action constraint, so the action rule
 		// is StorableAlarmAction and a preserved foreign action passes.
 		{"action", append(model.AlarmActions(), "NONE", "PROCEDURE", "X-APPLE-SOUND", "display", ""), model.StorableAlarmAction},
 		{"related", append(model.AlarmRelatedValues(), "STARTS", "end", ""), model.ValidAlarmRelated},

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -348,8 +348,10 @@ func TestCalendarsRejectInvalidRemoteMetadata(t *testing.T) {
 // value that passes the Go side but fails the constraint rolls back the
 // whole resource transaction during sync (issue #575). This test probes
 // both alarm tables with candidate values. The schema and
-// model.ValidAlarmAction / model.ValidAlarmRelated must give the same
-// verdict on each one.
+// model.StorableAlarmAction / model.ValidAlarmRelated must give the same
+// verdict on each one. The action rule is wide on purpose (issue #579):
+// the tables keep a sync-only action such as NONE or X-APPLE-SOUND, and
+// only the narrower model.FireableAlarmAction gates the alarm engine.
 func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 	db, q, err := Open(":memory:")
 	if err != nil {
@@ -393,7 +395,9 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 		// The valid candidates come from the model sets. The test then
 		// probes a value added to the model but not to a migration
 		// against the CHECK constraint, and the value fails here.
-		{"action", append(model.AlarmActions(), "NONE", "PROCEDURE", "display", ""), model.ValidAlarmAction},
+		// Migration 043 widened the action constraint, so the action rule
+		// is StorableAlarmAction and a preserved foreign action passes.
+		{"action", append(model.AlarmActions(), "NONE", "PROCEDURE", "X-APPLE-SOUND", "display", ""), model.StorableAlarmAction},
 		{"related", append(model.AlarmRelatedValues(), "STARTS", "end", ""), model.ValidAlarmRelated},
 	}
 

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -459,7 +459,7 @@ func TestFireableAlarmQueriesMatchModelPredicate(t *testing.T) {
 	// The non-fireable probes stay fixed: they cover the preserved actions
 	// (issue #579) and a lowercase near-miss.
 	candidates := map[string]string{}
-	for i, action := range model.FireableAlarmActions() {
+	for i, action := range model.AlarmActions() {
 		candidates[action] = fmt.Sprintf("-PT%dM", i+1)
 	}
 	for i, action := range []string{"NONE", "X-APPLE-SOUND", "display"} {

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -419,3 +419,115 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 		}
 	}
 }
+
+// The fireable-filtered queries and model.FireableAlarmAction must agree.
+// The WHERE lists in the query files are copies of the Go set with only a
+// comment as the tie. This test probes both with the same candidates, in
+// the same way TestAlarmConstraintsMatchModelValidators pins the CHECK
+// constraints.
+func TestFireableAlarmQueriesMatchModelPredicate(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("list calendars: %v", err)
+	}
+	calID := cals[0].ID
+	res, err := db.Exec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time, all_day, status, transp, sequence, priority)
+		 VALUES ('fireable-q-event', ?, 'Test', '2026-04-01T00:00:00Z', '2026-04-01T01:00:00Z', 0, 'CONFIRMED', 'OPAQUE', 0, 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	eventID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO todos (uid, calendar_id, summary, status, priority, sequence)
+		 VALUES ('fireable-q-todo', ?, 'Test', 'NEEDS-ACTION', 0, 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert todo: %v", err)
+	}
+	todoID, _ := res.LastInsertId()
+
+	// One candidate per action, each with a unique trigger. The trigger
+	// then identifies the action in the distinct-trigger results.
+	candidates := map[string]string{
+		"AUDIO":         "-PT1M",
+		"DISPLAY":       "-PT2M",
+		"EMAIL":         "-PT3M",
+		"NONE":          "-PT4M",
+		"X-APPLE-SOUND": "-PT5M",
+		"display":       "-PT6M",
+	}
+	for action, trigger := range candidates {
+		if _, err := db.Exec(
+			`INSERT INTO event_alarms (event_id, action, trigger_value) VALUES (?, ?, ?)`,
+			eventID, action, trigger); err != nil {
+			t.Fatalf("insert event alarm %q: %v", action, err)
+		}
+		if _, err := db.Exec(
+			`INSERT INTO todo_alarms (todo_id, action, trigger_value) VALUES (?, ?, ?)`,
+			todoID, action, trigger); err != nil {
+			t.Fatalf("insert todo alarm %q: %v", action, err)
+		}
+	}
+	wantTriggers := map[string]bool{}
+	for action, trigger := range candidates {
+		if model.FireableAlarmAction(action) {
+			wantTriggers[trigger] = true
+		}
+	}
+
+	check := func(name string, got []string) {
+		t.Helper()
+		if len(got) != len(wantTriggers) {
+			t.Errorf("%s returned %d triggers %v, want %d", name, len(got), got, len(wantTriggers))
+			return
+		}
+		for _, trig := range got {
+			if !wantTriggers[trig] {
+				t.Errorf("%s returned trigger %q of a non-fireable action", name, trig)
+			}
+		}
+	}
+
+	evTrigs, err := q.ListDistinctAlarmTriggers(ctx)
+	if err != nil {
+		t.Fatalf("ListDistinctAlarmTriggers: %v", err)
+	}
+	check("ListDistinctAlarmTriggers", evTrigs)
+
+	tdTrigs, err := q.ListDistinctTodoAlarmTriggers(ctx)
+	if err != nil {
+		t.Fatalf("ListDistinctTodoAlarmTriggers: %v", err)
+	}
+	check("ListDistinctTodoAlarmTriggers", tdTrigs)
+
+	evRows, err := q.ListFireableAlarmsByEventIDs(ctx, []int64{eventID})
+	if err != nil {
+		t.Fatalf("ListFireableAlarmsByEventIDs: %v", err)
+	}
+	evGot := make([]string, len(evRows))
+	for i, r := range evRows {
+		if !model.FireableAlarmAction(r.Action) {
+			t.Errorf("ListFireableAlarmsByEventIDs returned non-fireable action %q", r.Action)
+		}
+		evGot[i] = r.TriggerValue
+	}
+	check("ListFireableAlarmsByEventIDs", evGot)
+
+	tdRows, err := q.ListFireableTodoAlarmsByTodoID(ctx, todoID)
+	if err != nil {
+		t.Fatalf("ListFireableTodoAlarmsByTodoID: %v", err)
+	}
+	tdGot := make([]string, len(tdRows))
+	for i, r := range tdRows {
+		if !model.FireableAlarmAction(r.Action) {
+			t.Errorf("ListFireableTodoAlarmsByTodoID returned non-fireable action %q", r.Action)
+		}
+		tdGot[i] = r.TriggerValue
+	}
+	check("ListFireableTodoAlarmsByTodoID", tdGot)
+}

--- a/internal/storage/todo_alarm_state.sql.go
+++ b/internal/storage/todo_alarm_state.sql.go
@@ -23,6 +23,23 @@ func (q *Queries) AcknowledgeTodoAlarmState(ctx context.Context, arg Acknowledge
 	return err
 }
 
+const acknowledgeTodoAlarmStatesByAlarmID = `-- name: AcknowledgeTodoAlarmStatesByAlarmID :exec
+UPDATE todo_alarm_state SET acked_at = ? WHERE alarm_id = ? AND acked_at IS NULL
+`
+
+type AcknowledgeTodoAlarmStatesByAlarmIDParams struct {
+	AckedAt *string
+	AlarmID int64
+}
+
+// Retire the live state of one alarm. A sync pull can rewrite an alarm
+// to a sync-only action in place. The check loop never fires that alarm
+// again, so an open state row would stay pending forever.
+func (q *Queries) AcknowledgeTodoAlarmStatesByAlarmID(ctx context.Context, arg AcknowledgeTodoAlarmStatesByAlarmIDParams) error {
+	_, err := q.db.ExecContext(ctx, acknowledgeTodoAlarmStatesByAlarmID, arg.AckedAt, arg.AlarmID)
+	return err
+}
+
 const countTodoAlarmStates = `-- name: CountTodoAlarmStates :one
 SELECT COUNT(*) FROM todo_alarm_state WHERE todo_id = ?
 `

--- a/internal/storage/todo_alarm_state.sql.go
+++ b/internal/storage/todo_alarm_state.sql.go
@@ -23,23 +23,6 @@ func (q *Queries) AcknowledgeTodoAlarmState(ctx context.Context, arg Acknowledge
 	return err
 }
 
-const acknowledgeTodoAlarmStatesByAlarmID = `-- name: AcknowledgeTodoAlarmStatesByAlarmID :exec
-UPDATE todo_alarm_state SET acked_at = ? WHERE alarm_id = ? AND acked_at IS NULL
-`
-
-type AcknowledgeTodoAlarmStatesByAlarmIDParams struct {
-	AckedAt *string
-	AlarmID int64
-}
-
-// Retire the live state of one alarm. A sync pull can rewrite an alarm
-// to a sync-only action in place. The check loop never fires that alarm
-// again, so an open state row would stay pending forever.
-func (q *Queries) AcknowledgeTodoAlarmStatesByAlarmID(ctx context.Context, arg AcknowledgeTodoAlarmStatesByAlarmIDParams) error {
-	_, err := q.db.ExecContext(ctx, acknowledgeTodoAlarmStatesByAlarmID, arg.AckedAt, arg.AlarmID)
-	return err
-}
-
 const countTodoAlarmStates = `-- name: CountTodoAlarmStates :one
 SELECT COUNT(*) FROM todo_alarm_state WHERE todo_id = ?
 `
@@ -106,7 +89,12 @@ func (q *Queries) GetTodoAlarmStateByID(ctx context.Context, id int64) (TodoAlar
 
 const insertTodoAlarmState = `-- name: InsertTodoAlarmState :one
 INSERT INTO todo_alarm_state (alarm_id, todo_id, trigger_at, fired_at, acked_at, snoozed_to)
-VALUES (?, ?, ?, ?, ?, ?)
+SELECT ?1, ?2, ?3,
+       ?4, ?5, ?6
+WHERE EXISTS (
+    SELECT 1 FROM todo_alarms
+    WHERE id = ?1 AND action IN ('AUDIO','DISPLAY','EMAIL')
+)
 RETURNING id, alarm_id, todo_id, trigger_at, fired_at, acked_at, snoozed_to
 `
 
@@ -119,6 +107,11 @@ type InsertTodoAlarmStateParams struct {
 	SnoozedTo *string
 }
 
+// Claim a fire slot for one todo alarm. The EXISTS arm reads the action in
+// the same statement as the insert, so a sync pull that rewrites the alarm
+// to a sync-only action between the check and the claim cannot leave a
+// fired state for an alarm the user disabled (issue #579).
+// Keep the action list in lockstep with model.FireableAlarmAction.
 func (q *Queries) InsertTodoAlarmState(ctx context.Context, arg InsertTodoAlarmStateParams) (TodoAlarmState, error) {
 	row := q.db.QueryRowContext(ctx, insertTodoAlarmState,
 		arg.AlarmID,
@@ -142,14 +135,18 @@ func (q *Queries) InsertTodoAlarmState(ctx context.Context, arg InsertTodoAlarmS
 }
 
 const listExpiredTodoSnoozed = `-- name: ListExpiredTodoSnoozed :many
-SELECT id, alarm_id, todo_id, trigger_at, fired_at, acked_at, snoozed_to FROM todo_alarm_state
-WHERE fired_at IS NOT NULL
-  AND acked_at IS NULL
-  AND snoozed_to IS NOT NULL
-  AND snoozed_to <= ?
-ORDER BY snoozed_to
+SELECT s.id, s.alarm_id, s.todo_id, s.trigger_at, s.fired_at, s.acked_at, s.snoozed_to FROM todo_alarm_state s
+JOIN todo_alarms a ON a.id = s.alarm_id
+WHERE s.fired_at IS NOT NULL
+  AND s.acked_at IS NULL
+  AND s.snoozed_to IS NOT NULL
+  AND s.snoozed_to <= ?
+  AND a.action IN ('AUDIO','DISPLAY','EMAIL')
+ORDER BY s.snoozed_to
 `
 
+// The same sync-only filter as ListPendingTodoAlarmStates, for the re-fire
+// path. Keep the action list in lockstep with model.FireableAlarmAction.
 func (q *Queries) ListExpiredTodoSnoozed(ctx context.Context, snoozedTo *string) ([]TodoAlarmState, error) {
 	rows, err := q.db.QueryContext(ctx, listExpiredTodoSnoozed, snoozedTo)
 	if err != nil {
@@ -219,11 +216,17 @@ func (q *Queries) ListFiredTodoAlarmStates(ctx context.Context, todoID int64) ([
 }
 
 const listPendingTodoAlarmStates = `-- name: ListPendingTodoAlarmStates :many
-SELECT id, alarm_id, todo_id, trigger_at, fired_at, acked_at, snoozed_to FROM todo_alarm_state
-WHERE acked_at IS NULL AND (fired_at IS NOT NULL OR snoozed_to IS NOT NULL)
-ORDER BY trigger_at
+SELECT s.id, s.alarm_id, s.todo_id, s.trigger_at, s.fired_at, s.acked_at, s.snoozed_to FROM todo_alarm_state s
+JOIN todo_alarms a ON a.id = s.alarm_id
+WHERE s.acked_at IS NULL AND (s.fired_at IS NOT NULL OR s.snoozed_to IS NOT NULL)
+  AND a.action IN ('AUDIO','DISPLAY','EMAIL')
+ORDER BY s.trigger_at
 `
 
+// Hide the state of an alarm a sync pull rewrote to a sync-only action.
+// The filter reads the current action, so the row comes back when a later
+// pull restores a fireable action (issue #579).
+// Keep the action list in lockstep with model.FireableAlarmAction.
 func (q *Queries) ListPendingTodoAlarmStates(ctx context.Context) ([]TodoAlarmState, error) {
 	rows, err := q.db.QueryContext(ctx, listPendingTodoAlarmStates)
 	if err != nil {

--- a/internal/storage/todo_alarms.sql.go
+++ b/internal/storage/todo_alarms.sql.go
@@ -115,6 +115,54 @@ func (q *Queries) ListDistinctTodoAlarmTriggers(ctx context.Context) ([]string, 
 	return items, nil
 }
 
+const listFireableTodoAlarmsByTodoID = `-- name: ListFireableTodoAlarmsByTodoID :many
+SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM todo_alarms
+WHERE todo_id = ?
+  AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
+ORDER BY id
+`
+
+// The action list mirrors model.FireableAlarmAction. Keep the two in
+// lockstep. The alarm check loop is the only caller, and a preserved
+// sync-only action must not reach it.
+func (q *Queries) ListFireableTodoAlarmsByTodoID(ctx context.Context, todoID int64) ([]TodoAlarm, error) {
+	rows, err := q.db.QueryContext(ctx, listFireableTodoAlarmsByTodoID, todoID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []TodoAlarm
+	for rows.Next() {
+		var i TodoAlarm
+		if err := rows.Scan(
+			&i.ID,
+			&i.TodoID,
+			&i.Action,
+			&i.TriggerValue,
+			&i.Description,
+			&i.Repeat,
+			&i.Duration,
+			&i.Related,
+			&i.Summary,
+			&i.Uid,
+			&i.Acknowledged,
+			&i.AttachUri,
+			&i.AttachFmttype,
+			&i.AttachBinary,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTodoAlarmsByTodoID = `-- name: ListTodoAlarmsByTodoID :many
 SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM todo_alarms WHERE todo_id = ? ORDER BY id
 `

--- a/internal/storage/todo_alarms.sql.go
+++ b/internal/storage/todo_alarms.sql.go
@@ -86,8 +86,12 @@ func (q *Queries) DeleteTodoAlarmsByTodoID(ctx context.Context, todoID int64) er
 
 const listDistinctTodoAlarmTriggers = `-- name: ListDistinctTodoAlarmTriggers :many
 SELECT DISTINCT trigger_value FROM todo_alarms
+WHERE action IN ('AUDIO', 'DISPLAY', 'EMAIL')
 `
 
+// The action list mirrors model.FireableAlarmAction. Keep the two in
+// lockstep. A preserved sync-only action never fires, so its trigger
+// must not size the alarm check window.
 func (q *Queries) ListDistinctTodoAlarmTriggers(ctx context.Context) ([]string, error) {
 	rows, err := q.db.QueryContext(ctx, listDistinctTodoAlarmTriggers)
 	if err != nil {

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -1048,29 +1048,13 @@ func syncMatchedTodoAlarm(ctx context.Context, qtx *storage.Queries, a model.Ala
 // updateTodoAlarmInPlace rewrites a UID-matched alarm's content on its
 // stored row. The row ID stays so todo_alarm_state entries survive.
 func updateTodoAlarmInPlace(ctx context.Context, qtx *storage.Queries, todoID int64, a model.Alarm, ex model.Alarm) error {
-	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
-		return fmt.Errorf("update alarm: %w", err)
-	}
-	// A rewrite to a sync-only action disables the alarm. Retire its
-	// live state in the same transaction: the check loop never fires
-	// this alarm again, so an open state row would stay pending in
-	// `alarm list` forever (issue #579). This write point is the only
-	// place a stored action can change, so the read paths need no
-	// retirement of their own.
-	if !model.FireableAlarmAction(a.Action) {
-		acked := time.Now().UTC().Format(time.RFC3339)
-		if err := qtx.AcknowledgeTodoAlarmStatesByAlarmID(ctx, storage.AcknowledgeTodoAlarmStatesByAlarmIDParams{
-			AckedAt: &acked,
-			AlarmID: ex.ID,
-		}); err != nil {
-			return fmt.Errorf("retire alarm state: %w", err)
-		}
-	}
-	// Same ACKNOWLEDGED policy as syncMatchedTodoAlarm. A malformed
-	// value that arrives must not clobber valid stored state.
-	ack := a.Acknowledged
-	if !model.ValidateAcknowledged(ack) {
-		ack = ex.Acknowledged
+	// A rewrite to a sync-only action disables the alarm, but this code
+	// leaves todo_alarm_state alone. The pending and snooze queries
+	// filter on the current action, so the state of the alarm comes back
+	// when a later pull restores a fireable action (issue #579).
+	ack, err := model.PrepareAlarmUpdate(a, ex)
+	if err != nil {
+		return err
 	}
 	if err := qtx.UpdateTodoAlarmContentByID(ctx, storage.UpdateTodoAlarmContentByIDParams{
 		Action:        a.Action,

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -1051,6 +1051,21 @@ func updateTodoAlarmInPlace(ctx context.Context, qtx *storage.Queries, todoID in
 	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
 		return fmt.Errorf("update alarm: %w", err)
 	}
+	// A rewrite to a sync-only action disables the alarm. Retire its
+	// live state in the same transaction: the check loop never fires
+	// this alarm again, so an open state row would stay pending in
+	// `alarm list` forever (issue #579). This write point is the only
+	// place a stored action can change, so the read paths need no
+	// retirement of their own.
+	if !model.FireableAlarmAction(a.Action) {
+		acked := time.Now().UTC().Format(time.RFC3339)
+		if err := qtx.AcknowledgeTodoAlarmStatesByAlarmID(ctx, storage.AcknowledgeTodoAlarmStatesByAlarmIDParams{
+			AckedAt: &acked,
+			AlarmID: ex.ID,
+		}); err != nil {
+			return fmt.Errorf("retire alarm state: %w", err)
+		}
+	}
 	// Same ACKNOWLEDGED policy as syncMatchedTodoAlarm. A malformed
 	// value that arrives must not clobber valid stored state.
 	ack := a.Acknowledged

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -879,6 +879,18 @@ func fromStorageTodoAlarm(r storage.TodoAlarm) model.Alarm {
 	}
 }
 
+// ReplaceFireableAlarms replaces the fireable alarms of a todo and
+// carries the stored sync-only rows forward, like the event method of the
+// same name (issue #579). A caller that must delete such a row calls
+// ReplaceAlarms instead.
+func (s *Service) ReplaceFireableAlarms(ctx context.Context, todoID int64, alarms []model.Alarm) error {
+	stored, err := s.ListAlarms(ctx, todoID)
+	if err != nil {
+		return fmt.Errorf("list stored alarms: %w", err)
+	}
+	return s.ReplaceAlarms(ctx, todoID, model.KeepSyncOnlyAlarms(stored, alarms))
+}
+
 func (s *Service) ReplaceAlarms(ctx context.Context, todoID int64, alarms []model.Alarm) error {
 	// Prepare before the transaction opens. A standalone call then
 	// rejects a bad alarm without a write lock. A sync caller already

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -1035,6 +1035,12 @@ func syncMatchedTodoAlarm(ctx context.Context, qtx *storage.Queries, a model.Ala
 // updateTodoAlarmInPlace rewrites a UID-matched alarm's content on its
 // stored row. The row ID stays so todo_alarm_state entries survive.
 func updateTodoAlarmInPlace(ctx context.Context, qtx *storage.Queries, todoID int64, a model.Alarm, ex model.Alarm) error {
+	// Reject an unstorable action in Go, with a named error. The raw
+	// CHECK constraint would roll back the whole resource transaction
+	// during sync (issue #575).
+	if !model.StorableAlarmAction(a.Action) {
+		return fmt.Errorf("update alarm: action %q is not storable", a.Action)
+	}
 	// Same ACKNOWLEDGED policy as syncMatchedTodoAlarm. A malformed
 	// value that arrives must not clobber valid stored state.
 	ack := a.Acknowledged
@@ -1091,6 +1097,12 @@ func isUniqueUIDViolation(err error) bool {
 // UID collision (for example a server that duplicates a todo with its VALARM
 // UIDs), mint a fresh local UID. Do not fail the sync forever.
 func createNewTodoAlarm(ctx context.Context, qtx *storage.Queries, todoID int64, a model.Alarm) error {
+	// Reject an unstorable action in Go, with a named error. The raw
+	// CHECK constraint would roll back the whole resource transaction
+	// during sync (issue #575).
+	if !model.StorableAlarmAction(a.Action) {
+		return fmt.Errorf("create alarm: action %q is not storable", a.Action)
+	}
 	uid := a.UID
 	if uid == "" {
 		uid = uuid.New().String()

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -798,19 +798,32 @@ func (s *Service) ListOverridesByUID(ctx context.Context, uid string) ([]Todo, e
 // Alarm CRUD
 
 func (s *Service) ListAlarms(ctx context.Context, todoID int64) ([]model.Alarm, error) {
-	return s.listAlarms(ctx, todoID, true)
+	return s.listAlarms(ctx, todoID, true, false)
 }
 
 // ListAlarmsLean returns a todo's alarms with attendees (needed to fire
 // EMAIL alarms) but without X-properties, which are round-trip-only and
-// never read at fire time. The alarm check loop calls this per todo every
-// tick, so it skips the per-todo x_properties query that export/sync need.
+// never read at fire time.
 func (s *Service) ListAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error) {
-	return s.listAlarms(ctx, todoID, false)
+	return s.listAlarms(ctx, todoID, false, false)
 }
 
-func (s *Service) listAlarms(ctx context.Context, todoID int64, withXProps bool) ([]model.Alarm, error) {
-	rows, err := s.q.ListTodoAlarmsByTodoID(ctx, todoID)
+// ListFireableAlarmsLean is ListAlarmsLean restricted to fireable actions.
+// The query excludes preserved sync-only actions (issue #579): the alarm
+// check loop calls this per todo every tick, and a sync-only alarm must
+// not reach it.
+func (s *Service) ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error) {
+	return s.listAlarms(ctx, todoID, false, true)
+}
+
+func (s *Service) listAlarms(ctx context.Context, todoID int64, withXProps, fireableOnly bool) ([]model.Alarm, error) {
+	var rows []storage.TodoAlarm
+	var err error
+	if fireableOnly {
+		rows, err = s.q.ListFireableTodoAlarmsByTodoID(ctx, todoID)
+	} else {
+		rows, err = s.q.ListTodoAlarmsByTodoID(ctx, todoID)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1035,11 +1048,8 @@ func syncMatchedTodoAlarm(ctx context.Context, qtx *storage.Queries, a model.Ala
 // updateTodoAlarmInPlace rewrites a UID-matched alarm's content on its
 // stored row. The row ID stays so todo_alarm_state entries survive.
 func updateTodoAlarmInPlace(ctx context.Context, qtx *storage.Queries, todoID int64, a model.Alarm, ex model.Alarm) error {
-	// Reject an unstorable action in Go, with a named error. The raw
-	// CHECK constraint would roll back the whole resource transaction
-	// during sync (issue #575).
-	if !model.StorableAlarmAction(a.Action) {
-		return fmt.Errorf("update alarm: action %q is not storable", a.Action)
+	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
+		return fmt.Errorf("update alarm: %w", err)
 	}
 	// Same ACKNOWLEDGED policy as syncMatchedTodoAlarm. A malformed
 	// value that arrives must not clobber valid stored state.
@@ -1097,11 +1107,8 @@ func isUniqueUIDViolation(err error) bool {
 // UID collision (for example a server that duplicates a todo with its VALARM
 // UIDs), mint a fresh local UID. Do not fail the sync forever.
 func createNewTodoAlarm(ctx context.Context, qtx *storage.Queries, todoID int64, a model.Alarm) error {
-	// Reject an unstorable action in Go, with a named error. The raw
-	// CHECK constraint would roll back the whole resource transaction
-	// during sync (issue #575).
-	if !model.StorableAlarmAction(a.Action) {
-		return fmt.Errorf("create alarm: action %q is not storable", a.Action)
+	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
+		return fmt.Errorf("create alarm: %w", err)
 	}
 	uid := a.UID
 	if uid == "" {

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -619,14 +619,6 @@ func TestTodoService_ReplaceAlarms_RejectsInvalidAlarm(t *testing.T) {
 	td := createTodo(t, svc)
 
 	err := svc.ReplaceAlarms(ctx, td.ID, []model.Alarm{
-		{Action: "DISPLAY", TriggerValue: "-PT15M"},
-		{Action: "NONE", TriggerValue: "-PT5M"},
-	})
-	if !errors.Is(err, model.ErrInvalidAlarm) {
-		t.Fatalf("invalid action: err = %v, want model.ErrInvalidAlarm", err)
-	}
-
-	err = svc.ReplaceAlarms(ctx, td.ID, []model.Alarm{
 		{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "end"},
 	})
 	if !errors.Is(err, model.ErrInvalidAlarm) {
@@ -639,6 +631,14 @@ func TestTodoService_ReplaceAlarms_RejectsInvalidAlarm(t *testing.T) {
 	}
 	if len(alarms) != 0 {
 		t.Errorf("alarms = %d, want 0 (a rejected write must store no row)", len(alarms))
+	}
+
+	// A preserved foreign action passes. Migration 043 widened the action
+	// constraint, so the boundary accepts it (issue #579).
+	if err := svc.ReplaceAlarms(ctx, td.ID, []model.Alarm{
+		{Action: "NONE", TriggerValue: "-PT5M"},
+	}); err != nil {
+		t.Fatalf("preserved action: err = %v, want nil", err)
 	}
 }
 

--- a/internal/tui/alarm_editor.go
+++ b/internal/tui/alarm_editor.go
@@ -144,8 +144,8 @@ func alarmSummary(alarms []model.Alarm) string {
 
 // formatAlarmWithAction renders an alarm for a read surface outside the
 // alarm editor. A preserved sync-only action (issue #579) never fires.
-// The bare trigger text would read as an armed reminder, so append the
-// action label to break that misreading.
+// The bare trigger text would read as an armed reminder. The appended
+// action label shows that the alarm does not fire.
 func formatAlarmWithAction(a model.Alarm) string {
 	if model.FireableAlarmAction(a.Action) {
 		return formatAlarm(a)
@@ -234,6 +234,12 @@ func (m AlarmListEditorModel) BoxSize() (int, int) {
 func (m *AlarmListEditorModel) enterEditMode(idx int) {
 	var a model.Alarm
 	if idx >= 0 && idx < len(m.alarms) {
+		// Self-guard: the form cannot represent a view-only alarm, and
+		// a save through it would rewrite the action as DISPLAY. Every
+		// present and future caller inherits this gate.
+		if !alarmEditable(m.alarms[idx]) {
+			return
+		}
 		a = m.alarms[idx]
 	} else {
 		a = model.Alarm{
@@ -482,18 +488,14 @@ func (m AlarmListEditorModel) updateListMode(msg tea.Msg) (AlarmListEditorModel,
 			m.done = true
 		default:
 			if kp.String() == "enter" && m.cursor >= 0 && m.cursor <= last {
-				if alarmEditable(m.alarms[m.cursor]) {
-					m.enterEditMode(m.cursor)
-				}
+				m.enterEditMode(m.cursor)
 			}
 		}
 	case "n":
 		m.enterEditMode(-1)
 	case "e":
 		if m.cursor >= 0 && m.cursor <= last {
-			if alarmEditable(m.alarms[m.cursor]) {
-				m.enterEditMode(m.cursor)
-			}
+			m.enterEditMode(m.cursor)
 		}
 	case "d":
 		if m.btnFocus == -1 && m.cursor >= 0 && m.cursor <= last {

--- a/internal/tui/alarm_editor.go
+++ b/internal/tui/alarm_editor.go
@@ -423,6 +423,21 @@ func actionDisplayLabel(action string) string {
 	return titleCaseAscii(v)
 }
 
+// alarmEditable reports whether the edit form can represent the alarm
+// without loss. The form only offers single-unit relative triggers and the
+// fireable actions. A preserved sync-only action (issue #579) stays
+// view-only: a save through the form would rewrite it as DISPLAY, which
+// resurrects a reminder the user disabled (ACTION:NONE) or converts the
+// alarm of another client. The list still shows and deletes the row.
+func alarmEditable(a model.Alarm) bool {
+	// An empty action means the DISPLAY default, so it stays editable.
+	if act := strings.ToUpper(strings.TrimSpace(a.Action)); act != "" && !model.FireableAlarmAction(act) {
+		return false
+	}
+	_, _, _, ok := parseOffsetTrigger(a.TriggerValue)
+	return ok
+}
+
 func (m AlarmListEditorModel) updateListMode(msg tea.Msg) (AlarmListEditorModel, tea.Cmd) {
 	kp, ok := msg.(tea.KeyPressMsg)
 	if !ok {
@@ -452,7 +467,7 @@ func (m AlarmListEditorModel) updateListMode(msg tea.Msg) (AlarmListEditorModel,
 			m.done = true
 		default:
 			if kp.String() == "enter" && m.cursor >= 0 && m.cursor <= last {
-				if _, _, _, ok := parseOffsetTrigger(m.alarms[m.cursor].TriggerValue); ok {
+				if alarmEditable(m.alarms[m.cursor]) {
 					m.enterEditMode(m.cursor)
 				}
 			}
@@ -461,7 +476,7 @@ func (m AlarmListEditorModel) updateListMode(msg tea.Msg) (AlarmListEditorModel,
 		m.enterEditMode(-1)
 	case "e":
 		if m.cursor >= 0 && m.cursor <= last {
-			if _, _, _, ok := parseOffsetTrigger(m.alarms[m.cursor].TriggerValue); ok {
+			if alarmEditable(m.alarms[m.cursor]) {
 				m.enterEditMode(m.cursor)
 			}
 		}

--- a/internal/tui/alarm_editor.go
+++ b/internal/tui/alarm_editor.go
@@ -147,7 +147,7 @@ func alarmSummary(alarms []model.Alarm) string {
 // The bare trigger text would read as an armed reminder, so append the
 // action label to break that misreading.
 func formatAlarmWithAction(a model.Alarm) string {
-	if a.Action == "" || model.FireableAlarmAction(a.Action) {
+	if model.FireableAlarmAction(a.Action) {
 		return formatAlarm(a)
 	}
 	return formatAlarm(a) + " (" + actionDisplayLabel(a.Action) + ", never fires)"
@@ -444,8 +444,9 @@ func actionDisplayLabel(action string) string {
 // non-canonical value (for example "display") never fires, so the form
 // must not rewrite it either.
 func alarmEditable(a model.Alarm) bool {
-	// An empty action means the DISPLAY default, so it stays editable.
-	if a.Action != "" && !model.FireableAlarmAction(a.Action) {
+	// An empty action cannot occur here: the DB CHECK forbids it, the
+	// parser defaults it, and the dropdown always sets one.
+	if !model.FireableAlarmAction(a.Action) {
 		return false
 	}
 	_, _, _, ok := parseOffsetTrigger(a.TriggerValue)

--- a/internal/tui/alarm_editor.go
+++ b/internal/tui/alarm_editor.go
@@ -136,10 +136,21 @@ func alarmSummary(alarms []model.Alarm) string {
 	case 0:
 		return "None"
 	case 1:
-		return formatAlarm(alarms[0])
+		return formatAlarmWithAction(alarms[0])
 	default:
 		return strconv.Itoa(len(alarms)) + " alarms"
 	}
+}
+
+// formatAlarmWithAction renders an alarm for a read surface outside the
+// alarm editor. A preserved sync-only action (issue #579) never fires.
+// The bare trigger text would read as an armed reminder, so append the
+// action label to break that misreading.
+func formatAlarmWithAction(a model.Alarm) string {
+	if a.Action == "" || model.FireableAlarmAction(a.Action) {
+		return formatAlarm(a)
+	}
+	return formatAlarm(a) + " (" + actionDisplayLabel(a.Action) + ", never fires)"
 }
 
 // AlarmListEditorModel manages the list of alarms attached to an event.
@@ -426,12 +437,15 @@ func actionDisplayLabel(action string) string {
 // alarmEditable reports whether the edit form can represent the alarm
 // without loss. The form only offers single-unit relative triggers and the
 // fireable actions. A preserved sync-only action (issue #579) stays
-// view-only: a save through the form would rewrite it as DISPLAY, which
-// resurrects a reminder the user disabled (ACTION:NONE) or converts the
-// alarm of another client. The list still shows and deletes the row.
+// view-only. A save through the form would rewrite it as DISPLAY. That
+// rewrite resurrects a reminder the user disabled (ACTION:NONE) or
+// converts the alarm of another client. The list still shows and deletes
+// the row. The action compares raw, exactly like the fire path: a stored
+// non-canonical value (for example "display") never fires, so the form
+// must not rewrite it either.
 func alarmEditable(a model.Alarm) bool {
 	// An empty action means the DISPLAY default, so it stays editable.
-	if act := strings.ToUpper(strings.TrimSpace(a.Action)); act != "" && !model.FireableAlarmAction(act) {
+	if a.Action != "" && !model.FireableAlarmAction(a.Action) {
 		return false
 	}
 	_, _, _, ok := parseOffsetTrigger(a.TriggerValue)
@@ -615,6 +629,11 @@ func (m AlarmListEditorModel) renderList() string {
 		for i, a := range m.alarms {
 			label := "  " + formatAlarm(a)
 			label += faint.Render("  (" + actionDisplayLabel(a.Action) + ")")
+			// Mark a row the edit form cannot open. Without the mark,
+			// "e" and "enter" read as dead keys on this row.
+			if !alarmEditable(a) {
+				label += faint.Render("  view-only")
+			}
 			if m.btnFocus == -1 && i == m.cursor {
 				label = reverse.Render(label)
 			}

--- a/internal/tui/alarm_editor_test.go
+++ b/internal/tui/alarm_editor_test.go
@@ -350,16 +350,40 @@ func TestAlarmEditor_EditModeMouseClickOnCancelReturnsToList(t *testing.T) {
 	assert.Empty(t, m.Alarms(), "clicking cancel must not save the alarm")
 }
 
-// Every action the dropdown offers must pass model.ValidAlarmAction. The
-// predicate mirrors the storage CHECK constraints, so a drifted option
-// would let the user pick an action the insert rejects — the issue #575
-// rollback class through the TUI.
+// Every action the dropdown offers must pass model.FireableAlarmAction.
+// The TUI creates local alarms, and a local alarm must be one the engine
+// can fire. A sync-only action (issue #579) enters the database from
+// import alone; the dropdown must never offer it.
 func TestAlarmActionOptsMatchModelValidator(t *testing.T) {
 	require.NotEmpty(t, alarmActionOpts)
 	assert.Len(t, alarmActionOpts, len(model.AlarmActions()),
 		"the dropdown must offer every accepted action")
 	for _, opt := range alarmActionOpts {
-		assert.True(t, model.ValidAlarmAction(opt.Value),
-			"dropdown option %q (%s) fails model.ValidAlarmAction", opt.Value, opt.Label)
+		assert.True(t, model.FireableAlarmAction(opt.Value),
+			"dropdown option %q (%s) fails model.FireableAlarmAction", opt.Value, opt.Label)
 	}
+}
+
+// A preserved sync-only action (issue #579) must stay view-only in the
+// alarm editor. An edit-form save would rewrite the action as DISPLAY,
+// which resurrects a reminder the user disabled (ACTION:NONE) or converts
+// the alarm of another client. The row still renders and still deletes.
+func TestAlarmEditor_SyncOnlyActionIsViewOnly(t *testing.T) {
+	alarms := []model.Alarm{{Action: "NONE", TriggerValue: "-PT15M", Related: "START"}}
+	m := NewAlarmListEditorModel(alarms, 80, 24, Theme{})
+
+	m.cursor = 0
+	m, _ = m.Update(keyMsg("e"))
+	assert.Equal(t, alarmModeList, m.mode, "edit key must not open the form for a sync-only action")
+
+	m, _ = m.Update(keyMsg("enter"))
+	assert.Equal(t, alarmModeList, m.mode, "enter must not open the form for a sync-only action")
+
+	assert.NotPanics(t, func() { _ = m.View() }, "the list must render a sync-only action")
+
+	// A fireable action with the same trigger still opens the form.
+	m2 := NewAlarmListEditorModel([]model.Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"}}, 80, 24, Theme{})
+	m2.cursor = 0
+	m2, _ = m2.Update(keyMsg("e"))
+	assert.Equal(t, alarmModeEdit, m2.mode, "a fireable action must stay editable")
 }

--- a/internal/tui/alarm_editor_test.go
+++ b/internal/tui/alarm_editor_test.go
@@ -59,10 +59,12 @@ func TestParseOffsetTrigger_Unsupported(t *testing.T) {
 func TestAlarmSummary(t *testing.T) {
 	assert.Equal(t, "None", alarmSummary(nil))
 	assert.Equal(t, "15 min. before", alarmSummary([]model.Alarm{
-		{TriggerValue: "-PT15M"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
 	}))
 	assert.Equal(t, "3 alarms", alarmSummary([]model.Alarm{
-		{TriggerValue: "-PT15M"}, {TriggerValue: "-P1D"}, {TriggerValue: "-PT1H"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+		{Action: "DISPLAY", TriggerValue: "-P1D"},
+		{Action: "DISPLAY", TriggerValue: "-PT1H"},
 	}))
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2918,6 +2918,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return eventEditLoadedMsg{err: err}
 			}
 			fresh.Attendees = attendees
+			// Load the alarms too. A save writes the form list over the
+			// stored rows, so an empty list deletes every alarm of the
+			// event, including a preserved sync-only one (issue #579).
+			alarms, err := m.app.Events.ListAlarms(ctx, ev.ID)
+			if err != nil {
+				return eventEditLoadedMsg{err: err}
+			}
+			fresh.Alarms = alarms
 			// For a recurring instance, overwrite the master's DTSTART with
 			// the clicked occurrence. The form's date/time fields then
 			// reflect what the user actually clicked, not the original

--- a/internal/tui/event_dialog.go
+++ b/internal/tui/event_dialog.go
@@ -875,7 +875,7 @@ func eventDetailLines(ev event.Event, cal CalendarInfo, w, labelWidth int, rsvpL
 		lines = append(lines, "")
 		lines = append(lines, faint.Render("Reminders:"))
 		for _, a := range ev.Alarms {
-			lines = append(lines, truncateTo("  "+formatAlarm(a), w))
+			lines = append(lines, truncateTo("  "+formatAlarmWithAction(a), w))
 		}
 	}
 

--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -503,6 +503,16 @@ func NewEventFormModelForEditInstance(ev event.Event, instanceTime time.Time, ca
 func NewEventFormModelForDuplicate(ev event.Event, calendars map[int64]CalendarInfo, theme Theme) (EventFormModel, tea.Cmd) {
 	m, cmd := NewEventFormModelForEdit(ev, calendars, theme)
 	m.editID = 0
+	// A duplicate is a new local event. Keep only the fireable alarms:
+	// a preserved sync-only VALARM belongs to another client, and a copy
+	// would publish that sentinel under a fresh UID (issue #579).
+	kept := m.alarms[:0:0]
+	for _, a := range m.alarms {
+		if model.FireableAlarmAction(a.Action) {
+			kept = append(kept, a)
+		}
+	}
+	m.alarms = kept
 	m.rebuildDialog()
 	return m, cmd
 }

--- a/internal/tui/event_form_test.go
+++ b/internal/tui/event_form_test.go
@@ -659,3 +659,23 @@ func TestEventFormForEdit_MultiDayEndUsesDisplayTimezone(t *testing.T) {
 		t.Errorf("rangeEndDate = %v, want display-tz day %v", m.rangeEndDate, want)
 	}
 }
+
+// A duplicate is a new local event. The copy must not carry a preserved
+// sync-only alarm: the copy would publish the sentinel of another client
+// under a fresh UID (issue #579). A fireable alarm stays in the copy.
+func TestEventForm_DuplicateStripsSyncOnlyAlarms(t *testing.T) {
+	m, _ := NewEventFormModelForDuplicate(event.Event{
+		ID:         7,
+		Title:      "Synced",
+		StartTime:  time.Date(2026, 4, 22, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 22, 15, 0, 0, 0, time.UTC),
+		CalendarID: 1,
+		Alarms: []model.Alarm{
+			{Action: "NONE", TriggerValue: "-PT1M"},
+			{Action: "DISPLAY", TriggerValue: "-PT15M"},
+		},
+	}, testEventFormCalendars(), Theme{})
+
+	require.Len(t, m.alarms, 1)
+	assert.Equal(t, "DISPLAY", m.alarms[0].Action)
+}

--- a/internal/tui/event_view_dialog.go
+++ b/internal/tui/event_view_dialog.go
@@ -588,7 +588,7 @@ func (m EventViewDialogModel) buildBodyLines(w int) []string {
 		lines = append(lines, "")
 		lines = append(lines, faint.Render("Alarms"))
 		for _, a := range ev.Alarms {
-			lines = append(lines, truncateTo("  "+formatAlarm(a), w))
+			lines = append(lines, truncateTo("  "+formatAlarmWithAction(a), w))
 		}
 	}
 


### PR DESCRIPTION
Fixes #579 (follow-up to #575 and PR #577).

PR #577 drops a VALARM with an ACTION outside {AUDIO, DISPLAY, EMAIL} at import. The drop is destructive across sync: every later push omits the VALARM and deletes the alarm of another client server-side. For the Google `ACTION:NONE` sentinel, the drop lets Google re-apply the default reminders the user disabled. This PR stores such an alarm and skips it on the fire path.

## Design decisions

**Constraint choice: `CHECK(action <> '')`, not a full drop.** Migration 043 rebuilds `event_alarms` and `todo_alarms` (SQLite cannot alter a CHECK constraint) and widens the action CHECK to any non-empty value. A minimal CHECK stays so the NOT NULL DEFAULT contract keeps one enforced invariant, and so the lockstep test still pins schema to a model predicate (`model.StorableAlarmAction`). The `related` CHECK stays narrow. Two rebuild hazards the migration handles:

- Foreign keys are ON during migrations, and `DROP TABLE` performs an implicit DELETE. The `ON DELETE CASCADE` clauses would erase `alarm_state`, `todo_alarm_state`, and both attendee tables. The migration backs those tables up first and restores them id-intact.
- The `x_properties` owner-exists triggers reference the alarm tables by name and would choke the rename; they are dropped and recreated, together with the AFTER DELETE cleanup triggers that die with the DROP. Alarm-owned `x_properties` rows survive in place (the implicit DELETE fires no triggers).

`TestMigration043UpDown` proves the round trip with live state, attendee, and x-prop rows. The Down migration deletes non-representable alarms first (documented, intentional loss — the 031 precedent).

**Model semantics: two named predicates.** `ValidAlarmAction` is renamed to `FireableAlarmAction` ("action the engine can fire") — the old name claimed to mirror the schema, which is no longer true. The new `StorableAlarmAction` (any non-empty string) mirrors the widened CHECK. Each call site now names which rule it wants.

**`ACTION:NONE` handling: preserved, not dropped.** Preservation is the fix, not an exception: dropping the sentinel is exactly what resurrects Google's default reminders. NONE round-trips verbatim like any other non-fireable action.

**No import warning for a preserved action.** The alarm now round-trips faithfully, so nothing is lost — and sync re-imports the same ICS on every pull, so a warning would spam `sync run` output forever. `ImportResult.Warnings` documents itself as "what ImportFile could not represent faithfully"; this case no longer qualifies.

**Fire path.** `Check` (events and todos) and `CheckMissed` skip a non-fireable action in silence — the row is healthy, not a defect, so no error and no log. `fireAlarm` in the CLI keeps a defense-in-depth guard that dispatches nothing (its old `default:` branch fell back to DISPLAY, which would show a disabled reminder).

**Export.** `buildValarm` already emitted the action verbatim. The ATTACH re-emit gate changes from "AUDIO or EMAIL only" to "any action except DISPLAY", so the ATTACH of an x-name action (e.g. `X-APPLE-SOUND`) round-trips too. DISPLAY keeps the RFC 5545 rule (no ATTACH).

**TUI editor: sync-only alarms are view-only.** The list renders them (the action label falls back to a title-cased raw value) and `d` still deletes them, but `e`/enter refuse to open the edit form — the same existing gate absolute triggers use. Opening the form would silently rewrite the action as DISPLAY on save, which converts the alarm of another client or resurrects a NONE reminder. The dropdown still offers only fireable actions.

**CLI.** `--alarm ACTION:...` still rejects a non-fireable action for new alarms; a sync-only action enters the database from import alone.

## Tests

- `TestRoundtrip_UnsupportedAlarmActionsSurvive`: `ACTION:NONE` + `ACTION:X-APPLE-SOUND` (with ATTACH) survive import → export → re-import verbatim.
- `TestCheck_SkipsSyncOnlyAction`: `Check` fires only the DISPLAY alarm on a record that also carries NONE and X-APPLE-SOUND alarms; `CheckMissed` never reports them.
- `TestImport_UnsupportedAlarmAction_PreservesAlarm` replaces the PR #577 drop test.
- `TestAlarmConstraintsMatchModelValidators` re-pinned: action half now uses `StorableAlarmAction`; related half unchanged.
- `TestAlarmEditor_SyncOnlyActionIsViewOnly` pins the editor gate.
- `TestMigration043UpDown` pins the rebuild (cascade restore, trigger recreation, both CHECK directions).
- Two child-failure tests in `cmd/chroncal` and `internal/icaltransfer` forced a failure via a bogus action; they now use a bogus `related` (the action constraint no longer rejects it) — behavior under test unchanged.

`normalizeAlarmRepeatPairs` (startup heal) touches only repeat/duration and is unaffected, confirmed.

## Verification

- `sqlc generate` (v1.30.0, the version the repo's generated headers pin): zero diff — no columns changed, no `scan_helpers.go` update needed.
- `go build ./...`, `go vet ./...`, full `go test ./...` green.
- gofmt clean on all touched files (pre-existing drift in `cmd/chroncal/output_test.go` and `internal/sync/engine.go` left untouched).

## Caveats

- A sync-only alarm counts toward the event-form alarm summary ("2 alarms") like any other alarm; it is visible and deletable in the editor list, just not editable.
- The Down migration intentionally deletes alarms whose action the narrow CHECK cannot hold, with their state, attendee, and x-property rows.
- `sqlc@latest` (> v1.30.0) fails on the pre-existing `db/queries/calendars.sql:121` ambiguity; v1.30.0 — which generated the checked-in code — works. Not introduced by this PR.
