### PR TITLE
fix(alarm): guard, order, and degrade the alarm write path

### DIFF
--- a/cmd/chroncal/alarm_flag_write_rule_test.go
+++ b/cmd/chroncal/alarm_flag_write_rule_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+// The create commands validate the parsed alarms with
+// model.PrepareAlarmsForWrite before they create the event or the todo. A
+// rejection after the create would leave a row the next run duplicates
+// (issue #585).
+//
+// The flag syntax cannot state an alarm the service rule rejects today:
+// parseOneAlarm assigns a fireable action and a START or END anchor
+// itself. This test pins that agreement. A later change that loosens the
+// flag parser fails here, before it can produce an orphaned row.
+func TestParseAlarmFlags_OutputPassesTheServiceWriteRule(t *testing.T) {
+	flags := []string{
+		"-PT15M",
+		"+PT5M",
+		"PT1H",
+		"DISPLAY:-PT30M",
+		"EMAIL:-PT1H",
+		"AUDIO:-PT5M",
+		"display:-PT10M",
+		"-PT30M:Stand up",
+		"-PT30M:Stand up:3:PT5M",
+		"-PT30M:Stand up:3:PT5M:END",
+		"-PT30M:Stand up:3:PT5M:START",
+		"20260401T090000Z",
+		"2026-04-01T09:00:00Z",
+		// An unknown prefix is not an action. The parser keeps the whole
+		// value as the trigger, so the action stays DISPLAY.
+		"PROCEDURE:-PT15M",
+	}
+
+	for _, flag := range flags {
+		t.Run(flag, func(t *testing.T) {
+			alarms, err := parseAlarmFlags([]string{flag})
+			if err != nil {
+				t.Skipf("the parser rejects %q, so the service rule never sees it: %v", flag, err)
+			}
+			if _, err := model.PrepareAlarmsForWrite(alarms); err != nil {
+				t.Fatalf("the parser accepted %q but the service rule rejects it: %v"+
+					" (a create would leave an orphaned row)", flag, err)
+			}
+		})
+	}
+}
+
+// A value the service rule rejects must fail before any row is written.
+// The check runs on the parsed slice, so it holds for every producer that
+// reaches the create commands.
+func TestPrepareAlarmsForWrite_RejectsABadAnchor(t *testing.T) {
+	_, err := model.PrepareAlarmsForWrite([]model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "MIDDLE"},
+	})
+	if !errors.Is(err, model.ErrInvalidAlarm) {
+		t.Fatalf("error = %v, want ErrInvalidAlarm", err)
+	}
+}

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -764,6 +764,14 @@ Alarms default to ACTION=DISPLAY unless prefixed (e.g. EMAIL:-PT1H).`,
 				if err != nil {
 					return err
 				}
+				// Apply the service write rule here too. The create
+				// commits before the alarms are written, so a rejection
+				// after it would leave an event row the next run
+				// duplicates (issue #585).
+				alarms, err = model.PrepareAlarmsForWrite(alarms)
+				if err != nil {
+					return err
+				}
 			}
 			var relations []model.Relation
 			if len(relationFlags) > 0 {

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -420,6 +420,14 @@ and percent-complete to 100.`,
 				if err != nil {
 					return err
 				}
+				// Apply the service write rule here too. The create
+				// commits before the alarms are written, so a rejection
+				// after it would leave a todo row the next run
+				// duplicates (issue #585).
+				alarms, err = model.PrepareAlarmsForWrite(alarms)
+				if err != nil {
+					return err
+				}
 			}
 			var relations []model.Relation
 			if len(relationFlags) > 0 {

--- a/internal/event/calendaraccess_guard_test.go
+++ b/internal/event/calendaraccess_guard_test.go
@@ -32,6 +32,18 @@ func insertGuardedCalendar(t *testing.T, db *sql.DB, name, access, components st
 	return id
 }
 
+func countAlarms(t *testing.T, db *sql.DB, eventID int64) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(
+		context.Background(),
+		`SELECT COUNT(*) FROM event_alarms WHERE event_id = ?`, eventID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count alarms: %v", err)
+	}
+	return n
+}
+
 func countEvents(t *testing.T, db *sql.DB) int {
 	t.Helper()
 	var n int
@@ -412,5 +424,48 @@ func TestEventAccessGuard_ReplaceAttendeesRSVPRejected(t *testing.T) {
 	}
 	if got := countAttendees(t, db, seeded.ID); got != 1 {
 		t.Fatalf("attendee rows after ReplaceAttendeesForSync = %d, want 1", got)
+	}
+}
+
+// TestEventAccessGuard_ReplaceAlarmsRejected proves a user-originated alarm
+// edit on a read-only collection is refused and writes no row (issue #585).
+// The sync engine keeps its unguarded path, so a server-originated VALARM
+// still reaches the local cache.
+func TestEventAccessGuard_ReplaceAlarmsRejected(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	readOnly := insertGuardedCalendar(t, db, "Read-Only Alarms", "read", "VEVENT")
+	seeded, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:        "alarm-guard-uid",
+		CalendarID: readOnly,
+		Title:      "Alarm Target",
+		StartTime:  time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	alarm := model.Alarm{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"}
+
+	if err := svc.ReplaceAlarms(ctx, seeded.ID, []model.Alarm{alarm}); !errors.Is(err, calendaraccess.ErrReadOnly) {
+		t.Fatalf("ReplaceAlarms on read-only calendar: error = %v, want ErrReadOnly", err)
+	}
+	if got := countAlarms(t, db, seeded.ID); got != 0 {
+		t.Fatalf("alarm rows after rejected ReplaceAlarms = %d, want 0", got)
+	}
+
+	// ReplaceFireableAlarms is the CLI path. It routes through the guard too.
+	if err := svc.ReplaceFireableAlarms(ctx, seeded.ID, []model.Alarm{alarm}); !errors.Is(err, calendaraccess.ErrReadOnly) {
+		t.Fatalf("ReplaceFireableAlarms on read-only calendar: error = %v, want ErrReadOnly", err)
+	}
+
+	// The CalDAV sync engine must still mirror a server-originated alarm.
+	if err := svc.ReplaceAlarmsForSync(ctx, seeded.ID, []model.Alarm{alarm}); err != nil {
+		t.Fatalf("ReplaceAlarmsForSync on read-only calendar: %v (sync path must stay unguarded)", err)
+	}
+	if got := countAlarms(t, db, seeded.ID); got != 1 {
+		t.Fatalf("alarm rows after ReplaceAlarmsForSync = %d, want 1", got)
 	}
 }

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1696,6 +1696,18 @@ func (s *Service) replaceFireableAlarms(ctx context.Context, eventID int64, alar
 }
 
 func (s *Service) ReplaceAlarms(ctx context.Context, eventID int64, alarms []model.Alarm) error {
+	if err := s.ensureEventWritable(ctx, eventID, 0); err != nil {
+		return err
+	}
+	return s.ReplaceAlarmsForSync(ctx, eventID, alarms)
+}
+
+// ReplaceAlarmsForSync applies an alarm set without the remote access and
+// component policy. It is reserved for the CalDAV sync engine, which
+// mirrors a server-originated VEVENT into the local cache whatever the
+// linked collection advertises. A user-originated edit must route through
+// ReplaceAlarms, so the policy holds.
+func (s *Service) ReplaceAlarmsForSync(ctx context.Context, eventID int64, alarms []model.Alarm) error {
 	// Prepare before the transaction opens. A standalone call then
 	// rejects a bad alarm without a write lock. A sync caller already
 	// holds its own transaction. See model.PrepareAlarmsForWrite.

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -328,6 +328,37 @@ func PrepareAlarmsForWrite(alarms []Alarm) ([]Alarm, error) {
 	return prepared, nil
 }
 
+// InvalidAlarm reports one alarm PartitionAlarmsForWrite dropped, with
+// the reason. Index counts from one, like the PrepareAlarmsForWrite
+// error, so a report names the same alarm either way.
+type InvalidAlarm struct {
+	Index int
+	Alarm Alarm
+	Err   error
+}
+
+// PartitionAlarmsForWrite splits alarms into the ones a write accepts and
+// the ones it rejects. It applies the rule of PrepareAlarmsForWrite to
+// each element on its own, so one bad alarm does not reject the rest.
+//
+// A caller that must store what it can uses this function. The CalDAV
+// sync engine does: a server resource carries the event and its alarms
+// together, and a whole resource that fails on one alarm never converges.
+// A caller that must reject the whole set keeps PrepareAlarmsForWrite.
+func PartitionAlarmsForWrite(alarms []Alarm) ([]Alarm, []InvalidAlarm) {
+	var ok []Alarm
+	var bad []InvalidAlarm
+	for i, a := range alarms {
+		prepared := a
+		if err := prepareAlarmForWrite(&prepared); err != nil {
+			bad = append(bad, InvalidAlarm{Index: i + 1, Alarm: a, Err: err})
+			continue
+		}
+		ok = append(ok, prepared)
+	}
+	return ok, bad
+}
+
 // prepareAlarmForWrite fills the defaults and validates one alarm.
 //
 // The action rule is StorableAlarmAction, not the fireable set. Migration

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/event"
 	icalPkg "github.com/douglasdemoura/chroncal/internal/ical"
 	"github.com/douglasdemoura/chroncal/internal/journal"
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/synclock"
 	"github.com/douglasdemoura/chroncal/internal/todo"
@@ -1010,11 +1011,12 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 
 		// Persist imported data to the database
 		ownerType := detectOwnerType(importResult)
-		revs, persistErr := e.persistImported(ctx, calendarID, importResult)
+		revs, alarmWarnings, persistErr := e.persistImported(ctx, calendarID, importResult)
 		if persistErr != nil {
 			e.logger.Error("persist imported resource", "uid", uid, "path", res.Path, "error", persistErr)
 			continue
 		}
+		result.warnings = append(result.warnings, e.notePersistWarnings(res.Path, uid, alarmWarnings)...)
 
 		// Upsert sync resource tracking. UpsertSyncResource's ON CONFLICT is
 		// keyed by (calendar_id, uid), so a stale remote_url from a prior
@@ -1317,7 +1319,7 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 				continue
 			}
 			ownerType := detectOwnerType(importResult)
-			revs, persistErr := e.persistImported(ctx, calendarID, importResult)
+			revs, alarmWarnings, persistErr := e.persistImported(ctx, calendarID, importResult)
 			if persistErr != nil {
 				// A changed body we fetched but couldn't store (transient
 				// SQLite busy/lock, or a malformed component a Replace*
@@ -1330,6 +1332,7 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 				e.logger.Error("persist imported resource", "uid", uid, "path", res.Path, "error", persistErr)
 				continue
 			}
+			result.warnings = append(result.warnings, e.notePersistWarnings(res.Path, uid, alarmWarnings)...)
 			if err := e.q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
 				CalendarID:   calendarID,
 				Uid:          uid,
@@ -1751,8 +1754,15 @@ func hydrateJournal(ctx context.Context, e *Engine, j *journal.Journal) error {
 // local edit could then slip in and have its dirty flag wiped. That is the
 // lost-update window of issue #494. A UID with no sync_resources row yet (a
 // first pull) reports rev 0.
-func (e *Engine) persistImported(ctx context.Context, calendarID int64, result icalPkg.ImportResult) (map[string]int64, error) {
+// persistImported writes an imported payload and returns the per-UID revs.
+// The second return value lists the alarms it dropped. An alarm the write
+// rule rejects must not fail its whole resource: the event and its valid
+// alarms still persist, and the caller reports the drop as a warning
+// (issue #585). Every other error still fails the resource, so the caller
+// keeps it dirty and retries.
+func (e *Engine) persistImported(ctx context.Context, calendarID int64, result icalPkg.ImportResult) (map[string]int64, []string, error) {
 	revs := make(map[string]int64)
+	var alarmWarnings []string
 
 	// Build the prune inputs up front: per-UID keep-sets of the components
 	// the server sent, plus each prunable UID's dirty flag — which must be
@@ -1772,7 +1782,7 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		var err error
 		dirtyBefore, err = e.preImportDirty(ctx, calendarID, eventKeep, todoKeep, journalKeep)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -1813,7 +1823,12 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			// via UpsertByUID. A full CalDAV pull sends the complete component, so
 			// the absence of a property means "cleared", not "unknown". Propagate
 			// any replace error so the caller keeps the resource dirty and retries.
-			if err := events.ReplaceAlarms(ctx, saved.ID, ev.Alarms); err != nil {
+			okAlarms, badAlarms := model.PartitionAlarmsForWrite(ev.Alarms)
+			for _, bad := range badAlarms {
+				alarmWarnings = append(alarmWarnings,
+					fmt.Sprintf("event %q: alarm %d dropped: %v", ev.UID, bad.Index, bad.Err))
+			}
+			if err := events.ReplaceAlarmsForSync(ctx, saved.ID, okAlarms); err != nil {
 				return fmt.Errorf("replace alarms for event %q: %w", ev.UID, err)
 			}
 			if err := events.ReplaceAttendeesForSync(ctx, saved.ID, ev.Attendees); err != nil {
@@ -1844,7 +1859,7 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			revs[ev.UID] = rev
 			return nil
 		}); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -1869,7 +1884,12 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			}
 			// Replace child collections unconditionally so server-side removals
 			// (an empty list) are propagated. See the event loop above.
-			if err := todos.ReplaceAlarms(ctx, saved.ID, t.Alarms); err != nil {
+			okAlarms, badAlarms := model.PartitionAlarmsForWrite(t.Alarms)
+			for _, bad := range badAlarms {
+				alarmWarnings = append(alarmWarnings,
+					fmt.Sprintf("todo %q: alarm %d dropped: %v", t.UID, bad.Index, bad.Err))
+			}
+			if err := todos.ReplaceAlarmsForSync(ctx, saved.ID, okAlarms); err != nil {
 				return fmt.Errorf("replace alarms for todo %q: %w", t.UID, err)
 			}
 			if err := todos.ReplaceAttendees(ctx, saved.ID, t.Attendees); err != nil {
@@ -1900,7 +1920,7 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			revs[t.UID] = rev
 			return nil
 		}); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -1948,7 +1968,7 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			revs[j.UID] = rev
 			return nil
 		}); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -1960,7 +1980,7 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		func(v storage.Event) string { return v.RecurrenceID },
 		(*storage.Queries).SoftDeleteEvent,
 	); err != nil {
-		return nil, fmt.Errorf("prune stale event overrides: %w", err)
+		return nil, nil, fmt.Errorf("prune stale event overrides: %w", err)
 	}
 	if err := pruneStaleOverrides(ctx, e, calendarID, todoKeep, dirtyBefore, revs,
 		e.q.ListTodoOverridesByUID,
@@ -1968,7 +1988,7 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		func(v storage.Todo) string { return v.RecurrenceID },
 		(*storage.Queries).SoftDeleteTodo,
 	); err != nil {
-		return nil, fmt.Errorf("prune stale todo overrides: %w", err)
+		return nil, nil, fmt.Errorf("prune stale todo overrides: %w", err)
 	}
 	if err := pruneStaleOverrides(ctx, e, calendarID, journalKeep, dirtyBefore, revs,
 		e.q.ListJournalOverridesByUID,
@@ -1976,10 +1996,10 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 		func(v storage.Journal) string { return v.RecurrenceID },
 		(*storage.Queries).SoftDeleteJournal,
 	); err != nil {
-		return nil, fmt.Errorf("prune stale journal overrides: %w", err)
+		return nil, nil, fmt.Errorf("prune stale journal overrides: %w", err)
 	}
 
-	return revs, nil
+	return revs, alarmWarnings, nil
 }
 
 // keepSets groups imported components into per-UID keep-sets of their
@@ -2184,10 +2204,11 @@ func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) 
 	if err != nil {
 		return false, nil, nil, err
 	}
-	revs, err = e.persistImported(ctx, calendarID, importResult)
+	revs, alarmWarnings, err := e.persistImported(ctx, calendarID, importResult)
 	if err != nil {
 		return false, nil, nil, err
 	}
+	warnings = append(warnings, e.notePersistWarnings("", "", alarmWarnings)...)
 	if afterImportPersist != nil {
 		afterImportPersist()
 	}
@@ -2298,6 +2319,24 @@ func soleUID(result icalPkg.ImportResult) string {
 // warnings also travel as data for entry points that discard the logger.
 func (e *Engine) noteImportWarnings(path string, result icalPkg.ImportResult) []ImportWarning {
 	warnings := collectImportWarnings(path, result)
+	logImportWarnings(e.logger, warnings)
+	return warnings
+}
+
+// notePersistWarnings turns the alarms persistImported dropped into
+// ImportWarnings and logs them. A dropped alarm is a silent local change
+// otherwise: the resource persists without it, and the next push writes
+// the shorter alarm set over the server copy. The caller appends the
+// returned slice to its result, so an entry point that discards the
+// logger still reports the drop (issue #585).
+func (e *Engine) notePersistWarnings(path, uid string, messages []string) []ImportWarning {
+	if len(messages) == 0 {
+		return nil
+	}
+	warnings := make([]ImportWarning, 0, len(messages))
+	for _, msg := range messages {
+		warnings = append(warnings, ImportWarning{Path: path, UID: uid, Message: msg})
+	}
 	logImportWarnings(e.logger, warnings)
 	return warnings
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1754,12 +1754,12 @@ func hydrateJournal(ctx context.Context, e *Engine, j *journal.Journal) error {
 // local edit could then slip in and have its dirty flag wiped. That is the
 // lost-update window of issue #494. A UID with no sync_resources row yet (a
 // first pull) reports rev 0.
-// persistImported writes an imported payload and returns the per-UID revs.
-// The second return value lists the alarms it dropped. An alarm the write
-// rule rejects must not fail its whole resource: the event and its valid
-// alarms still persist, and the caller reports the drop as a warning
-// (issue #585). Every other error still fails the resource, so the caller
-// keeps it dirty and retries.
+//
+// The second return value lists the alarms this function dropped. An alarm
+// the write rule rejects must not fail its whole resource: the record and
+// its valid alarms still persist, and the caller reports each drop as a
+// warning (issue #585). Every other error still fails the resource, so the
+// caller keeps it dirty and retries.
 func (e *Engine) persistImported(ctx context.Context, calendarID int64, result icalPkg.ImportResult) (map[string]int64, []string, error) {
 	revs := make(map[string]int64)
 	var alarmWarnings []string
@@ -1823,6 +1823,8 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 			// via UpsertByUID. A full CalDAV pull sends the complete component, so
 			// the absence of a property means "cleared", not "unknown". Propagate
 			// any replace error so the caller keeps the resource dirty and retries.
+			// An alarm the write rule rejects is the one exception. The partition
+			// drops it, and the record still persists (issue #585).
 			okAlarms, badAlarms := model.PartitionAlarmsForWrite(ev.Alarms)
 			for _, bad := range badAlarms {
 				alarmWarnings = append(alarmWarnings,

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -691,7 +691,7 @@ func TestEnginePersistImportedKeepsDirtyOnChildReplaceError(t *testing.T) {
 		}},
 	}
 
-	if _, err := engine.persistImported(ctx, calendarID, result); err == nil {
+	if _, _, err := engine.persistImported(ctx, calendarID, result); err == nil {
 		t.Fatal("persistImported returned nil, want child-replace error to propagate")
 	}
 
@@ -3055,7 +3055,7 @@ END:VCALENDAR
 	if err != nil {
 		t.Fatalf("ImportFile (with alarm): %v", err)
 	}
-	if _, err := engine.persistImported(ctx, calendarID, withAlarmResult); err != nil {
+	if _, _, err := engine.persistImported(ctx, calendarID, withAlarmResult); err != nil {
 		t.Fatalf("persistImported (with alarm): %v", err)
 	}
 
@@ -3089,7 +3089,7 @@ END:VCALENDAR
 	if err != nil {
 		t.Fatalf("ImportFile (no alarm): %v", err)
 	}
-	if _, err := engine.persistImported(ctx, calendarID, noAlarmResult); err != nil {
+	if _, _, err := engine.persistImported(ctx, calendarID, noAlarmResult); err != nil {
 		t.Fatalf("persistImported (no alarm): %v", err)
 	}
 
@@ -3257,7 +3257,7 @@ func TestPersistImportedRollsBackOnReplaceFailure(t *testing.T) {
 		t.Fatalf("drop event_comments: %v", err)
 	}
 
-	if _, err := engine.persistImported(ctx, calendarID, result); err == nil {
+	if _, _, err := engine.persistImported(ctx, calendarID, result); err == nil {
 		t.Fatal("expected persistImported to fail when a Replace step errors")
 	}
 
@@ -3655,7 +3655,7 @@ func TestPersistImportedPrunesStaleOverrides(t *testing.T) {
 	const keptRID = "2026-08-27T17:00:00Z"
 
 	// First sync: master + two overrides.
-	_, err = engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	_, _, err = engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events: []event.Event{
 			pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;INTERVAL=2;BYDAY=TH"),
 			pruneTestEvent(uid, calendarID, deletedRID, ""),
@@ -3678,7 +3678,7 @@ func TestPersistImportedPrunesStaleOverrides(t *testing.T) {
 	// VEVENT removed) but kept the 8/27 override.
 	secondMaster := pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;INTERVAL=2;BYDAY=TH")
 	secondMaster.ExDates = deletedRID
-	_, err = engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	_, _, err = engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events: []event.Event{
 			secondMaster,
 			pruneTestEvent(uid, calendarID, keptRID, ""),
@@ -3777,7 +3777,7 @@ func TestPersistImportedPruneSkipsDirtyResource(t *testing.T) {
 	const localRID = "2026-07-02T17:00:00Z"
 
 	// First pull: master only, then the tracking row settles clean.
-	if _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	if _, _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events: []event.Event{pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;INTERVAL=2;BYDAY=TH")},
 	}); err != nil {
 		t.Fatalf("first persistImported: %v", err)
@@ -3800,7 +3800,7 @@ func TestPersistImportedPruneSkipsDirtyResource(t *testing.T) {
 
 	// Second pull before the push lands (e.g. the series title changed on the
 	// server). The server body has no override — because it has never seen it.
-	if _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	if _, _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events: []event.Event{pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;INTERVAL=2;BYDAY=TH")},
 	}); err != nil {
 		t.Fatalf("second persistImported: %v", err)
@@ -3828,7 +3828,7 @@ func TestPersistImportedPrunesCleanSyncedResource(t *testing.T) {
 	const uid = "clean-prune-test"
 	const staleRID = "2026-07-02T17:00:00Z"
 
-	if _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	if _, _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events: []event.Event{
 			pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;INTERVAL=2;BYDAY=TH"),
 			pruneTestEvent(uid, calendarID, staleRID, ""),
@@ -3841,7 +3841,7 @@ func TestPersistImportedPrunesCleanSyncedResource(t *testing.T) {
 	// Server deleted the instance: EXDATE on the master, override gone.
 	master := pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;INTERVAL=2;BYDAY=TH")
 	master.ExDates = staleRID
-	if _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	if _, _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events: []event.Event{master},
 	}); err != nil {
 		t.Fatalf("second persistImported: %v", err)
@@ -3874,7 +3874,7 @@ func TestPersistImportedPruneSkipsIncompleteParse(t *testing.T) {
 	const uid = "partial-parse-test"
 	const rid = "2026-07-02T17:00:00Z"
 
-	if _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	if _, _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events: []event.Event{
 			pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;INTERVAL=2;BYDAY=TH"),
 			pruneTestEvent(uid, calendarID, rid, ""),
@@ -3885,7 +3885,7 @@ func TestPersistImportedPruneSkipsIncompleteParse(t *testing.T) {
 
 	// Second pull: the override VEVENT was dropped by the parser, not by the
 	// server. The keep-set is an incomplete inventory — no pruning.
-	if _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	if _, _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events:            []event.Event{pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;INTERVAL=2;BYDAY=TH")},
 		SkippedComponents: 1,
 	}); err != nil {
@@ -3922,7 +3922,7 @@ func TestPersistImportedPrunePerUID(t *testing.T) {
 	const ridB = "2026-07-03T17:00:00Z"
 
 	for uid, rid := range map[string]string{uidA: ridA, uidB: ridB} {
-		if _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+		if _, _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 			Events: []event.Event{
 				pruneTestEvent(uid, calendarID, "", "FREQ=WEEKLY;BYDAY=TH"),
 				pruneTestEvent(uid, calendarID, rid, ""),
@@ -3934,7 +3934,7 @@ func TestPersistImportedPrunePerUID(t *testing.T) {
 
 	// One malformed resource: B's override listed before A's master, and B's
 	// master absent. Only A — whose own master is present — may be pruned.
-	if _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
+	if _, _, err := engine.persistImported(ctx, calendarID, icalPkg.ImportResult{
 		Events: []event.Event{
 			pruneTestEvent(uidB, calendarID, ridB, ""),
 			pruneTestEvent(uidA, calendarID, "", "FREQ=WEEKLY;BYDAY=TH"),
@@ -4307,5 +4307,105 @@ func TestNewEngine_NilLoggerIsSilent(t *testing.T) {
 
 	if buf.Len() > 0 {
 		t.Fatalf("nil-logger engine wrote to slog.Default (stderr in production, which corrupts the TUI): %q", buf.String())
+	}
+}
+
+// TestPersistImportedDropsInvalidAlarm covers issue #585. A server
+// resource that carries one alarm the write rule rejects must still
+// persist: the event and its valid alarms land, the drop travels back as
+// a warning, and the pull does not fail. The old code propagated the
+// error, so the whole resource stayed absent and retried on every cycle
+// while the report showed nothing.
+func TestPersistImportedDropsInvalidAlarm(t *testing.T) {
+	t.Parallel()
+
+	engine, _, q := newTestEngine(t)
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	start := time.Date(2026, 6, 18, 17, 0, 0, 0, time.UTC)
+	// The iCal parser sanitizes an alarm, so the bad value is built here
+	// the way a future producer would deliver it.
+	result := icalPkg.ImportResult{
+		Events: []event.Event{{
+			UID:        "bad-alarm-uid",
+			CalendarID: calendarID,
+			Title:      "Carries one bad alarm",
+			StartTime:  start,
+			EndTime:    start.Add(time.Hour),
+			Alarms: []model.Alarm{
+				{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"},
+				{Action: "DISPLAY", TriggerValue: "-PT30M", Related: "MIDDLE"},
+			},
+		}},
+	}
+
+	revs, warnings, err := engine.persistImported(ctx, calendarID, result)
+	if err != nil {
+		t.Fatalf("persistImported must not fail the resource for one bad alarm: %v", err)
+	}
+	if _, ok := revs["bad-alarm-uid"]; !ok {
+		t.Fatalf("revs = %v, want an entry for the persisted event", revs)
+	}
+
+	saved, err := q.GetEventByUID(ctx, "bad-alarm-uid")
+	if err != nil {
+		t.Fatalf("GetEventByUID: the event must persist: %v", err)
+	}
+	alarms, err := engine.events.ListAlarms(ctx, saved.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms: %v", err)
+	}
+	if len(alarms) != 1 {
+		t.Fatalf("alarms = %d, want 1 (the valid one); got %+v", len(alarms), alarms)
+	}
+	if alarms[0].TriggerValue != "-PT15M" {
+		t.Errorf("kept alarm trigger = %q, want -PT15M", alarms[0].TriggerValue)
+	}
+
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d, want 1; got %v", len(warnings), warnings)
+	}
+	for _, want := range []string{"bad-alarm-uid", "alarm 2", "MIDDLE"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Errorf("warning %q does not name %q", warnings[0], want)
+		}
+	}
+}
+
+// A failure that is not an invalid alarm still fails the resource, so the
+// caller keeps it dirty and retries.
+func TestPersistImportedStillFailsOnOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	engine, _, q := newTestEngine(t)
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	start := time.Date(2026, 6, 18, 17, 0, 0, 0, time.UTC)
+	// An attendee outside the PARTSTAT CHECK constraint fails the write.
+	// That is not an alarm error, so it must still fail the resource.
+	result := icalPkg.ImportResult{
+		Events: []event.Event{{
+			UID:        "bad-attendee-uid",
+			CalendarID: calendarID,
+			Title:      "Carries a bad attendee",
+			StartTime:  start,
+			EndTime:    start.Add(time.Hour),
+			Attendees: []model.Attendee{
+				{Email: "alice@example.com", RSVPStatus: "NOT-A-PARTSTAT", Role: "REQ-PARTICIPANT"},
+			},
+		}},
+	}
+	if _, _, err := engine.persistImported(ctx, calendarID, result); err == nil {
+		t.Fatal("persistImported must still fail for a non-alarm error")
 	}
 }

--- a/internal/todo/access_test.go
+++ b/internal/todo/access_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/calendaraccess"
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
 
@@ -357,4 +358,50 @@ func TestTodoDeleteSeries_UnsupportedComponentWithPurgedMaster(t *testing.T) {
 	if _, err := svc.GetByUIDAndRecurrenceID(ctx, uid, recID); err != nil {
 		t.Errorf("orphan override dropped or soft-deleted by rejected DeleteSeries: %v", err)
 	}
+}
+
+// A read-only collection rejects a user-originated alarm edit and writes no
+// alarm row (issue #585). The sync engine keeps its unguarded path, so a
+// server-originated VALARM still reaches the local cache.
+func TestTodoReplaceAlarms_ReadOnlyRejected(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	svc := NewService(db, q)
+	ctx := context.Background()
+
+	td := createTodo(t, svc)
+	setTodoCalendarAccess(t, db, "read", "")
+
+	alarm := model.Alarm{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"}
+
+	if err := svc.ReplaceAlarms(ctx, td.ID, []model.Alarm{alarm}); !errors.Is(err, calendaraccess.ErrReadOnly) {
+		t.Fatalf("ReplaceAlarms: error = %v, want ErrReadOnly", err)
+	}
+	if got := countTodoAlarms(t, db, td.ID); got != 0 {
+		t.Fatalf("alarm rows after rejected ReplaceAlarms = %d, want 0", got)
+	}
+
+	// ReplaceFireableAlarms is the CLI path. It routes through the guard too.
+	if err := svc.ReplaceFireableAlarms(ctx, td.ID, []model.Alarm{alarm}); !errors.Is(err, calendaraccess.ErrReadOnly) {
+		t.Fatalf("ReplaceFireableAlarms: error = %v, want ErrReadOnly", err)
+	}
+
+	// The CalDAV sync engine must still mirror a server-originated alarm.
+	if err := svc.ReplaceAlarmsForSync(ctx, td.ID, []model.Alarm{alarm}); err != nil {
+		t.Fatalf("ReplaceAlarmsForSync on read-only calendar: %v (sync path must stay unguarded)", err)
+	}
+	if got := countTodoAlarms(t, db, td.ID); got != 1 {
+		t.Fatalf("alarm rows after ReplaceAlarmsForSync = %d, want 1", got)
+	}
+}
+
+func countTodoAlarms(t *testing.T, db *sql.DB, todoID int64) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(
+		context.Background(),
+		`SELECT COUNT(*) FROM todo_alarms WHERE todo_id = ?`, todoID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count todo alarms: %v", err)
+	}
+	return n
 }

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -913,6 +913,22 @@ func (s *Service) replaceFireableAlarms(ctx context.Context, todoID int64, alarm
 }
 
 func (s *Service) ReplaceAlarms(ctx context.Context, todoID int64, alarms []model.Alarm) error {
+	td, err := s.Get(ctx, todoID)
+	if err != nil {
+		return err
+	}
+	if err := calendaraccess.EnsureWritable(ctx, s.q, td.CalendarID, todoComponent); err != nil {
+		return err
+	}
+	return s.ReplaceAlarmsForSync(ctx, todoID, alarms)
+}
+
+// ReplaceAlarmsForSync applies an alarm set without the remote access and
+// component policy. It is reserved for the CalDAV sync engine, which
+// mirrors a server-originated VTODO into the local cache whatever the
+// linked collection advertises. A user-originated edit must route through
+// ReplaceAlarms, so the policy holds.
+func (s *Service) ReplaceAlarmsForSync(ctx context.Context, todoID int64, alarms []model.Alarm) error {
 	// Prepare before the transaction opens. A standalone call then
 	// rejects a bad alarm without a write lock. A sync caller already
 	// holds its own transaction. See model.PrepareAlarmsForWrite.


### PR DESCRIPTION
Fixes #585 — the three alarm write-path gaps left open when the service boundary landed in #578.

## 1. Writability guard on the alarm write path

`event.Service.ReplaceAttendees` guards with `ensureEventWritable` and delegates the unguarded variant to `ReplaceAttendeesForSync`. The alarm path had no equivalent, so a TUI or CLI alarm edit on a read-only remote collection committed locally, marked the resource dirty, and only failed later with a 403 on push — the local row and the server disagreeing with no rejection at the point of edit.

Both services now mirror that split:

- `ReplaceAlarms` checks the policy (`ensureEventWritable` for events, `calendaraccess.EnsureWritable` for todos, matching how the todo service guards elsewhere).
- New `ReplaceAlarmsForSync` keeps the unguarded body.
- **Only** the sync engine calls the `ForSync` variants. The TUI, the CLI, icaltransfer, and the `ReplaceFireableAlarms` wrappers stay guarded, because a user-initiated edit on a read-only calendar should be refused.

## 2. CLI create no longer orphans the row

`event add` / `todo add` committed the create before writing alarms, so a service-level rejection returned non-zero while leaving a dirty row behind, and a corrected re-run created a duplicate. Both commands now apply `model.PrepareAlarmsForWrite` to the parsed alarms in the existing "validate before create" block, so a bad alarm fails before anything is written.

## 3. Sync degrades an invalid alarm instead of failing the resource

`persistImported` propagated any `ReplaceAlarms` error, so one bad alarm made the whole resource fail and retry on every cycle — while `chroncal sync` reported zero warnings, because `result.warnings` only carried parse-time messages. The resource (title, times, attendees) stayed absent indefinitely and invisibly.

It now applies the iCal import parser's policy — drop the bad alarm, warn, persist the rest:

- New `model.PartitionAlarmsForWrite` splits the set using the same per-alarm rule as `PrepareAlarmsForWrite` (it reuses the unexported `prepareAlarmForWrite`; the rule is not duplicated).
- `persistImported` writes the valid alarms and returns one message per dropped alarm, naming the owning UID, the alarm position, and the reason.
- All three callers append them through the new `notePersistWarnings`, so they reach `SyncResult.Warnings` and the log exactly like `noteImportWarnings` output.
- **Every other error still fails the resource**, so a transient SQLite failure keeps it dirty for retry.

## Tests

- Event and todo: an alarm edit on a read-only calendar is refused and writes no row, `ReplaceFireableAlarms` is refused too, and `ReplaceAlarmsForSync` still writes.
- Sync: a resource carrying one invalid alarm persists the event and its valid alarm, surfaces exactly one warning naming the UID and reason, and does not fail the pull; a non-alarm failure still fails the resource.
- CLI: the flag parser's output is pinned to satisfy the service write rule, so a future loosening of `parseOneAlarm` fails the test rather than silently producing orphaned rows.

`go build`, `go vet`, and the full `go test ./...` are green.
