### PR TITLE
fix(alarm): screen the todo span, correct the state comments

### DIFF
--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -519,9 +519,10 @@ func (s *Service) ListExpiredSnoozed(ctx context.Context, now time.Time) ([]DueA
 		if matched.ID == 0 {
 			continue // alarm definition was removed
 		}
-		// A rewrite to a sync-only action retires the state row at the
-		// write point (updateAlarmInPlace), so this list never returns
-		// such a row.
+		// ListExpiredSnoozedAlarmStates joins event_alarms and filters
+		// on the current action, so a snoozed alarm a pull rewrote to a
+		// sync-only action never reaches here. Keep that filter: this
+		// loop does not test the action itself.
 
 		triggerAt, _ := time.Parse(time.RFC3339, storage.NullableToString(st.SnoozedTo))
 
@@ -717,15 +718,18 @@ func (s *Service) Snooze(ctx context.Context, stateID int64, until time.Time) er
 	})
 }
 
-// ListPending returns all fired alarms that are not acknowledged. A
-// rewrite to a sync-only action retires the alarm's state at the write
-// point (updateAlarmInPlace), so this list never returns such a row.
+// ListPending returns all fired alarms that are not acknowledged.
+// ListPendingAlarmStates joins event_alarms and filters on the current
+// action, so an alarm a pull rewrote to a sync-only action drops out.
+// The state row itself stays, so the entry returns when a later pull
+// restores a fireable action. Keep the filter in the query.
 func (s *Service) ListPending(ctx context.Context) ([]storage.AlarmState, error) {
 	return s.q.ListPendingAlarmStates(ctx)
 }
 
 // ListPendingTodoAlarms returns all fired todo alarms that are not
-// acknowledged, with the same write-point retirement as ListPending.
+// acknowledged. ListPendingTodoAlarmStates carries the same action
+// filter as ListPending.
 func (s *Service) ListPendingTodoAlarms(ctx context.Context) ([]storage.TodoAlarmState, error) {
 	return s.q.ListPendingTodoAlarmStates(ctx)
 }

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -28,8 +28,8 @@ type TodoDueAlarm struct {
 // Lean variants omit X-properties (round-trip-only metadata) — the check
 // loop calls them per todo every tick and never reads them. The Fireable
 // variant also excludes preserved sync-only actions in SQL. The snooze
-// lister uses the unfiltered list: the write point retires the state of
-// a rewritten alarm, so every snoozed state it matches is fireable.
+// lister uses the unfiltered list, because its own state query already
+// filters on the current action.
 type TodoAlarmLister interface {
 	ListAlarms(ctx context.Context, todoID int64) ([]model.Alarm, error)
 	ListAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error)
@@ -371,9 +371,10 @@ func (s *TodoService) ListExpiredTodoSnoozed(ctx context.Context, now time.Time)
 		if matched.ID == 0 {
 			continue
 		}
-		// A rewrite to a sync-only action retires the state row at the
-		// write point (updateTodoAlarmInPlace), so this list never
-		// returns such a row.
+		// ListExpiredSnoozedTodoAlarmStates joins todo_alarms and
+		// filters on the current action, so a snoozed alarm a pull
+		// rewrote to a sync-only action never reaches here. Keep that
+		// filter: this loop does not test the action itself.
 
 		triggerAt, _ := time.Parse(time.RFC3339, storage.NullableToString(st.SnoozedTo))
 

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1665,7 +1665,29 @@ func deleteUnmatchedAlarms(ctx context.Context, qtx *storage.Queries, existing [
 // preserved action — the CLI --alarm flag — uses this method, so a
 // routine edit does not delete the VALARM of another client (issue #579).
 // A caller that must delete such a row calls ReplaceAlarms instead.
+// The read of the stored rows and the write share one transaction. A read
+// on its own connection could return a row a concurrent pull has already
+// deleted. The carry-over would then write that row again, and the next
+// push would restore the deleted VALARM on the server.
 func (s *Service) ReplaceFireableAlarms(ctx context.Context, eventID int64, alarms []model.Alarm) error {
+	if s.tx != nil {
+		return s.replaceFireableAlarms(ctx, eventID, alarms)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.WithTx(tx).replaceFireableAlarms(ctx, eventID, alarms); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// replaceFireableAlarms carries the stored sync-only rows forward. The
+// caller supplies the transaction.
+func (s *Service) replaceFireableAlarms(ctx context.Context, eventID int64, alarms []model.Alarm) error {
 	stored, err := s.ListAlarms(ctx, eventID)
 	if err != nil {
 		return fmt.Errorf("list stored alarms: %w", err)

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -360,7 +360,7 @@ func TestEventService_ReplaceAlarms_RejectsInvalidAlarm(t *testing.T) {
 		t.Errorf("alarms = %d, want 0 (a rejected write must store no row)", len(alarms))
 	}
 
-	// A preserved foreign action passes. Migration 043 widened the action
+	// A preserved foreign action passes. Migration 044 widened the action
 	// constraint, so the boundary accepts it (issue #579).
 	if err := svc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
 		{Action: "NONE", TriggerValue: "-PT5M"},
@@ -372,6 +372,52 @@ func TestEventService_ReplaceAlarms_RejectsInvalidAlarm(t *testing.T) {
 // TestEventService_ReplaceAlarms_DefaultsEmptyFields keeps the defaults
 // contract. An empty Action becomes DISPLAY. An empty Related becomes
 // START. Validation runs after the defaults, so current callers pass.
+// ReplaceFireableAlarms reads the stored rows and writes them back in one
+// transaction. The carry-over must keep a preserved sync-only row that the
+// caller cannot state (issue #579).
+func TestEventService_ReplaceFireableAlarms_CarriesSyncOnlyRows(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	e := createEvent(t, svc)
+
+	if err := svc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "NONE", TriggerValue: "-PT5M"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+	}); err != nil {
+		t.Fatalf("seed alarms: %v", err)
+	}
+
+	// The caller states only the fireable alarm it wants.
+	if err := svc.ReplaceFireableAlarms(ctx, e.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT30M"},
+	}); err != nil {
+		t.Fatalf("ReplaceFireableAlarms: %v", err)
+	}
+
+	alarms, err := svc.ListAlarms(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms: %v", err)
+	}
+	if len(alarms) != 2 {
+		t.Fatalf("alarms = %d, want 2 (the new fireable one and the carried row); got %+v", len(alarms), alarms)
+	}
+	var foundSyncOnly, foundNew bool
+	for _, a := range alarms {
+		if a.Action == "NONE" && a.TriggerValue == "-PT5M" {
+			foundSyncOnly = true
+		}
+		if a.Action == "DISPLAY" && a.TriggerValue == "-PT30M" {
+			foundNew = true
+		}
+	}
+	if !foundSyncOnly {
+		t.Errorf("the preserved sync-only row is gone; alarms = %+v", alarms)
+	}
+	if !foundNew {
+		t.Errorf("the stated fireable alarm is missing; alarms = %+v", alarms)
+	}
+}
+
 func TestEventService_ReplaceAlarms_DefaultsEmptyFields(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -179,6 +179,18 @@ func ImportFile(r io.Reader) (ImportResult, error) {
 	return result, nil
 }
 
+// todoSpanStorable reports whether the DTSTART plus the DURATION lands on
+// a time the database can hold. See timeutil.Storable for that rule. An
+// unparseable start gives no end to test, so the function accepts it. The
+// todo service applies the same rule in validateTiming.
+func todoSpanStorable(startDate, dur string) bool {
+	start := timeutil.ParseDate(startDate)
+	if start.IsZero() {
+		return true
+	}
+	return timeutil.Storable(duration.Add(start, dur))
+}
+
 func todoFromVTodo(comp *ical.Component) (todo.Todo, []string, error) {
 	props := comp.Props
 
@@ -201,10 +213,11 @@ func todoFromVTodo(comp *ical.Component) (todo.Todo, []string, error) {
 		todoWarnings = append(todoWarnings, w)
 	}
 
-	// Screen the DURATION on the same three rules the todo service
+	// Screen the DURATION on the same four rules the todo service
 	// applies. The value must be a positive span (RFC 5545 §3.8.2.5).
 	// DUE and DURATION are mutually exclusive, and a DURATION needs a
-	// DTSTART (§3.6.2).
+	// DTSTART (§3.6.2). The end must also land on a time the database
+	// can hold.
 	//
 	// Drop the DURATION and warn when a rule fails. A stored bad value
 	// would re-export verbatim and would poison a RELATED=END alarm
@@ -223,6 +236,9 @@ func todoFromVTodo(comp *ical.Component) (todo.Todo, []string, error) {
 		case startDate == "":
 			todoWarnings = append(todoWarnings, fmt.Sprintf(
 				"todo %q: DURATION %q needs a DTSTART; dropped", uid, prop.Value))
+		case !todoSpanStorable(startDate, prop.Value):
+			todoWarnings = append(todoWarnings, fmt.Sprintf(
+				"todo %q: DURATION %q ends past year %d; dropped", uid, prop.Value, timeutil.MaxStorableYear))
 		default:
 			durationValue = prop.Value
 		}

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -1511,3 +1511,35 @@ END:VCALENDAR`
 		t.Errorf("no DURATION-without-DTSTART warning; warnings = %v", result.Warnings)
 	}
 }
+
+// A DURATION whose end passes the storable year is dropped at import. The
+// todo service rejects such a span in validateTiming, and the sync engine
+// stops at the first resource error, so a stored value would fail the
+// whole calendar pull on every run (issue #585).
+func TestImport_TodoUnstorableDuration_DroppedWithWarning(t *testing.T) {
+	t.Parallel()
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:unstorable-duration
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T140000Z
+DURATION:P3000000D
+SUMMARY:Unstorable Span
+END:VTODO
+END:VCALENDAR`
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile error: %v", err)
+	}
+	if len(result.Todos) != 1 {
+		t.Fatalf("todos = %d, want 1", len(result.Todos))
+	}
+	if result.Todos[0].Duration != "" {
+		t.Errorf("Duration = %q, want it dropped", result.Todos[0].Duration)
+	}
+	joined := strings.Join(result.Warnings, " | ")
+	if !strings.Contains(joined, "ends past year") {
+		t.Errorf("no unstorable-DURATION warning; warnings = %v", result.Warnings)
+	}
+}

--- a/internal/ical/integration_test.go
+++ b/internal/ical/integration_test.go
@@ -560,3 +560,43 @@ END:VCALENDAR
 func readerFromBytes(data []byte) *bytes.Reader {
 	return bytes.NewReader(data)
 }
+
+// A VTODO whose DURATION ends past the storable year must persist. The
+// importer drops the value, so UpsertByUID accepts the todo. Before the
+// drop, validateTiming rejected it, and the sync engine failed the whole
+// calendar pull on every run (issue #585).
+func TestIntegration_TodoUnstorableDurationPersists(t *testing.T) {
+	const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:unstorable-span-todo
+DTSTAMP:20260401T100000Z
+DTSTART:20260401T140000Z
+DURATION:P3000000D
+SUMMARY:Unstorable Span
+END:VTODO
+END:VCALENDAR`
+
+	result, err := ImportFile(bytes.NewReader([]byte(ics)))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Todos) != 1 {
+		t.Fatalf("todos = %d, want 1", len(result.Todos))
+	}
+
+	db, q := testutil.NewTestDB(t)
+	ctx := context.Background()
+	calSvc := calendar.NewService(db, q)
+	todoSvc := todo.NewService(db, q)
+	cals, _ := calSvc.List(ctx)
+
+	td := result.Todos[0]
+	if _, err := todoSvc.UpsertByUID(ctx, todo.UpsertParams{
+		UID: td.UID, CalendarID: cals[0].ID,
+		Summary: td.Summary, StartDate: td.StartDate, Duration: td.Duration,
+		Status: td.Status, Priority: td.Priority, Sequence: td.Sequence,
+	}); err != nil {
+		t.Fatalf("the todo must persist after the importer drops the span: %v", err)
+	}
+}

--- a/internal/model/alarm_validate_test.go
+++ b/internal/model/alarm_validate_test.go
@@ -61,7 +61,7 @@ func TestPrepareAlarmsForWrite_KeepsValidValues(t *testing.T) {
 	}
 }
 
-// Migration 043 widened the action constraint, so the write boundary
+// Migration 044 widened the action constraint, so the write boundary
 // accepts a preserved foreign action (issue #579). Only an empty action
 // fails, and prepareAlarmForWrite fills that with the default first, so
 // the reject path needs a caller that clears the field after the fill.

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -883,7 +883,28 @@ func fromStorageTodoAlarm(r storage.TodoAlarm) model.Alarm {
 // carries the stored sync-only rows forward, like the event method of the
 // same name (issue #579). A caller that must delete such a row calls
 // ReplaceAlarms instead.
+// The read of the stored rows and the write share one transaction, like
+// the event method of the same name. A read on its own connection could
+// return a row a concurrent pull has already deleted.
 func (s *Service) ReplaceFireableAlarms(ctx context.Context, todoID int64, alarms []model.Alarm) error {
+	if s.tx != nil {
+		return s.replaceFireableAlarms(ctx, todoID, alarms)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.WithTx(tx).replaceFireableAlarms(ctx, todoID, alarms); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// replaceFireableAlarms carries the stored sync-only rows forward. The
+// caller supplies the transaction.
+func (s *Service) replaceFireableAlarms(ctx context.Context, todoID int64, alarms []model.Alarm) error {
 	stored, err := s.ListAlarms(ctx, todoID)
 	if err != nil {
 		return fmt.Errorf("list stored alarms: %w", err)

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -633,12 +633,57 @@ func TestTodoService_ReplaceAlarms_RejectsInvalidAlarm(t *testing.T) {
 		t.Errorf("alarms = %d, want 0 (a rejected write must store no row)", len(alarms))
 	}
 
-	// A preserved foreign action passes. Migration 043 widened the action
+	// A preserved foreign action passes. Migration 044 widened the action
 	// constraint, so the boundary accepts it (issue #579).
 	if err := svc.ReplaceAlarms(ctx, td.ID, []model.Alarm{
 		{Action: "NONE", TriggerValue: "-PT5M"},
 	}); err != nil {
 		t.Fatalf("preserved action: err = %v, want nil", err)
+	}
+}
+
+// ReplaceFireableAlarms reads the stored rows and writes them back in one
+// transaction, like the event method. The carry-over must keep a preserved
+// sync-only row that the caller cannot state (issue #579).
+func TestTodoService_ReplaceFireableAlarms_CarriesSyncOnlyRows(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	td := createTodo(t, svc)
+
+	if err := svc.ReplaceAlarms(ctx, td.ID, []model.Alarm{
+		{Action: "NONE", TriggerValue: "-PT5M"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+	}); err != nil {
+		t.Fatalf("seed alarms: %v", err)
+	}
+
+	if err := svc.ReplaceFireableAlarms(ctx, td.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT30M"},
+	}); err != nil {
+		t.Fatalf("ReplaceFireableAlarms: %v", err)
+	}
+
+	alarms, err := svc.ListAlarms(ctx, td.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms: %v", err)
+	}
+	if len(alarms) != 2 {
+		t.Fatalf("alarms = %d, want 2 (the new fireable one and the carried row); got %+v", len(alarms), alarms)
+	}
+	var foundSyncOnly, foundNew bool
+	for _, a := range alarms {
+		if a.Action == "NONE" && a.TriggerValue == "-PT5M" {
+			foundSyncOnly = true
+		}
+		if a.Action == "DISPLAY" && a.TriggerValue == "-PT30M" {
+			foundNew = true
+		}
+	}
+	if !foundSyncOnly {
+		t.Errorf("the preserved sync-only row is gone; alarms = %+v", alarms)
+	}
+	if !foundNew {
+		t.Errorf("the stated fireable alarm is missing; alarms = %+v", alarms)
 	}
 }
 

--- a/internal/tui/event_copy.go
+++ b/internal/tui/event_copy.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/atotto/clipboard"
@@ -87,7 +88,15 @@ func formatRSVPCopy(status string) string {
 	case "NEEDS-ACTION", "":
 		return "No response"
 	default:
+		// A server can send any PARTSTAT value, so the first character
+		// can take more than one byte. Split on the first rune. A byte
+		// split would cut a multi-byte character in half and render a
+		// replacement character.
 		s := strings.ToLower(strings.TrimSpace(status))
-		return strings.ToUpper(s[:1]) + s[1:]
+		first, size := utf8.DecodeRuneInString(s)
+		if size == 0 {
+			return s
+		}
+		return strings.ToUpper(string(first)) + s[size:]
 	}
 }

--- a/internal/tui/event_copy_test.go
+++ b/internal/tui/event_copy_test.go
@@ -62,3 +62,23 @@ func TestHelpDialog_EventsSectionDocumentsCopy(t *testing.T) {
 		t.Fatalf("copy key = %q, want %q", got, "p")
 	}
 }
+
+// A server can send any PARTSTAT value. formatRSVPCopy must split the
+// first character on a rune, so a multi-byte value keeps its characters.
+func TestFormatRSVPCopy_MultiByteValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{"multi-byte first rune", "ÉBAUCHE", "Ébauche"},
+		{"known value", "accepted", "Accepted"},
+		{"single byte fallback", "X-CUSTOM", "X-custom"},
+		{"empty", "", "No response"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatRSVPCopy(tc.status))
+		})
+	}
+}


### PR DESCRIPTION
A code review of merged master found five defects in the work merged this session. This PR fixes all five. None of them is a regression from an unmerged branch; every one is on master today.

## 1. A poison-pill VTODO aborts every sync pull (medium)

`todoFromVTodo` screened the DURATION on three of the four rules `todo.validateTiming` applies. It did not test storability, which the event importer does test.

A VTODO with a DTSTART, no DUE, and `DURATION:P3000000D` passed the parser: `duration.ValidateSpan` returns nil, but the end lands in year 10239, so `timeutil.Storable` is false. `UpsertByUID` then rejected the todo, and the sync engine returns `upsert todo %q: %w`, which fails the resource and the whole calendar pull, on every run.

The importer now drops the DURATION with a warning, which is what the comment above that block already promised.

## 2. Five comments describe a mechanism that does not exist (low)

Comments in `internal/alarm/service.go` and `internal/alarm/todo_service.go` claimed a rewrite to a sync-only action "retires the state row at the write point (updateAlarmInPlace / updateTodoAlarmInPlace)". Those functions state the opposite: they leave `alarm_state` alone, and the queries filter on the current action.

The real mechanism is the `action IN ('AUDIO','DISPLAY','EMAIL')` join filter in `db/queries/alarm_state.sql` and `db/queries/todo_alarm_state.sql`. The comments now describe that filter and say it carries the rule, so nobody deletes it as redundant.

## 3. Wrong migration number (low)

Three comments said "Migration 043 widened the action constraint". Migration 043 heals the span columns; `db/migrations/044_alarm_action_preserve.sql` widened the action CHECK.

## 4. A read outside the write transaction (low)

`ReplaceFireableAlarms` read the stored alarms with `ListAlarms` on its own connection, then called `ReplaceAlarms`, which opened a separate transaction. A concurrent `sync run` that removed a preserved VALARM between the two steps made the stale read write the row again, and the next push restored it on the server.

Both services now read and write in one transaction. The public API does not change.

## 5. A byte split on a multi-byte character (low)

`formatRSVPCopy` did `strings.ToUpper(s[:1]) + s[1:]`. `RSVPStatus` holds whatever the server sent, so a value such as `ÉBAUCHE` produced a replacement character in the copied text. The split now uses `utf8.DecodeRuneInString`.

## Tests

Each fix has a test, and I verified the three behavioural ones fail without the fix:

- `TestImport_TodoUnstorableDuration_DroppedWithWarning` and `TestIntegration_TodoUnstorableDurationPersists` — without the screen, the second fails with `invalid todo timing: the end time is past year 9999`, which is the pull-aborting error.
- `TestFormatRSVPCopy_MultiByteValue` — without the fix, it produces `"�\xa9bauche"`.
- `TestEventService_ReplaceFireableAlarms_CarriesSyncOnlyRows` and the todo equivalent pin the carry-over across the transaction change.

`gofmt`, `go build ./...`, `go vet ./...`, and the full `go test ./...` are green. The only remaining `gofmt` drift is the two pre-existing files (`cmd/chroncal/output_test.go`, `internal/sync/engine.go`), which this PR does not touch.