### PR TITLE
fix(model): refuse a malformed alarm action at the write boundary

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -675,21 +675,6 @@ func parseCategories(ve ical.Event) string {
 	return timeutil.JoinCategoryList(cats)
 }
 
-// validActionToken reports whether s is an RFC 5545 iana-token or x-name:
-// one or more ALPHA, DIGIT, or "-" characters. Any other byte would make
-// export emit an invalid ACTION line that a strict server rejects.
-func validActionToken(s string) bool {
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-':
-		default:
-			return false
-		}
-	}
-	return len(s) > 0
-}
-
 // parseAlarm extracts a model.Alarm from a VALARM component.
 // The second return value is a warning string (empty if no issues). A VALARM
 // with several problems reports all of them. Each one changes what the alarm
@@ -714,7 +699,7 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 			// empty value.
 		case model.FireableAlarmAction(up):
 			alarm.Action = up
-		case validActionToken(raw):
+		case model.ValidAlarmActionToken(raw):
 			alarm.Action = raw
 		default:
 			// A malformed action cannot round-trip: export would emit

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -226,13 +226,34 @@ func FireableAlarmAction(action string) bool {
 	return slices.Contains(alarmActions, action)
 }
 
-// StorableAlarmAction returns true if action is a value the alarm tables
-// accept: any non-empty string. The rule mirrors the CHECK constraints in
-// db/migrations/044. Keep this function and the two constraints in
-// lockstep. A value that passes here but fails the constraint rolls back
-// the whole resource transaction during sync (issue #575).
+// ValidAlarmActionToken returns true if s has the shape RFC 5545 gives an
+// iana-token or an x-name: one or more ALPHA, DIGIT, or "-" characters.
+// The import parser and the write rule share this test. Any other byte
+// makes export emit an ACTION line a strict server rejects.
+func ValidAlarmActionToken(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-':
+		default:
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+// StorableAlarmAction returns true if action is a value a write accepts:
+// a well-shaped token (see ValidAlarmActionToken). The rule is stricter
+// than the CHECK constraints in db/migrations/044, which reject only an
+// empty value. A whitespace-only action passes the constraint but exports
+// as a bare ACTION line with no value, so the write rule refuses it here
+// (issue #595).
+//
+// Keep the rule at least as strict as the constraints. A value that
+// passes here but fails a constraint rolls back the whole resource
+// transaction during sync (issue #575).
 func StorableAlarmAction(action string) bool {
-	return action != ""
+	return ValidAlarmActionToken(action)
 }
 
 // CheckStorableAlarmAction returns a named error for an action the alarm

--- a/internal/model/alarm_validate_test.go
+++ b/internal/model/alarm_validate_test.go
@@ -105,3 +105,49 @@ func TestPrepareAlarmsForWrite_RejectsInvalidRelated(t *testing.T) {
 		t.Errorf("err = %q, want the field name and the value", err)
 	}
 }
+
+// The write rule and the token shape must agree on every candidate. The
+// import parser calls ValidAlarmActionToken and the services call
+// StorableAlarmAction. A value the parser stores must therefore also pass
+// a write (issue #595).
+func TestStorableAlarmActionTokenShape(t *testing.T) {
+	cases := []struct {
+		action string
+		want   bool
+		why    string
+	}{
+		{"AUDIO", true, "a fireable action"},
+		{"DISPLAY", true, "a fireable action"},
+		{"NONE", true, "the Google sentinel"},
+		{"PROCEDURE", true, "a legacy iana-token"},
+		{"X-APPLE-SOUND", true, "an x-name with a hyphen"},
+		{"X-VENDOR2", true, "an x-name with a digit"},
+		{"display", true, "a token shape, whatever the case"},
+		{"", false, "an empty action"},
+		{" ", false, "a whitespace-only action"},
+		{"\t", false, "a tab-only action"},
+		{"NO NE", false, "an embedded space"},
+		{"X-A;B", false, "a parameter separator"},
+		{"X-A:B", false, "a value separator"},
+		{"NEW\nLINE", false, "a line break"},
+	}
+	for _, c := range cases {
+		if got := StorableAlarmAction(c.action); got != c.want {
+			t.Errorf("StorableAlarmAction(%q) = %v, want %v (%s)", c.action, got, c.want, c.why)
+		}
+		if got := ValidAlarmActionToken(c.action); got != c.want {
+			t.Errorf("ValidAlarmActionToken(%q) = %v, want %v (%s)", c.action, got, c.want, c.why)
+		}
+	}
+}
+
+// A write refuses a malformed action with the typed error. A caller can
+// then tell the refusal apart from a storage failure.
+func TestPrepareAlarmsForWrite_RejectsMalformedAction(t *testing.T) {
+	for _, action := range []string{" ", "\t", "NO NE"} {
+		_, err := PrepareAlarmsForWrite([]Alarm{{Action: action, TriggerValue: "-PT15M"}})
+		if !errors.Is(err, ErrInvalidAlarm) {
+			t.Errorf("PrepareAlarmsForWrite(action %q) error = %v, want ErrInvalidAlarm", action, err)
+		}
+	}
+}

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -345,14 +345,18 @@ func TestCalendarsRejectInvalidRemoteMetadata(t *testing.T) {
 	}
 }
 
-// The alarm CHECK constraints and the model predicates must agree. A
-// value that passes the Go side but fails the constraint rolls back the
-// whole resource transaction during sync (issue #575). This test probes
-// both alarm tables with candidate values. The schema and
-// model.StorableAlarmAction / model.ValidAlarmRelated must give the same
-// verdict on each one. The action rule is wide on purpose (issue #579):
-// the tables keep a sync-only action such as NONE or X-APPLE-SOUND, and
-// only the narrower model.FireableAlarmAction gates the alarm engine.
+// Every value a model predicate accepts must also pass the alarm CHECK
+// constraints. A value that passes the Go side but fails a constraint
+// rolls back the whole resource transaction during sync (issue #575).
+// This test probes both alarm tables with candidate values.
+//
+// The related column holds the two rules to the same verdict. The action
+// column checks one direction only, because the two rules differ on
+// purpose. The constraint rejects an empty action alone (issue #579 keeps
+// a sync-only action such as NONE or X-APPLE-SOUND). The Go rule also
+// rejects a whitespace-only action, which the constraint stores but
+// export cannot represent (issue #595). Go therefore accepts a subset,
+// which is the safe direction.
 func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 	db, q, err := Open(":memory:")
 	if err != nil {
@@ -392,14 +396,17 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 		col    string
 		values []string
 		valid  func(string) bool
+		// exact holds the constraint to the same verdict as the model
+		// predicate. A column where the Go rule is stricter on purpose
+		// sets it to false, and the test then checks only that every
+		// value the Go rule accepts also reaches the table.
+		exact bool
 	}{
 		// The valid candidates come from the model sets. The test then
 		// probes a value added to the model but not to a migration
 		// against the CHECK constraint, and the value fails here.
-		// Migration 044 widened the action constraint, so the action rule
-		// is StorableAlarmAction and a preserved foreign action passes.
-		{"action", append(model.AlarmActions(), "NONE", "PROCEDURE", "X-APPLE-SOUND", "display", ""), model.StorableAlarmAction},
-		{"related", append(model.AlarmRelatedValues(), "STARTS", "end", ""), model.ValidAlarmRelated},
+		{"action", append(model.AlarmActions(), "NONE", "PROCEDURE", "X-APPLE-SOUND", "display", " ", "\t", "NO NE", ""), model.StorableAlarmAction, false},
+		{"related", append(model.AlarmRelatedValues(), "STARTS", "end", ""), model.ValidAlarmRelated, true},
 	}
 
 	for _, ins := range inserts {
@@ -409,9 +416,13 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 					`INSERT INTO `+ins.table+` (`+ins.fk+`, `+c.col+`, trigger_value) VALUES (?, ?, '-PT15M')`,
 					ins.id, v,
 				)
-				if got, want := err == nil, c.valid(v); got != want {
-					t.Errorf("%s %s %q: insert ok = %v, model predicate = %v (err: %v)",
-						ins.table, c.col, v, got, want, err)
+				if c.valid(v) && err != nil {
+					t.Errorf("%s %s %q: the model predicate accepts it, but the insert failed: %v",
+						ins.table, c.col, v, err)
+				}
+				if c.exact && !c.valid(v) && err == nil {
+					t.Errorf("%s %s %q: the model predicate rejects it, but the insert passed",
+						ins.table, c.col, v)
 				}
 				if err != nil && !strings.Contains(err.Error(), "CHECK constraint failed") {
 					t.Errorf("%s %s %q: rejected by %v, not by the CHECK constraint", ins.table, c.col, v, err)


### PR DESCRIPTION
Fixes #595.

## The problem

`model.StorableAlarmAction` was `action != ""`, so a whitespace-only action such as `" "` passed the service write rule and also satisfied the database constraint `CHECK(action <> '')`. The row stored, and `buildValarm` emitted it verbatim as a bare `ACTION:` line with no usable value. A strict CalDAV server rejects that VALARM and fails the whole resource on the next push.

The import parser already refused the same value through its own `validActionToken` helper, so the two layers disagreed about what a storable action is.

## The change

- `model.ValidAlarmActionToken` holds the rule: the shape RFC 5545 gives an iana-token or an x-name (ALPHA, DIGIT, or `-`).
- `StorableAlarmAction` requires that shape. A preserved foreign action (`NONE`, `X-APPLE-SOUND`, `PROCEDURE`) still passes, so issue #579 behaviour is unchanged.
- The parser calls the model rule and no longer keeps a copy, so one owner holds the definition.

## The lockstep test

No migration tightens the CHECK constraint, so the Go rule is now deliberately stricter than the constraint: `" "` fails the Go rule and passes the constraint.

`TestAlarmConstraintsMatchModelValidators` asserted that the two give the same verdict. The action column now asserts the direction that matters instead: every value the Go rule accepts must also reach the table. That still catches the drift the test exists for, because the failure it guards against is a value that passes the write rule and then fails the insert, which rolls back the whole resource during sync. The related column keeps the exact-agreement check.

I verified the test still catches drift rather than passing vacuously: with `StorableAlarmAction` temporarily loosened to accept everything, it fails on both alarm tables; restored, it passes.

## Tests

- `TestStorableAlarmActionTokenShape` drives both the write rule and the token rule over one corpus, including `" "`, `"\t"`, an embedded space, `;` and `:` separators, and a line break.
- `TestPrepareAlarmsForWrite_RejectsMalformedAction` pins the typed `ErrInvalidAlarm` at the service boundary.
- The existing `TestImport_MalformedActionToken_DropsAlarm` exercises the moved rule through the parser.

`gofmt`, `go build ./...`, `go vet ./...`, and the full `go test ./...` are green; the only remaining gofmt drift is the two pre-existing files.