### PR TITLE
feat(cli): add --clear-foreign-alarms to remove a preserved alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,22 @@ chroncal event add "Release" --date 2026-06-15 --time 14:00 --alarm "DISPLAY:-PT
 
 See `chroncal event add --help` for the extra fields.
 
+A synced calendar can hold an alarm this app does not fire. A server sends
+one as a "no reminder" sentinel, and another client sends one with its own
+action, such as `X-APPLE-SOUND`. The `--alarm` flag has no syntax for those
+actions, so `chroncal event update` and `chroncal todo update` keep the
+stored rows. Without that rule, a routine reminder edit deletes the alarm
+of the other client from the server.
+
+Pass `--clear-foreign-alarms` to delete them. Use the flag with `--alarm`
+to make the new list the whole list. Use the flag on its own to remove the
+stored rows and keep the alarms you can state:
+
+```bash
+chroncal event update 12 --clear-foreign-alarms              # remove them, keep your own
+chroncal event update 12 --alarm "-PT30M" --clear-foreign-alarms  # the new alarm is the only one
+```
+
 #### Receive notifications
 
 A stored alarm does not fire on its own. Something must run `chroncal alarm check` on a schedule. Two options:

--- a/cmd/chroncal/alarm_clear_foreign_cli_test.go
+++ b/cmd/chroncal/alarm_clear_foreign_cli_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+// seedEventWithForeignAlarm creates one event that carries a preserved
+// sync-only alarm and one alarm the CLI can state. A sync pull writes such
+// a pair, and the CLI parser cannot state the sync-only action, so the seed
+// goes through the service.
+func seedEventWithForeignAlarm(t *testing.T, dbPath string) {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Synced meeting",
+		"--calendar", "Work",
+		"--date", "2026-04-21",
+		"--time", "09:00",
+		"--duration", "30m",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	seed, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (seed): %v", err)
+	}
+	defer seed.Close()
+	if err := seed.Events.ReplaceAlarms(ctx, 1, []model.Alarm{
+		{Action: "NONE", TriggerValue: "19760401T005545Z", UID: "google-none@test"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+	}); err != nil {
+		t.Fatalf("seed alarms: %v", err)
+	}
+}
+
+// eventAlarmActions lists the stored actions of event 1.
+func eventAlarmActions(t *testing.T, dbPath string) []string {
+	t.Helper()
+	check, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (check): %v", err)
+	}
+	defer check.Close()
+	alarms, err := check.Events.ListAlarms(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("list alarms: %v", err)
+	}
+	actions := make([]string, 0, len(alarms))
+	for _, a := range alarms {
+		actions = append(actions, a.Action)
+	}
+	return actions
+}
+
+// TestEventUpdateClearForeignAlarmsWithAlarmFlag pins the escape from the
+// carry-over rule (issue #593). The flag makes the --alarm set the whole
+// set, so the preserved row goes with the rows the flag replaces.
+func TestEventUpdateClearForeignAlarmsWithAlarmFlag(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	seedEventWithForeignAlarm(t, dbPath)
+
+	if _, _, err := runChroncalCommand(t,
+		"event", "update", "1", "--alarm", "-PT30M", "--clear-foreign-alarms",
+	); err != nil {
+		t.Fatalf("event update --alarm --clear-foreign-alarms: %v", err)
+	}
+
+	actions := eventAlarmActions(t, dbPath)
+	if len(actions) != 1 || actions[0] != "DISPLAY" {
+		t.Fatalf("actions = %v, want one DISPLAY alarm and no preserved row", actions)
+	}
+}
+
+// TestEventUpdateClearForeignAlarmsAlone pins the flag on its own. It
+// removes the preserved rows and keeps the alarms the user can state.
+func TestEventUpdateClearForeignAlarmsAlone(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	seedEventWithForeignAlarm(t, dbPath)
+
+	if _, _, err := runChroncalCommand(t,
+		"event", "update", "1", "--clear-foreign-alarms",
+	); err != nil {
+		t.Fatalf("event update --clear-foreign-alarms: %v", err)
+	}
+
+	actions := eventAlarmActions(t, dbPath)
+	if len(actions) != 1 || actions[0] != "DISPLAY" {
+		t.Fatalf("actions = %v, want the stored DISPLAY alarm to stay and the preserved row to go", actions)
+	}
+}
+
+// TestEventUpdateWithoutFlagKeepsForeignAlarm pins the default. An update
+// that does not pass the flag keeps the preserved row.
+func TestEventUpdateWithoutFlagKeepsForeignAlarm(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	seedEventWithForeignAlarm(t, dbPath)
+
+	if _, _, err := runChroncalCommand(t,
+		"event", "update", "1", "--title", "Renamed",
+	); err != nil {
+		t.Fatalf("event update --title: %v", err)
+	}
+
+	actions := eventAlarmActions(t, dbPath)
+	if len(actions) != 2 {
+		t.Fatalf("actions = %v, want both alarms to stay", actions)
+	}
+}
+
+// TestTodoUpdateClearForeignAlarms pins the todo twin of the flag.
+func TestTodoUpdateClearForeignAlarms(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"todo", "add", "Synced task", "--calendar", "Work",
+	); err != nil {
+		t.Fatalf("todo add: %v", err)
+	}
+
+	seed, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (seed): %v", err)
+	}
+	if err := seed.Todos.ReplaceAlarms(ctx, 1, []model.Alarm{
+		{Action: "X-APPLE-SOUND", TriggerValue: "-PT5M", UID: "apple-sound@test"},
+		{Action: "DISPLAY", TriggerValue: "-PT15M"},
+	}); err != nil {
+		seed.Close()
+		t.Fatalf("seed alarms: %v", err)
+	}
+	seed.Close()
+
+	if _, _, err := runChroncalCommand(t,
+		"todo", "update", "1", "--clear-foreign-alarms",
+	); err != nil {
+		t.Fatalf("todo update --clear-foreign-alarms: %v", err)
+	}
+
+	check, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (check): %v", err)
+	}
+	defer check.Close()
+	alarms, err := check.Todos.ListAlarms(ctx, 1)
+	if err != nil {
+		t.Fatalf("list alarms: %v", err)
+	}
+	if len(alarms) != 1 || alarms[0].Action != "DISPLAY" {
+		t.Fatalf("alarms = %+v, want only the DISPLAY alarm", alarms)
+	}
+}

--- a/cmd/chroncal/event.go
+++ b/cmd/chroncal/event.go
@@ -934,6 +934,7 @@ func eventUpdateCmd() *cobra.Command {
 		relationFlags []string
 		recurrenceID  string
 		organizer     string
+		clearForeign  bool
 	)
 	cmd := &cobra.Command{
 		Use:   "update <id|uid>",
@@ -1211,9 +1212,22 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				}
 			}
 
-			if cmd.Flags().Changed("alarm") {
+			switch {
+			case cmd.Flags().Changed("alarm") && clearForeign:
+				// The flag makes the replacement set the whole set, so a
+				// preserved alarm goes with the rows the flags replace.
+				if err := a.Events.ReplaceAlarms(ctx, e.ID, alarms); err != nil {
+					return fmt.Errorf("update alarms: %w", err)
+				}
+			case cmd.Flags().Changed("alarm"):
 				if err := a.Events.ReplaceFireableAlarms(ctx, e.ID, alarms); err != nil {
 					return fmt.Errorf("update alarms: %w", err)
+				}
+			case clearForeign:
+				// The flag on its own removes the preserved rows and keeps
+				// the alarms the user can state.
+				if err := a.Events.ClearSyncOnlyAlarms(ctx, e.ID); err != nil {
+					return fmt.Errorf("clear foreign alarms: %w", err)
 				}
 			}
 
@@ -1298,6 +1312,7 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 	cmd.Flags().MarkHidden("rdate")
 	cmd.Flags().StringArrayVar(&attachFlags, "attach", nil, "attachment (file path or URL, repeatable)")
 	cmd.Flags().StringArrayVar(&alarmFlags, "alarm", nil, alarmFlagHelp)
+	cmd.Flags().BoolVar(&clearForeign, "clear-foreign-alarms", false, clearForeignAlarmsHelp)
 	cmd.Flags().StringArrayVar(&attendeeFlags, "attendee", nil, "attendee (email or \"Name <email>\", repeatable, replaces all)")
 	cmd.Flags().StringVar(&organizer, "organizer", "", "event organizer (email or \"Name <email>\", replaces existing)")
 	cmd.Flags().StringArrayVar(&commentFlags, "comment", nil, "comment annotation (repeatable, replaces all)")
@@ -1659,6 +1674,11 @@ func smtpConfiguredForEmailAlarms() bool {
 // model exports, so it stays in lockstep with the model sets.
 var alarmFlagHelp = `alarm in format [ACTION:]TRIGGER[:DESC:REPEAT:DURATION:RELATED:ATTENDEES]; ACTION is one of ` +
 	model.AlarmActionsList() + ` (default ` + model.DefaultAlarmAction + `); extended fields are optional, e.g. "DISPLAY:-PT30M::3:PT5M:END" or "EMAIL:-PT1H:::::user@example.com"; repeatable`
+
+// clearForeignAlarmsHelp documents the escape from the carry-over rule.
+// The --alarm flag cannot state an action this app does not fire, so an
+// update keeps those rows by default.
+const clearForeignAlarmsHelp = `delete the stored alarms this app cannot fire, such as a server "no reminder" sentinel or the alarm of another client; the default keeps them, because an --alarm edit cannot state them`
 
 func parseOneAlarm(val string) (model.Alarm, error) {
 	action := model.DefaultAlarmAction

--- a/cmd/chroncal/todo.go
+++ b/cmd/chroncal/todo.go
@@ -578,6 +578,7 @@ func todoUpdateCmd() *cobra.Command {
 		relationFlags []string
 		organizer     string
 		recurrenceID  string
+		clearForeign  bool
 	)
 	cmd := &cobra.Command{
 		Use:   "update <id|uid>",
@@ -814,9 +815,22 @@ a --progress value other than 100.`,
 					return fmt.Errorf("update attachments: %w", err)
 				}
 			}
-			if cmd.Flags().Changed("alarm") {
+			switch {
+			case cmd.Flags().Changed("alarm") && clearForeign:
+				// The flag makes the replacement set the whole set, so a
+				// preserved alarm goes with the rows the flags replace.
+				if err := a.Todos.ReplaceAlarms(ctx, t.ID, alarms); err != nil {
+					return fmt.Errorf("update alarms: %w", err)
+				}
+			case cmd.Flags().Changed("alarm"):
 				if err := a.Todos.ReplaceFireableAlarms(ctx, t.ID, alarms); err != nil {
 					return fmt.Errorf("update alarms: %w", err)
+				}
+			case clearForeign:
+				// The flag on its own removes the preserved rows and keeps
+				// the alarms the user can state.
+				if err := a.Todos.ClearSyncOnlyAlarms(ctx, t.ID); err != nil {
+					return fmt.Errorf("clear foreign alarms: %w", err)
 				}
 			}
 			if cmd.Flags().Changed("attendee") || cmd.Flags().Changed("organizer") {
@@ -887,6 +901,7 @@ a --progress value other than 100.`,
 	cmd.Flags().StringArrayVar(&rdates, "recurrence-date-times", nil, "add extra recurrence date (YYYY-MM-DD, repeatable)")
 	cmd.Flags().StringArrayVar(&attachFlags, "attach", nil, "attachment (file path or URL, repeatable)")
 	cmd.Flags().StringArrayVar(&alarmFlags, "alarm", nil, alarmFlagHelp)
+	cmd.Flags().BoolVar(&clearForeign, "clear-foreign-alarms", false, clearForeignAlarmsHelp)
 	cmd.Flags().StringArrayVar(&attendeeFlags, "attendee", nil, "attendee (email or \"Name <email>\"; repeatable)")
 	cmd.Flags().StringVar(&organizer, "organizer", "", "organizer (email or \"Name <email>\")")
 	cmd.Flags().StringArrayVar(&commentFlags, "comment", nil, "comment annotation (free-form text, repeatable)")

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1695,6 +1695,39 @@ func (s *Service) replaceFireableAlarms(ctx context.Context, eventID int64, alar
 	return s.ReplaceAlarms(ctx, eventID, model.KeepSyncOnlyAlarms(stored, alarms))
 }
 
+// ClearSyncOnlyAlarms deletes every stored alarm the engine cannot fire and
+// keeps the rest. ReplaceFireableAlarms carries those rows forward, so a
+// --alarm edit alone can never remove one. This method gives the user a way
+// out on a local calendar (issue #593).
+//
+// The read of the stored rows and the write share one transaction, like
+// ReplaceFireableAlarms.
+func (s *Service) ClearSyncOnlyAlarms(ctx context.Context, eventID int64) error {
+	if s.tx != nil {
+		return s.clearSyncOnlyAlarms(ctx, eventID)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.WithTx(tx).clearSyncOnlyAlarms(ctx, eventID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// clearSyncOnlyAlarms keeps the fireable stored rows. The caller supplies
+// the transaction.
+func (s *Service) clearSyncOnlyAlarms(ctx context.Context, eventID int64) error {
+	stored, err := s.ListAlarms(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("list stored alarms: %w", err)
+	}
+	return s.ReplaceAlarms(ctx, eventID, model.FireableAlarmsOnly(stored))
+}
+
 func (s *Service) ReplaceAlarms(ctx context.Context, eventID int64, alarms []model.Alarm) error {
 	if err := s.ensureEventWritable(ctx, eventID, 0); err != nil {
 		return err

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -264,6 +264,20 @@ func KeepSyncOnlyAlarms(stored, replacement []Alarm) []Alarm {
 	return replacement
 }
 
+// FireableAlarmsOnly drops every alarm the engine cannot fire. It is the
+// opposite of KeepSyncOnlyAlarms: a caller uses it to remove a preserved
+// row that no flag can state. The CLI --clear-foreign-alarms flag takes
+// this path (issue #593).
+func FireableAlarmsOnly(stored []Alarm) []Alarm {
+	kept := make([]Alarm, 0, len(stored))
+	for _, a := range stored {
+		if FireableAlarmAction(a.Action) {
+			kept = append(kept, a)
+		}
+	}
+	return kept
+}
+
 // PrepareAlarmUpdate checks an alarm that a caller writes over the stored
 // row ex. It returns the ACKNOWLEDGED value for the update. A malformed
 // value that arrives must not clobber valid stored state, so the function

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -912,6 +912,35 @@ func (s *Service) replaceFireableAlarms(ctx context.Context, todoID int64, alarm
 	return s.ReplaceAlarms(ctx, todoID, model.KeepSyncOnlyAlarms(stored, alarms))
 }
 
+// ClearSyncOnlyAlarms deletes every stored alarm the engine cannot fire and
+// keeps the rest, like the event method of the same name (issue #593). The
+// read of the stored rows and the write share one transaction.
+func (s *Service) ClearSyncOnlyAlarms(ctx context.Context, todoID int64) error {
+	if s.tx != nil {
+		return s.clearSyncOnlyAlarms(ctx, todoID)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.WithTx(tx).clearSyncOnlyAlarms(ctx, todoID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// clearSyncOnlyAlarms keeps the fireable stored rows. The caller supplies
+// the transaction.
+func (s *Service) clearSyncOnlyAlarms(ctx context.Context, todoID int64) error {
+	stored, err := s.ListAlarms(ctx, todoID)
+	if err != nil {
+		return fmt.Errorf("list stored alarms: %w", err)
+	}
+	return s.ReplaceAlarms(ctx, todoID, model.FireableAlarmsOnly(stored))
+}
+
 func (s *Service) ReplaceAlarms(ctx context.Context, todoID int64, alarms []model.Alarm) error {
 	td, err := s.Get(ctx, todoID)
 	if err != nil {


### PR DESCRIPTION
Fixes #593.

## Scope

Issue #593 listed two problems. The first — "the rule lives in the CLI, not the service" — is **already solved on master**: `event.Service.ReplaceFireableAlarms` and the todo twin own the carry-over, read the stored rows in-transaction, and call `model.KeepSyncOnlyAlarms`. The non-preserving `ReplaceAlarms` stays for callers that must delete. This PR does not redo that.

The second problem is the work here: nothing let a user **remove** a preserved sync-only alarm from the CLI. `ReplaceFireableAlarms` re-appended it on every `--alarm` update, so only the TUI alarm editor could clear one. A user who imported an `X-APPLE-SOUND` VALARM into a purely local, unsynced calendar kept it forever.

## The flag

`--clear-foreign-alarms` on `chroncal event update` and `chroncal todo update`:

| Flags | Behavior |
|---|---|
| `--alarm X` | unchanged: the new list plus the preserved rows |
| `--alarm X --clear-foreign-alarms` | the new list is the whole list; preserved rows go |
| `--clear-foreign-alarms` alone | removes the preserved rows, keeps the alarms the user can state |
| neither | unchanged |

I chose the explicit CLI escape (option 2 in the issue) over scoping by calendar kind. A local calendar is not the only case: a user may also want the row gone from a synced calendar, and a flag says so plainly.

## Changes

- `model.FireableAlarmsOnly` drops the rows the engine cannot fire — the opposite of `KeepSyncOnlyAlarms`, so both sides of the rule sit together.
- `Service.ClearSyncOnlyAlarms` on the event and todo services reads the stored rows and writes inside one transaction, mirroring `ReplaceFireableAlarms`. A read on its own connection could return a row a concurrent pull has already deleted, which is the race PR #596 fixed for the carry-over path.
- The CLI update commands select the path with a `switch`, so the three cases are visible in one place.
- README documents the flag and why the default protects those rows.

## Tests

Four CLI tests in `cmd/chroncal/alarm_clear_foreign_cli_test.go`: the flag with `--alarm`, the flag on its own, the todo twin, and the unchanged default. I verified the two behavioral ones **fail without the fix** (they report `actions = [NONE DISPLAY]` when the flag is neutered).

`gofmt`, `go build ./...`, `go vet ./...`, and the full `go test ./...` are green.