### PR TITLE
fix(alarm): keep a foreign VALARM whole, batch the todo alarm read

### DIFF
--- a/db/queries/todo_alarms.sql
+++ b/db/queries/todo_alarms.sql
@@ -14,6 +14,16 @@ WHERE todo_id = ?
   AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
 ORDER BY id;
 
+-- name: ListFireableTodoAlarmsByTodoIDs :many
+-- The action list mirrors model.FireableAlarmAction. Keep the two in
+-- lockstep. The alarm check loop is the only caller, and a preserved
+-- sync-only action must not reach it. The loop reads every todo on each
+-- tick, so it fetches the whole set in one query.
+SELECT * FROM todo_alarms
+WHERE todo_id IN (sqlc.slice(todo_ids))
+  AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
+ORDER BY id;
+
 -- name: ListDistinctTodoAlarmTriggers :many
 -- The action list mirrors model.FireableAlarmAction. Keep the two in
 -- lockstep. A preserved sync-only action never fires, so its trigger

--- a/internal/alarm/querycount_test.go
+++ b/internal/alarm/querycount_test.go
@@ -1,0 +1,142 @@
+package alarm
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io/fs"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+	sqlitedrv "modernc.org/sqlite"
+
+	dbembed "github.com/douglasdemoura/chroncal/db"
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/todo"
+)
+
+// isTodoAlarmFetch reports whether a query reads todo_alarms rows keyed by
+// the todo. Both the per-todo ListFireableTodoAlarmsByTodoID and the
+// batched ListFireableTodoAlarmsByTodoIDs match. A count of them measures
+// the N+1 the batch removes. The window-sizing query
+// ListDistinctTodoAlarmTriggers reads no todo_id, so it does not match.
+func isTodoAlarmFetch(query string) bool {
+	return strings.Contains(query, "FROM todo_alarms") && strings.Contains(query, "todo_id")
+}
+
+// countingDriver wraps another driver and counts the todo-alarm queries,
+// so a test can assert the check loop issues one query, not one per todo.
+type countingDriver struct {
+	base driver.Driver
+	n    *int64
+}
+
+func (d countingDriver) Open(name string) (driver.Conn, error) {
+	c, err := d.base.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return countingConn{Conn: c, n: d.n}, nil
+}
+
+type countingConn struct {
+	driver.Conn
+	n *int64
+}
+
+func (c countingConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if isTodoAlarmFetch(query) {
+		atomic.AddInt64(c.n, 1)
+	}
+	return c.Conn.(driver.QueryerContext).QueryContext(ctx, query, args)
+}
+
+func (c countingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	return c.Conn.(driver.ExecerContext).ExecContext(ctx, query, args)
+}
+
+var countingDriverSeq atomic.Int64
+
+// newCountingDB opens an in-memory database through the count driver. It
+// runs the schema migrations. It returns the todo-alarm query counter.
+func newCountingDB(t *testing.T) (*sql.DB, *storage.Queries, *int64) {
+	t.Helper()
+	var n int64
+	name := fmt.Sprintf("sqlite-alarm-count-%d", countingDriverSeq.Add(1))
+	sql.Register(name, countingDriver{base: &sqlitedrv.Driver{}, n: &n})
+
+	conn, err := sql.Open(name, ":memory:?_pragma=foreign_keys(ON)&_txlock=immediate")
+	if err != nil {
+		t.Fatalf("open counting db: %v", err)
+	}
+	// :memory: is per-connection, so pin the pool to one connection or the
+	// migrations and the queries would reach different empty databases.
+	conn.SetMaxOpenConns(1)
+	t.Cleanup(func() { conn.Close() })
+
+	migrationsFS, err := fs.Sub(dbembed.Migrations, "migrations")
+	if err != nil {
+		t.Fatalf("sub migrations: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS)
+	if err != nil {
+		t.Fatalf("goose provider: %v", err)
+	}
+	if _, err := provider.Up(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return conn, storage.New(conn), &n
+}
+
+// TestCheckTodos_BatchesAlarmFetch guards issue #586 item (e). The check
+// loop runs on a timer over every open todo. It must read the alarms of
+// the whole set in one query, not one query per todo.
+func TestCheckTodos_BatchesAlarmFetch(t *testing.T) {
+	conn, q, counter := newCountingDB(t)
+	ctx := context.Background()
+	todoSvc := todo.NewService(conn, q)
+	evtSvc := event.NewService(conn, q)
+	svc := NewService(conn, q, evtSvc, todoSvc)
+	todoAlarms := NewTodoService(conn, q, todoSvc)
+
+	now := time.Now().UTC()
+	const todos = 5
+	for i := 0; i < todos; i++ {
+		due := now.Add(time.Duration(i+1) * time.Hour)
+		td, err := todoSvc.Create(ctx, todo.CreateParams{
+			CalendarID: 1,
+			Summary:    fmt.Sprintf("Todo %d", i),
+			DueDate:    due.Format(time.RFC3339),
+		})
+		if err != nil {
+			t.Fatalf("create todo %d: %v", i, err)
+		}
+		if err := todoSvc.ReplaceAlarms(ctx, td.ID, []model.Alarm{{
+			Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START",
+		}}); err != nil {
+			t.Fatalf("replace alarms %d: %v", i, err)
+		}
+	}
+
+	atomic.StoreInt64(counter, 0)
+	if _, err := todoAlarms.CheckTodos(ctx, now); err != nil {
+		t.Fatalf("CheckTodos: %v", err)
+	}
+	if got := atomic.LoadInt64(counter); got != 1 {
+		t.Errorf("CheckTodos issued %d todo-alarm queries for %d todos, want 1 (no N+1)", got, todos)
+	}
+
+	atomic.StoreInt64(counter, 0)
+	if _, _, err := svc.CheckMissed(ctx, now, StaleThreshold); err != nil {
+		t.Fatalf("CheckMissed: %v", err)
+	}
+	if got := atomic.LoadInt64(counter); got != 1 {
+		t.Errorf("CheckMissed issued %d todo-alarm queries for %d todos, want 1 (no N+1)", got, todos)
+	}
+}

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -174,14 +174,29 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 		// trigger as missed when the override fired at a rescheduled time.
 		overrideKeys := buildOverrideSuppressionKeys(rows)
 
+		// Read the alarms of every open todo in one query, like CheckTodos
+		// does (issue #586).
+		openIDs := make([]int64, 0, len(rows))
+		for _, row := range rows {
+			td := todoFromRow(row)
+			if td.Status == "COMPLETED" || td.Status == "CANCELLED" {
+				continue
+			}
+			openIDs = append(openIDs, td.ID)
+		}
+		todoAlarmMap, err := s.todos.ListFireableAlarmsByTodoIDs(ctx, openIDs)
+		if err != nil {
+			return missed, nil, err
+		}
+
 		for _, row := range rows {
 			td := todoFromRow(row)
 			if td.Status == "COMPLETED" || td.Status == "CANCELLED" {
 				continue
 			}
 
-			alarms, err := s.todos.ListFireableAlarmsLean(ctx, td.ID)
-			if err != nil || len(alarms) == 0 {
+			alarms := todoAlarmMap[td.ID]
+			if len(alarms) == 0 {
 				continue
 			}
 

--- a/internal/alarm/service_integration_test.go
+++ b/internal/alarm/service_integration_test.go
@@ -27,12 +27,8 @@ func (m *mockAlarmLister) ListAlarmsLean(ctx context.Context, todoID int64) ([]m
 	return m.ListAlarms(ctx, todoID)
 }
 
-func (m *mockAlarmLister) ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error) {
-	alarms, err := m.ListAlarmsLean(ctx, todoID)
-	if err != nil {
-		return nil, err
-	}
-	return filterFireable(alarms), nil
+func (m *mockAlarmLister) ListFireableAlarmsByTodoIDs(ctx context.Context, todoIDs []int64) (map[int64][]model.Alarm, error) {
+	return batchFireable(ctx, m.ListAlarmsLean, todoIDs)
 }
 
 func TestService_Check_BothEventAndTodoAlarms(t *testing.T) {

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -26,14 +26,15 @@ type TodoDueAlarm struct {
 
 // TodoAlarmLister defines the interface for a list of todo alarms. The
 // Lean variants omit X-properties (round-trip-only metadata) — the check
-// loop calls them per todo every tick and never reads them. The Fireable
-// variant also excludes preserved sync-only actions in SQL. The snooze
-// lister uses the unfiltered list, because its own state query already
-// filters on the current action.
+// loop never reads them. The Fireable variants also exclude preserved
+// sync-only actions in SQL. The check loop reads every todo on each tick,
+// so it uses the batch variant and pays one query for the whole set. The
+// snooze lister uses the unfiltered per-todo list, because its own state
+// query already filters on the current action.
 type TodoAlarmLister interface {
 	ListAlarms(ctx context.Context, todoID int64) ([]model.Alarm, error)
 	ListAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error)
-	ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error)
+	ListFireableAlarmsByTodoIDs(ctx context.Context, todoIDs []int64) (map[int64][]model.Alarm, error)
 }
 
 // TodoService handles alarm operations for todos
@@ -72,6 +73,21 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 	// (possibly rescheduled) time with its own alarm definition.
 	overrideKeys := buildOverrideSuppressionKeys(rows)
 
+	// Read the alarms of every open todo in one query. A read per todo
+	// costs one query per todo on each tick (issue #586).
+	openIDs := make([]int64, 0, len(rows))
+	for _, row := range rows {
+		t := todoFromRow(row)
+		if t.Status == "COMPLETED" || t.Status == "CANCELLED" {
+			continue
+		}
+		openIDs = append(openIDs, t.ID)
+	}
+	alarmMap, err := s.todos.ListFireableAlarmsByTodoIDs(ctx, openIDs)
+	if err != nil {
+		return nil, fmt.Errorf("list todo alarms: %w", err)
+	}
+
 	var due []TodoDueAlarm
 
 	for _, row := range rows {
@@ -82,8 +98,8 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 			continue
 		}
 
-		alarms, err := s.todos.ListFireableAlarmsLean(ctx, t.ID)
-		if err != nil || len(alarms) == 0 {
+		alarms := alarmMap[t.ID]
+		if len(alarms) == 0 {
 			continue
 		}
 

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -24,24 +24,26 @@ func (m *mockTodoAlarmLister) ListAlarmsLean(ctx context.Context, todoID int64) 
 	return m.ListAlarms(ctx, todoID)
 }
 
-func (m *mockTodoAlarmLister) ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error) {
-	alarms, err := m.ListAlarmsLean(ctx, todoID)
-	if err != nil {
-		return nil, err
-	}
-	return filterFireable(alarms), nil
+func (m *mockTodoAlarmLister) ListFireableAlarmsByTodoIDs(ctx context.Context, todoIDs []int64) (map[int64][]model.Alarm, error) {
+	return batchFireable(ctx, m.ListAlarmsLean, todoIDs)
 }
 
-// filterFireable keeps the alarms the engine can fire. Both lister mocks
-// in this package share it, so the two cannot drift.
-func filterFireable(alarms []model.Alarm) []model.Alarm {
-	kept := make([]model.Alarm, 0, len(alarms))
-	for _, a := range alarms {
-		if model.FireableAlarmAction(a.Action) {
-			kept = append(kept, a)
+// batchFireable builds the fireable alarm map the check loop reads. Both
+// lister mocks in this package share it, so the two cannot drift.
+func batchFireable(ctx context.Context, lean func(context.Context, int64) ([]model.Alarm, error), todoIDs []int64) (map[int64][]model.Alarm, error) {
+	out := make(map[int64][]model.Alarm, len(todoIDs))
+	for _, id := range todoIDs {
+		alarms, err := lean(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		for _, a := range alarms {
+			if model.FireableAlarmAction(a.Action) {
+				out[id] = append(out[id], a)
+			}
 		}
 	}
-	return kept
+	return out, nil
 }
 
 // TestComputeTodoTrigger_RelatedEnd_DtStartPlusDue guards issue #367: a VTODO

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -914,11 +914,14 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 		})
 	}
 
-	// X-* extension properties — preserved for round-trip fidelity only.
+	// Every property parseAlarm does not read — preserved for round-trip
+	// fidelity only. The set covers an X- extension and an IANA property
+	// alike, for example the RFC 9074 PROXIMITY. A drop would rewrite the
+	// VALARM of another client without it on the next push (issue #586).
 	// Normalize to a non-nil slice: for ReplaceAlarms, non-nil means "this
 	// is the complete X-prop set" (empty = remote cleared them), while nil
 	// means "caller has no X-prop knowledge, keep stored rows".
-	alarm.XProperties = extractXPropertiesWithSet(comp.Props, nil)
+	alarm.XProperties = extractXPropertiesWithSet(comp.Props, handledAlarmProps)
 	if alarm.XProperties == nil {
 		alarm.XProperties = []model.XProperty{}
 	}
@@ -1407,6 +1410,16 @@ func journalFromVJournal(comp *ical.Component) (journal.Journal, []string, error
 		XProperties:    extractXPropertiesWithSet(props, handledJournalProps),
 		Relations:      relations,
 	}, journalWarnings, nil
+}
+
+// handledAlarmProps is the set of property names parseAlarm reads into
+// the alarm model. parseAlarm preserves every other property, so a
+// foreign VALARM round-trips whole (issue #586).
+var handledAlarmProps = map[string]bool{
+	ical.PropAction: true, ical.PropTrigger: true, ical.PropDescription: true,
+	ical.PropSummary: true, "REPEAT": true, ical.PropDuration: true,
+	ical.PropUID: true, "ACKNOWLEDGED": true, ical.PropAttach: true,
+	ical.PropAttendee: true,
 }
 
 // handledEventProps is the set of property names explicitly parsed by eventFromVEvent.

--- a/internal/ical/roundtrip_test.go
+++ b/internal/ical/roundtrip_test.go
@@ -2543,3 +2543,56 @@ func TestRoundtrip_FireableAlarmRepeatStillClamps(t *testing.T) {
 		t.Errorf("export lacks %q; output:\n%s", want, string(data))
 	}
 }
+
+// A VALARM property the parser does not read must survive the round trip.
+// The parser used to keep only an X- property, so an IANA property such as
+// the RFC 9074 PROXIMITY was lost, and the next push rewrote the VALARM of
+// another client without it (issue #586, item f).
+func TestRoundtrip_UnhandledAlarmPropertiesSurvive(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:iana-alarm-props@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:Event with an IANA alarm property\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:DISPLAY\r\n" +
+		"TRIGGER:-PT15M\r\n" +
+		"DESCRIPTION:Reminder\r\n" +
+		"PROXIMITY:DEPART\r\n" +
+		"X-VENDOR-FLAG:keep-me\r\n" +
+		"END:VALARM\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Alarms) != 1 {
+		t.Fatalf("events/alarms = %d/%+v, want 1 event with 1 alarm", len(result.Events), result.Events)
+	}
+
+	data, err := ExportEvents(result.Events, "")
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	out := string(data)
+	for _, want := range []string{"PROXIMITY:DEPART", "X-VENDOR-FLAG:keep-me"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("export lacks %q; output:\n%s", want, out)
+		}
+	}
+	// The parser still reads the properties it owns, so they must not
+	// also appear a second time as preserved properties.
+	if n := strings.Count(out, "DESCRIPTION:Reminder"); n != 1 {
+		t.Errorf("DESCRIPTION appears %d times, want 1", n)
+	}
+	if n := strings.Count(out, "TRIGGER"); n != 1 {
+		t.Errorf("TRIGGER appears %d times, want 1", n)
+	}
+}

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -295,16 +295,35 @@ func normalizeAlarmRepeatPairs(conn *sql.DB) error {
 
 // backfillAlarmUIDs assigns random UUIDs to alarms that have empty UIDs.
 // This runs once after upgrade from pre-UID schema.
+//
+// An alarm the engine cannot fire keeps its empty UID. Import preserves
+// such an alarm from another client (issue #579), and a local UID would
+// travel back to the server on the next push. Some servers and clients
+// read a new UID as a different alarm. The row still matches on its
+// content during a pull, and it holds no alarm state, because it never
+// fires (issue #586).
 func backfillAlarmUIDs(conn *sql.DB, q *Queries) error {
 	ctx := context.Background()
 
-	alarms, err := q.ListAlarmsWithEmptyUID(ctx)
+	storedAlarms, err := q.ListAlarmsWithEmptyUID(ctx)
 	if err != nil {
 		return fmt.Errorf("list alarms with empty uid: %w", err)
 	}
-	todoAlarms, err := q.ListTodoAlarmsWithEmptyUID(ctx)
+	storedTodoAlarms, err := q.ListTodoAlarmsWithEmptyUID(ctx)
 	if err != nil {
 		return fmt.Errorf("list todo alarms with empty uid: %w", err)
+	}
+	var alarms []EventAlarm
+	for _, a := range storedAlarms {
+		if model.FireableAlarmAction(a.Action) {
+			alarms = append(alarms, a)
+		}
+	}
+	var todoAlarms []TodoAlarm
+	for _, a := range storedTodoAlarms {
+		if model.FireableAlarmAction(a.Action) {
+			todoAlarms = append(todoAlarms, a)
+		}
 	}
 	if len(alarms) == 0 && len(todoAlarms) == 0 {
 		return nil

--- a/internal/storage/connect_test.go
+++ b/internal/storage/connect_test.go
@@ -460,3 +460,78 @@ func TestHealSpanColumns(t *testing.T) {
 		}
 	}
 }
+
+// A preserved alarm from another client keeps its empty UID. The backfill
+// mints a UID only for an alarm the engine can fire. A UID on a foreign
+// VALARM travels to the server on the next push, and some clients read it
+// as a different alarm (issue #586, item c).
+func TestBackfillAlarmUIDs_SkipsSyncOnlyActions(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open error: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	res, err := db.ExecContext(ctx,
+		`INSERT INTO events (uid, calendar_id, title, start_time, end_time, all_day, status, transp, sequence, priority)
+		 VALUES ('uid-backfill-586', 1, 'Test', '2026-04-01T10:00:00Z', '2026-04-01T11:00:00Z', 0, 'CONFIRMED', 'OPAQUE', 0, 0)`)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	eventID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId: %v", err)
+	}
+	res, err = db.ExecContext(ctx,
+		`INSERT INTO todos (uid, calendar_id, summary) VALUES ('todo-backfill-586', 1, 'Test')`)
+	if err != nil {
+		t.Fatalf("insert todo: %v", err)
+	}
+	todoID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId: %v", err)
+	}
+
+	// Seed one fireable alarm and one preserved foreign alarm per domain.
+	// Both carry the empty UID of the pre-UID schema.
+	seeds := []struct {
+		table  string
+		column string
+		id     int64
+		action string
+	}{
+		{"event_alarms", "event_id", eventID, "DISPLAY"},
+		{"event_alarms", "event_id", eventID, "X-APPLE-SOUND"},
+		{"todo_alarms", "todo_id", todoID, "DISPLAY"},
+		{"todo_alarms", "todo_id", todoID, "NONE"},
+	}
+	for _, s := range seeds {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO `+s.table+` (`+s.column+`, action, trigger_value, uid) VALUES (?, ?, '-PT15M', NULL)`,
+			s.id, s.action); err != nil {
+			t.Fatalf("insert %s %s: %v", s.table, s.action, err)
+		}
+	}
+
+	if err := backfillAlarmUIDs(db, q); err != nil {
+		t.Fatalf("backfillAlarmUIDs error: %v", err)
+	}
+
+	for _, s := range seeds {
+		var uid string
+		if err := db.QueryRowContext(ctx,
+			`SELECT COALESCE(uid, '') FROM `+s.table+` WHERE action = ?`, s.action).Scan(&uid); err != nil {
+			t.Fatalf("read %s %s: %v", s.table, s.action, err)
+		}
+		if model.FireableAlarmAction(s.action) {
+			if uid == "" {
+				t.Errorf("%s %s: uid is empty, want a minted UID", s.table, s.action)
+			}
+			continue
+		}
+		if uid != "" {
+			t.Errorf("%s %s: uid = %q, want it to stay empty", s.table, s.action, uid)
+		}
+	}
+}

--- a/internal/storage/todo_alarms.sql.go
+++ b/internal/storage/todo_alarms.sql.go
@@ -7,6 +7,7 @@ package storage
 
 import (
 	"context"
+	"strings"
 )
 
 const createTodoAlarm = `-- name: CreateTodoAlarm :one
@@ -127,6 +128,65 @@ ORDER BY id
 // sync-only action must not reach it.
 func (q *Queries) ListFireableTodoAlarmsByTodoID(ctx context.Context, todoID int64) ([]TodoAlarm, error) {
 	rows, err := q.db.QueryContext(ctx, listFireableTodoAlarmsByTodoID, todoID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []TodoAlarm
+	for rows.Next() {
+		var i TodoAlarm
+		if err := rows.Scan(
+			&i.ID,
+			&i.TodoID,
+			&i.Action,
+			&i.TriggerValue,
+			&i.Description,
+			&i.Repeat,
+			&i.Duration,
+			&i.Related,
+			&i.Summary,
+			&i.Uid,
+			&i.Acknowledged,
+			&i.AttachUri,
+			&i.AttachFmttype,
+			&i.AttachBinary,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listFireableTodoAlarmsByTodoIDs = `-- name: ListFireableTodoAlarmsByTodoIDs :many
+SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM todo_alarms
+WHERE todo_id IN (/*SLICE:todo_ids*/?)
+  AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
+ORDER BY id
+`
+
+// The action list mirrors model.FireableAlarmAction. Keep the two in
+// lockstep. The alarm check loop is the only caller, and a preserved
+// sync-only action must not reach it. The loop reads every todo on each
+// tick, so it fetches the whole set in one query.
+func (q *Queries) ListFireableTodoAlarmsByTodoIDs(ctx context.Context, todoIds []int64) ([]TodoAlarm, error) {
+	query := listFireableTodoAlarmsByTodoIDs
+	var queryParams []interface{}
+	if len(todoIds) > 0 {
+		for _, v := range todoIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:todo_ids*/?", strings.Repeat(",?", len(todoIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:todo_ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -816,6 +816,35 @@ func (s *Service) ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]m
 	return s.listAlarms(ctx, todoID, false, true)
 }
 
+// ListFireableAlarmsByTodoIDs fetches the fireable alarms for many todo
+// IDs in one query. It returns a map of the todo ID to its alarms. The
+// alarm check loop reads every todo on each tick, so a call per todo
+// costs one query per todo (issue #586). The query excludes a preserved
+// sync-only action, like ListFireableAlarmsLean.
+func (s *Service) ListFireableAlarmsByTodoIDs(ctx context.Context, todoIDs []int64) (map[int64][]model.Alarm, error) {
+	if len(todoIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := s.q.ListFireableTodoAlarmsByTodoIDs(ctx, todoIDs)
+	if err != nil {
+		return nil, err
+	}
+	alarms, err := s.buildAlarms(ctx, rows, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(alarms) == 0 {
+		return nil, nil
+	}
+	// fromStorageTodoAlarm maps the todo ID onto the EventID field of the
+	// shared alarm model, like the event service does with its own ID.
+	alarmMap := make(map[int64][]model.Alarm, len(todoIDs))
+	for _, a := range alarms {
+		alarmMap[a.EventID] = append(alarmMap[a.EventID], a)
+	}
+	return alarmMap, nil
+}
+
 func (s *Service) listAlarms(ctx context.Context, todoID int64, withXProps, fireableOnly bool) ([]model.Alarm, error) {
 	var rows []storage.TodoAlarm
 	var err error
@@ -827,6 +856,13 @@ func (s *Service) listAlarms(ctx context.Context, todoID int64, withXProps, fire
 	if err != nil {
 		return nil, err
 	}
+	return s.buildAlarms(ctx, rows, withXProps)
+}
+
+// buildAlarms turns todo_alarms rows into the shared alarm model. It
+// attaches the attendees, and the X-properties when the caller asks for
+// them. The per-todo read and the batch read share it.
+func (s *Service) buildAlarms(ctx context.Context, rows []storage.TodoAlarm, withXProps bool) ([]model.Alarm, error) {
 	if len(rows) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
Closes the remaining follow-ups of #586. Items (a) and (b) landed with PR #584; item (d) stays a documented accepted risk.

## (c) The UID backfill no longer stamps a foreign VALARM

`backfillAlarmUIDs` minted a UUID for every alarm row with an empty UID. A VALARM from another client arrives without one, so the next push wrote a UID that client never authored — and some servers and clients read a new UID as a different alarm. That mutated the very VALARM the preservation feature promises to round-trip.

The backfill now mints a UID only for an alarm the engine can fire, filtered in Go with `model.FireableAlarmAction`. I filtered in Go rather than in SQL on purpose: the fireable set already appears in four SQL `IN` lists, and earlier reviews flagged each copy as a drift risk.

**Checked, as asked:** nothing downstream needs every alarm to carry a UID. `matchAlarmByUID` returns false when either side is empty and the caller falls back to the content match, and `buildValarm` emits `UID` only when it holds a value. A preserved alarm also holds no `alarm_state`, because it never fires.

## (e) The todo alarm check reads one batch, not one query per todo

`CheckTodos` and `CheckMissed` each called `ListFireableAlarmsLean` once per todo. With 200 todos that is about 400 single-row queries on every 30-second tick. A new `ListFireableTodoAlarmsByTodoIDs` (sqlc.slice) reads the whole set in one query and both loops build the map once, mirroring the event side's `ListFireableAlarmsByEventIDs`.

The per-todo `ListFireableAlarmsLean` had no other caller, so it is gone from the `TodoAlarmLister` interface and from both test mocks, which now share one `batchFireable` helper.

`TestCheckTodos_BatchesAlarmFetch` counts the todo-alarm queries the driver runs, following the `internal/recurrence` counting-driver precedent. It asserts one query per check. I verified it fails (6 queries for 5 todos) against a simulated per-todo loop.

## (f) A property the parser does not read now survives

`parseAlarm` passed `nil` as the handled-property set, so `extractXPropertiesWithSet` kept only `X-` properties. An IANA-registered property such as the RFC 9074 `PROXIMITY` was dropped, and the next push rewrote the other client's alarm without it.

No schema work was needed: `x_properties` already accepts the `event_alarm` and `todo_alarm` owner types (migration 031) and its `name` column is unconstrained text, and `emitXProperties` already documents itself as writing "X-properties (and other unhandled properties)". The fix defines `handledAlarmProps` (the ten properties `parseAlarm` reads) and passes it, which is the same mechanism the event, todo, and journal parsers already use.

`TestRoundtrip_UnhandledAlarmPropertiesSurvive` pins `PROXIMITY` and an `X-` property through import and export, and asserts the handled properties are not emitted twice. I verified it fails without the fix.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, and the full `go test ./...` are green. `make generate` produced the sqlc output with the pinned v1.30.0.