### PR TITLE
fix(attendee): clamp the constrained parameters, guard the write

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -507,9 +507,13 @@ func (s *Service) UpdateWithRelations(ctx context.Context, id int64, p UpdatePar
 	if err := s.ensureEventWritable(ctx, id, p.CalendarID); err != nil {
 		return Event{}, err
 	}
-	// Reject a bad alarm before the transaction opens. See
-	// model.PrepareAlarmsForWrite.
-	alarms, err := model.PrepareAlarmsForWrite(alarms)
+	// Reject a bad attendee or alarm before the transaction opens. See
+	// model.PrepareAttendeesForWrite and model.PrepareAlarmsForWrite.
+	attendees, err := model.PrepareAttendeesForWrite(model.EventAttendee, attendees)
+	if err != nil {
+		return Event{}, err
+	}
+	alarms, err = model.PrepareAlarmsForWrite(alarms)
 	if err != nil {
 		return Event{}, err
 	}
@@ -1004,9 +1008,13 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 func (s *Service) UpdateInstanceWithRelations(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
 	p.applyDefaults()
 
-	// Reject a bad alarm before the transaction opens. See
-	// model.PrepareAlarmsForWrite.
-	alarms, err := model.PrepareAlarmsForWrite(alarms)
+	// Reject a bad attendee or alarm before the transaction opens. See
+	// model.PrepareAttendeesForWrite and model.PrepareAlarmsForWrite.
+	attendees, err := model.PrepareAttendeesForWrite(model.EventAttendee, attendees)
+	if err != nil {
+		return Event{}, err
+	}
+	alarms, err = model.PrepareAlarmsForWrite(alarms)
 	if err != nil {
 		return Event{}, err
 	}
@@ -1214,9 +1222,13 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 func (s *Service) UpdateFromInstanceWithRelations(ctx context.Context, uid string, instanceTime time.Time, p UpdateParams, attendees []model.Attendee, alarms []model.Alarm) (Event, error) {
 	p.applyDefaults()
 
-	// Reject a bad alarm before the transaction opens. See
-	// model.PrepareAlarmsForWrite.
-	alarms, err := model.PrepareAlarmsForWrite(alarms)
+	// Reject a bad attendee or alarm before the transaction opens. See
+	// model.PrepareAttendeesForWrite and model.PrepareAlarmsForWrite.
+	attendees, err := model.PrepareAttendeesForWrite(model.EventAttendee, attendees)
+	if err != nil {
+		return Event{}, err
+	}
+	alarms, err = model.PrepareAlarmsForWrite(alarms)
 	if err != nil {
 		return Event{}, err
 	}
@@ -1817,6 +1829,13 @@ func (s *Service) ReplaceAttendees(ctx context.Context, eventID int64, attendees
 // example the TUI RSVP flow) must route through ReplaceAttendees so the
 // policy is enforced.
 func (s *Service) ReplaceAttendeesForSync(ctx context.Context, eventID int64, attendees []model.Attendee) error {
+	// Prepare before the transaction opens. A standalone call then
+	// rejects a bad attendee without a write lock. See
+	// model.PrepareAttendeesForWrite.
+	attendees, err := model.PrepareAttendeesForWrite(model.EventAttendee, attendees)
+	if err != nil {
+		return err
+	}
 	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
 		return err

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -339,7 +339,11 @@ func todoFromVTodo(comp *ical.Component) (todo.Todo, []string, error) {
 	}
 
 	// ATTENDEE + ORGANIZER
-	attendees := parseAttendeesFromProps(props)
+	attendees, attendeeWarnings := parseAttendeesFromProps(props, model.TaskAttendee)
+	for _, w := range attendeeWarnings {
+		// Name the owning record: the clamp leaves no other trace.
+		todoWarnings = append(todoWarnings, fmt.Sprintf("todo %q: %s", uid, w))
+	}
 
 	// ATTACH, COMMENT, CONTACT, RELATED-TO
 	attachments, err := parseAttachmentsFromProps(props)
@@ -605,7 +609,11 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 	}
 
 	// ATTENDEE + ORGANIZER
-	attendees := parseAttendees(ve)
+	attendees, attendeeWarnings := parseAttendees(ve)
+	for _, w := range attendeeWarnings {
+		// Name the owning record: the clamp leaves no other trace.
+		alarmWarnings = append(alarmWarnings, fmt.Sprintf("event %q: %s", uid, w))
+	}
 
 	// ATTACH, COMMENT, RELATED-TO
 	attachments, err := parseAttachmentsFromProps(ve.Props)
@@ -936,8 +944,11 @@ func parseAlarm(comp *ical.Component) (model.Alarm, string) {
 	return alarm, strings.Join(warns, "; ")
 }
 
-func parseAttendees(ve ical.Event) []model.Attendee {
+// parseAttendees reads the attendees of a VEVENT. The second return
+// value lists the parameters attendeeFromProp clamped.
+func parseAttendees(ve ical.Event) ([]model.Attendee, []string) {
 	var attendees []model.Attendee
+	var warns []string
 
 	// ORGANIZER — track email so we can deduplicate against ATTENDEE below.
 	var organizerEmail string
@@ -961,11 +972,12 @@ func parseAttendees(ve ical.Event) []model.Attendee {
 		if organizerEmail != "" && strings.EqualFold(email, organizerEmail) {
 			continue
 		}
-		a := attendeeFromProp(&prop)
+		a, w := attendeeFromProp(&prop, model.EventAttendee)
+		warns = append(warns, w...)
 		attendees = append(attendees, a)
 	}
 
-	return attendees
+	return attendees, warns
 }
 
 func stripMailto(s string) string {
@@ -1115,8 +1127,12 @@ func parseDateListFromProps(props ical.Props, propName string, fallback *time.Lo
 	return strings.Join(dates, ",")
 }
 
-func parseAttendeesFromProps(props ical.Props) []model.Attendee {
+// parseAttendeesFromProps reads the attendees of a VTODO or a VJOURNAL.
+// Those two tables accept the wider PARTSTAT set, so the caller passes
+// model.TaskAttendee. The second return value lists the clamps.
+func parseAttendeesFromProps(props ical.Props, kind model.AttendeeKind) ([]model.Attendee, []string) {
 	var attendees []model.Attendee
+	var warns []string
 
 	var organizerEmail string
 	if prop := props.Get(ical.PropOrganizer); prop != nil {
@@ -1138,22 +1154,46 @@ func parseAttendeesFromProps(props ical.Props) []model.Attendee {
 		if organizerEmail != "" && strings.EqualFold(email, organizerEmail) {
 			continue
 		}
-		a := attendeeFromProp(&prop)
+		a, w := attendeeFromProp(&prop, kind)
+		warns = append(warns, w...)
 		attendees = append(attendees, a)
 	}
 
-	return attendees
+	return attendees, warns
 }
 
 // attendeeFromProp extracts a model.Attendee from an iCal ATTENDEE property.
 // All RFC 5545 parameters are included.
-func attendeeFromProp(prop *ical.Prop) model.Attendee {
+// attendeeFromProp builds one attendee and clamps the three parameters
+// the attendee tables constrain. RFC 5545 permits an x-name or an
+// iana-token for PARTSTAT (§3.2.12), ROLE (§3.2.16), and CUTYPE
+// (§3.2.3), but each column carries a CHECK constraint. A stored
+// out-of-set value would fail the insert inside the sync transaction and
+// roll back the whole resource on every pass (issue #587). The second
+// return value lists the clamps, so the caller reports them.
+func attendeeFromProp(prop *ical.Prop, kind model.AttendeeKind) (model.Attendee, []string) {
+	var warns []string
+	partstat := clampAttendeeParam(&warns, "PARTSTAT",
+		strings.ToUpper(paramOrDefault(prop, ical.ParamParticipationStatus, model.DefaultRSVPStatus)),
+		model.DefaultRSVPStatus,
+		func(v string) bool { return model.ValidRSVPStatus(kind, v) })
+	role := clampAttendeeParam(&warns, "ROLE",
+		strings.ToUpper(paramOrDefault(prop, ical.ParamRole, model.DefaultAttendeeRole)),
+		model.DefaultAttendeeRole,
+		model.ValidAttendeeRole)
+	// RFC 5545 §3.2.3 tells a reader to treat a CUTYPE it does not know
+	// the same way as UNKNOWN, so the clamp keeps that meaning.
+	cutype := clampAttendeeParam(&warns, "CUTYPE",
+		strings.ToUpper(paramOrDefault(prop, ical.ParamCalendarUserType, "INDIVIDUAL")),
+		model.UnknownCUType,
+		model.ValidAttendeeCUType)
+
 	return model.Attendee{
 		Email:         stripMailto(prop.Value),
 		Name:          prop.Params.Get(ical.ParamCommonName),
-		RSVPStatus:    strings.ToUpper(paramOrDefault(prop, ical.ParamParticipationStatus, "NEEDS-ACTION")),
-		Role:          strings.ToUpper(paramOrDefault(prop, ical.ParamRole, "REQ-PARTICIPANT")),
-		CUType:        strings.ToUpper(paramOrDefault(prop, ical.ParamCalendarUserType, "INDIVIDUAL")),
+		RSVPStatus:    partstat,
+		Role:          role,
+		CUType:        cutype,
 		RSVPRequested: strings.EqualFold(prop.Params.Get(ical.ParamRSVP), "TRUE"),
 		SentBy:        stripMailto(prop.Params.Get(ical.ParamSentBy)),
 		DelegatedTo:   joinMailtoParams(prop.Params.Values(ical.ParamDelegatedTo)),
@@ -1161,7 +1201,17 @@ func attendeeFromProp(prop *ical.Prop) model.Attendee {
 		Member:        joinMailtoParams(prop.Params.Values(ical.ParamMember)),
 		Dir:           prop.Params.Get(ical.ParamDir),
 		Language:      prop.Params.Get(ical.ParamLanguage),
+	}, warns
+}
+
+// clampAttendeeParam returns value when valid reports it. Otherwise it
+// records a warning and returns fallback.
+func clampAttendeeParam(warns *[]string, param, value, fallback string, valid func(string) bool) string {
+	if valid(value) {
+		return value
 	}
+	*warns = append(*warns, fmt.Sprintf("ATTENDEE %s=%q: unsupported value, using %s", param, value, fallback))
+	return fallback
 }
 
 // joinMailtoParams joins multiple mailto URI param values into a comma-separated
@@ -1372,7 +1422,11 @@ func journalFromVJournal(comp *ical.Component) (journal.Journal, []string, error
 	}
 
 	// ATTENDEE + ORGANIZER
-	attendees := parseAttendeesFromProps(props)
+	attendees, attendeeWarnings := parseAttendeesFromProps(props, model.TaskAttendee)
+	for _, w := range attendeeWarnings {
+		// Name the owning record: the clamp leaves no other trace.
+		journalWarnings = append(journalWarnings, fmt.Sprintf("journal %q: %s", uid, w))
+	}
 
 	// ATTACH, COMMENT, CONTACT, RELATED-TO
 	attachments, err := parseAttachmentsFromProps(props)

--- a/internal/ical/import_warnings_test.go
+++ b/internal/ical/import_warnings_test.go
@@ -317,3 +317,87 @@ func TestImport_MalformedActionToken_DropsAlarm(t *testing.T) {
 		t.Errorf("no malformed-ACTION warning; warnings = %v", result.Warnings)
 	}
 }
+
+// RFC 5545 permits an x-name or an iana-token for PARTSTAT, ROLE, and
+// CUTYPE, but each attendee column carries a CHECK constraint. Before
+// the clamp, a server-sent x-name value failed the insert inside the
+// sync transaction and rolled back the whole resource on every pass
+// (issue #587). The parser now clamps the value and warns.
+func TestImport_UnsupportedAttendeeParams_ClampWithWarning(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:x-name-partstat@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:Event with foreign attendee params\r\n" +
+		"ATTENDEE;PARTSTAT=X-FOO;ROLE=X-BAR;CUTYPE=X-CUSTOM:mailto:a@example.com\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Attendees) != 1 {
+		t.Fatalf("events/attendees = %d/%+v, want 1 event with 1 attendee", len(result.Events), result.Events)
+	}
+	a := result.Events[0].Attendees[0]
+	if a.RSVPStatus != model.DefaultRSVPStatus {
+		t.Errorf("RSVPStatus = %q, want the %s default", a.RSVPStatus, model.DefaultRSVPStatus)
+	}
+	if a.Role != model.DefaultAttendeeRole {
+		t.Errorf("Role = %q, want the %s default", a.Role, model.DefaultAttendeeRole)
+	}
+	if a.CUType != model.UnknownCUType {
+		t.Errorf("CUType = %q, want %s", a.CUType, model.UnknownCUType)
+	}
+
+	// The clamped values must pass the write rule, so the resource
+	// persists instead of failing the pull.
+	if _, err := model.PrepareAttendeesForWrite(model.EventAttendee, result.Events[0].Attendees); err != nil {
+		t.Fatalf("the clamped attendee must pass the write rule: %v", err)
+	}
+
+	for _, want := range []string{"PARTSTAT", "ROLE", "CUTYPE"} {
+		if !warningMentions(result.Warnings, `event "x-name-partstat@example.com"`, want) {
+			t.Errorf("no %s clamp warning that names the event; warnings = %v", want, result.Warnings)
+		}
+	}
+}
+
+// A VTODO accepts COMPLETED and IN-PROCESS on PARTSTAT, because its
+// table carries the wider CHECK constraint. The clamp must not degrade
+// those two values to the default.
+func TestImport_TaskPartStat_KeepsCompleted(t *testing.T) {
+	t.Parallel()
+	const ics = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"PRODID:-//test//EN\r\n" +
+		"BEGIN:VTODO\r\n" +
+		"UID:task-partstat@example.com\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"SUMMARY:Todo with a task PARTSTAT\r\n" +
+		"ATTENDEE;PARTSTAT=COMPLETED:mailto:a@example.com\r\n" +
+		"END:VTODO\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Todos) != 1 || len(result.Todos[0].Attendees) != 1 {
+		t.Fatalf("todos/attendees = %d/%+v, want 1 todo with 1 attendee", len(result.Todos), result.Todos)
+	}
+	if got := result.Todos[0].Attendees[0].RSVPStatus; got != "COMPLETED" {
+		t.Errorf("RSVPStatus = %q, want COMPLETED", got)
+	}
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "PARTSTAT") {
+			t.Errorf("a valid task PARTSTAT must not warn; got %q", w)
+		}
+	}
+}

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -669,6 +669,13 @@ func (s *Service) ListAttendees(ctx context.Context, journalID int64) ([]model.A
 }
 
 func (s *Service) ReplaceAttendees(ctx context.Context, journalID int64, attendees []model.Attendee) error {
+	// Prepare before the transaction opens. A standalone call then
+	// rejects a bad attendee without a write lock. See
+	// model.PrepareAttendeesForWrite.
+	attendees, err := model.PrepareAttendeesForWrite(model.TaskAttendee, attendees)
+	if err != nil {
+		return err
+	}
 	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
 		return err

--- a/internal/model/attendee.go
+++ b/internal/model/attendee.go
@@ -1,5 +1,12 @@
 package model
 
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
 type Attendee struct {
 	ID            int64
 	EventID       int64
@@ -16,4 +23,165 @@ type Attendee struct {
 	Member        string // MEMBER: comma-separated group membership mailto URIs
 	Dir           string // DIR: directory entry URI
 	Language      string // LANGUAGE: language tag (e.g. en-US)
+}
+
+// AttendeeKind selects the PARTSTAT set one component accepts. The event
+// table and the task tables carry different CHECK constraints, so a
+// caller must name the component it writes.
+type AttendeeKind int
+
+const (
+	// EventAttendee names the PARTSTAT set of event_attendees.
+	EventAttendee AttendeeKind = iota
+	// TaskAttendee names the wider PARTSTAT set of todo_attendees and
+	// journal_attendees. Those two tables also accept COMPLETED and
+	// IN-PROCESS (RFC 5545 §3.2.12).
+	TaskAttendee
+)
+
+// The default values the attendee tables carry on the two NOT NULL
+// columns. PrepareAttendeesForWrite fills an empty field with them.
+const (
+	DefaultRSVPStatus   = "NEEDS-ACTION"
+	DefaultAttendeeRole = "REQ-PARTICIPANT"
+	// UnknownCUType is the value RFC 5545 §3.2.3 reserves for a
+	// calendar user type the reader does not know. The import parser
+	// maps an x-name or iana-token CUTYPE to it.
+	UnknownCUType = "UNKNOWN"
+)
+
+// The accepted attendee values, in a fixed order. Each slice mirrors one
+// CHECK constraint in db/migrations/003, 006, and 013. Keep every slice
+// and its constraints in lockstep. A value that passes here but fails a
+// constraint rolls back the whole resource transaction during sync
+// (issue #575). The match is case-sensitive, the same as the
+// constraints. The slices are unexported so no other package can change
+// a set at run time.
+var (
+	eventRSVPStatuses = []string{"NEEDS-ACTION", "ACCEPTED", "DECLINED", "TENTATIVE", "DELEGATED"}
+	taskRSVPStatuses  = []string{"NEEDS-ACTION", "ACCEPTED", "DECLINED", "TENTATIVE", "DELEGATED", "COMPLETED", "IN-PROCESS"}
+	attendeeRoles     = []string{"CHAIR", "REQ-PARTICIPANT", "OPT-PARTICIPANT", "NON-PARTICIPANT"}
+	attendeeCUTypes   = []string{"INDIVIDUAL", "GROUP", "RESOURCE", "ROOM", "UNKNOWN"}
+)
+
+// The joined lists render once at package load, so every error message
+// stays in lockstep with the slices.
+var (
+	eventRSVPStatusesList = strings.Join(eventRSVPStatuses, ", ")
+	taskRSVPStatusesList  = strings.Join(taskRSVPStatuses, ", ")
+	attendeeRolesList     = strings.Join(attendeeRoles, ", ")
+	attendeeCUTypesList   = strings.Join(attendeeCUTypes, ", ")
+)
+
+// RSVPStatuses returns the accepted PARTSTAT values of one component as
+// a fresh slice. A caller can keep or change the returned slice. The set
+// does not change.
+func RSVPStatuses(kind AttendeeKind) []string {
+	return slices.Clone(rsvpStatusesFor(kind))
+}
+
+// AttendeeRoles returns the accepted ROLE values as a fresh slice, like
+// RSVPStatuses.
+func AttendeeRoles() []string {
+	return slices.Clone(attendeeRoles)
+}
+
+// AttendeeCUTypes returns the accepted CUTYPE values as a fresh slice,
+// like RSVPStatuses.
+func AttendeeCUTypes() []string {
+	return slices.Clone(attendeeCUTypes)
+}
+
+// RSVPStatusesList returns the accepted PARTSTAT values of one component
+// as one joined string, for an error message or help text.
+func RSVPStatusesList(kind AttendeeKind) string {
+	if kind == TaskAttendee {
+		return taskRSVPStatusesList
+	}
+	return eventRSVPStatusesList
+}
+
+// AttendeeRolesList returns the accepted ROLE values as one joined
+// string, like RSVPStatusesList.
+func AttendeeRolesList() string {
+	return attendeeRolesList
+}
+
+// AttendeeCUTypesList returns the accepted CUTYPE values as one joined
+// string, like RSVPStatusesList.
+func AttendeeCUTypesList() string {
+	return attendeeCUTypesList
+}
+
+func rsvpStatusesFor(kind AttendeeKind) []string {
+	if kind == TaskAttendee {
+		return taskRSVPStatuses
+	}
+	return eventRSVPStatuses
+}
+
+// ValidRSVPStatus returns true if status is a PARTSTAT value the table of
+// that component accepts.
+func ValidRSVPStatus(kind AttendeeKind, status string) bool {
+	return slices.Contains(rsvpStatusesFor(kind), status)
+}
+
+// ValidAttendeeRole returns true if role is a ROLE value the attendee
+// tables accept.
+func ValidAttendeeRole(role string) bool {
+	return slices.Contains(attendeeRoles, role)
+}
+
+// ValidAttendeeCUType returns true if cutype is a CUTYPE value the
+// attendee tables accept. The column holds NULL, so an empty value
+// passes.
+func ValidAttendeeCUType(cutype string) bool {
+	return cutype == "" || slices.Contains(attendeeCUTypes, cutype)
+}
+
+// ErrInvalidAttendee marks an attendee field value the attendee tables
+// reject. PrepareAttendeesForWrite wraps it with the field and the value.
+var ErrInvalidAttendee = errors.New("invalid attendee")
+
+// PrepareAttendeesForWrite returns a prepared copy of attendees. For each
+// element it fills an empty RSVPStatus with DefaultRSVPStatus and an
+// empty Role with DefaultAttendeeRole. It then validates the three
+// fields with a CHECK constraint against the sets the tables accept. For
+// a bad value it returns an error that wraps ErrInvalidAttendee and
+// names the index, the field, and the value. The caller's slice does not
+// change.
+//
+// The event, todo, and journal services call this function before every
+// attendee write. The iCal import parser stays the first guard: it
+// clamps an out-of-set value and warns. The typed error names the cause
+// instead of a raw CHECK failure (issues #575, #587).
+func PrepareAttendeesForWrite(kind AttendeeKind, attendees []Attendee) ([]Attendee, error) {
+	prepared := slices.Clone(attendees)
+	for i := range prepared {
+		if err := prepareAttendeeForWrite(kind, &prepared[i]); err != nil {
+			return nil, fmt.Errorf("attendee %d: %w", i+1, err)
+		}
+	}
+	return prepared, nil
+}
+
+// prepareAttendeeForWrite fills the defaults and validates one attendee.
+// The CUTYPE column holds NULL, so an empty value stays empty.
+func prepareAttendeeForWrite(kind AttendeeKind, a *Attendee) error {
+	if a.RSVPStatus == "" {
+		a.RSVPStatus = DefaultRSVPStatus
+	}
+	if a.Role == "" {
+		a.Role = DefaultAttendeeRole
+	}
+	if !ValidRSVPStatus(kind, a.RSVPStatus) {
+		return fmt.Errorf("%w: partstat %q is not one of %s", ErrInvalidAttendee, a.RSVPStatus, RSVPStatusesList(kind))
+	}
+	if !ValidAttendeeRole(a.Role) {
+		return fmt.Errorf("%w: role %q is not one of %s", ErrInvalidAttendee, a.Role, attendeeRolesList)
+	}
+	if !ValidAttendeeCUType(a.CUType) {
+		return fmt.Errorf("%w: cutype %q is not one of %s", ErrInvalidAttendee, a.CUType, attendeeCUTypesList)
+	}
+	return nil
 }

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -571,3 +571,90 @@ func TestFireableAlarmQueriesMatchModelPredicate(t *testing.T) {
 	}
 	check("ListPendingTodoAlarmStates", tdStateTrigs)
 }
+
+// The attendee CHECK constraints and the model predicates must agree. A
+// value that passes the Go side but fails a constraint rolls back the
+// whole resource transaction during sync (issue #587). This test probes
+// the three attendee tables with candidate values. The schema and the
+// model predicates must give the same verdict on each one.
+//
+// The PARTSTAT set is per component on purpose. The event table refuses
+// COMPLETED and IN-PROCESS. The todo table and the journal table accept
+// them, because RFC 5545 allows those two values on a task.
+func TestAttendeeConstraintsMatchModelValidators(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("list calendars: %v", err)
+	}
+	calID := cals[0].ID
+
+	res, err := db.Exec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time, all_day, status, transp, sequence, priority)
+		 VALUES ('attendee-lockstep-event', ?, 'Test', '2026-04-01T00:00:00Z', '2026-04-01T01:00:00Z', 0, 'CONFIRMED', 'OPAQUE', 0, 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	eventID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO todos (uid, calendar_id, summary, status, priority, sequence)
+		 VALUES ('attendee-lockstep-todo', ?, 'Test', 'NEEDS-ACTION', 0, 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert todo: %v", err)
+	}
+	todoID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO journals (uid, calendar_id, summary, status, sequence)
+		 VALUES ('attendee-lockstep-journal', ?, 'Test', 'FINAL', 0)`, calID)
+	if err != nil {
+		t.Fatalf("insert journal: %v", err)
+	}
+	journalID, _ := res.LastInsertId()
+
+	// The extra candidates cover the shapes RFC 5545 allows and the
+	// constraints refuse: an x-name, the two task-only values, a
+	// lowercase near-miss, and an unknown token.
+	extra := []string{"X-FOO", "COMPLETED", "IN-PROCESS", "accepted", "BOGUS"}
+
+	tables := []struct {
+		table string
+		fk    string
+		id    int64
+		kind  model.AttendeeKind
+	}{
+		{"event_attendees", "event_id", eventID, model.EventAttendee},
+		{"todo_attendees", "todo_id", todoID, model.TaskAttendee},
+		{"journal_attendees", "journal_id", journalID, model.TaskAttendee},
+	}
+
+	for _, tc := range tables {
+		checks := []struct {
+			col    string
+			values []string
+			valid  func(string) bool
+		}{
+			{"rsvp_status", append(model.RSVPStatuses(tc.kind), extra...),
+				func(v string) bool { return model.ValidRSVPStatus(tc.kind, v) }},
+			{"role", append(model.AttendeeRoles(), extra...), model.ValidAttendeeRole},
+			{"cutype", append(model.AttendeeCUTypes(), extra...), model.ValidAttendeeCUType},
+		}
+		for _, c := range checks {
+			for _, v := range c.values {
+				_, err := db.Exec(
+					`INSERT INTO `+tc.table+` (`+tc.fk+`, email, `+c.col+`) VALUES (?, 'a@example.com', ?)`,
+					tc.id, v,
+				)
+				if got, want := err == nil, c.valid(v); got != want {
+					t.Errorf("%s %s %q: insert ok = %v, model predicate = %v (err: %v)",
+						tc.table, c.col, v, got, want, err)
+				}
+				if err != nil && !strings.Contains(err.Error(), "CHECK constraint failed") {
+					t.Errorf("%s %s %q: rejected by %v, not by the CHECK constraint", tc.table, c.col, v, err)
+				}
+			}
+		}
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -1229,6 +1229,13 @@ func (s *Service) ListAttendees(ctx context.Context, todoID int64) ([]model.Atte
 }
 
 func (s *Service) ReplaceAttendees(ctx context.Context, todoID int64, attendees []model.Attendee) error {
+	// Prepare before the transaction opens. A standalone call then
+	// rejects a bad attendee without a write lock. See
+	// model.PrepareAttendeesForWrite.
+	attendees, err := model.PrepareAttendeesForWrite(model.TaskAttendee, attendees)
+	if err != nil {
+		return err
+	}
 	qtx, commit, rollback, err := s.txscope(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Fixes #587.

RFC 5545 permits an x-name or an iana-token for `PARTSTAT` (§3.2.12), `ROLE` (§3.2.16), and `CUTYPE` (§3.2.3). Every attendee column carries a CHECK constraint that refuses those values. A server that sent `PARTSTAT=X-FOO` therefore failed the insert inside the per-resource sync transaction, rolled the whole resource back, and the resource retried on every pass — the issue #575 failure class through the attendee columns.

This applies the treatment PRs #583 and #584 established for alarms, at both layers.

## Parser clamp

`attendeeFromProp` now clamps an out-of-set value and records a warning, mirroring the unsupported `VALARM RELATED` fallback. The clamp targets:

| Parameter | Clamp target | Reason |
|---|---|---|
| `PARTSTAT` | `NEEDS-ACTION` | the column default |
| `ROLE` | `REQ-PARTICIPANT` | the column default |
| `CUTYPE` | `UNKNOWN` | RFC 5545 §3.2.3 tells a reader to treat a CUTYPE it does not know the same way as `UNKNOWN` |

Each warning names the owning record, like the alarm warnings.

## Service boundary

New `model.PrepareAttendeesForWrite(kind, attendees)` fills the two NOT NULL defaults, validates the three constrained fields, and returns an error wrapping the new `model.ErrInvalidAttendee` that names the index, the field, and the value. The sets live in sealed unexported slices with accessors and joined lists, so each set has one owner.

It is called from:

- `event.Service.ReplaceAttendeesForSync` — the single writer behind both public event entry points
- the three event `*WithRelations` methods, which reach `replaceAttendeesTx` directly
- `todo.Service.ReplaceAttendees` and `journal.Service.ReplaceAttendees`

## The PARTSTAT set is per component

This is the one place the design is not uniform, and it is deliberate. The three tables do not agree:

- `event_attendees` refuses `COMPLETED` and `IN-PROCESS`
- `todo_attendees` and `journal_attendees` accept them

`model.AttendeeKind` (`EventAttendee` / `TaskAttendee`) selects the set, so the clamp does not degrade a valid task value. A single shared set would have silently rewritten a legitimate `PARTSTAT=COMPLETED` on a todo.

## Tests

- `TestAttendeeConstraintsMatchModelValidators` pins the model sets to the CHECK constraints of all three tables, deriving candidates from the model, in the same shape as the alarm lockstep test.
- `TestImport_UnsupportedAttendeeParams_ClampWithWarning` proves a server-sent x-name `PARTSTAT`/`ROLE`/`CUTYPE` imports clamped with warnings, and that the result passes the write rule instead of failing the resource.
- `TestImport_TaskPartStat_KeepsCompleted` proves a valid task `PARTSTAT=COMPLETED` survives with no warning.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, and the full `go test ./...` are green. No migration, and no generated file was edited.
