### PR TITLE
fix(alarm): keep a foreign UID empty, guard the exported action

### DIFF
--- a/db/queries/todo_alarms.sql
+++ b/db/queries/todo_alarms.sql
@@ -5,15 +5,6 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 -- name: ListTodoAlarmsByTodoID :many
 SELECT * FROM todo_alarms WHERE todo_id = ? ORDER BY id;
 
--- name: ListFireableTodoAlarmsByTodoID :many
--- The action list mirrors model.FireableAlarmAction. Keep the two in
--- lockstep. The alarm check loop is the only caller, and a preserved
--- sync-only action must not reach it.
-SELECT * FROM todo_alarms
-WHERE todo_id = ?
-  AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
-ORDER BY id;
-
 -- name: ListFireableTodoAlarmsByTodoIDs :many
 -- The action list mirrors model.FireableAlarmAction. Keep the two in
 -- lockstep. The alarm check loop is the only caller, and a preserved

--- a/internal/alarm/querycount_test.go
+++ b/internal/alarm/querycount_test.go
@@ -5,16 +5,13 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"io/fs"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/pressly/goose/v3"
 	sqlitedrv "modernc.org/sqlite"
 
-	dbembed "github.com/douglasdemoura/chroncal/db"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/storage"
@@ -80,11 +77,9 @@ func newCountingDB(t *testing.T) (*sql.DB, *storage.Queries, *int64) {
 	conn.SetMaxOpenConns(1)
 	t.Cleanup(func() { conn.Close() })
 
-	migrationsFS, err := fs.Sub(dbembed.Migrations, "migrations")
-	if err != nil {
-		t.Fatalf("sub migrations: %v", err)
-	}
-	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS)
+	// Build through the production constructor, so the test database runs
+	// every Go migration too and cannot drift from the real schema.
+	provider, err := storage.NewMigrationProvider(conn)
 	if err != nil {
 		t.Fatalf("goose provider: %v", err)
 	}

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -178,11 +178,10 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 		// does (issue #586).
 		openIDs := make([]int64, 0, len(rows))
 		for _, row := range rows {
-			td := todoFromRow(row)
-			if td.Status == "COMPLETED" || td.Status == "CANCELLED" {
+			if !todoIsOpen(row) {
 				continue
 			}
-			openIDs = append(openIDs, td.ID)
+			openIDs = append(openIDs, row.ID)
 		}
 		todoAlarmMap, err := s.todos.ListFireableAlarmsByTodoIDs(ctx, openIDs)
 		if err != nil {
@@ -190,10 +189,10 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 		}
 
 		for _, row := range rows {
-			td := todoFromRow(row)
-			if td.Status == "COMPLETED" || td.Status == "CANCELLED" {
+			if !todoIsOpen(row) {
 				continue
 			}
+			td := todoFromRow(row)
 
 			alarms := todoAlarmMap[td.ID]
 			if len(alarms) == 0 {

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -77,11 +77,10 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 	// costs one query per todo on each tick (issue #586).
 	openIDs := make([]int64, 0, len(rows))
 	for _, row := range rows {
-		t := todoFromRow(row)
-		if t.Status == "COMPLETED" || t.Status == "CANCELLED" {
+		if !todoIsOpen(row) {
 			continue
 		}
-		openIDs = append(openIDs, t.ID)
+		openIDs = append(openIDs, row.ID)
 	}
 	alarmMap, err := s.todos.ListFireableAlarmsByTodoIDs(ctx, openIDs)
 	if err != nil {
@@ -93,8 +92,8 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 	for _, row := range rows {
 		t := todoFromRow(row)
 
-		// Skip completed/cancelled todos
-		if t.Status == "COMPLETED" || t.Status == "CANCELLED" {
+		// Skip a completed or a cancelled todo.
+		if !todoIsOpen(row) {
 			continue
 		}
 
@@ -221,6 +220,14 @@ func buildOverrideSuppressionKeys(rows []storage.Todo) map[string]map[string]str
 }
 
 // todoFromRow converts a storage view row to a todo.Todo
+// todoIsOpen reports whether a todo can still fire an alarm. A completed
+// or a cancelled todo cannot. The batch alarm read and the loops that
+// process the rows share this test, so a new terminal status cannot reach
+// one of them alone and silently stop an alarm.
+func todoIsOpen(row storage.Todo) bool {
+	return row.Status != "COMPLETED" && row.Status != "CANCELLED"
+}
+
 func todoFromRow(row storage.Todo) todo.Todo {
 	return todo.Todo{
 		ID:              row.ID,

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1498,11 +1498,10 @@ func matchAlarm(existing []model.Alarm, matched []bool, a model.Alarm) (int, boo
 	return 0, false
 }
 
+// alarmUID returns the UID this service stores for a. See
+// model.AlarmUIDForWrite for the rule, which the todo service shares.
 func alarmUID(a model.Alarm) string {
-	if a.UID != "" {
-		return a.UID
-	}
-	return uuid.New().String()
+	return model.AlarmUIDForWrite(a)
 }
 
 // matchAlarmByUID tries to match a new alarm with stored ones by
@@ -1574,10 +1573,12 @@ func updateAlarmInPlace(ctx context.Context, qtx *storage.Queries, eventID int64
 
 // syncMatchedAlarm syncs a matched alarm's UID and ACKNOWLEDGED state.
 func syncMatchedAlarm(ctx context.Context, qtx *storage.Queries, eventID int64, a model.Alarm, ex model.Alarm) error {
-	// If existing alarm has no UID, backfill it now.
-	if ex.UID == "" {
+	// Backfill the UID of a stored row that carries none. A preserved
+	// foreign alarm keeps its empty UID, so the backfill writes nothing
+	// for it (issue #586).
+	if uid := alarmUID(a); ex.UID == "" && uid != "" {
 		if err := qtx.UpdateAlarmUID(ctx, storage.UpdateAlarmUIDParams{
-			Uid: storage.StringToNullable(alarmUID(a)),
+			Uid: storage.StringToNullable(uid),
 			ID:  ex.ID,
 		}); err != nil {
 			return fmt.Errorf("backfill alarm uid: %w", err)
@@ -1827,7 +1828,8 @@ func replaceAlarmsTx(ctx context.Context, qtx *storage.Queries, eventID int64, a
 // Queries. The *WithRelations methods can then write both child collections
 // inside the same transaction as the event row.
 func replaceRelationsTx(ctx context.Context, qtx *storage.Queries, eventID int64, attendees []model.Attendee, alarms []model.Alarm) error {
-	// The *WithRelations methods prepare the alarms at method entry.
+	// The *WithRelations methods prepare the attendees and the alarms at
+	// method entry.
 	if err := replaceAttendeesTx(ctx, qtx, eventID, attendees); err != nil {
 		return err
 	}

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -1180,3 +1180,55 @@ func TestValidateDurationValue_StorableEnd(t *testing.T) {
 		t.Errorf("a zero start must skip the storability check: %v", err)
 	}
 }
+
+// A preserved foreign alarm keeps an empty UID. A minted UID would reach
+// the server on the next push, and the client that wrote the VALARM never
+// authored that value (issue #586). The rule must hold on the first write
+// and on a later write that content-matches the stored row.
+func TestEventService_ReplaceAlarms_KeepsForeignAlarmUIDEmpty(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	e := createEvent(t, svc)
+
+	foreign := model.Alarm{Action: "X-APPLE-SOUND", TriggerValue: "-PT5M", Related: "START"}
+	fireable := model.Alarm{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"}
+
+	if err := svc.ReplaceAlarms(ctx, e.ID, []model.Alarm{foreign, fireable}); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	assertAlarmUIDs(t, svc, e.ID)
+
+	// A re-import writes the same content again. syncMatchedAlarm must not
+	// backfill a UID onto the preserved row.
+	if err := svc.ReplaceAlarms(ctx, e.ID, []model.Alarm{foreign, fireable}); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	assertAlarmUIDs(t, svc, e.ID)
+}
+
+// assertAlarmUIDs checks that the preserved alarm carries no UID and the
+// fireable alarm carries one.
+func assertAlarmUIDs(t *testing.T, svc *Service, eventID int64) {
+	t.Helper()
+	alarms, err := svc.ListAlarms(context.Background(), eventID)
+	if err != nil {
+		t.Fatalf("ListAlarms: %v", err)
+	}
+	if len(alarms) != 2 {
+		t.Fatalf("alarms = %d, want 2", len(alarms))
+	}
+	for _, a := range alarms {
+		switch a.Action {
+		case "X-APPLE-SOUND":
+			if a.UID != "" {
+				t.Errorf("preserved alarm UID = %q, want empty", a.UID)
+			}
+		case "DISPLAY":
+			if a.UID == "" {
+				t.Error("fireable alarm UID is empty, want a minted value")
+			}
+		default:
+			t.Errorf("unexpected action %q", a.Action)
+		}
+	}
+}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -764,13 +764,16 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	if alarm.UID != "" {
 		valarm.Props.SetText(ical.PropUID, alarm.UID)
 	}
-	// Normalize the action once. An empty action means DISPLAY everywhere
-	// else, and a bare "ACTION:" line is invalid iCal that a strict server
-	// rejects. The write paths default the empty value, so this arm covers
-	// an in-memory alarm that skipped them.
+	// Normalize the action once. A value that is not an RFC 5545
+	// iana-token or x-name cannot be written: a bare or malformed
+	// "ACTION:" line is invalid iCal, and a strict server rejects the
+	// whole resource for it. The write rule refuses such a value now
+	// (issue #595), so this guard covers a row an older build stored and
+	// an in-memory alarm that skipped the write paths. DISPLAY is the
+	// same fallback the parser and the write rule use for an empty value.
 	action := alarm.Action
-	if action == "" {
-		action = "DISPLAY"
+	if !model.ValidAlarmActionToken(action) {
+		action = model.DefaultAlarmAction
 	}
 	valarm.Props.SetText(ical.PropAction, action)
 

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -1552,3 +1552,29 @@ func TestExport_AllDayJournalOverrideRecurrenceIDIsDate(t *testing.T) {
 		t.Errorf("all-day journal override RECURRENCE-ID must be date-only, got %q", line)
 	}
 }
+
+// A stored row an older build wrote can hold a malformed action, because
+// the constraint refuses an empty value alone. Export must not write it:
+// a bare or malformed ACTION line is invalid iCal, and a strict server
+// rejects the whole resource for it (issue #595).
+func TestExport_MalformedStoredActionFallsBackToDisplay(t *testing.T) {
+	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	for _, action := range []string{" ", "\t", "NO NE", ""} {
+		evt := event.Event{
+			UID: "malformed-action@example.com", Title: "Test",
+			StartTime: start, EndTime: start.Add(time.Hour),
+			Alarms: []model.Alarm{{Action: action, TriggerValue: "-PT15M", Related: "START"}},
+		}
+		raw, err := ExportEvents([]event.Event{evt}, "Work")
+		if err != nil {
+			t.Fatalf("ExportEvents(action %q): %v", action, err)
+		}
+		out := string(raw)
+		if strings.Contains(out, "ACTION:"+action) && action != "" {
+			t.Errorf("action %q: export emitted it verbatim:\n%s", action, out)
+		}
+		if !strings.Contains(out, "ACTION:DISPLAY") {
+			t.Errorf("action %q: export did not fall back to DISPLAY:\n%s", action, out)
+		}
+	}
+}

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -593,7 +593,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 
 	// VALARM children
 	var alarms []model.Alarm
-	var alarmWarnings []string
+	var childWarnings []string
 	for _, child := range ve.Children {
 		if child.Name != ical.CompAlarm {
 			continue
@@ -601,7 +601,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		alarm, w := parseAlarm(child)
 		if w != "" {
 			// Name the owning record: the dropped alarm leaves no other trace.
-			alarmWarnings = append(alarmWarnings, fmt.Sprintf("event %q: %s", uid, w))
+			childWarnings = append(childWarnings, fmt.Sprintf("event %q: %s", uid, w))
 		}
 		if alarm.TriggerValue != "" {
 			alarms = append(alarms, alarm)
@@ -612,7 +612,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 	attendees, attendeeWarnings := parseAttendees(ve)
 	for _, w := range attendeeWarnings {
 		// Name the owning record: the clamp leaves no other trace.
-		alarmWarnings = append(alarmWarnings, fmt.Sprintf("event %q: %s", uid, w))
+		childWarnings = append(childWarnings, fmt.Sprintf("event %q: %s", uid, w))
 	}
 
 	// ATTACH, COMMENT, RELATED-TO
@@ -657,7 +657,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		Resources:      resources,
 		Relations:      relations,
 		XProperties:    extractXPropertiesWithSet(ve.Props, handledEventProps),
-	}, append(alarmWarnings, dtendWarnings...), nil
+	}, append(childWarnings, dtendWarnings...), nil
 }
 
 func textOrDefault(ve ical.Event, prop, def string) string {
@@ -1150,10 +1150,9 @@ func parseAttendeesFromProps(props ical.Props, kind model.AttendeeKind) ([]model
 	return attendees, warns
 }
 
-// attendeeFromProp extracts a model.Attendee from an iCal ATTENDEE property.
-// All RFC 5545 parameters are included.
-// attendeeFromProp builds one attendee and clamps the three parameters
-// the attendee tables constrain. RFC 5545 permits an x-name or an
+// attendeeFromProp extracts a model.Attendee from an iCal ATTENDEE
+// property. It keeps every RFC 5545 parameter. It clamps the three
+// parameters the attendee tables constrain. RFC 5545 permits an x-name or an
 // iana-token for PARTSTAT (§3.2.12), ROLE (§3.2.16), and CUTYPE
 // (§3.2.3), but each column carries a CHECK constraint. A stored
 // out-of-set value would fail the insert inside the sync transaction and

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/douglasdemoura/chroncal/internal/duration"
 )
 
@@ -256,6 +258,26 @@ func StorableAlarmAction(action string) bool {
 	return ValidAlarmActionToken(action)
 }
 
+// AlarmUIDForWrite returns the UID a write stores for a. It keeps a UID
+// the alarm already carries. For an alarm with no UID it mints one, unless
+// the alarm holds an action the engine cannot fire.
+//
+// A preserved foreign VALARM keeps an empty UID on purpose (issue #586).
+// A minted UID would reach the server on the next push, and the client that
+// wrote the VALARM never authored that value. An empty UID is safe: the
+// UID match refuses an empty value on both sides and falls back to the
+// content match, the export writes the property only for a non-empty
+// value, and the unique index covers a non-null uid alone.
+func AlarmUIDForWrite(a Alarm) string {
+	if a.UID != "" {
+		return a.UID
+	}
+	if !FireableAlarmAction(a.Action) {
+		return ""
+	}
+	return uuid.NewString()
+}
+
 // CheckStorableAlarmAction returns a named error for an action the alarm
 // tables reject. It converts an opaque CHECK failure into a named error.
 // The enclosing transaction still rolls back on it. The alarm write
@@ -276,9 +298,14 @@ func CheckStorableAlarmAction(action string) error {
 // A caller that must remove a preserved alarm skips this function and
 // calls ReplaceAlarms with the exact list instead. The TUI alarm editor
 // works that way, so a local calendar keeps a way to delete such a row.
+// A stored row an older build wrote can hold a malformed action, which
+// the write rule now refuses (issue #595). Carrying it forward would make
+// every --alarm update fail on it, so this function leaves it behind. The
+// row cannot fire and the export writes the default in its place, so it
+// carries nothing the user or another client can use.
 func KeepSyncOnlyAlarms(stored, replacement []Alarm) []Alarm {
 	for _, a := range stored {
-		if !FireableAlarmAction(a.Action) {
+		if !FireableAlarmAction(a.Action) && StorableAlarmAction(a.Action) {
 			replacement = append(replacement, a)
 		}
 	}
@@ -408,7 +435,7 @@ func prepareAlarmForWrite(a *Alarm) error {
 		a.Related = DefaultAlarmRelated
 	}
 	if !StorableAlarmAction(a.Action) {
-		return fmt.Errorf("%w: action %q is empty", ErrInvalidAlarm, a.Action)
+		return fmt.Errorf("%w: action %q is not an RFC 5545 iana-token or x-name", ErrInvalidAlarm, a.Action)
 	}
 	if !ValidAlarmRelated(a.Related) {
 		return fmt.Errorf("%w: related %q is not one of %s", ErrInvalidAlarm, a.Related, alarmRelatedValuesList)

--- a/internal/model/alarm_validate_test.go
+++ b/internal/model/alarm_validate_test.go
@@ -148,6 +148,45 @@ func TestPrepareAlarmsForWrite_RejectsMalformedAction(t *testing.T) {
 		_, err := PrepareAlarmsForWrite([]Alarm{{Action: action, TriggerValue: "-PT15M"}})
 		if !errors.Is(err, ErrInvalidAlarm) {
 			t.Errorf("PrepareAlarmsForWrite(action %q) error = %v, want ErrInvalidAlarm", action, err)
+			continue
 		}
+		// The defaults replace an empty action before this check, so the
+		// message must name the real cause. A user reads this text, and
+		// the sync engine repeats it through InvalidAlarm.Err.
+		if strings.Contains(err.Error(), "is empty") {
+			t.Errorf("PrepareAlarmsForWrite(action %q) error = %v, want it to name the token shape, not emptiness", action, err)
+		}
+		if !strings.Contains(err.Error(), "iana-token") {
+			t.Errorf("PrepareAlarmsForWrite(action %q) error = %v, want it to name the accepted shape", action, err)
+		}
+	}
+}
+
+// A stored row an older build wrote can hold a malformed action. The
+// carry-over must leave it behind: feeding it back through the write rule
+// would fail every --alarm update on it (issue #595).
+func TestKeepSyncOnlyAlarms_DropsAnUnwritableStoredRow(t *testing.T) {
+	stored := []Alarm{
+		{Action: "X-APPLE-SOUND", TriggerValue: "-PT5M"},
+		{Action: " ", TriggerValue: "-PT10M"},
+	}
+	kept := KeepSyncOnlyAlarms(stored, []Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M"}})
+
+	if _, err := PrepareAlarmsForWrite(kept); err != nil {
+		t.Fatalf("the carry-over must stay writable: %v", err)
+	}
+	for _, a := range kept {
+		if a.Action == " " {
+			t.Error("the carry-over kept a row the write rule refuses")
+		}
+	}
+	var foundForeign bool
+	for _, a := range kept {
+		if a.Action == "X-APPLE-SOUND" {
+			foundForeign = true
+		}
+	}
+	if !foundForeign {
+		t.Error("the carry-over dropped a valid preserved alarm")
 	}
 }

--- a/internal/model/attendee.go
+++ b/internal/model/attendee.go
@@ -133,10 +133,12 @@ func ValidAttendeeRole(role string) bool {
 }
 
 // ValidAttendeeCUType returns true if cutype is a CUTYPE value the
-// attendee tables accept. The column holds NULL, so an empty value
-// passes.
+// attendee tables accept as a stored value. The constraint reads
+// "cutype IS NULL OR cutype IN (...)", so it refuses an empty string.
+// A write maps an unset CUTYPE to NULL instead, and
+// prepareAttendeeForWrite skips this test for that case.
 func ValidAttendeeCUType(cutype string) bool {
-	return cutype == "" || slices.Contains(attendeeCUTypes, cutype)
+	return slices.Contains(attendeeCUTypes, cutype)
 }
 
 // ErrInvalidAttendee marks an attendee field value the attendee tables
@@ -178,10 +180,12 @@ func prepareAttendeeForWrite(kind AttendeeKind, a *Attendee) error {
 		return fmt.Errorf("%w: partstat %q is not one of %s", ErrInvalidAttendee, a.RSVPStatus, RSVPStatusesList(kind))
 	}
 	if !ValidAttendeeRole(a.Role) {
-		return fmt.Errorf("%w: role %q is not one of %s", ErrInvalidAttendee, a.Role, attendeeRolesList)
+		return fmt.Errorf("%w: role %q is not one of %s", ErrInvalidAttendee, a.Role, AttendeeRolesList())
 	}
-	if !ValidAttendeeCUType(a.CUType) {
-		return fmt.Errorf("%w: cutype %q is not one of %s", ErrInvalidAttendee, a.CUType, attendeeCUTypesList)
+	// An unset CUTYPE stays unset. The write maps it to NULL, which the
+	// column accepts.
+	if a.CUType != "" && !ValidAttendeeCUType(a.CUType) {
+		return fmt.Errorf("%w: cutype %q is not one of %s", ErrInvalidAttendee, a.CUType, AttendeeCUTypesList())
 	}
 	return nil
 }

--- a/internal/recurrence/querycount_test.go
+++ b/internal/recurrence/querycount_test.go
@@ -5,16 +5,13 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"io/fs"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/pressly/goose/v3"
 	sqlitedrv "modernc.org/sqlite"
 
-	dbembed "github.com/douglasdemoura/chroncal/db"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
@@ -74,11 +71,9 @@ func newCountingDB(t *testing.T) (*sql.DB, *storage.Queries, *int64) {
 	conn.SetMaxOpenConns(1)
 	t.Cleanup(func() { conn.Close() })
 
-	migrationsFS, err := fs.Sub(dbembed.Migrations, "migrations")
-	if err != nil {
-		t.Fatalf("sub migrations: %v", err)
-	}
-	provider, err := goose.NewProvider(goose.DialectSQLite3, conn, migrationsFS)
+	// Build through the production constructor, so the test database runs
+	// every Go migration too and cannot drift from the real schema.
+	provider, err := storage.NewMigrationProvider(conn)
 	if err != nil {
 		t.Fatalf("goose provider: %v", err)
 	}

--- a/internal/storage/schema_constraints_test.go
+++ b/internal/storage/schema_constraints_test.go
@@ -401,12 +401,17 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 		// sets it to false, and the test then checks only that every
 		// value the Go rule accepts also reaches the table.
 		exact bool
+		// mustReject lists the values the constraint itself has to
+		// refuse, whatever the model rule says. Without it a one-way
+		// column would pass even if a later migration recreated the
+		// table without the constraint.
+		mustReject []string
 	}{
 		// The valid candidates come from the model sets. The test then
 		// probes a value added to the model but not to a migration
 		// against the CHECK constraint, and the value fails here.
-		{"action", append(model.AlarmActions(), "NONE", "PROCEDURE", "X-APPLE-SOUND", "display", " ", "\t", "NO NE", ""), model.StorableAlarmAction, false},
-		{"related", append(model.AlarmRelatedValues(), "STARTS", "end", ""), model.ValidAlarmRelated, true},
+		{"action", append(model.AlarmActions(), "NONE", "PROCEDURE", "X-APPLE-SOUND", "display", " ", "\t", "NO NE", ""), model.StorableAlarmAction, false, []string{""}},
+		{"related", append(model.AlarmRelatedValues(), "STARTS", "end", ""), model.ValidAlarmRelated, true, nil},
 	}
 
 	for _, ins := range inserts {
@@ -426,6 +431,18 @@ func TestAlarmConstraintsMatchModelValidators(t *testing.T) {
 				}
 				if err != nil && !strings.Contains(err.Error(), "CHECK constraint failed") {
 					t.Errorf("%s %s %q: rejected by %v, not by the CHECK constraint", ins.table, c.col, v, err)
+				}
+			}
+			// The constraint must still refuse these, whatever the model
+			// rule says, so a one-way column cannot pass vacuously.
+			for _, v := range c.mustReject {
+				_, err := db.Exec(
+					`INSERT INTO `+ins.table+` (`+ins.fk+`, `+c.col+`, trigger_value) VALUES (?, ?, '-PT15M')`,
+					ins.id, v,
+				)
+				if err == nil {
+					t.Errorf("%s %s %q: the constraint accepted it, want a CHECK failure",
+						ins.table, c.col, v)
 				}
 			}
 		}
@@ -533,18 +550,18 @@ func TestFireableAlarmQueriesMatchModelPredicate(t *testing.T) {
 	}
 	check("ListFireableAlarmsByEventIDs", evGot)
 
-	tdRows, err := q.ListFireableTodoAlarmsByTodoID(ctx, todoID)
+	tdRows, err := q.ListFireableTodoAlarmsByTodoIDs(ctx, []int64{todoID})
 	if err != nil {
-		t.Fatalf("ListFireableTodoAlarmsByTodoID: %v", err)
+		t.Fatalf("ListFireableTodoAlarmsByTodoIDs: %v", err)
 	}
 	tdGot := make([]string, len(tdRows))
 	for i, r := range tdRows {
 		if !model.FireableAlarmAction(r.Action) {
-			t.Errorf("ListFireableTodoAlarmsByTodoID returned non-fireable action %q", r.Action)
+			t.Errorf("ListFireableTodoAlarmsByTodoIDs returned non-fireable action %q", r.Action)
 		}
 		tdGot[i] = r.TriggerValue
 	}
-	check("ListFireableTodoAlarmsByTodoID", tdGot)
+	check("ListFireableTodoAlarmsByTodoIDs", tdGot)
 
 	// The state queries filter on the same action list. Give every alarm a
 	// fired state row, then check that only the fireable actions surface.
@@ -628,7 +645,10 @@ func TestAttendeeConstraintsMatchModelValidators(t *testing.T) {
 	// The extra candidates cover the shapes RFC 5545 allows and the
 	// constraints refuse: an x-name, the two task-only values, a
 	// lowercase near-miss, and an unknown token.
-	extra := []string{"X-FOO", "COMPLETED", "IN-PROCESS", "accepted", "BOGUS"}
+	// The empty string probes the one value where the model rule and the
+	// constraint could disagree: the columns hold NULL for an unset value,
+	// so a literal empty string must fail on both sides.
+	extra := []string{"X-FOO", "COMPLETED", "IN-PROCESS", "accepted", "BOGUS", ""}
 
 	tables := []struct {
 		table string

--- a/internal/storage/todo_alarms.sql.go
+++ b/internal/storage/todo_alarms.sql.go
@@ -116,54 +116,6 @@ func (q *Queries) ListDistinctTodoAlarmTriggers(ctx context.Context) ([]string, 
 	return items, nil
 }
 
-const listFireableTodoAlarmsByTodoID = `-- name: ListFireableTodoAlarmsByTodoID :many
-SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM todo_alarms
-WHERE todo_id = ?
-  AND action IN ('AUDIO', 'DISPLAY', 'EMAIL')
-ORDER BY id
-`
-
-// The action list mirrors model.FireableAlarmAction. Keep the two in
-// lockstep. The alarm check loop is the only caller, and a preserved
-// sync-only action must not reach it.
-func (q *Queries) ListFireableTodoAlarmsByTodoID(ctx context.Context, todoID int64) ([]TodoAlarm, error) {
-	rows, err := q.db.QueryContext(ctx, listFireableTodoAlarmsByTodoID, todoID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []TodoAlarm
-	for rows.Next() {
-		var i TodoAlarm
-		if err := rows.Scan(
-			&i.ID,
-			&i.TodoID,
-			&i.Action,
-			&i.TriggerValue,
-			&i.Description,
-			&i.Repeat,
-			&i.Duration,
-			&i.Related,
-			&i.Summary,
-			&i.Uid,
-			&i.Acknowledged,
-			&i.AttachUri,
-			&i.AttachFmttype,
-			&i.AttachBinary,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listFireableTodoAlarmsByTodoIDs = `-- name: ListFireableTodoAlarmsByTodoIDs :many
 SELECT id, todo_id, "action", trigger_value, description, repeat, duration, related, summary, uid, acknowledged, attach_uri, attach_fmttype, attach_binary FROM todo_alarms
 WHERE todo_id IN (/*SLICE:todo_ids*/?)

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -798,29 +798,21 @@ func (s *Service) ListOverridesByUID(ctx context.Context, uid string) ([]Todo, e
 // Alarm CRUD
 
 func (s *Service) ListAlarms(ctx context.Context, todoID int64) ([]model.Alarm, error) {
-	return s.listAlarms(ctx, todoID, true, false)
+	return s.listAlarms(ctx, todoID, true)
 }
 
 // ListAlarmsLean returns a todo's alarms with attendees (needed to fire
 // EMAIL alarms) but without X-properties, which are round-trip-only and
 // never read at fire time.
 func (s *Service) ListAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error) {
-	return s.listAlarms(ctx, todoID, false, false)
-}
-
-// ListFireableAlarmsLean is ListAlarmsLean restricted to fireable actions.
-// The query excludes preserved sync-only actions (issue #579): the alarm
-// check loop calls this per todo every tick, and a sync-only alarm must
-// not reach it.
-func (s *Service) ListFireableAlarmsLean(ctx context.Context, todoID int64) ([]model.Alarm, error) {
-	return s.listAlarms(ctx, todoID, false, true)
+	return s.listAlarms(ctx, todoID, false)
 }
 
 // ListFireableAlarmsByTodoIDs fetches the fireable alarms for many todo
 // IDs in one query. It returns a map of the todo ID to its alarms. The
 // alarm check loop reads every todo on each tick, so a call per todo
 // costs one query per todo (issue #586). The query excludes a preserved
-// sync-only action, like ListFireableAlarmsLean.
+// sync-only action.
 func (s *Service) ListFireableAlarmsByTodoIDs(ctx context.Context, todoIDs []int64) (map[int64][]model.Alarm, error) {
 	if len(todoIDs) == 0 {
 		return nil, nil
@@ -845,14 +837,8 @@ func (s *Service) ListFireableAlarmsByTodoIDs(ctx context.Context, todoIDs []int
 	return alarmMap, nil
 }
 
-func (s *Service) listAlarms(ctx context.Context, todoID int64, withXProps, fireableOnly bool) ([]model.Alarm, error) {
-	var rows []storage.TodoAlarm
-	var err error
-	if fireableOnly {
-		rows, err = s.q.ListFireableTodoAlarmsByTodoID(ctx, todoID)
-	} else {
-		rows, err = s.q.ListTodoAlarmsByTodoID(ctx, todoID)
-	}
+func (s *Service) listAlarms(ctx context.Context, todoID int64, withXProps bool) ([]model.Alarm, error) {
+	rows, err := s.q.ListTodoAlarmsByTodoID(ctx, todoID)
 	if err != nil {
 		return nil, err
 	}
@@ -1130,11 +1116,10 @@ func matchTodoAlarmByUID(existing []model.Alarm, matched []bool, a model.Alarm) 
 
 // syncMatchedTodoAlarm syncs a content-matched alarm's UID and ACKNOWLEDGED state.
 func syncMatchedTodoAlarm(ctx context.Context, qtx *storage.Queries, a model.Alarm, ex model.Alarm) error {
-	if ex.UID == "" {
-		uid := a.UID
-		if uid == "" {
-			uid = uuid.New().String()
-		}
+	// Backfill the UID of a stored row that carries none. A preserved
+	// foreign alarm keeps its empty UID, so the backfill writes nothing
+	// for it (issue #586).
+	if uid := model.AlarmUIDForWrite(a); ex.UID == "" && uid != "" {
 		if err := qtx.UpdateTodoAlarmUID(ctx, storage.UpdateTodoAlarmUIDParams{
 			Uid: storage.StringToNullable(uid),
 			ID:  ex.ID,
@@ -1223,10 +1208,7 @@ func createNewTodoAlarm(ctx context.Context, qtx *storage.Queries, todoID int64,
 	if err := model.CheckStorableAlarmAction(a.Action); err != nil {
 		return fmt.Errorf("create alarm: %w", err)
 	}
-	uid := a.UID
-	if uid == "" {
-		uid = uuid.New().String()
-	}
+	uid := model.AlarmUIDForWrite(a)
 	params := storage.CreateTodoAlarmParams{
 		TodoID:        todoID,
 		Uid:           storage.StringToNullable(uid),

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -791,3 +791,36 @@ func TestValidateTiming_RejectsAnUnstorableEnd(t *testing.T) {
 		t.Errorf("a storable span must pass: %v", err)
 	}
 }
+
+// The todo service shares the alarm UID rule with the event service: a
+// preserved foreign alarm keeps an empty UID, on the first write and on a
+// later write that content-matches the stored row (issue #586).
+func TestTodoService_ReplaceAlarms_KeepsForeignAlarmUIDEmpty(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	td := createTodo(t, svc)
+
+	foreign := model.Alarm{Action: "NONE", TriggerValue: "-PT5M", Related: "START"}
+	fireable := model.Alarm{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"}
+
+	for _, pass := range []string{"first", "second"} {
+		if err := svc.ReplaceAlarms(ctx, td.ID, []model.Alarm{foreign, fireable}); err != nil {
+			t.Fatalf("%s write: %v", pass, err)
+		}
+		alarms, err := svc.ListAlarms(ctx, td.ID)
+		if err != nil {
+			t.Fatalf("ListAlarms: %v", err)
+		}
+		if len(alarms) != 2 {
+			t.Fatalf("%s pass: alarms = %d, want 2", pass, len(alarms))
+		}
+		for _, a := range alarms {
+			if a.Action == "NONE" && a.UID != "" {
+				t.Errorf("%s pass: preserved alarm UID = %q, want empty", pass, a.UID)
+			}
+			if a.Action == "DISPLAY" && a.UID == "" {
+				t.Errorf("%s pass: fireable alarm UID is empty, want a minted value", pass)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes found by the post-merge code reviews of PR #597, PR #599, and PR #600. None of them block anything today; the first is the only one that made a shipped fix ineffective.

## The UID rule did not hold (from the #599 review)

PR #599 stopped `backfillAlarmUIDs` from minting a UID for a preserved foreign alarm, so the alarm keeps the absent UID its author left. Every other write path still minted one:

- `createNewAlarm` mints on the first insert, so a foreign VALARM got a chroncal UID the moment it arrived.
- `syncMatchedAlarm` backfills whenever the stored row has none, so a later pull that content-matched the row stamped one on.
- The todo twins did the same.

The next push then wrote a UID the other client never authored. `model.AlarmUIDForWrite` now owns the rule and both services call it. An empty UID is safe: the UID match refuses an empty value on both sides and falls back to the content match, the export writes the property only for a non-empty value, and the unique index covers a non-null uid alone.

## The export boundary was still open (from the #597 review)

Issue #595 closed the write boundary against a malformed action, but `buildValarm` still guarded `action == ""` alone and wrote the value verbatim. A row an older build stored still exported as an invalid `ACTION:` line, and a strict server still rejected the whole resource — the exact failure #595 describes. The guard now uses `model.ValidAlarmActionToken` and falls back to DISPLAY, on the same principle as the RELATED and DURATION guards beside it.

The same legacy row also made every `event update --alarm ...` fail hard, because the carry-over fed it back through the write rule. `KeepSyncOnlyAlarms` now leaves such a row behind: it cannot fire, and the export writes the default in its place, so it carries nothing anyone can use.

## Test coverage that had gone one-way or vacuous

- The alarm lockstep test set `exact: false` for the action column, which dropped the reverse direction for every value — a migration that recreated the tables without `CHECK(action <> '')` would have kept it green. A `mustReject` list now pins the values the constraint itself must refuse. Verified by dropping the constraint and watching the test fail.
- The test pinned the per-todo fireable query, which production no longer uses. It now pins the batch query the check loop calls.
- `internal/alarm/querycount_test.go` and `internal/recurrence/querycount_test.go` built their own goose provider, so the Go migrations never ran against the test database. Both use `storage.NewMigrationProvider` now.

## Smaller items

- The malformed-action error said `action " " is empty`, but the defaults replace an empty action two lines above, so only non-empty malformed tokens reach it. It now names the token shape, and the test pins the wording.
- `ValidAttendeeCUType("")` returned true while the constraint refuses a literal empty string. The rule now matches the column, `prepareAttendeeForWrite` skips the check for an unset value, and the lockstep test probes `""`.
- The dead `ListFireableAlarmsLean` and its query are gone.
- One `todoIsOpen` helper replaces the open-todo test written twice at each of two call sites, which also drops a duplicate row conversion per tick.
- Merged the stacked `attendeeFromProp` doc comments, used the list accessors in the attendee errors, corrected the `replaceRelationsTx` comment, and renamed `alarmWarnings` to `childWarnings` where it carries attendee warnings too.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, and the full `go test ./...` are green. The three behavioural fixes each have a test verified to fail without the fix.
