### PR TITLE
fix(alarm): repair a malformed stored action, keep every preserved row

### DIFF
--- a/db/migrations/045_repair_malformed_alarm_action.sql
+++ b/db/migrations/045_repair_malformed_alarm_action.sql
@@ -1,0 +1,37 @@
+-- +goose Up
+
+-- Repair a stored alarm action that is not an RFC 5545 iana-token or
+-- x-name (issue #595). A build older than that rule stored any non-empty
+-- value, so a row can hold " " or "NO NE". Export writes such a value as a
+-- malformed ACTION line, and a strict CalDAV server rejects the whole
+-- resource for it.
+--
+-- The write rule now refuses these values, which left every path that
+-- reads a stored row and writes it back with a choice between two bad
+-- outcomes: fail every edit of the owning record, or drop the row and
+-- delete another client's VALARM on the next push. Repair the value once
+-- here instead, so no later path has to compensate.
+--
+-- DISPLAY is the fallback the parser, the write rule, and the exporter all
+-- use for an action they cannot represent, so the repaired row keeps the
+-- behavior the exporter already gave it.
+--
+-- The GLOB pattern matches a value that holds a character outside the
+-- token set (ALPHA, DIGIT, and "-"). It mirrors model.ValidAlarmActionToken.
+-- A preserved foreign action such as X-APPLE-SOUND or the Google NONE
+-- sentinel holds only token characters, so this migration leaves it alone.
+
+UPDATE event_alarms
+SET action = 'DISPLAY'
+WHERE action = '' OR action GLOB '*[^A-Za-z0-9-]*';
+
+UPDATE todo_alarms
+SET action = 'DISPLAY'
+WHERE action = '' OR action GLOB '*[^A-Za-z0-9-]*';
+
+-- +goose Down
+
+-- The repair is irreversible. The original malformed value is gone, and no
+-- column records it, so a Down cannot tell a repaired row from a row that
+-- always held DISPLAY. This statement is deliberately empty.
+SELECT 1;

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -219,7 +219,6 @@ func buildOverrideSuppressionKeys(rows []storage.Todo) map[string]map[string]str
 	return m
 }
 
-// todoFromRow converts a storage view row to a todo.Todo
 // todoIsOpen reports whether a todo can still fire an alarm. A completed
 // or a cancelled todo cannot. The batch alarm read and the loops that
 // process the rows share this test, so a new terminal status cannot reach
@@ -228,6 +227,7 @@ func todoIsOpen(row storage.Todo) bool {
 	return row.Status != "COMPLETED" && row.Status != "CANCELLED"
 }
 
+// todoFromRow converts a storage view row to a todo.Todo
 func todoFromRow(row storage.Todo) todo.Todo {
 	return todo.Todo{
 		ID:              row.ID,

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -1639,7 +1639,13 @@ func createNewAlarm(ctx context.Context, qtx *storage.Queries, eventID int64, a 
 	}
 	row, err := qtx.CreateAlarm(ctx, params)
 	if isUniqueUIDViolation(err) {
-		params.Uid = storage.StringToNullable(uuid.New().String())
+		// A server can send the same VALARM UID on two resources. Retry
+		// through the shared rule, so the retry does not stamp a minted
+		// UID on a preserved foreign alarm (issue #586). The rule mints
+		// for a fireable action and yields an empty value otherwise.
+		retry := a
+		retry.UID = ""
+		params.Uid = storage.StringToNullable(model.AlarmUIDForWrite(retry))
 		row, err = qtx.CreateAlarm(ctx, params)
 	}
 	if err != nil {

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -1159,6 +1159,34 @@ func TestEventService_ReplaceAlarms_CrossEventUIDCollision(t *testing.T) {
 	}
 }
 
+// The UID-collision retry must not stamp a minted UID on a preserved
+// foreign alarm. A server can duplicate a resource, so the same foreign
+// VALARM UID arrives on two events. The retry mints for a fireable action
+// only, so the second row keeps an empty UID and the next push carries no
+// value the other client never authored (issue #586).
+func TestEventService_ReplaceAlarms_ForeignUIDCollisionMintsNothing(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	e1 := createEvent(t, svc)
+	e2 := createEvent(t, svc)
+
+	foreign := model.Alarm{UID: "foreign-dup", Action: "X-APPLE-SOUND", TriggerValue: "-PT15M"}
+	if err := svc.ReplaceAlarms(ctx, e1.ID, []model.Alarm{foreign}); err != nil {
+		t.Fatalf("ReplaceAlarms e1: %v", err)
+	}
+	if err := svc.ReplaceAlarms(ctx, e2.ID, []model.Alarm{foreign}); err != nil {
+		t.Fatalf("ReplaceAlarms e2 (uid collision): %v", err)
+	}
+
+	alarms, err := svc.ListAlarms(ctx, e2.ID)
+	if err != nil || len(alarms) != 1 {
+		t.Fatalf("ListAlarms e2: %v (n=%d)", err, len(alarms))
+	}
+	if alarms[0].UID != "" {
+		t.Errorf("e2 foreign alarm UID = %q, want an empty value after the collision retry", alarms[0].UID)
+	}
+}
+
 // validateDurationValue must reject a span that carries the end past
 // the storable range, and it must accept the same span on a normal
 // start (issue #582 round 5).

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -268,6 +268,12 @@ func StorableAlarmAction(action string) bool {
 // UID match refuses an empty value on both sides and falls back to the
 // content match, the export writes the property only for a non-empty
 // value, and the unique index covers a non-null uid alone.
+//
+// The rule governs a write from now on. It does not repair a row an
+// earlier build already stamped: that row holds a non-empty UID, so this
+// function keeps it and syncMatchedAlarm backfills an empty value only.
+// A minted UID cannot be told from an authored one after the fact, so no
+// repair is possible.
 func AlarmUIDForWrite(a Alarm) string {
 	if a.UID != "" {
 		return a.UID
@@ -298,14 +304,16 @@ func CheckStorableAlarmAction(action string) error {
 // A caller that must remove a preserved alarm skips this function and
 // calls ReplaceAlarms with the exact list instead. The TUI alarm editor
 // works that way, so a local calendar keeps a way to delete such a row.
-// A stored row an older build wrote can hold a malformed action, which
-// the write rule now refuses (issue #595). Carrying it forward would make
-// every --alarm update fail on it, so this function leaves it behind. The
-// row cannot fire and the export writes the default in its place, so it
-// carries nothing the user or another client can use.
+//
+// The carry-over covers every stored row the engine cannot fire. It
+// applies no further test on the action. A row that fails the write rule
+// must never be left behind here, because the replacement then deletes it
+// and the next push deletes the VALARM of another client. Migration 045
+// repairs the malformed actions an older build stored, so no such row
+// reaches this function.
 func KeepSyncOnlyAlarms(stored, replacement []Alarm) []Alarm {
 	for _, a := range stored {
-		if !FireableAlarmAction(a.Action) && StorableAlarmAction(a.Action) {
+		if !FireableAlarmAction(a.Action) {
 			replacement = append(replacement, a)
 		}
 	}

--- a/internal/model/alarm_validate_test.go
+++ b/internal/model/alarm_validate_test.go
@@ -176,7 +176,7 @@ func TestKeepSyncOnlyAlarms_KeepsEveryNonFireableRow(t *testing.T) {
 	}
 	kept := KeepSyncOnlyAlarms(stored, []Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M"}})
 
-	var actions []string
+	actions := make([]string, 0, len(kept))
 	for _, a := range kept {
 		actions = append(actions, a.Action)
 	}

--- a/internal/model/alarm_validate_test.go
+++ b/internal/model/alarm_validate_test.go
@@ -162,31 +162,46 @@ func TestPrepareAlarmsForWrite_RejectsMalformedAction(t *testing.T) {
 	}
 }
 
-// A stored row an older build wrote can hold a malformed action. The
-// carry-over must leave it behind: feeding it back through the write rule
-// would fail every --alarm update on it (issue #595).
-func TestKeepSyncOnlyAlarms_DropsAnUnwritableStoredRow(t *testing.T) {
+// The carry-over keeps every stored row the engine cannot fire, and it
+// applies no further test. A dropped row is a deleted row: the caller
+// feeds the result to a replace, which removes what the list omits, and
+// the next push then deletes the VALARM of another client (issue #579).
+// Migration 045 repairs the malformed actions an older build stored, so
+// the carry-over never meets one.
+func TestKeepSyncOnlyAlarms_KeepsEveryNonFireableRow(t *testing.T) {
 	stored := []Alarm{
 		{Action: "X-APPLE-SOUND", TriggerValue: "-PT5M"},
-		{Action: " ", TriggerValue: "-PT10M"},
+		{Action: "NONE", TriggerValue: "-PT10M"},
+		{Action: "DISPLAY", TriggerValue: "-PT20M"},
 	}
 	kept := KeepSyncOnlyAlarms(stored, []Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M"}})
 
-	if _, err := PrepareAlarmsForWrite(kept); err != nil {
-		t.Fatalf("the carry-over must stay writable: %v", err)
-	}
+	var actions []string
 	for _, a := range kept {
-		if a.Action == " " {
-			t.Error("the carry-over kept a row the write rule refuses")
+		actions = append(actions, a.Action)
+	}
+	if len(kept) != 3 {
+		t.Fatalf("kept = %v, want the replacement plus both preserved rows", actions)
+	}
+	for _, want := range []string{"X-APPLE-SOUND", "NONE"} {
+		var found bool
+		for _, a := range kept {
+			if a.Action == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("the carry-over dropped %q, which a replace would then delete", want)
 		}
 	}
-	var foundForeign bool
+	// The stored fireable row is not carried: the replacement states it.
+	var fireable int
 	for _, a := range kept {
-		if a.Action == "X-APPLE-SOUND" {
-			foundForeign = true
+		if a.Action == "DISPLAY" {
+			fireable++
 		}
 	}
-	if !foundForeign {
-		t.Error("the carry-over dropped a valid preserved alarm")
+	if fireable != 1 {
+		t.Errorf("DISPLAY appears %d times, want only the replacement copy", fireable)
 	}
 }

--- a/internal/storage/connect.go
+++ b/internal/storage/connect.go
@@ -313,16 +313,22 @@ func backfillAlarmUIDs(conn *sql.DB, q *Queries) error {
 	if err != nil {
 		return fmt.Errorf("list todo alarms with empty uid: %w", err)
 	}
-	var alarms []EventAlarm
+	// model.AlarmUIDForWrite owns the rule. It yields an empty value for
+	// an action the engine cannot fire, and such a row keeps its absent
+	// UID (issue #586).
+	type uidFix struct {
+		id  int64
+		uid string
+	}
+	var alarms, todoAlarms []uidFix
 	for _, a := range storedAlarms {
-		if model.FireableAlarmAction(a.Action) {
-			alarms = append(alarms, a)
+		if uid := model.AlarmUIDForWrite(model.Alarm{Action: a.Action}); uid != "" {
+			alarms = append(alarms, uidFix{id: a.ID, uid: uid})
 		}
 	}
-	var todoAlarms []TodoAlarm
 	for _, a := range storedTodoAlarms {
-		if model.FireableAlarmAction(a.Action) {
-			todoAlarms = append(todoAlarms, a)
+		if uid := model.AlarmUIDForWrite(model.Alarm{Action: a.Action}); uid != "" {
+			todoAlarms = append(todoAlarms, uidFix{id: a.ID, uid: uid})
 		}
 	}
 	if len(alarms) == 0 && len(todoAlarms) == 0 {
@@ -338,16 +344,16 @@ func backfillAlarmUIDs(conn *sql.DB, q *Queries) error {
 	qtx := q.WithTx(tx)
 	for _, a := range alarms {
 		if err := qtx.UpdateAlarmUID(ctx, UpdateAlarmUIDParams{
-			Uid: StringToNullable(uuid.New().String()),
-			ID:  a.ID,
+			Uid: StringToNullable(a.uid),
+			ID:  a.id,
 		}); err != nil {
 			return err
 		}
 	}
 	for _, a := range todoAlarms {
 		if err := qtx.UpdateTodoAlarmUID(ctx, UpdateTodoAlarmUIDParams{
-			Uid: StringToNullable(uuid.New().String()),
-			ID:  a.ID,
+			Uid: StringToNullable(a.uid),
+			ID:  a.id,
 		}); err != nil {
 			return err
 		}

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/pressly/goose/v3"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
 )
 
 // migHelpers returns exec and count helpers bound to conn. The migration
@@ -406,5 +408,98 @@ func TestMigration043RunsOncePerDatabase(t *testing.T) {
 	}
 	if span != "-PT1H" {
 		t.Errorf("duration = %q, want the row untouched by a second Up", span)
+	}
+}
+
+// Verifies migration 045 repairs a malformed stored alarm action and
+// leaves every well-shaped value alone. A build older than the token rule
+// of issue #595 stored any non-empty action, so a row can hold " " or
+// "NO NE". A preserved foreign action such as X-APPLE-SOUND holds only
+// token characters and must survive untouched.
+func TestMigration045RepairsMalformedAction(t *testing.T) {
+	conn, _, err := Open(t.TempDir() + "/mig045.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := context.Background()
+	mustExec, count := migHelpers(t, ctx, conn)
+	provider := migProvider(t, conn)
+
+	// Go back before the repair, so the seeds can hold the malformed
+	// values an older build stored.
+	if _, err := provider.DownTo(ctx, 44); err != nil {
+		t.Fatalf("down to 44: %v", err)
+	}
+
+	mustExec(`INSERT INTO events (uid, calendar_id, title, start_time, end_time)
+		VALUES ('mig045-evt', 1, 'Mig', '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z')`)
+	mustExec(`INSERT INTO todos (uid, calendar_id, summary) VALUES ('mig045-todo', 1, 'Mig')`)
+
+	seeds := []struct {
+		id     int
+		action string
+		repair bool
+	}{
+		{1, " ", true},
+		{2, "NO NE", true},
+		{3, "X-APPLE-SOUND", false},
+		{4, "NONE", false},
+		{5, "DISPLAY", false},
+		{6, "PROCEDURE", false},
+	}
+	for _, s := range seeds {
+		mustExec(`INSERT INTO event_alarms (id, event_id, action, trigger_value) VALUES (?, 1, ?, '-PT15M')`,
+			s.id, s.action)
+		mustExec(`INSERT INTO todo_alarms (id, todo_id, action, trigger_value) VALUES (?, 1, ?, '-PT15M')`,
+			s.id, s.action)
+	}
+
+	if _, err := provider.Up(ctx); err != nil {
+		t.Fatalf("up: %v", err)
+	}
+
+	for _, table := range []string{"event_alarms", "todo_alarms"} {
+		for _, s := range seeds {
+			want := s.action
+			if s.repair {
+				want = "DISPLAY"
+			}
+			if n := count(`SELECT COUNT(*) FROM `+table+` WHERE id = ? AND action = ?`, s.id, want); n != 1 {
+				t.Errorf("%s id %d: action %q did not end as %q", table, s.id, s.action, want)
+			}
+		}
+	}
+}
+
+// The migration 045 GLOB pattern and model.ValidAlarmActionToken must give
+// the same verdict. A value the Go rule refuses must be repaired, and a
+// value it accepts must survive. Two hand-written rules would otherwise
+// drift, and the migration would leave a row every later write refuses.
+func TestMigration045PatternMatchesTokenRule(t *testing.T) {
+	conn, _, err := Open(t.TempDir() + "/mig045-pattern.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer conn.Close()
+
+	candidates := []string{
+		"DISPLAY", "AUDIO", "EMAIL", "NONE", "PROCEDURE", "X-APPLE-SOUND",
+		"x-lower-case", "A1", "-", "9",
+		"", " ", "  ", "\t", "NO NE", "X APPLE", "DISPLAY;", "a.b", "caf\u00e9",
+	}
+	for _, v := range candidates {
+		var matched int
+		if err := conn.QueryRowContext(context.Background(),
+			`SELECT CASE WHEN ? = '' OR ? GLOB '*[^A-Za-z0-9-]*' THEN 1 ELSE 0 END`,
+			v, v).Scan(&matched); err != nil {
+			t.Fatalf("probe %q: %v", v, err)
+		}
+		wantRepair := !model.ValidAlarmActionToken(v)
+		if (matched == 1) != wantRepair {
+			t.Errorf("action %q: the migration repairs it = %v, but the token rule calls it malformed = %v",
+				v, matched == 1, wantRepair)
+		}
 	}
 }

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -1226,7 +1226,12 @@ func createNewTodoAlarm(ctx context.Context, qtx *storage.Queries, todoID int64,
 	}
 	row, err := qtx.CreateTodoAlarm(ctx, params)
 	if isUniqueUIDViolation(err) {
-		params.Uid = storage.StringToNullable(uuid.New().String())
+		// Retry through the shared rule, like the event service does.
+		// The retry must not stamp a minted UID on a preserved foreign
+		// alarm (issue #586).
+		retry := a
+		retry.UID = ""
+		params.Uid = storage.StringToNullable(model.AlarmUIDForWrite(retry))
 		row, err = qtx.CreateTodoAlarm(ctx, params)
 	}
 	if err != nil {


### PR DESCRIPTION
Applies the five findings from the post-merge review of PR #602.

## The core problem

PR #602 met a stored alarm whose action an older build wrote before the token rule of issue #595 existed (`" "`, `"NO NE"`). It compensated in two places, and both were wrong:

- `KeepSyncOnlyAlarms` left such a row behind. The caller feeds the result to a replace, so the row was **deleted**, and the next push deleted the VALARM of another client — the exact loss the carry-over exists to prevent, and worse than the loud failure it replaced.
- The TUI edit path loads every stored alarm and writes the whole list back through `PrepareAlarmsForWrite`, which refuses the entire set on one bad action. With such a row present, **no edit of that event could be saved**.

## The fix: repair once, stop compensating

**Migration 045** rewrites a malformed action to `DISPLAY` in `event_alarms` and `todo_alarms`. `DISPLAY` is the fallback the parser, the write rule, and the exporter already use for a value they cannot represent.

The GLOB pattern (`action = '' OR action GLOB '*[^A-Za-z0-9-]*'`) mirrors `model.ValidAlarmActionToken`. `TestMigration045PatternMatchesTokenRule` probes both rules over 19 candidates — including `X-APPLE-SOUND`, `NONE`, a tab, an embedded space, and a non-ASCII value — so the two cannot drift. A preserved foreign action holds only token characters and survives untouched.

The Down is deliberately empty and says so: the original value is gone, and no column records it.

**`KeepSyncOnlyAlarms` returns to the fireable / non-fireable split alone.** With no malformed row left, no later path has to compensate, and the TUI scenario closes with it (verified: every re-validation site is a `*WithRelations` method or `ReplaceAlarmsForSync`).

The export guard in `buildValarm` stays as correct defense in depth.

## The three low findings

- The UID-collision retry in both services minted a UUID directly, so a server that duplicates a resource could stamp a chroncal UID on a preserved foreign alarm. Both now route through `model.AlarmUIDForWrite`, which mints for a fireable action and yields an empty value otherwise. The startup backfill uses the same rule, removing a third copy of the fireable-then-mint logic.
- `todoIsOpen` sat between `todoFromRow`'s doc comment and its function, so godoc attributed the comment to the wrong function. Moved back.
- `AlarmUIDForWrite`'s doc now states the rule governs writes from now on. A row an earlier build stamped keeps its minted UID; a minted value cannot be told from an authored one after the fact, so no repair is possible.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, and the full `go test ./...` are green (only the two pre-existing drift files remain unformatted).

Both new behavioural tests are verified non-vacuous:
- Neutering the migration's `WHERE` clause fails `TestMigration045RepairsMalformedAction` on all four seeded rows.
- Restoring the unconditional mint fails `TestEventService_ReplaceAlarms_ForeignUIDCollisionMintsNothing` with a stamped UUID.