### PR TITLE
fix(alarm): repair a malformed action to a reserved x-name

### DIFF
--- a/cmd/chroncal/event_alarm_preserve_cli_test.go
+++ b/cmd/chroncal/event_alarm_preserve_cli_test.go
@@ -79,3 +79,72 @@ func TestEventUpdateAlarmKeepsSyncOnlyRows(t *testing.T) {
 		t.Errorf("the new DISPLAY alarm is missing; alarms = %+v", alarms)
 	}
 }
+
+// TestEventUpdateAlarmKeepsRepairedRow guards the issue #603 outcome. A
+// row migration 045 repaired holds the reserved x-name, not DISPLAY, so
+// the carry-over still protects it: an --alarm update keeps it, and no
+// write mints a UID for it. DISPLAY there would make the row a normal
+// reminder, and the next push would delete the VALARM of another client.
+func TestEventUpdateAlarmKeepsRepairedRow(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t,
+		"event", "add", "Synced meeting",
+		"--calendar", "Work",
+		"--date", "2026-04-21",
+		"--time", "09:00",
+		"--duration", "30m",
+	); err != nil {
+		t.Fatalf("event add: %v", err)
+	}
+
+	// Seed the row a repair leaves behind: the reserved action and no UID,
+	// the shape a preserved foreign alarm keeps.
+	seed, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (seed): %v", err)
+	}
+	if err := seed.Events.ReplaceAlarms(ctx, 1, []model.Alarm{
+		{Action: model.UnsupportedAlarmAction, TriggerValue: "-PT5M"},
+	}); err != nil {
+		seed.Close()
+		t.Fatalf("seed repaired alarm: %v", err)
+	}
+	seed.Close()
+
+	if _, _, err := runChroncalCommand(t,
+		"event", "update", "1", "--alarm", "-PT30M",
+	); err != nil {
+		t.Fatalf("event update --alarm: %v", err)
+	}
+
+	// A reopen runs the UID backfill, which must leave the row alone.
+	check, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New (check): %v", err)
+	}
+	defer check.Close()
+	alarms, err := check.Events.ListAlarms(ctx, 1)
+	if err != nil {
+		t.Fatalf("list alarms: %v", err)
+	}
+	if len(alarms) != 2 {
+		t.Fatalf("alarms = %d, want 2 (the new DISPLAY and the repaired row); got %+v", len(alarms), alarms)
+	}
+	var repaired *model.Alarm
+	for i, a := range alarms {
+		if a.Action == model.UnsupportedAlarmAction {
+			repaired = &alarms[i]
+		}
+	}
+	if repaired == nil {
+		t.Fatalf("the update deleted the repaired row; alarms = %+v", alarms)
+	}
+	if repaired.UID != "" {
+		t.Errorf("UID = %q, want an empty UID: a minted value reaches the server on the next push", repaired.UID)
+	}
+}

--- a/db/migrations/045_repair_malformed_alarm_action.sql
+++ b/db/migrations/045_repair_malformed_alarm_action.sql
@@ -12,9 +12,18 @@
 -- delete another client's VALARM on the next push. Repair the value once
 -- here instead, so no later path has to compensate.
 --
--- DISPLAY is the fallback the parser, the write rule, and the exporter all
--- use for an action they cannot represent, so the repaired row keeps the
--- behavior the exporter already gave it.
+-- The repair writes X-CHRONCAL-UNSUPPORTED, not DISPLAY. A row with a
+-- malformed action holds the VALARM of another client, which an older
+-- build stored verbatim. DISPLAY would make that row a normal reminder:
+-- the carry-over would stop protecting it, so the next --alarm edit would
+-- delete it; the UID backfill would stamp a chroncal UID on it; and the
+-- alarm engine would fire it. X-CHRONCAL-UNSUPPORTED is a valid x-name, so
+-- every write rule accepts it, and it stays outside the fireable set, so
+-- the row keeps the treatment a preserved foreign alarm gets (issue #603).
+--
+-- The repair loses the original malformed bytes. Export could never write
+-- them, and the engine could never fire them, so the row keeps every
+-- behavior it had.
 --
 -- The GLOB pattern matches a value that holds a character outside the
 -- token set (ALPHA, DIGIT, and "-"). It mirrors model.ValidAlarmActionToken.
@@ -22,16 +31,16 @@
 -- sentinel holds only token characters, so this migration leaves it alone.
 
 UPDATE event_alarms
-SET action = 'DISPLAY'
+SET action = 'X-CHRONCAL-UNSUPPORTED'
 WHERE action = '' OR action GLOB '*[^A-Za-z0-9-]*';
 
 UPDATE todo_alarms
-SET action = 'DISPLAY'
+SET action = 'X-CHRONCAL-UNSUPPORTED'
 WHERE action = '' OR action GLOB '*[^A-Za-z0-9-]*';
 
 -- +goose Down
 
 -- The repair is irreversible. The original malformed value is gone, and no
--- column records it, so a Down cannot tell a repaired row from a row that
--- always held DISPLAY. This statement is deliberately empty.
+-- column records it, so a Down cannot restore it. This statement is
+-- deliberately empty.
 SELECT 1;

--- a/internal/alarm/service_test.go
+++ b/internal/alarm/service_test.go
@@ -180,6 +180,9 @@ func TestCheck_SkipsSyncOnlyAction(t *testing.T) {
 	if err := evtSvc.ReplaceAlarms(ctx, e.ID, []model.Alarm{
 		{Action: "NONE", TriggerValue: "-PT15M"},
 		{Action: "X-APPLE-SOUND", TriggerValue: "-PT15M"},
+		// A row migration 045 repaired keeps the foreign treatment, so
+		// the engine skips it too (issue #603).
+		{Action: model.UnsupportedAlarmAction, TriggerValue: "-PT15M"},
 		{Action: "DISPLAY", TriggerValue: "-PT15M", Description: "real reminder"},
 	}); err != nil {
 		t.Fatal(err)

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -769,11 +769,19 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	// "ACTION:" line is invalid iCal, and a strict server rejects the
 	// whole resource for it. The write rule refuses such a value now
 	// (issue #595), so this guard covers a row an older build stored and
-	// an in-memory alarm that skipped the write paths. DISPLAY is the
-	// same fallback the parser and the write rule use for an empty value.
+	// an in-memory alarm that skipped the write paths.
+	//
+	// The two cases take different fallbacks. An empty action is an unset
+	// value, and DISPLAY is the default the parser and the write rule fill
+	// in. A malformed non-empty action belongs to the VALARM of another
+	// client, so it takes the reserved x-name instead. DISPLAY would push
+	// that alarm to the server as a firing reminder (issue #603).
 	action := alarm.Action
-	if !model.ValidAlarmActionToken(action) {
+	switch {
+	case action == "":
 		action = model.DefaultAlarmAction
+	case !model.ValidAlarmActionToken(action):
+		action = model.UnsupportedAlarmAction
 	}
 	valarm.Props.SetText(ical.PropAction, action)
 

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -1557,9 +1557,19 @@ func TestExport_AllDayJournalOverrideRecurrenceIDIsDate(t *testing.T) {
 // the constraint refuses an empty value alone. Export must not write it:
 // a bare or malformed ACTION line is invalid iCal, and a strict server
 // rejects the whole resource for it (issue #595).
-func TestExport_MalformedStoredActionFallsBackToDisplay(t *testing.T) {
+func TestExport_MalformedStoredActionTakesTheReservedToken(t *testing.T) {
 	start := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
-	for _, action := range []string{" ", "\t", "NO NE", ""} {
+	// An empty action is an unset value, so it takes the DISPLAY default.
+	// A malformed non-empty action belongs to the VALARM of another
+	// client, so it takes the reserved x-name. DISPLAY there would push
+	// that alarm to the server as a firing reminder (issue #603).
+	cases := map[string]string{
+		"":      model.DefaultAlarmAction,
+		" ":     model.UnsupportedAlarmAction,
+		"\t":    model.UnsupportedAlarmAction,
+		"NO NE": model.UnsupportedAlarmAction,
+	}
+	for action, want := range cases {
 		evt := event.Event{
 			UID: "malformed-action@example.com", Title: "Test",
 			StartTime: start, EndTime: start.Add(time.Hour),
@@ -1570,11 +1580,11 @@ func TestExport_MalformedStoredActionFallsBackToDisplay(t *testing.T) {
 			t.Fatalf("ExportEvents(action %q): %v", action, err)
 		}
 		out := string(raw)
-		if strings.Contains(out, "ACTION:"+action) && action != "" {
+		if action != "" && strings.Contains(out, "ACTION:"+action) {
 			t.Errorf("action %q: export emitted it verbatim:\n%s", action, out)
 		}
-		if !strings.Contains(out, "ACTION:DISPLAY") {
-			t.Errorf("action %q: export did not fall back to DISPLAY:\n%s", action, out)
+		if !strings.Contains(out, "ACTION:"+want) {
+			t.Errorf("action %q: export did not write %q:\n%s", action, want, out)
 		}
 	}
 }

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -228,6 +228,32 @@ func FireableAlarmAction(action string) bool {
 	return slices.Contains(alarmActions, action)
 }
 
+// UnsupportedAlarmAction replaces a stored action that is not a valid
+// token. It is an RFC 5545 x-name, so it passes every write rule, and it
+// is outside the fireable set, so the alarm keeps the treatment a
+// preserved foreign alarm gets: the carry-over protects the row, no write
+// mints a UID for it, and the alarm engine skips it.
+//
+// Migration 045 writes this value over the malformed bytes an older build
+// stored. The engine could never fire those rows, and export could never
+// write them (issue #603).
+const UnsupportedAlarmAction = "X-CHRONCAL-UNSUPPORTED"
+
+// NormalizeAlarmActionForWrite returns the action a write stores for a
+// value that reaches a write path. It replaces a malformed token with
+// UnsupportedAlarmAction and keeps every other value.
+//
+// Migration 045 repairs the stored rows, but that repair is version-gated:
+// an older release run against a repaired database writes a malformed
+// action again. This function keeps such a row writable, so an edit of the
+// owning record cannot fail and the row is never deleted (issue #603).
+func NormalizeAlarmActionForWrite(action string) string {
+	if action == "" || ValidAlarmActionToken(action) {
+		return action
+	}
+	return UnsupportedAlarmAction
+}
+
 // ValidAlarmActionToken returns true if s has the shape RFC 5545 gives an
 // iana-token or an x-name: one or more ALPHA, DIGIT, or "-" characters.
 // The import parser and the write rule share this test. Any other byte
@@ -305,17 +331,20 @@ func CheckStorableAlarmAction(action string) error {
 // calls ReplaceAlarms with the exact list instead. The TUI alarm editor
 // works that way, so a local calendar keeps a way to delete such a row.
 //
-// The carry-over covers every stored row the engine cannot fire. It
-// applies no further test on the action. A row that fails the write rule
-// must never be left behind here, because the replacement then deletes it
-// and the next push deletes the VALARM of another client. Migration 045
-// repairs the malformed actions an older build stored, so no such row
-// reaches this function.
+// The carry-over covers every stored row the engine cannot fire. A row
+// must never drop out here, because the replacement then deletes it and
+// the next push deletes the VALARM of another client. Migration 045
+// repairs the malformed actions an older build stored, but that repair is
+// version-gated: an older release run against a repaired database writes
+// one again. So this function normalizes a malformed action instead of
+// leaving a row the write rule refuses (issue #603).
 func KeepSyncOnlyAlarms(stored, replacement []Alarm) []Alarm {
 	for _, a := range stored {
-		if !FireableAlarmAction(a.Action) {
-			replacement = append(replacement, a)
+		if FireableAlarmAction(a.Action) {
+			continue
 		}
+		a.Action = NormalizeAlarmActionForWrite(a.Action)
+		replacement = append(replacement, a)
 	}
 	return replacement
 }

--- a/internal/model/alarm_validate_test.go
+++ b/internal/model/alarm_validate_test.go
@@ -205,3 +205,68 @@ func TestKeepSyncOnlyAlarms_KeepsEveryNonFireableRow(t *testing.T) {
 		t.Errorf("DISPLAY appears %d times, want only the replacement copy", fireable)
 	}
 }
+
+// A stored row with a malformed action must stay in the carry-over. An
+// older release run against a repaired database writes one again, and a
+// drop here would delete the VALARM of another client on the next push
+// (issue #603). The carry-over normalizes the value instead.
+func TestKeepSyncOnlyAlarms_NormalizesMalformedAction(t *testing.T) {
+	stored := []Alarm{
+		{Action: " ", TriggerValue: "-PT5M"},
+		{Action: "NO NE", TriggerValue: "-PT10M"},
+	}
+	kept := KeepSyncOnlyAlarms(stored, []Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M"}})
+
+	if len(kept) != 3 {
+		t.Fatalf("kept = %d rows, want the replacement plus both stored rows", len(kept))
+	}
+	for _, a := range kept[1:] {
+		if a.Action != UnsupportedAlarmAction {
+			t.Errorf("carried action = %q, want %q", a.Action, UnsupportedAlarmAction)
+		}
+		if !StorableAlarmAction(a.Action) {
+			t.Errorf("carried action %q fails the write rule, so the edit fails", a.Action)
+		}
+		if FireableAlarmAction(a.Action) {
+			t.Errorf("carried action %q is fireable, so the engine would fire the alarm of another client", a.Action)
+		}
+		if AlarmUIDForWrite(a) != "" {
+			t.Errorf("a write mints a UID for %q, which the next push sends to the server", a.Action)
+		}
+	}
+}
+
+// The reserved token must satisfy every rule the repaired row meets later.
+func TestUnsupportedAlarmActionKeepsForeignTreatment(t *testing.T) {
+	if !ValidAlarmActionToken(UnsupportedAlarmAction) {
+		t.Errorf("%q is not a valid token, so a write refuses the repaired row", UnsupportedAlarmAction)
+	}
+	if !StorableAlarmAction(UnsupportedAlarmAction) {
+		t.Errorf("%q fails the write rule", UnsupportedAlarmAction)
+	}
+	if FireableAlarmAction(UnsupportedAlarmAction) {
+		t.Errorf("%q is fireable, so the engine fires a repaired foreign alarm", UnsupportedAlarmAction)
+	}
+	if got := AlarmUIDForWrite(Alarm{Action: UnsupportedAlarmAction}); got != "" {
+		t.Errorf("AlarmUIDForWrite = %q, want an empty UID for a preserved row", got)
+	}
+}
+
+// NormalizeAlarmActionForWrite keeps every value a write already accepts.
+func TestNormalizeAlarmActionForWrite(t *testing.T) {
+	cases := map[string]string{
+		"DISPLAY":       "DISPLAY",
+		"X-APPLE-SOUND": "X-APPLE-SOUND",
+		"x-apple-sound": "x-apple-sound",
+		"NONE":          "NONE",
+		"":              "",
+		" ":             UnsupportedAlarmAction,
+		"NO NE":         UnsupportedAlarmAction,
+		"a.b":           UnsupportedAlarmAction,
+	}
+	for in, want := range cases {
+		if got := NormalizeAlarmActionForWrite(in); got != want {
+			t.Errorf("NormalizeAlarmActionForWrite(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -3,10 +3,12 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/pressly/goose/v3"
 
+	dbembed "github.com/douglasdemoura/chroncal/db"
 	"github.com/douglasdemoura/chroncal/internal/model"
 )
 
@@ -437,6 +439,9 @@ func TestMigration045RepairsMalformedAction(t *testing.T) {
 		VALUES ('mig045-evt', 1, 'Mig', '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z')`)
 	mustExec(`INSERT INTO todos (uid, calendar_id, summary) VALUES ('mig045-todo', 1, 'Mig')`)
 
+	// The lowercase seed matters: parseAlarm keeps the original case of a
+	// preserved action, so a pattern that covered only uppercase would
+	// clobber it and both tests would still pass.
 	seeds := []struct {
 		id     int
 		action string
@@ -448,6 +453,8 @@ func TestMigration045RepairsMalformedAction(t *testing.T) {
 		{4, "NONE", false},
 		{5, "DISPLAY", false},
 		{6, "PROCEDURE", false},
+		{7, "x-apple-sound", false},
+		{8, "a.b", true},
 	}
 	for _, s := range seeds {
 		mustExec(`INSERT INTO event_alarms (id, event_id, action, trigger_value) VALUES (?, 1, ?, '-PT15M')`,
@@ -464,13 +471,43 @@ func TestMigration045RepairsMalformedAction(t *testing.T) {
 		for _, s := range seeds {
 			want := s.action
 			if s.repair {
-				want = "DISPLAY"
+				want = model.UnsupportedAlarmAction
 			}
 			if n := count(`SELECT COUNT(*) FROM `+table+` WHERE id = ? AND action = ?`, s.id, want); n != 1 {
 				t.Errorf("%s id %d: action %q did not end as %q", table, s.id, s.action, want)
 			}
 		}
 	}
+}
+
+// migration045Pattern returns the GLOB literal the migration 045 file
+// holds, including its quotes. The pattern test probes that value, so an
+// edit to the migration reaches the test.
+func migration045Pattern(t *testing.T) string {
+	t.Helper()
+	body, err := dbembed.Migrations.ReadFile("migrations/045_repair_malformed_alarm_action.sql")
+	if err != nil {
+		t.Fatalf("read migration 045: %v", err)
+	}
+	const marker = "GLOB "
+	for _, line := range strings.Split(string(body), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		i := strings.Index(trimmed, marker)
+		if i < 0 {
+			continue
+		}
+		rest := trimmed[i+len(marker):]
+		end := strings.Index(rest[1:], "'")
+		if !strings.HasPrefix(rest, "'") || end < 0 {
+			t.Fatalf("migration 045: cannot read the GLOB literal from %q", trimmed)
+		}
+		return rest[:end+2]
+	}
+	t.Fatal("migration 045: found no GLOB pattern")
+	return ""
 }
 
 // The migration 045 GLOB pattern and model.ValidAlarmActionToken must give
@@ -484,6 +521,11 @@ func TestMigration045PatternMatchesTokenRule(t *testing.T) {
 	}
 	defer conn.Close()
 
+	// Read the predicate out of the migration itself. A copy typed here
+	// would keep passing after an edit to the migration, which is the
+	// drift this test exists to catch.
+	pattern := migration045Pattern(t)
+
 	candidates := []string{
 		"DISPLAY", "AUDIO", "EMAIL", "NONE", "PROCEDURE", "X-APPLE-SOUND",
 		"x-lower-case", "A1", "-", "9",
@@ -492,7 +534,7 @@ func TestMigration045PatternMatchesTokenRule(t *testing.T) {
 	for _, v := range candidates {
 		var matched int
 		if err := conn.QueryRowContext(context.Background(),
-			`SELECT CASE WHEN ? = '' OR ? GLOB '*[^A-Za-z0-9-]*' THEN 1 ELSE 0 END`,
+			`SELECT CASE WHEN ? = '' OR ? GLOB `+pattern+` THEN 1 ELSE 0 END`,
 			v, v).Scan(&matched); err != nil {
 			t.Fatalf("probe %q: %v", v, err)
 		}


### PR DESCRIPTION
Applies the post-merge review of PR #603.

## The problem

Migration 045 repaired a malformed stored alarm action (`" "`, `"NO NE"`) to `DISPLAY`. Those rows hold the VALARM of **another client**, stored verbatim by a build older than the #595 token rule. `DISPLAY` made such a row indistinguishable from a reminder the user typed, with three verified results:

- `KeepSyncOnlyAlarms` carries forward only non-fireable rows, so a repaired row lost its protection. `chroncal event update <id> --alarm -15m` deleted it, and the next push removed another client's VALARM — the issue #579 loss the carry-over exists to prevent.
- `Open()` runs the migration and then `backfillAlarmUIDs`, so the now-fireable row with an empty UID was stamped with a chroncal UID at once — the issue #586 harm.
- The alarm engine fired a desktop notification for an alarm that could never fire before.

## The fix

The repair writes `model.UnsupportedAlarmAction` (`X-CHRONCAL-UNSUPPORTED`). It is a valid RFC 5545 x-name, so every write rule accepts it, and it stays outside the fireable set, so the row keeps the treatment a preserved foreign alarm gets: the carry-over protects it, no write mints a UID, and the engine skips it.

Per finding:

1. **Migration 045** writes the reserved x-name. The comment explains the choice and states what is lost (the original malformed bytes, which export could never write and the engine could never fire).
2. **Export fallback split.** An empty action still means `DISPLAY`, an unset value. A malformed action takes the reserved x-name, so a push does not turn another client's alarm into a firing reminder.
3. **Version-gated invariant guarded.** `KeepSyncOnlyAlarms` normalizes a malformed action through the new `model.NormalizeAlarmActionForWrite` instead of leaving a row the write rule refuses. An older release run against a repaired database writes one again; the row stays writable and is never deleted.
4. **The drift test now reads the migration.** `TestMigration045PatternMatchesTokenRule` held a third hand-typed copy of the GLOB, so an edit to the migration could not fail it. It now reads the literal out of the embedded file. The repair test also seeds a lowercase `x-apple-sound`, which an uppercase-only pattern would clobber.
5. **Comment corrected.** The parser drops a malformed action and warns; it defaults to `DISPLAY` only for an empty value. Only the write rule and the exporter fall back.

## On migration 045 and existing databases

No tag contains the commit that added 045 (`v0.7.7` predates it by a day), so **no release carries it**. The migration is edited in place rather than renumbered. A developer database that already ran the old version keeps the `DISPLAY` value: a re-repair cannot tell such a row from a reminder the user typed, so it is not attempted.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, the full `go test ./...`, and `golangci-lint` (v2.11.4, matching CI) are all clean.

The drift test is verified non-vacuous: narrowing the migration's pattern to `'*[^A-Z0-9-]*'` fails both migration tests (the pattern probe on `x-lower-case`, and the repair test on the `x-apple-sound` seed); restoring it passes.

New tests cover the required behavior: a repaired row survives an `--alarm` update and gets no minted UID after a reopen, the fire path skips the reserved action, and the export split writes the right value for each case.