### PR TITLE
ci: give the race suite a timeout it can meet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Run tests
-        run: go test -race -count=1 ./...
+        # The race suite is slow: cmd/chroncal alone runs past Go's
+        # default 10m per-package timeout on the Linux runner, so a
+        # legitimate run fails as though a test hung (issue #569).
+        run: go test -race -count=1 -timeout 30m ./...
 
   lint:
     name: Lint


### PR DESCRIPTION
`cmd/chroncal` now exceeds Go's default 10-minute per-package timeout under `-race` on the Linux runner. Two consecutive CI runs failed at 600.5s with `panic: test timed out after 10m0s`, while the macOS runner passed the identical commit.

The tests do not hang — they are legitimately slow. The race detector plus the CLI helper processes are costly, and the package grew this cycle. Raising the limit to 30 minutes lets a slow run report its real result instead of failing as though something deadlocked.

Refs #569, which tracked the suite sitting seconds away from this ceiling.