### PR TITLE
fix(storage): drop the empty-action clause, guard both repair patterns

### DIFF
--- a/db/migrations/045_repair_malformed_alarm_action.sql
+++ b/db/migrations/045_repair_malformed_alarm_action.sql
@@ -32,11 +32,11 @@
 
 UPDATE event_alarms
 SET action = 'X-CHRONCAL-UNSUPPORTED'
-WHERE action = '' OR action GLOB '*[^A-Za-z0-9-]*';
+WHERE action GLOB '*[^A-Za-z0-9-]*';
 
 UPDATE todo_alarms
 SET action = 'X-CHRONCAL-UNSUPPORTED'
-WHERE action = '' OR action GLOB '*[^A-Za-z0-9-]*';
+WHERE action GLOB '*[^A-Za-z0-9-]*';
 
 -- +goose Down
 

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -490,6 +490,7 @@ func migration045Pattern(t *testing.T) string {
 		t.Fatalf("read migration 045: %v", err)
 	}
 	const marker = "GLOB "
+	var found []string
 	for _, line := range strings.Split(string(body), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "--") {
@@ -504,10 +505,17 @@ func migration045Pattern(t *testing.T) string {
 		if !strings.HasPrefix(rest, "'") || end < 0 {
 			t.Fatalf("migration 045: cannot read the GLOB literal from %q", trimmed)
 		}
-		return rest[:end+2]
+		found = append(found, rest[:end+2])
 	}
-	t.Fatal("migration 045: found no GLOB pattern")
-	return ""
+	// The migration repairs both alarm tables. Read every pattern, so a
+	// narrowed literal in either statement fails this test.
+	if len(found) != 2 {
+		t.Fatalf("migration 045: found %d GLOB patterns, want one per alarm table", len(found))
+	}
+	if found[0] != found[1] {
+		t.Fatalf("migration 045: the two statements use different patterns: %s and %s", found[0], found[1])
+	}
+	return found[0]
 }
 
 // The migration 045 GLOB pattern and model.ValidAlarmActionToken must give
@@ -526,16 +534,19 @@ func TestMigration045PatternMatchesTokenRule(t *testing.T) {
 	// drift this test exists to catch.
 	pattern := migration045Pattern(t)
 
+	// The empty value is out of scope. The CHECK constraint of migration
+	// 044 forbids it, and every other path reads it as "unset" and uses
+	// DISPLAY, so the migration must not rewrite it to the reserved token.
 	candidates := []string{
 		"DISPLAY", "AUDIO", "EMAIL", "NONE", "PROCEDURE", "X-APPLE-SOUND",
 		"x-lower-case", "A1", "-", "9",
-		"", " ", "  ", "\t", "NO NE", "X APPLE", "DISPLAY;", "a.b", "caf\u00e9",
+		" ", "  ", "\t", "NO NE", "X APPLE", "DISPLAY;", "a.b", "caf\u00e9",
 	}
 	for _, v := range candidates {
 		var matched int
 		if err := conn.QueryRowContext(context.Background(),
-			`SELECT CASE WHEN ? = '' OR ? GLOB `+pattern+` THEN 1 ELSE 0 END`,
-			v, v).Scan(&matched); err != nil {
+			`SELECT CASE WHEN ? GLOB `+pattern+` THEN 1 ELSE 0 END`,
+			v).Scan(&matched); err != nil {
 			t.Fatalf("probe %q: %v", v, err)
 		}
 		wantRepair := !model.ValidAlarmActionToken(v)


### PR DESCRIPTION
Two low-severity findings from the post-merge review of PR #604.

**The empty-action clause contradicted the empty-vs-malformed split.** Migration 045 repaired `action = ''` to the reserved x-name, but `buildValarm` and `NormalizeAlarmActionForWrite` both read an empty action as *unset* and map it to `DISPLAY`. Repairing it to a non-fireable token would have converted a user's own reminder into a foreign row no `--alarm` edit can reach. The clause was dead — migration 044's `CHECK(action <> '')` forbids the value — but the test's hand-typed probe locked the contradiction in. The migration now repairs only a malformed token, and the test documents why the empty value is out of scope.

**The drift guard covered only half the migration.** `migration045Pattern` returned on the first `GLOB` literal, which is the `event_alarms` statement, so narrowing the `todo_alarms` pattern alone still passed. It now reads every pattern and asserts they match.

Verified non-vacuous: narrowing only the todo pattern to `'*[^A-Z0-9-]*'` fails both the pattern test and the repair test on the `x-apple-sound` seed; restoring passes.