### PR TITLE
fix(alarm): normalize a malformed stored action as the row loads

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -2254,12 +2254,16 @@ func (s *Service) populateCategories(ctx context.Context, events []Event) {
 	}
 }
 
+// fromStorageAlarm converts an alarm row to the model value. It maps a
+// malformed stored action to model.UnsupportedAlarmAction, so every
+// reader holds a value the write rule accepts. See
+// model.NormalizeAlarmAction for the rule (issue #607).
 func fromStorageAlarm(r storage.EventAlarm) model.Alarm {
 	return model.Alarm{
 		ID:            r.ID,
 		EventID:       r.EventID,
 		UID:           storage.NullableToString(r.Uid),
-		Action:        r.Action,
+		Action:        model.NormalizeAlarmAction(r.Action),
 		TriggerValue:  r.TriggerValue,
 		Description:   storage.NullableToString(r.Description),
 		Summary:       storage.NullableToString(r.Summary),

--- a/internal/event/service_test.go
+++ b/internal/event/service_test.go
@@ -1260,3 +1260,72 @@ func assertAlarmUIDs(t *testing.T, svc *Service, eventID int64) {
 		}
 	}
 }
+
+// A malformed stored action must not lock the owning event. An older
+// release run against a repaired database writes such a row again,
+// because migration 045 does not run a second time. The service maps the
+// value as it reads the row, so every later write accepts it (issue #607).
+func TestListAlarms_NormalizesMalformedStoredAction(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	e := createEvent(t, svc)
+	seedMalformedEventAlarm(t, svc, e.ID)
+
+	alarms, err := svc.ListAlarms(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms: %v", err)
+	}
+	if len(alarms) != 1 {
+		t.Fatalf("alarms = %d, want 1", len(alarms))
+	}
+	if alarms[0].Action != model.UnsupportedAlarmAction {
+		t.Errorf("action = %q, want %q", alarms[0].Action, model.UnsupportedAlarmAction)
+	}
+}
+
+// The TUI edit path loads the stored alarms and writes the whole list
+// back. A malformed stored action made that save fail, so no edit of the
+// event could land (issue #607).
+func TestUpdateWithRelations_SavesWithMalformedStoredAction(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	e := createEvent(t, svc)
+	seedMalformedEventAlarm(t, svc, e.ID)
+
+	alarms, err := svc.ListAlarms(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms: %v", err)
+	}
+
+	// The form carries the loaded alarms back into the save.
+	if _, err := svc.UpdateWithRelations(ctx, e.ID, UpdateParams{
+		Title:      "A new title",
+		StartTime:  e.StartTime,
+		EndTime:    e.EndTime,
+		CalendarID: e.CalendarID,
+	}, nil, alarms); err != nil {
+		t.Fatalf("the save must succeed with a malformed stored alarm: %v", err)
+	}
+
+	after, err := svc.ListAlarms(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms after the save: %v", err)
+	}
+	if len(after) != 1 {
+		t.Fatalf("alarms after the save = %d, want 1; the row must survive", len(after))
+	}
+	if after[0].Action != model.UnsupportedAlarmAction {
+		t.Errorf("action after the save = %q, want %q", after[0].Action, model.UnsupportedAlarmAction)
+	}
+}
+
+// seedMalformedEventAlarm writes an alarm row through SQL. The service
+// write rule refuses the value, so only an older build could store it.
+func seedMalformedEventAlarm(t *testing.T, svc *Service, eventID int64) {
+	t.Helper()
+	if _, err := svc.db.ExecContext(context.Background(),
+		`INSERT INTO event_alarms (event_id, action, trigger_value, related) VALUES (?, 'NO NE', '-PT15M', 'START')`,
+		eventID); err != nil {
+		t.Fatalf("seed the malformed row: %v", err)
+	}
+}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -768,8 +768,9 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 	// iana-token or x-name cannot be written: a bare or malformed
 	// "ACTION:" line is invalid iCal, and a strict server rejects the
 	// whole resource for it. The write rule refuses such a value now
-	// (issue #595), so this guard covers a row an older build stored and
-	// an in-memory alarm that skipped the write paths.
+	// (issue #595), and the services normalize a stored row as they read
+	// it (issue #607). This guard therefore covers an in-memory alarm
+	// that reached the exporter without either path.
 	//
 	// The two cases take different fallbacks. An empty action is an unset
 	// value, and DISPLAY is the default the parser and the write rule fill

--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -239,15 +239,23 @@ func FireableAlarmAction(action string) bool {
 // write them (issue #603).
 const UnsupportedAlarmAction = "X-CHRONCAL-UNSUPPORTED"
 
-// NormalizeAlarmActionForWrite returns the action a write stores for a
-// value that reaches a write path. It replaces a malformed token with
-// UnsupportedAlarmAction and keeps every other value.
+// NormalizeAlarmAction returns the action a stored row carries into the
+// model. It replaces a malformed token with UnsupportedAlarmAction and
+// keeps every other value. An empty value passes through, because the
+// write rule maps it to DefaultAlarmAction.
+//
+// The event service and the todo service call this function where a
+// storage row becomes a model value. Every reader then holds a value the
+// write rule accepts, so an edit of the owning record cannot fail and the
+// row is never deleted (issue #607).
+//
+// The parsers and the CLI flag keep their own strict test, so a producer
+// that supplies a malformed action still fails loudly.
 //
 // Migration 045 repairs the stored rows, but that repair is version-gated:
 // an older release run against a repaired database writes a malformed
-// action again. This function keeps such a row writable, so an edit of the
-// owning record cannot fail and the row is never deleted (issue #603).
-func NormalizeAlarmActionForWrite(action string) string {
+// action again (issue #603).
+func NormalizeAlarmAction(action string) string {
 	if action == "" || ValidAlarmActionToken(action) {
 		return action
 	}
@@ -333,17 +341,14 @@ func CheckStorableAlarmAction(action string) error {
 //
 // The carry-over covers every stored row the engine cannot fire. A row
 // must never drop out here, because the replacement then deletes it and
-// the next push deletes the VALARM of another client. Migration 045
-// repairs the malformed actions an older build stored, but that repair is
-// version-gated: an older release run against a repaired database writes
-// one again. So this function normalizes a malformed action instead of
-// leaving a row the write rule refuses (issue #603).
+// the next push deletes the VALARM of another client. The stored rows
+// arrive through NormalizeAlarmAction, so every action here already
+// passes the write rule (issue #607).
 func KeepSyncOnlyAlarms(stored, replacement []Alarm) []Alarm {
 	for _, a := range stored {
 		if FireableAlarmAction(a.Action) {
 			continue
 		}
-		a.Action = NormalizeAlarmActionForWrite(a.Action)
 		replacement = append(replacement, a)
 	}
 	return replacement

--- a/internal/model/alarm_validate_test.go
+++ b/internal/model/alarm_validate_test.go
@@ -206,14 +206,14 @@ func TestKeepSyncOnlyAlarms_KeepsEveryNonFireableRow(t *testing.T) {
 	}
 }
 
-// A stored row with a malformed action must stay in the carry-over. An
-// older release run against a repaired database writes one again, and a
-// drop here would delete the VALARM of another client on the next push
-// (issue #603). The carry-over normalizes the value instead.
-func TestKeepSyncOnlyAlarms_NormalizesMalformedAction(t *testing.T) {
+// A row the read boundary normalized must stay in the carry-over. The
+// services map a malformed stored action to UnsupportedAlarmAction, so
+// that value is what the carry-over sees (issue #607). A drop here would
+// delete the VALARM of another client on the next push.
+func TestKeepSyncOnlyAlarms_KeepsTheNormalizedRow(t *testing.T) {
 	stored := []Alarm{
-		{Action: " ", TriggerValue: "-PT5M"},
-		{Action: "NO NE", TriggerValue: "-PT10M"},
+		{Action: UnsupportedAlarmAction, TriggerValue: "-PT5M"},
+		{Action: "X-APPLE-SOUND", TriggerValue: "-PT10M"},
 	}
 	kept := KeepSyncOnlyAlarms(stored, []Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M"}})
 
@@ -221,9 +221,6 @@ func TestKeepSyncOnlyAlarms_NormalizesMalformedAction(t *testing.T) {
 		t.Fatalf("kept = %d rows, want the replacement plus both stored rows", len(kept))
 	}
 	for _, a := range kept[1:] {
-		if a.Action != UnsupportedAlarmAction {
-			t.Errorf("carried action = %q, want %q", a.Action, UnsupportedAlarmAction)
-		}
 		if !StorableAlarmAction(a.Action) {
 			t.Errorf("carried action %q fails the write rule, so the edit fails", a.Action)
 		}
@@ -252,8 +249,8 @@ func TestUnsupportedAlarmActionKeepsForeignTreatment(t *testing.T) {
 	}
 }
 
-// NormalizeAlarmActionForWrite keeps every value a write already accepts.
-func TestNormalizeAlarmActionForWrite(t *testing.T) {
+// NormalizeAlarmAction keeps every value a write already accepts.
+func TestNormalizeAlarmAction(t *testing.T) {
 	cases := map[string]string{
 		"DISPLAY":       "DISPLAY",
 		"X-APPLE-SOUND": "X-APPLE-SOUND",
@@ -265,8 +262,20 @@ func TestNormalizeAlarmActionForWrite(t *testing.T) {
 		"a.b":           UnsupportedAlarmAction,
 	}
 	for in, want := range cases {
-		if got := NormalizeAlarmActionForWrite(in); got != want {
-			t.Errorf("NormalizeAlarmActionForWrite(%q) = %q, want %q", in, got, want)
+		if got := NormalizeAlarmAction(in); got != want {
+			t.Errorf("NormalizeAlarmAction(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The read boundary normalizes a stored row, but the write rule stays
+// strict. A caller that supplies a malformed action still fails, so a
+// producer defect cannot pass in silence (issue #607).
+func TestPrepareAlarmsForWrite_StillRefusesACallerValue(t *testing.T) {
+	for _, action := range []string{" ", "NO NE", "a.b"} {
+		_, err := PrepareAlarmsForWrite([]Alarm{{Action: action, TriggerValue: "-PT15M"}})
+		if !errors.Is(err, ErrInvalidAlarm) {
+			t.Errorf("PrepareAlarmsForWrite(%q) error = %v, want ErrInvalidAlarm", action, err)
 		}
 	}
 }

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -883,11 +883,14 @@ func (s *Service) buildAlarms(ctx context.Context, rows []storage.TodoAlarm, wit
 }
 
 // fromStorageTodoAlarm maps a todo_alarms row to the shared alarm model.
+// fromStorageTodoAlarm converts an alarm row to the model value. It maps
+// a malformed stored action to model.UnsupportedAlarmAction, like the
+// event service does. See model.NormalizeAlarmAction (issue #607).
 func fromStorageTodoAlarm(r storage.TodoAlarm) model.Alarm {
 	return model.Alarm{
 		ID: r.ID, EventID: r.TodoID,
 		UID:           storage.NullableToString(r.Uid),
-		Action:        r.Action,
+		Action:        model.NormalizeAlarmAction(r.Action),
 		TriggerValue:  r.TriggerValue,
 		Description:   storage.NullableToString(r.Description),
 		Summary:       storage.NullableToString(r.Summary),

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -824,3 +824,35 @@ func TestTodoService_ReplaceAlarms_KeepsForeignAlarmUIDEmpty(t *testing.T) {
 		}
 	}
 }
+
+// The todo service maps a malformed stored action as it reads the row,
+// like the event service does (issue #607).
+func TestTodoListAlarms_NormalizesMalformedStoredAction(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	td := createTodo(t, svc)
+
+	// Write the row through SQL. The service write rule refuses this
+	// value, so only an older build could store it.
+	if _, err := svc.db.ExecContext(ctx,
+		`INSERT INTO todo_alarms (todo_id, action, trigger_value, related) VALUES (?, 'NO NE', '-PT15M', 'START')`,
+		td.ID); err != nil {
+		t.Fatalf("seed the malformed row: %v", err)
+	}
+
+	alarms, err := svc.ListAlarms(ctx, td.ID)
+	if err != nil {
+		t.Fatalf("ListAlarms: %v", err)
+	}
+	if len(alarms) != 1 {
+		t.Fatalf("alarms = %d, want 1", len(alarms))
+	}
+	if alarms[0].Action != model.UnsupportedAlarmAction {
+		t.Errorf("action = %q, want %q", alarms[0].Action, model.UnsupportedAlarmAction)
+	}
+
+	// The row must still write back, so an edit of the todo cannot fail.
+	if err := svc.ReplaceAlarms(ctx, td.ID, alarms); err != nil {
+		t.Fatalf("the write must accept the normalized row: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #607, taking option 2 from the issue.

## The problem

`NormalizeAlarmActionForWrite` had exactly one caller, `KeepSyncOnlyAlarms`, so only the CLI carry-over survived a malformed stored action. Every other path still refused it.

The reachable case is version-gated: an older release run against an already-migrated database writes `ACTION:NO NE` verbatim, and migration 045 does not run a second time. From then on the TUI edit path loaded that row, wrote the whole list back through `PrepareAlarmsForWrite`, and the save rolled back — so no edit of that event could ever land.

## The change

Move the rule to the two places a storage row becomes a model value:

- `fromStorageAlarm` (`internal/event/service.go`)
- `fromStorageTodoAlarm` (`internal/todo/service.go`)

I checked that these are the only two: no other production code builds a `model.Alarm` from a storage row, and all three call sites are read paths. Every reader — the TUI form, the CLI carry-over, the exporter, the fire path — now holds a value the write rule accepts.

The parsers and the CLI flag keep their own strict test, so a producer that supplies a malformed action still fails loudly. That property is why this is better than normalizing inside `prepareAlarmForWrite`, which would have turned a producer defect into a silently non-firing alarm.

Also in this change:

- `NormalizeAlarmActionForWrite` becomes `NormalizeAlarmAction`. The call site is a read, so the old suffix was wrong.
- `KeepSyncOnlyAlarms` returns to a plain carry-over. It can no longer see a malformed action, and dead code that looks load-bearing has been flagged repeatedly in this repository's reviews.
- The `buildValarm` guard stays, with its comment corrected. It now covers only an in-memory alarm that reached the exporter without a parser and without a read.

## Tests

The scenario cannot be produced through normal writes, so the tests seed the row with SQL, the way an older build would have.

- `TestListAlarms_NormalizesMalformedStoredAction` and `TestTodoListAlarms_NormalizesMalformedStoredAction` — a seeded malformed row reads back as the reserved token on both services, and the todo row writes back without error.
- `TestUpdateWithRelations_SavesWithMalformedStoredAction` — the exact lock-up: a save through the `*WithRelations` path succeeds with the row present, and the row survives.
- `TestPrepareAlarmsForWrite_StillRefusesACallerValue` — a caller-supplied malformed action is still rejected, so the loud-failure property does not regress.
- `TestKeepSyncOnlyAlarms_NormalizesMalformedAction` is rewritten as `TestKeepSyncOnlyAlarms_KeepsTheNormalizedRow`. It pinned the behavior this change moves; it now pins the property that still matters, which is that a row never drops out of the carry-over.

Both behavioural tests are verified failing without the fix. With the event normalization reverted:

```
--- FAIL: TestListAlarms_NormalizesMalformedStoredAction
    action = "NO NE", want "X-CHRONCAL-UNSUPPORTED"
--- FAIL: TestUpdateWithRelations_SavesWithMalformedStoredAction
    the save must succeed with a malformed stored alarm: alarm 1: invalid alarm:
    action "NO NE" is not an RFC 5545 iana-token or x-name
```

The existing CLI carry-over tests and the alarm fire-path tests pass unchanged.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, the full `go test ./...`, and `golangci-lint` v2.11.4 (the CI-pinned version) are all clean. Only the two pre-existing gofmt drift files remain untouched.
