### PR TITLE
docs(alarm): drop a duplicated line, state the carry-over precondition

### DIFF
--- a/internal/model/alarm.go
+++ b/internal/model/alarm.go
@@ -341,9 +341,13 @@ func CheckStorableAlarmAction(action string) error {
 //
 // The carry-over covers every stored row the engine cannot fire. A row
 // must never drop out here, because the replacement then deletes it and
-// the next push deletes the VALARM of another client. The stored rows
-// arrive through NormalizeAlarmAction, so every action here already
-// passes the write rule (issue #607).
+// the next push deletes the VALARM of another client.
+//
+// The stored list must come from a service read. Such a read maps a
+// malformed action through NormalizeAlarmAction, so every action here
+// already passes the write rule. A caller that builds the list another
+// way must normalize it first. A carried row the write rule refuses
+// fails every later edit of the owning record (issue #607).
 func KeepSyncOnlyAlarms(stored, replacement []Alarm) []Alarm {
 	for _, a := range stored {
 		if FireableAlarmAction(a.Action) {

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -882,7 +882,6 @@ func (s *Service) buildAlarms(ctx context.Context, rows []storage.TodoAlarm, wit
 	return alarms, nil
 }
 
-// fromStorageTodoAlarm maps a todo_alarms row to the shared alarm model.
 // fromStorageTodoAlarm converts an alarm row to the model value. It maps
 // a malformed stored action to model.UnsupportedAlarmAction, like the
 // event service does. See model.NormalizeAlarmAction (issue #607).


### PR DESCRIPTION
Two documentation findings from the post-merge review of PR #608. No behavior change.

**`fromStorageTodoAlarm` named itself twice.** The patch prepended the new comment block but left the old opening line, so the block read as two openings. The event-side counterpart replaced its comment cleanly.

**`KeepSyncOnlyAlarms` states its precondition.** PR #608 removed the defensive `NormalizeAlarmAction` call from it, because reads now normalize. That makes its safety depend on an invariant enforced in `internal/event` and `internal/todo` — packages `internal/model` cannot import or test against. Rather than restore the call and give the rule two owners, the doc now says the stored list must come from a service read, and what breaks otherwise: a carried row the write rule refuses fails every later edit of the owning record.