### PR TITLE
fix(caldav): keep Radicale free/busy intervals from a REPORT

### DIFF
--- a/internal/caldav/freebusy.go
+++ b/internal/caldav/freebusy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -46,18 +47,81 @@ func QueryFreeBusy(ctx context.Context, httpClient webdav.HTTPClient, calendarUR
 	if err != nil {
 		return freebusy.Result{}, fmt.Errorf("parse REPORT response: %w", err)
 	}
+	return mergeFreeBusyResults(results, from, to), nil
+}
+
+func mergeFreeBusyResults(results []freebusy.Result, from, to time.Time) freebusy.Result {
+	from = from.UTC()
+	to = to.UTC()
 	if len(results) == 0 {
-		return freebusy.Result{Start: from.UTC(), End: to.UTC()}, nil
+		return freebusy.Result{Start: from, End: to}
 	}
 
-	result := results[0]
-	if result.Start.IsZero() {
-		result.Start = from.UTC()
+	merged := freebusy.Result{
+		UID:       results[0].UID,
+		Organizer: results[0].Organizer,
+		URL:       results[0].URL,
+		DTStamp:   results[0].DTStamp,
 	}
-	if result.End.IsZero() {
-		result.End = to.UTC()
+	var start, end time.Time
+	for _, next := range results {
+		if !next.Start.IsZero() && (start.IsZero() || next.Start.Before(start)) {
+			start = next.Start
+		}
+		if !next.End.IsZero() && (end.IsZero() || next.End.After(end)) {
+			end = next.End
+		}
+		if merged.UID == "" {
+			merged.UID = next.UID
+		}
+		if merged.Organizer == "" {
+			merged.Organizer = next.Organizer
+		}
+		if merged.URL == "" {
+			merged.URL = next.URL
+		}
+		if !next.DTStamp.IsZero() && (merged.DTStamp.IsZero() || next.DTStamp.After(merged.DTStamp)) {
+			merged.DTStamp = next.DTStamp
+		}
+		merged.Periods = append(merged.Periods, next.Periods...)
 	}
-	return result, nil
+	if start.IsZero() {
+		start = from
+	}
+	if end.IsZero() {
+		end = to
+	}
+	merged.Start = start
+	merged.End = end
+	// Radicale uses DTSTART/DTEND as the busy interval. Use the requested range.
+	if windowMatchesPeriodSpan(merged) {
+		merged.Start = from
+		merged.End = to
+	}
+	sort.Slice(merged.Periods, func(i, j int) bool {
+		if merged.Periods[i].Start.Equal(merged.Periods[j].Start) {
+			return merged.Periods[i].End.Before(merged.Periods[j].End)
+		}
+		return merged.Periods[i].Start.Before(merged.Periods[j].Start)
+	})
+	return merged
+}
+
+func windowMatchesPeriodSpan(result freebusy.Result) bool {
+	if len(result.Periods) == 0 {
+		return false
+	}
+	spanStart := result.Periods[0].Start
+	spanEnd := result.Periods[0].End
+	for _, period := range result.Periods[1:] {
+		if period.Start.Before(spanStart) {
+			spanStart = period.Start
+		}
+		if period.End.After(spanEnd) {
+			spanEnd = period.End
+		}
+	}
+	return result.Start.Equal(spanStart) && result.End.Equal(spanEnd)
 }
 
 // QueryFreeBusy executes a free-busy-query REPORT using the client's authenticated HTTP transport.

--- a/internal/caldav/freebusy_test.go
+++ b/internal/caldav/freebusy_test.go
@@ -63,6 +63,71 @@ END:VCALENDAR`)),
 	}
 }
 
+func TestQueryFreeBusy_MergesMultipleVFreeBusyComponents(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	client := testHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/calendar; charset=utf-8"}},
+				Body: io.NopCloser(strings.NewReader(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Radicale//NONSGML Radicale Server//EN
+BEGIN:VFREEBUSY
+DTSTART:20260819T090000Z
+DTEND:20260819T093000Z
+FBTYPE:BUSY
+END:VFREEBUSY
+BEGIN:VFREEBUSY
+DTSTART:20260819T140000Z
+DTEND:20260819T150000Z
+FBTYPE:BUSY
+END:VFREEBUSY
+BEGIN:VFREEBUSY
+DTSTART:20260819T160000Z
+DTEND:20260819T170000Z
+FBTYPE:BUSY-TENTATIVE
+END:VFREEBUSY
+END:VCALENDAR`)),
+			}, nil
+		},
+	}
+
+	result, err := QueryFreeBusy(context.Background(), client, "https://example.com/cal/work", from, to)
+	if err != nil {
+		t.Fatalf("QueryFreeBusy: %v", err)
+	}
+	if !result.Start.Equal(from) {
+		t.Fatalf("Start = %s, want requested %s", result.Start, from)
+	}
+	if !result.End.Equal(to) {
+		t.Fatalf("End = %s, want requested %s", result.End, to)
+	}
+	if len(result.Periods) != 3 {
+		t.Fatalf("periods = %d, want 3", len(result.Periods))
+	}
+	want := []struct {
+		start time.Time
+		end   time.Time
+		kind  string
+	}{
+		{time.Date(2026, 8, 19, 9, 0, 0, 0, time.UTC), time.Date(2026, 8, 19, 9, 30, 0, 0, time.UTC), "BUSY"},
+		{time.Date(2026, 8, 19, 14, 0, 0, 0, time.UTC), time.Date(2026, 8, 19, 15, 0, 0, 0, time.UTC), "BUSY"},
+		{time.Date(2026, 8, 19, 16, 0, 0, 0, time.UTC), time.Date(2026, 8, 19, 17, 0, 0, 0, time.UTC), "BUSY-TENTATIVE"},
+	}
+	for i, p := range want {
+		if !result.Periods[i].Start.Equal(p.start) || !result.Periods[i].End.Equal(p.end) {
+			t.Fatalf("period[%d] = %s/%s, want %s/%s", i, result.Periods[i].Start, result.Periods[i].End, p.start, p.end)
+		}
+		if result.Periods[i].Type != p.kind {
+			t.Fatalf("period[%d].type = %q, want %q", i, result.Periods[i].Type, p.kind)
+		}
+	}
+}
+
 func TestClientQueryFreeBusy_ResolvesRelativeHref(t *testing.T) {
 	t.Parallel()
 

--- a/internal/caldav/freebusy_test.go
+++ b/internal/caldav/freebusy_test.go
@@ -63,6 +63,41 @@ END:VCALENDAR`)),
 	}
 }
 
+func TestQueryFreeBusy_RFCEmptyWindowStaysFree(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	client := testHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/calendar; charset=utf-8"}},
+				Body: io.NopCloser(strings.NewReader(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//test//EN
+BEGIN:VFREEBUSY
+UID:fb-free
+DTSTART:20260819T000000Z
+DTEND:20260820T000000Z
+END:VFREEBUSY
+END:VCALENDAR`)),
+			}, nil
+		},
+	}
+
+	result, err := QueryFreeBusy(context.Background(), client, "https://example.com/cal/work", from, to)
+	if err != nil {
+		t.Fatalf("QueryFreeBusy: %v", err)
+	}
+	if !result.Start.Equal(from) || !result.End.Equal(to) {
+		t.Fatalf("window = %s/%s, want %s/%s", result.Start, result.End, from, to)
+	}
+	if len(result.Periods) != 0 {
+		t.Fatalf("periods = %+v, want none for an RFC free window", result.Periods)
+	}
+}
+
 func TestQueryFreeBusy_MergesMultipleVFreeBusyComponents(t *testing.T) {
 	t.Parallel()
 

--- a/internal/freebusy/parse.go
+++ b/internal/freebusy/parse.go
@@ -92,6 +92,14 @@ func ParseComponent(comp *goical.Component) (Result, error) {
 		}
 	}
 
+	if len(result.Periods) == 0 && !result.Start.IsZero() && !result.End.IsZero() {
+		result.Periods = []Period{{
+			Start: result.Start,
+			End:   result.End,
+			Type:  normalizeType(propValue(props, "FBTYPE")),
+		}}
+	}
+
 	sort.Slice(result.Periods, func(i, j int) bool {
 		if result.Periods[i].Start.Equal(result.Periods[j].Start) {
 			return result.Periods[i].End.Before(result.Periods[j].End)

--- a/internal/freebusy/parse.go
+++ b/internal/freebusy/parse.go
@@ -92,11 +92,15 @@ func ParseComponent(comp *goical.Component) (Result, error) {
 		}
 	}
 
-	if len(result.Periods) == 0 && !result.Start.IsZero() && !result.End.IsZero() {
+	// Radicale emits one VFREEBUSY per busy interval with DTSTART/DTEND and a
+	// component-level FBTYPE, and no FREEBUSY properties. RFC 5545 §3.6.4 and
+	// RFC 4791 §7.10 use DTSTART/DTEND with no FREEBUSY for a fully free window,
+	// so only synthesize a period when that non-standard FBTYPE is present.
+	if kind := propValue(props, "FBTYPE"); kind != "" && len(result.Periods) == 0 && !result.Start.IsZero() && !result.End.IsZero() {
 		result.Periods = []Period{{
 			Start: result.Start,
 			End:   result.End,
-			Type:  normalizeType(propValue(props, "FBTYPE")),
+			Type:  normalizeType(kind),
 		}}
 	}
 

--- a/internal/freebusy/parse_test.go
+++ b/internal/freebusy/parse_test.go
@@ -87,3 +87,28 @@ END:VCALENDAR`
 		t.Fatalf("period.type = %q, want %q", result.Periods[0].Type, Busy)
 	}
 }
+
+func TestParseComponent_DTStartDTEndWithoutFreeBusyIsFree(t *testing.T) {
+	t.Parallel()
+
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//test//EN
+BEGIN:VFREEBUSY
+UID:fb-free
+DTSTART:20260819T000000Z
+DTEND:20260820T000000Z
+END:VFREEBUSY
+END:VCALENDAR`
+
+	results, err := ParseCalendar(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ParseCalendar: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if len(results[0].Periods) != 0 {
+		t.Fatalf("periods = %+v, want none for an RFC free window", results[0].Periods)
+	}
+}

--- a/internal/freebusy/parse_test.go
+++ b/internal/freebusy/parse_test.go
@@ -50,3 +50,40 @@ END:VCALENDAR`
 		t.Fatalf("period[1].type = %q, want %q", result.Periods[1].Type, BusyTentative)
 	}
 }
+
+func TestParseComponent_DTStartDTEndWithoutFreeBusyIsAPeriod(t *testing.T) {
+	t.Parallel()
+
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//test//EN
+BEGIN:VFREEBUSY
+DTSTART:20260819T090000Z
+DTEND:20260819T093000Z
+FBTYPE:BUSY
+END:VFREEBUSY
+END:VCALENDAR`
+
+	results, err := ParseCalendar(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("ParseCalendar: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	result := results[0]
+	if len(result.Periods) != 1 {
+		t.Fatalf("periods = %d, want 1", len(result.Periods))
+	}
+	wantStart := time.Date(2026, 8, 19, 9, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 8, 19, 9, 30, 0, 0, time.UTC)
+	if !result.Periods[0].Start.Equal(wantStart) {
+		t.Fatalf("period.start = %s, want %s", result.Periods[0].Start, wantStart)
+	}
+	if !result.Periods[0].End.Equal(wantEnd) {
+		t.Fatalf("period.end = %s, want %s", result.Periods[0].End, wantEnd)
+	}
+	if result.Periods[0].Type != Busy {
+		t.Fatalf("period.type = %q, want %q", result.Periods[0].Type, Busy)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #611.

`chroncal freebusy --remote` dropped Radicale 3.x busy intervals and printed a misleading Range.

Radicale answers `free-busy-query` with one VFREEBUSY per busy interval. Each component carries `DTSTART`/`DTEND` and `FBTYPE`, and it does not carry `FREEBUSY` properties.

This change:

- Treats a non-zero `DTSTART`/`DTEND` as one busy period when the component has no `FREEBUSY` properties
- Merges every VFREEBUSY in the REPORT into one result
- Keeps the requested query window when component windows are the busy intervals themselves
- Keeps an RFC-shaped window when one component advertises a range larger than its `FREEBUSY` periods

`--format ical` then emits `FREEBUSY` lines for those intervals.

Tests:

- `TestParseComponent_DTStartDTEndWithoutFreeBusyIsAPeriod`
- `TestQueryFreeBusy_MergesMultipleVFreeBusyComponents`

`go test ./internal/freebusy/ ./internal/caldav/ -count=1` and `make lint` both passed.

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint reports no issues (`make lint`)
- [x] Add new tests for new functions
- [ ] Update the documentation when the change needs it
