### PR TITLE
test(ical): honor RADICALE_URL and skip an authenticated server

### DIFF
--- a/internal/ical/radicale_helpers_test.go
+++ b/internal/ical/radicale_helpers_test.go
@@ -1,0 +1,55 @@
+package ical
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestRadicaleURLFrom(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty uses default", in: "", want: defaultRadicaleURL},
+		{name: "whitespace uses default", in: "   ", want: defaultRadicaleURL},
+		{name: "override", in: "http://127.0.0.1:8080", want: "http://127.0.0.1:8080"},
+		{name: "trims space and slash", in: " http://127.0.0.1:8080/ ", want: "http://127.0.0.1:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := radicaleURLFrom(tt.in); got != tt.want {
+				t.Fatalf("radicaleURLFrom(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldSkipRadicale(t *testing.T) {
+	t.Parallel()
+	connErr := errors.New("connection refused")
+	tests := []struct {
+		name   string
+		err    error
+		status int
+		want   bool
+	}{
+		{name: "connection error", err: connErr, want: true},
+		{name: "unauthorized", status: http.StatusUnauthorized, want: true},
+		{name: "forbidden", status: http.StatusForbidden, want: true},
+		{name: "ok", status: http.StatusOK, want: false},
+		{name: "not found is reachable", status: http.StatusNotFound, want: false},
+		{name: "method not allowed is reachable", status: http.StatusMethodNotAllowed, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldSkipRadicale(tt.err, tt.status); got != tt.want {
+				t.Fatalf("shouldSkipRadicale(%v, %d) = %v, want %v", tt.err, tt.status, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ical/radicale_test.go
+++ b/internal/ical/radicale_test.go
@@ -3,6 +3,7 @@ package ical
 import (
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -17,9 +18,25 @@ import (
 // Set RADICALE_URL to override (e.g. http://localhost:5232).
 const defaultRadicaleURL = "http://localhost:5232"
 
-func radicaleURL() string { return defaultRadicaleURL }
+func radicaleURL() string { return radicaleURLFrom(os.Getenv("RADICALE_URL")) }
 
-// radicaleAvailable checks whether the Radicale server is reachable.
+func radicaleURLFrom(raw string) string {
+	raw = strings.TrimRight(strings.TrimSpace(raw), "/")
+	if raw == "" {
+		return defaultRadicaleURL
+	}
+	return raw
+}
+
+func shouldSkipRadicale(err error, status int) bool {
+	if err != nil {
+		return true
+	}
+	return status == http.StatusUnauthorized || status == http.StatusForbidden
+}
+
+// radicaleAvailable checks whether the Radicale server is reachable
+// for anonymous writes.
 func radicaleAvailable(t *testing.T) {
 	t.Helper()
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, radicaleURL()+"/", nil)
@@ -31,6 +48,9 @@ func radicaleAvailable(t *testing.T) {
 		t.Skipf("Radicale not available at %s: %v", radicaleURL(), err)
 	}
 	resp.Body.Close()
+	if shouldSkipRadicale(nil, resp.StatusCode) {
+		t.Skipf("Radicale at %s is not usable for anonymous writes: HTTP %d", radicaleURL(), resp.StatusCode)
+	}
 }
 
 // radicaleCalendar creates (or reuses) a shared calendar on Radicale and


### PR DESCRIPTION
## Summary

Fixes #614.

`radicaleURL` ignored the documented `RADICALE_URL` override. `radicaleAvailable` treated any TCP accept as a usable anonymous server. An htpasswd Radicale on `:5232` then failed every `TestRadicale_*` with 401 on MKCALENDAR.

This change:

- Reads `RADICALE_URL` and keeps `http://localhost:5232` when the value is empty
- Skips the suite when the probe returns 401 or 403
- Still skips when the server is unreachable

New unit tests cover `radicaleURLFrom` and `shouldSkipRadicale`. They do not need a live Radicale.

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint reports no issues (`make lint`)
- [x] Add new tests for new functions
- [x] Update the documentation when the change needs it
