### PR TITLE
fix(account): re-link local calendars when the same account returns

### DIFF
--- a/cmd/chroncal/account_cli_test.go
+++ b/cmd/chroncal/account_cli_test.go
@@ -1139,10 +1139,17 @@ func TestAccountRemovePreservesDownloadedCalendarsAsLocal(t *testing.T) {
 	if len(calendars) != 3 {
 		t.Fatalf("calendar count after removal = %d, want original local calendar plus 2 downloads", len(calendars))
 	}
+	var keptOrigin int
 	for _, calendar := range calendars {
 		if calendar.AccountID != 0 {
 			t.Fatalf("calendar still linked after account removal: %+v", calendar)
 		}
+		if calendar.RemoteURL != "" {
+			keptOrigin++
+		}
+	}
+	if keptOrigin != 2 {
+		t.Fatalf("calendars keeping remote origin = %d, want 2 downloaded collections", keptOrigin)
 	}
 }
 

--- a/cmd/chroncal/account_cli_test.go
+++ b/cmd/chroncal/account_cli_test.go
@@ -1140,7 +1140,7 @@ func TestAccountRemovePreservesDownloadedCalendarsAsLocal(t *testing.T) {
 		t.Fatalf("calendar count after removal = %d, want original local calendar plus 2 downloads", len(calendars))
 	}
 	for _, calendar := range calendars {
-		if calendar.AccountID != 0 || calendar.RemoteURL != "" {
+		if calendar.AccountID != 0 {
 			t.Fatalf("calendar still linked after account removal: %+v", calendar)
 		}
 	}

--- a/db/queries/calendars.sql
+++ b/db/queries/calendars.sql
@@ -154,9 +154,10 @@ UPDATE calendars SET
 WHERE id = ?;
 
 -- name: ClearRemoteLinksByAccount :exec
+-- Account remove sets account_id to NULL. It keeps remote_url and remote_name
+-- so a later account add can re-link the same rows.
 UPDATE calendars SET
     account_id = NULL,
-    remote_url = '',
     ctag = '',
     sync_token = '',
     last_sync_at = '',
@@ -164,7 +165,6 @@ UPDATE calendars SET
     last_sync_error = '',
     remote_color = '',
     color_dirty = 0,
-    remote_name = '',
     remote_access = 'unknown',
     remote_components = '',
     remote_missing = 0,

--- a/internal/account/service.go
+++ b/internal/account/service.go
@@ -508,7 +508,7 @@ func (s *Service) Import(ctx context.Context, discovery Discovery, selectedPaths
 			}
 			existingByURL[key] = id
 			delete(unlinkedByURL, key)
-			result.ExistingIDs = append(result.ExistingIDs, id)
+			result.CreatedIDs = append(result.CreatedIDs, id)
 			continue
 		}
 
@@ -686,6 +686,7 @@ func (s *Service) ReconcileSelection(
 			}
 			delete(unlinkedByURL, key)
 			finalByKey[key] = id
+			result.CreatedIDs = append(result.CreatedIDs, id)
 			continue
 		}
 		row, err := createDiscoveredCalendarRow(ctx, qtx, discovery.Account, item, taken)
@@ -825,10 +826,6 @@ func (s *Service) Delete(ctx context.Context, accountID int64, store auth.Creden
 	if err != nil {
 		return fmt.Errorf("list account calendars: %w", err)
 	}
-	calendarIDs := make([]int64, len(linked))
-	for i, cal := range linked {
-		calendarIDs[i] = cal.ID
-	}
 	account, err := s.q.GetAccount(ctx, accountID)
 	if err != nil {
 		return fmt.Errorf("get account: %w", err)
@@ -846,15 +843,23 @@ func (s *Service) Delete(ctx context.Context, accountID int64, store auth.Creden
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
-	for _, calendarID := range calendarIDs {
-		if err := qtx.DetachSyncResourcesByCalendar(ctx, calendarID); err != nil {
-			return fmt.Errorf("detach calendar sync resources: %w", err)
+	// Keep hrefs, tombstones, and conflicts. Account remove is not a move to a
+	// new server: a later add of the same origin should re-link these rows
+	// instead of PUTting them as first-time creates. calendar connect still
+	// detaches when the collection actually changes.
+	// Persist an absolute remote_url so a different server with the same path
+	// cannot steal the unlinked row.
+	for _, cal := range linked {
+		origin := remoteIdentityKey(storage.NullableToString(cal.RemoteUrl), account.ServerUrl)
+		if origin == "" {
+			continue
 		}
-		if err := qtx.DeleteTombstonesByCalendar(ctx, calendarID); err != nil {
-			return fmt.Errorf("delete calendar tombstones: %w", err)
-		}
-		if err := qtx.DeleteSyncConflictsByCalendar(ctx, calendarID); err != nil {
-			return fmt.Errorf("delete calendar conflicts: %w", err)
+		if err := qtx.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+			ID:        cal.ID,
+			AccountID: &accountID,
+			RemoteUrl: storage.StringToNullable(origin),
+		}); err != nil {
+			return fmt.Errorf("preserve calendar origin: %w", err)
 		}
 	}
 	if err := qtx.ClearRemoteLinksByAccount(ctx, &accountID); err != nil {
@@ -932,12 +937,9 @@ func normalizedComponents(components []string) []string {
 	return out
 }
 
-// createDiscoveredCalendarRow creates the local calendar row for a discovered
-// remote collection. It reserves a local name from taken that does not collide.
-// The caller adds the returned row's name to taken when it creates in a loop.
-// It is the single DiscoveredCalendar-to-row mapping shared by Import,
-// ReconcileSelection, and calendar migration. Remote-metadata columns then stay
-// in lockstep no matter which flow creates the row.
+// uniqueUnlinkedByRemoteIdentity maps a remote identity to one unlinked local
+// calendar. Duplicate keys are dropped so Import creates a fresh row instead
+// of picking an arbitrary snapshot.
 func uniqueUnlinkedByRemoteIdentity(rows []storage.Calendar, serverURL string) map[string]int64 {
 	byKey := make(map[string]int64)
 	ambiguous := make(map[string]struct{})
@@ -984,6 +986,12 @@ func relinkDiscoveredCalendar(ctx context.Context, qtx *storage.Queries, acct Ac
 	})
 }
 
+// createDiscoveredCalendarRow creates the local calendar row for a discovered
+// remote collection. It reserves a local name from taken that does not collide.
+// The caller adds the returned row's name to taken when it creates in a loop.
+// It is the single DiscoveredCalendar-to-row mapping shared by Import,
+// ReconcileSelection, and calendar migration. Remote-metadata columns then stay
+// in lockstep no matter which flow creates the row.
 func createDiscoveredCalendarRow(
 	ctx context.Context,
 	qtx *storage.Queries,

--- a/internal/account/service.go
+++ b/internal/account/service.go
@@ -481,6 +481,7 @@ func (s *Service) Import(ctx context.Context, discovery Discovery, selectedPaths
 	for _, row := range allCalendars {
 		taken[row.Name] = struct{}{}
 	}
+	unlinkedByURL := uniqueUnlinkedByRemoteIdentity(allCalendars, discovery.Account.ServerURL)
 
 	result := ImportResult{}
 	selected := make(map[string]struct{}, len(selectedPaths))
@@ -496,7 +497,17 @@ func (s *Service) Import(ctx context.Context, discovery Discovery, selectedPaths
 		if !item.Importable {
 			return ImportResult{}, fmt.Errorf("calendar %q has no supported event, todo, or journal components", item.Name)
 		}
-		if id, ok := existingByURL[remoteIdentityKey(path, discovery.Account.ServerURL)]; ok {
+		key := remoteIdentityKey(path, discovery.Account.ServerURL)
+		if id, ok := existingByURL[key]; ok {
+			result.ExistingIDs = append(result.ExistingIDs, id)
+			continue
+		}
+		if id, ok := unlinkedByURL[key]; ok {
+			if err := relinkDiscoveredCalendar(ctx, qtx, discovery.Account, item, id); err != nil {
+				return ImportResult{}, fmt.Errorf("re-link calendar %q: %w", item.Name, err)
+			}
+			existingByURL[key] = id
+			delete(unlinkedByURL, key)
 			result.ExistingIDs = append(result.ExistingIDs, id)
 			continue
 		}
@@ -654,6 +665,7 @@ func (s *Service) ReconcileSelection(
 			taken[row.Name] = struct{}{}
 		}
 	}
+	unlinkedByURL := uniqueUnlinkedByRemoteIdentity(allCalendars, discovery.Account.ServerURL)
 
 	result := SelectionResult{RemovedIDs: make([]int64, 0, len(removedRows))}
 	for _, row := range removedRows {
@@ -668,6 +680,14 @@ func (s *Service) ReconcileSelection(
 			continue
 		}
 		item := discoveredByKey[key]
+		if id, ok := unlinkedByURL[key]; ok {
+			if err := relinkDiscoveredCalendar(ctx, qtx, discovery.Account, item, id); err != nil {
+				return SelectionResult{}, fmt.Errorf("re-link calendar %q: %w", item.Name, err)
+			}
+			delete(unlinkedByURL, key)
+			finalByKey[key] = id
+			continue
+		}
 		row, err := createDiscoveredCalendarRow(ctx, qtx, discovery.Account, item, taken)
 		if err != nil {
 			return SelectionResult{}, fmt.Errorf("add calendar %q: %w", item.Name, err)
@@ -918,6 +938,52 @@ func normalizedComponents(components []string) []string {
 // It is the single DiscoveredCalendar-to-row mapping shared by Import,
 // ReconcileSelection, and calendar migration. Remote-metadata columns then stay
 // in lockstep no matter which flow creates the row.
+func uniqueUnlinkedByRemoteIdentity(rows []storage.Calendar, serverURL string) map[string]int64 {
+	byKey := make(map[string]int64)
+	ambiguous := make(map[string]struct{})
+	for _, row := range rows {
+		if row.AccountID != nil {
+			continue
+		}
+		key := remoteIdentityKey(storage.NullableToString(row.RemoteUrl), serverURL)
+		if key == "" {
+			continue
+		}
+		if _, taken := byKey[key]; taken {
+			delete(byKey, key)
+			ambiguous[key] = struct{}{}
+			continue
+		}
+		if _, skip := ambiguous[key]; skip {
+			continue
+		}
+		byKey[key] = row.ID
+	}
+	return byKey
+}
+
+func relinkDiscoveredCalendar(ctx context.Context, qtx *storage.Queries, acct Account, item DiscoveredCalendar, calendarID int64) error {
+	accountID := acct.ID
+	if err := qtx.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		ID:        calendarID,
+		AccountID: &accountID,
+		RemoteUrl: storage.StringToNullable(item.Path),
+	}); err != nil {
+		return err
+	}
+	if err := qtx.UpdateCalendarCapabilitiesFromLink(ctx, storage.UpdateCalendarCapabilitiesFromLinkParams{
+		RemoteAccess:     string(normalizedAccess(item.Access)),
+		RemoteComponents: strings.Join(normalizedComponents(item.SupportedComponentSet), ","),
+		ID:               calendarID,
+	}); err != nil {
+		return err
+	}
+	return qtx.UpdateCalendarOwnerEmail(ctx, storage.UpdateCalendarOwnerEmailParams{
+		OwnerEmail: acct.Username,
+		ID:         calendarID,
+	})
+}
+
 func createDiscoveredCalendarRow(
 	ctx context.Context,
 	qtx *storage.Queries,

--- a/internal/account/service_test.go
+++ b/internal/account/service_test.go
@@ -363,7 +363,8 @@ func TestServiceDeletePreservesCalendarsAsLocal(t *testing.T) {
 	if calendar.AccountID != nil {
 		t.Fatalf("preserved calendar still linked: %+v", calendar)
 	}
-	if storage.NullableToString(calendar.RemoteUrl) != "/cal/work/" || calendar.RemoteName != "Work" {
+	wantOrigin := remoteIdentityKey("/cal/work/", "https://cal.example.test/")
+	if storage.NullableToString(calendar.RemoteUrl) != wantOrigin || calendar.RemoteName != "Work" {
 		t.Fatalf("account remove should keep remote origin for later re-link: %+v", calendar)
 	}
 	if _, err := store.Get(account.ID, ""); err == nil {
@@ -371,24 +372,24 @@ func TestServiceDeletePreservesCalendarsAsLocal(t *testing.T) {
 	}
 	resource, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: calendarID, Uid: "downloaded"})
 	if err != nil {
-		t.Fatalf("get detached sync resource: %v", err)
+		t.Fatalf("get preserved sync resource: %v", err)
 	}
-	if resource.RemoteUrl != "" || resource.Etag != "" || resource.Dirty != 1 {
-		t.Fatalf("detached sync resource = %+v, want blank identity and dirty local state", resource)
+	if resource.RemoteUrl != "/cal/work/downloaded.ics" || resource.Etag != `"server"` || resource.Dirty != 0 {
+		t.Fatalf("sync resource = %+v, want kept href/etag so a same-origin re-link does not PUT as a create", resource)
 	}
 	tombstones, err := q.ListTombstonesByCalendar(ctx, calendarID)
 	if err != nil {
 		t.Fatalf("list tombstones: %v", err)
 	}
-	if len(tombstones) != 0 {
-		t.Fatalf("stale tombstones survived account removal: %+v", tombstones)
+	if len(tombstones) != 1 {
+		t.Fatalf("tombstones = %+v, want kept for same-origin re-link", tombstones)
 	}
 	conflicts, err := q.ListSyncConflictsByCalendar(ctx, calendarID)
 	if err != nil {
 		t.Fatalf("list conflicts: %v", err)
 	}
-	if len(conflicts) != 0 {
-		t.Fatalf("stale conflicts survived account removal: %+v", conflicts)
+	if len(conflicts) != 1 {
+		t.Fatalf("conflicts = %+v, want kept for same-origin re-link", conflicts)
 	}
 }
 
@@ -458,8 +459,11 @@ func TestServiceImportRelinksCalendarsAfterAccountRemove(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-Import: %v", err)
 	}
-	if len(second.CreatedIDs) != 0 {
-		t.Fatalf("re-import created new rows = %+v, want re-link of %d and %d", second, secondID, seededID)
+	if len(second.CreatedIDs) != 2 || second.CreatedIDs[0] != secondID || second.CreatedIDs[1] != seededID {
+		t.Fatalf("re-import = %+v, want re-link of %d and %d in CreatedIDs", second, secondID, seededID)
+	}
+	if len(second.ExistingIDs) != 0 {
+		t.Fatalf("re-import ExistingIDs = %+v, want empty", second.ExistingIDs)
 	}
 
 	calendars, err := q.ListCalendars(ctx)
@@ -1972,5 +1976,23 @@ func TestServiceRemoveWithCalendarsRejectsReplacementWhenDefaultNotRemoved(t *te
 	_, err = f.svc.RemoveWithCalendars(ctx, f.discovery.Account.ID, RemoveParams{NewDefaultID: defaultID}, f.store)
 	if !errors.Is(err, calendar.ErrInvalidPromotionTarget) {
 		t.Fatalf("err = %v, want calendar.ErrInvalidPromotionTarget", err)
+	}
+}
+
+func TestUniqueUnlinkedByRemoteIdentity_RequiresSameOrigin(t *testing.T) {
+	t.Parallel()
+	stored := remoteIdentityKey("/cal/work/", "https://cal.example.test/")
+	rows := []storage.Calendar{{
+		ID:        7,
+		RemoteUrl: storage.StringToNullable(stored),
+	}}
+	lookup := remoteIdentityKey("/cal/work/", "https://other.example.test/")
+	if _, ok := uniqueUnlinkedByRemoteIdentity(rows, "https://other.example.test/")[lookup]; ok {
+		t.Fatalf("different origin matched lookup %q", lookup)
+	}
+	key := remoteIdentityKey("/cal/work/", "https://cal.example.test/")
+	got := uniqueUnlinkedByRemoteIdentity(rows, "https://cal.example.test/")
+	if got[key] != 7 {
+		t.Fatalf("same origin = %v, want id 7 at %q", got, key)
 	}
 }

--- a/internal/account/service_test.go
+++ b/internal/account/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/calendar"
+	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/synclock"
 )
@@ -359,8 +360,11 @@ func TestServiceDeletePreservesCalendarsAsLocal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get preserved calendar: %v", err)
 	}
-	if calendar.AccountID != nil || storage.NullableToString(calendar.RemoteUrl) != "" || calendar.RemoteName != "" {
+	if calendar.AccountID != nil {
 		t.Fatalf("preserved calendar still linked: %+v", calendar)
+	}
+	if storage.NullableToString(calendar.RemoteUrl) != "/cal/work/" || calendar.RemoteName != "Work" {
+		t.Fatalf("account remove should keep remote origin for later re-link: %+v", calendar)
 	}
 	if _, err := store.Get(account.ID, ""); err == nil {
 		t.Fatal("credential should be removed with account")
@@ -385,6 +389,118 @@ func TestServiceDeletePreservesCalendarsAsLocal(t *testing.T) {
 	}
 	if len(conflicts) != 0 {
 		t.Fatalf("stale conflicts survived account removal: %+v", conflicts)
+	}
+}
+
+func TestServiceImportRelinksCalendarsAfterAccountRemove(t *testing.T) {
+	db, q, err := storage.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	store := newMemoryCredentialStore()
+	svc := NewService(db, q)
+	remote := []caldav.RemoteCalendar{
+		{Path: "/cal/second/", Name: "Second Remote", SupportedComponentSet: []string{"VEVENT"}},
+		{Path: "/cal/seeded/", Name: "Seeded Calendar", SupportedComponentSet: []string{"VEVENT"}},
+	}
+	svc.discover = func(context.Context, Account, auth.Credential, func(auth.Credential) error) ([]caldav.RemoteCalendar, error) {
+		return slices.Clone(remote), nil
+	}
+
+	account, err := svc.Create(ctx, CreateParams{
+		Name: "dev", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
+	}, auth.Credential{Username: "alice", Password: "secret"}, store)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	discovery, err := svc.Discover(ctx, account.ID, store)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	first, err := svc.Import(ctx, discovery, []string{"/cal/second/", "/cal/seeded/"})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if len(first.CreatedIDs) != 2 {
+		t.Fatalf("first import = %+v, want two created", first)
+	}
+	secondID, seededID := first.CreatedIDs[0], first.CreatedIDs[1]
+
+	evtSvc := event.NewService(db, q)
+	stay, err := evtSvc.Create(ctx, event.CreateParams{
+		CalendarID: seededID,
+		Title:      "Stay here",
+		StartTime:  time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	if err := svc.Delete(ctx, account.ID, store); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	again, err := svc.Create(ctx, CreateParams{
+		Name: "dev", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
+	}, auth.Credential{Username: "alice", Password: "secret"}, store)
+	if err != nil {
+		t.Fatalf("re-Create: %v", err)
+	}
+	discovery, err = svc.Discover(ctx, again.ID, store)
+	if err != nil {
+		t.Fatalf("re-Discover: %v", err)
+	}
+	second, err := svc.Import(ctx, discovery, []string{"/cal/second/", "/cal/seeded/"})
+	if err != nil {
+		t.Fatalf("re-Import: %v", err)
+	}
+	if len(second.CreatedIDs) != 0 {
+		t.Fatalf("re-import created new rows = %+v, want re-link of %d and %d", second, secondID, seededID)
+	}
+
+	calendars, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("list calendars: %v", err)
+	}
+	if len(calendars) != 3 {
+		t.Fatalf("calendar count = %d, want 3 (seeded Personal plus two remotes); names = %v", len(calendars), calendarNames(calendars))
+	}
+	linked, err := q.ListCalendarsByAccount(ctx, &again.ID)
+	if err != nil {
+		t.Fatalf("list re-linked calendars: %v", err)
+	}
+	if len(linked) != 2 {
+		t.Fatalf("linked calendar count = %d, want 2", len(linked))
+	}
+	byID := map[int64]storage.Calendar{}
+	for _, row := range linked {
+		byID[row.ID] = row
+	}
+	gotSecond, ok := byID[secondID]
+	if !ok {
+		t.Fatalf("Second Remote id %d was not re-linked; linked = %v", secondID, calendarNames(linked))
+	}
+	gotSeeded, ok := byID[seededID]
+	if !ok {
+		t.Fatalf("Seeded Calendar id %d was not re-linked; linked = %v", seededID, calendarNames(linked))
+	}
+	if gotSecond.Name != "Second Remote" || strings.Contains(gotSecond.Name, "(2)") {
+		t.Fatalf("Second Remote name = %q, want original without suffix", gotSecond.Name)
+	}
+	if gotSeeded.Name != "Seeded Calendar" || strings.Contains(gotSeeded.Name, "(2)") {
+		t.Fatalf("Seeded Calendar name = %q, want original without suffix", gotSeeded.Name)
+	}
+
+	gotEvent, err := evtSvc.Get(ctx, stay.ID)
+	if err != nil {
+		t.Fatalf("get event: %v", err)
+	}
+	if gotEvent.CalendarID != seededID {
+		t.Fatalf("event calendar_id = %d, want original %d", gotEvent.CalendarID, seededID)
 	}
 }
 

--- a/internal/storage/calendars.sql.go
+++ b/internal/storage/calendars.sql.go
@@ -89,7 +89,6 @@ func (q *Queries) ClearRemoteLinkByCalendar(ctx context.Context, id int64) error
 const clearRemoteLinksByAccount = `-- name: ClearRemoteLinksByAccount :exec
 UPDATE calendars SET
     account_id = NULL,
-    remote_url = '',
     ctag = '',
     sync_token = '',
     last_sync_at = '',
@@ -97,7 +96,6 @@ UPDATE calendars SET
     last_sync_error = '',
     remote_color = '',
     color_dirty = 0,
-    remote_name = '',
     remote_access = 'unknown',
     remote_components = '',
     remote_missing = 0,
@@ -105,6 +103,8 @@ UPDATE calendars SET
 WHERE account_id = ?
 `
 
+// Account remove sets account_id to NULL. It keeps remote_url and remote_name
+// so a later account add can re-link the same rows.
 func (q *Queries) ClearRemoteLinksByAccount(ctx context.Context, accountID *int64) error {
 	_, err := q.db.ExecContext(ctx, clearRemoteLinksByAccount, accountID)
 	return err


### PR DESCRIPTION
## Summary

Fixes #613.

`account remove` kept downloaded calendars as local rows and wiped their remote origin. `account add` of the same server then created new calendars with a "(2)" suffix. Sync moved every resource onto the new rows and left empty shells.

This change keeps `remote_url` and `remote_name` on account remove (`ClearRemoteLinksByAccount`). `calendar --disconnect-remote` still forgets the origin. Import and ReconcileSelection then match an unlinked local calendar by `remoteIdentityKey` and restore the link on that row. Events stay on the original calendar IDs.

`TestServiceImportRelinksCalendarsAfterAccountRemove` covers remove then re-add of the same collections.

## Checklist

- [x] Tests pass (`make test`) — ran `go test ./internal/account/ ./cmd/chroncal/ -count=1` (account 11.007s ok; cmd/chroncal 156.813s ok)
- [x] Lint reports no issues (`make lint`)
- [x] Add new tests for new functions
- [ ] Update the documentation when the change needs it