### PR TITLE
fix(sync): keep a conflicting local edit after opportunistic push

### DIFF
--- a/cmd/chroncal/push.go
+++ b/cmd/chroncal/push.go
@@ -15,6 +15,12 @@ import (
 
 const opportunisticPushTimeout = 30 * time.Second
 
+// opportunisticPushStrategy is the conflict policy for CLI write-path
+// pushes. ConflictPrompt records a 412 so the local edit and dirty flag
+// survive for `chroncal sync resolve`. The background tick stays
+// server-wins (tick.go).
+const opportunisticPushStrategy = syncPkg.ConflictPrompt
+
 // opportunisticPush is what every write path calls. It derives the two
 // streams once. stdout is the human sync note (discarded in JSON mode so
 // nothing trails the JSON object, issue #255). stderr is import warnings.
@@ -57,7 +63,7 @@ var pushCalendarAfterWrite = func(a *app.App, calendarID int64, outW, warnW io.W
 
 	svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
-	result, err := svc.PushCalendar(ctx, calendarID, syncPkg.ConflictServerWins)
+	result, err := svc.PushCalendar(ctx, calendarID, opportunisticPushStrategy)
 	if err != nil {
 		fmt.Fprintf(outW, "note: auto-sync failed (%v); change will upload on next sync\n", err)
 		return
@@ -67,17 +73,20 @@ var pushCalendarAfterWrite = func(a *app.App, calendarID int64, outW, warnW io.W
 
 // reportOpportunisticPush renders the outcome of an opportunistic push. The
 // engine runs with a discarded logger. The result is then the only place import
-// warnings from a server-wins conflict import surface. They go to warnW, not
-// outW. JSON callers (which pass io.Discard to keep stdout clean) still
-// see them on the ERROR stream. They never mix into stdout.
+// warnings surface. They go to warnW, not outW. JSON callers (which pass
+// io.Discard to keep stdout clean) still see them on the ERROR stream. They
+// never mix into stdout.
 func reportOpportunisticPush(outW, warnW io.Writer, calName string, result *syncPkg.SyncResult) {
 	fprintImportWarnings(warnW, result.Warnings)
-	if result.Pushed == 0 && result.Deleted == 0 && len(result.Errors) == 0 {
+	if result.Pushed == 0 && result.Deleted == 0 && len(result.Errors) == 0 && result.Conflicts == 0 {
 		return
 	}
 	if len(result.Errors) > 0 {
 		fmt.Fprintf(outW, "note: auto-sync partial (%d error(s)); change will retry on next sync\n", len(result.Errors))
-		return
+	} else if result.Pushed > 0 || result.Deleted > 0 {
+		fmt.Fprintf(outW, "Synced to %s · pushed %d · deleted %d\n", calName, result.Pushed, result.Deleted)
 	}
-	fmt.Fprintf(outW, "Synced to %s · pushed %d · deleted %d\n", calName, result.Pushed, result.Deleted)
+	if result.Conflicts > 0 {
+		fmt.Fprintf(outW, "note: %d local change(s) conflicted with the server; resolve with chroncal sync resolve\n", result.Conflicts)
+	}
 }

--- a/cmd/chroncal/sync_warnings_cli_test.go
+++ b/cmd/chroncal/sync_warnings_cli_test.go
@@ -83,6 +83,55 @@ func TestReportOpportunisticPushEmitsWarningsThroughInjectedWriter(t *testing.T)
 	}
 }
 
+// A 412 under ConflictPrompt records Conflicts and leaves the local edit
+// dirty. The report must not stay silent when that is the only outcome.
+func TestReportOpportunisticPushReportsConflicts(t *testing.T) {
+	t.Parallel()
+
+	var out, warn bytes.Buffer
+	reportOpportunisticPush(&out, &warn, "Work", &syncPkg.SyncResult{
+		Conflicts: 2,
+		Warnings: []syncPkg.ImportWarning{
+			{Message: "dropped alarm with unusable trigger"},
+		},
+	})
+	got := out.String()
+	if !strings.Contains(got, "note:") {
+		t.Fatalf("stdout writer got %q, want a conflict note", got)
+	}
+	if !strings.Contains(got, "2") {
+		t.Fatalf("stdout writer got %q, want the conflict count", got)
+	}
+	if !strings.Contains(got, "sync resolve") {
+		t.Fatalf("stdout writer got %q, want a pointer to chroncal sync resolve", got)
+	}
+	if strings.Contains(got, "import warning") {
+		t.Errorf("stdout writer got %q; warnings must stay on the warning writer", got)
+	}
+	if !strings.Contains(warn.String(), "dropped alarm") {
+		t.Errorf("warning writer got %q, want the import warning", warn.String())
+	}
+
+	// A JSON caller discards stdout; the warning must still reach warnW.
+	warn.Reset()
+	reportOpportunisticPush(io.Discard, &warn, "Work", &syncPkg.SyncResult{
+		Conflicts: 1,
+		Warnings:  []syncPkg.ImportWarning{{Message: "dropped alarm with unusable trigger"}},
+	})
+	if !strings.Contains(warn.String(), "dropped alarm") {
+		t.Errorf("warning writer got %q, want the warning despite discarded stdout", warn.String())
+	}
+}
+
+// A 412 must record a conflict and keep the local edit. ConflictServerWins
+// would import the server row and clear dirty before the user can resolve.
+func TestOpportunisticCLIPushUsesConflictPrompt(t *testing.T) {
+	t.Parallel()
+	if opportunisticPushStrategy != syncPkg.ConflictPrompt {
+		t.Fatalf("opportunistic CLI push strategy = %q, want %q", opportunisticPushStrategy, syncPkg.ConflictPrompt)
+	}
+}
+
 // `sync resolve <id> --pick server` imports the recorded server body through
 // the same importICal as the auto server-wins paths. The engine logger is nil
 // (silent). The warnings ResolveConflict returns are then the only place


### PR DESCRIPTION
Fixes #610, taking option 1 from the issue plus reporting.

## Summary

Opportunistic CLI push ran `PushCalendar` with `ConflictServerWins` and hid `result.Conflicts`. A 412 then imported the server row over the just-written local edit and cleared dirty, so `sync resolve` had nothing left.

This change:

- Uses `ConflictPrompt` for the CLI write-path push so a 412 records a conflict. The local edit and dirty flag survive.
- Prints a note when `Conflicts > 0` (`note: N local change(s) conflicted with the server; resolve with chroncal sync resolve`).
- Leaves the background tick on server-wins.

## Checklist

- [x] Tests pass (`go test ./cmd/chroncal/ -run TestReportOpportunisticPush|TestOpportunisticCLIPushUsesConflictPrompt`)
- [ ] Lint reports no issues (`make lint`)
- [x] Add new tests for new functions
- [x] Update the documentation when the change needs it