### PR TITLE
feat(cli): add account and calendar setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ chroncal account add              "<name>" --server URL --username USER [--auth 
 chroncal account get              <name|id>
 chroncal account list
 chroncal account update           <name|id> --name NAME
+chroncal account credentials      <name|id>
+chroncal account reauth           <name|id> [--oauth-client-id ID]
 chroncal account calendars list   <name|id>
 chroncal account calendars add    <name|id> (--calendar NAME_OR_URL ... | --all)
 chroncal account calendars set    <name|id> (--calendar NAME_OR_URL ... | --all | --none) [--default ID_OR_NAME_OR_URL] [--yes]
@@ -378,6 +380,8 @@ An account stores one credential. It discovers every CalDAV calendar collection 
 
 If you select none, the command also removes the empty account and credential. `account remove` deletes the credential and remote links. It keeps downloaded calendars as local copies.
 
+`account credentials` rotates the stored secret of a basic or bearer account. It reads the new value from `CHRONCAL_PASSWORD` (basic) or `CHRONCAL_BEARER_TOKEN` (bearer). `account reauth` repeats the Google OAuth consent flow for an oauth2 account; the client secret comes from `GOOGLE_CLIENT_SECRET` or the stored value, and `--oauth-client-id` replaces the stored client ID. Neither command accepts a secret as a CLI flag.
+
 You can open read-only collections locally and sync them pull-only. Chroncal does not send metadata changes, resources, or tombstones to them.
 
 ### Calendars
@@ -389,9 +393,13 @@ chroncal calendar create  "<name>" [--color HEX] [--description TEXT] [--email A
 chroncal calendar update  <id|name> [--name NAME] [--color HEX] [--description TEXT] [--email ADDR] [remote flags] [--disconnect-remote]
 chroncal calendar delete  <id>
 chroncal calendar set-default <id|name>
+chroncal calendar hide     <id|name>
+chroncal calendar show     <id|name>
 ```
 
 `set-default` makes a calendar the default. New events, todos, and journals without an explicit `--calendar` go there. Exactly one calendar is the default at any time.
+
+`calendar hide` opts a calendar out of the TUI sidebar without deleting it: events stay in the database and still sync. `calendar show` reverses it. Calendar JSON (`--output json`) carries the link and sync state per calendar: `account_id`, `account_name`, `remote_url`, `remote_access`, `last_sync_at`, `last_sync_error`, and `hidden`.
 
 You can still use remote flags with `create` or `update` to attach one local calendar to a known CalDAV collection. Prefer `chroncal account` when one credential exposes multiple collections:
 
@@ -419,7 +427,7 @@ Imports have size limits to reduce resource exhaustion from untrusted calendar d
 ### Sync
 
 ```
-chroncal sync run       [--calendar NAME] [--conflict MODE]
+chroncal sync run       [--calendar NAME] [--account NAME] [--conflict MODE]
 chroncal sync status
 chroncal sync conflicts
 chroncal sync resolve   <id> --pick {local,server}
@@ -427,6 +435,8 @@ chroncal sync reset     [--calendar NAME]
 ```
 
 Sync runs on each connected calendar on its own. Calendars that share an account reuse its credential and sync one after another. Distinct accounts can sync at the same time. Use `chroncal account calendars list` and `chroncal account calendars add` to inspect and import remote collections. Use the calendar remote flags above when you attach one known URL.
+
+Narrow a run with `--calendar NAME` (one local calendar) or `--account NAME` (every calendar linked to one CalDAV account). The two flags are mutually exclusive. An account with no linked calendars is a clean no-op.
 
 ### Google Calendar via CalDAV
 

--- a/cmd/chroncal/account.go
+++ b/cmd/chroncal/account.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -33,6 +35,7 @@ account share one stored credential.`,
 		accountListCmd(),
 		accountUpdateCmd(),
 		accountCredentialsCmd(),
+		accountReauthCmd(),
 		accountCalendarsCmd(),
 		accountRemoveCmd(),
 	)
@@ -304,6 +307,118 @@ backend failures leave the previous secret unchanged.`,
 			return nil
 		},
 	}
+	return cmd
+}
+
+func accountReauthCmd() *cobra.Command {
+	var oauthClientID string
+	cmd := &cobra.Command{
+		Use:   "reauth <name|id>",
+		Short: "Re-authenticate an OAuth account",
+		Long: `Run the Google OAuth consent flow again for one account and
+store the fresh tokens.
+
+Basic and bearer accounts rotate their secret with "chroncal account
+credentials" instead.
+
+The stored username and OAuth client config are kept. --oauth-client-id
+replaces the stored client ID for this and future runs. The client
+secret comes from GOOGLE_CLIENT_SECRET or the stored value and is
+prompted for when neither is available; it never comes from a flag.
+When Google's response omits a refresh token, the previous one is
+kept.`,
+		Example: `  chroncal account reauth "Personal Google"
+  GOOGLE_CLIENT_SECRET=... chroncal account reauth 3 --output json`,
+		Args: exactOneArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			a, err := initApp()
+			if err != nil {
+				return err
+			}
+			defer a.Close()
+			ctx := context.Background()
+			configured, err := resolveAccount(ctx, a.Accounts, args[0])
+			if err != nil {
+				return err
+			}
+
+			authType := normalizeAuthType(configured.AuthType)
+			if authType != "oauth2" {
+				if authType == "" {
+					authType = "basic"
+				}
+				return errInvalidInputf(
+					"account %q uses %s auth; run chroncal account credentials instead",
+					configured.DisplayName, authType,
+				)
+			}
+
+			store, err := newCalendarCredentialStore(
+				a.CredentialNamespace, a.PreviousCredentialNamespaces,
+				a.MigrateLegacyCredentials, a.AllowPlaintext,
+			)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
+			// Reauth needs the stored credential: it carries the username and
+			// the OAuth client config the flow reuses. Unlike rotation, a
+			// missing entry cannot be repaired here, so any load failure
+			// aborts before the browser opens.
+			fingerprint := configured.CredentialFingerprint()
+			cred, err := store.Get(configured.ID, fingerprint)
+			if err != nil {
+				return fmt.Errorf("load current credentials: %w", err)
+			}
+
+			clientID := oauthClientID
+			if clientID == "" {
+				clientID = cred.OAuthClientID
+			}
+			if clientID == "" {
+				return errInvalidInputf(
+					"account %q has no stored OAuth client ID; pass --oauth-client-id",
+					configured.DisplayName,
+				)
+			}
+			clientSecret := strings.TrimSpace(os.Getenv("GOOGLE_CLIENT_SECRET"))
+			if clientSecret == "" {
+				clientSecret = cred.OAuthClientSecret
+			}
+			if clientSecret == "" {
+				clientSecret, err = readGoogleClientSecret()
+				if err != nil {
+					return err
+				}
+			}
+
+			result, err := runGoogleOAuthFlow(ctx, clientID, clientSecret)
+			if err != nil {
+				return fmt.Errorf("OAuth flow: %w", err)
+			}
+			// Same contract as the TUI's reauth: replace the token triple,
+			// keep everything else. An empty refresh token from Google keeps
+			// the previous one — overwriting it would brick refresh once the
+			// ~1h access token expires.
+			cred.AccessToken = result.AccessToken
+			if result.RefreshToken != "" {
+				cred.RefreshToken = result.RefreshToken
+			}
+			cred.TokenExpiry = result.Expiry.Format(time.RFC3339)
+			cred.OAuthClientID = clientID
+			cred.OAuthClientSecret = clientSecret
+			if err := a.Accounts.StoreCredential(ctx, configured.ID, fingerprint, cred, store); err != nil {
+				return err
+			}
+
+			if outputFmt != "text" {
+				return printOutput(cmd.OutOrStdout(), toJSONAccount(configured))
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Re-authenticated %q.\n",
+				textsafe.Display(configured.DisplayName))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "Google OAuth desktop client ID (overrides the stored client ID)")
 	return cmd
 }
 

--- a/cmd/chroncal/account.go
+++ b/cmd/chroncal/account.go
@@ -32,6 +32,7 @@ account share one stored credential.`,
 		accountGetCmd(),
 		accountListCmd(),
 		accountUpdateCmd(),
+		accountCredentialsCmd(),
 		accountCalendarsCmd(),
 		accountRemoveCmd(),
 	)
@@ -222,6 +223,87 @@ authentication type, or stored credential.`,
 	}
 	cmd.Flags().StringVar(&name, "name", "", "new account display name (required)")
 	_ = cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func accountCredentialsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "credentials <name|id>",
+		Short: "Rotate a basic or bearer account secret",
+		Long: `Replace the stored password or bearer token for one account.
+
+The server URL, username, and authentication type stay the same. OAuth
+accounts must use "chroncal account reauth" instead.
+
+Secrets come from the environment, never from flags:
+  basic   CHRONCAL_PASSWORD
+  bearer  CHRONCAL_BEARER_TOKEN
+
+A missing or identity-mismatched keyring entry is repaired. Other
+backend failures leave the previous secret unchanged.`,
+		Example: `  CHRONCAL_PASSWORD=... chroncal account credentials Work --output json
+  CHRONCAL_BEARER_TOKEN=... chroncal account credentials 3 --output json`,
+		Args: exactOneArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			a, err := initApp()
+			if err != nil {
+				return err
+			}
+			defer a.Close()
+			ctx := context.Background()
+			configured, err := resolveAccount(ctx, a.Accounts, args[0])
+			if err != nil {
+				return err
+			}
+
+			authType := strings.ToLower(strings.TrimSpace(configured.AuthType))
+			var secret string
+			switch authType {
+			case "oauth2":
+				return errInvalidInputf(
+					"account %q uses OAuth 2.0; run chroncal account reauth instead",
+					configured.DisplayName,
+				)
+			case "bearer":
+				secret, err = readBearerToken()
+			case "basic", "":
+				secret, err = readBasicPassword()
+			default:
+				return errInvalidInputf("unsupported auth type %q", configured.AuthType)
+			}
+			if err != nil {
+				return err
+			}
+
+			store, err := newCalendarCredentialStore(
+				a.CredentialNamespace, a.PreviousCredentialNamespaces,
+				a.MigrateLegacyCredentials, a.AllowPlaintext,
+			)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
+			fingerprint := configured.CredentialFingerprint()
+			cred, err := credentialForRotation(store.Get(configured.ID, fingerprint))
+			if err != nil {
+				return err
+			}
+			if authType == "bearer" {
+				cred.AccessToken = secret
+			} else {
+				cred.Password = secret
+			}
+			if err := a.Accounts.StoreCredential(ctx, configured.ID, fingerprint, cred, store); err != nil {
+				return err
+			}
+
+			if outputFmt != "text" {
+				return printOutput(cmd.OutOrStdout(), toJSONAccount(configured))
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated credentials for %q.\n",
+				textsafe.Display(configured.DisplayName))
+			return nil
+		},
+	}
 	return cmd
 }
 
@@ -763,4 +845,18 @@ func printAccountDiscovery(w interface{ Write([]byte) (int, error) }, discovery 
 		_, _ = fmt.Fprintf(w, "  [%s] %s\t%s\t%s\n", status,
 			textsafe.Display(remote.Name), access, textsafe.Display(remote.Path))
 	}
+}
+
+// credentialForRotation matches the TUI repair contract: a missing or
+// identity-mismatched keyring entry is a broken state rotation exists to
+// fix. Other backend errors abort so a transient failure cannot clobber
+// a still-valid secret.
+func credentialForRotation(cred auth.Credential, err error) (auth.Credential, error) {
+	if err == nil {
+		return cred, nil
+	}
+	if auth.IsCredentialNotFound(err) || errors.Is(err, auth.ErrCredentialIdentityMismatch) {
+		return auth.Credential{}, nil
+	}
+	return auth.Credential{}, fmt.Errorf("load current credentials: %w", err)
 }

--- a/cmd/chroncal/account_cli_test.go
+++ b/cmd/chroncal/account_cli_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,11 +13,15 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/douglasdemoura/chroncal/internal/account"
 	"github.com/douglasdemoura/chroncal/internal/app"
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/caldav"
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
 
@@ -680,6 +686,316 @@ func TestAccountCredentialsRepairsBrokenKeyring(t *testing.T) {
 	if got.AccessToken != "repaired-token" {
 		t.Fatalf("access token = %q, want repaired-token", got.AccessToken)
 	}
+}
+
+func TestAccountReauthStoresFreshTokens(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Personal Google", ServerURL: "https://apidata.googleusercontent.com/caldav",
+		Username: "me@gmail.com", AuthType: "oauth2",
+	}, auth.Credential{
+		Username: "me@gmail.com", AccessToken: "old-access", RefreshToken: "old-refresh",
+		OAuthClientID: "stored-client-id", OAuthClientSecret: "stored-secret",
+	}, store)
+	if err != nil {
+		t.Fatalf("create oauth account: %v", err)
+	}
+	a.Close()
+	t.Setenv("GOOGLE_CLIENT_SECRET", "")
+
+	expiry := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	calls := stubGoogleOAuthFlow(t, &auth.GoogleOAuthResult{
+		AccessToken: "new-access", RefreshToken: "new-refresh", Expiry: expiry,
+	})
+	stdout, _, err := runAccountCommandInProcess(t,
+		"account", "reauth", "Personal Google",
+		"--output", "json", "--allow-plaintext",
+	)
+	if err != nil {
+		t.Fatalf("account reauth: %v", err)
+	}
+	assertAccountJSONWithoutSecrets(t, stdout, "Personal Google", "oauth2")
+	for _, secret := range []string{
+		"new-access", "old-access", "new-refresh", "old-refresh", "stored-secret",
+	} {
+		if strings.Contains(stdout, secret) {
+			t.Fatalf("json leaked secret %q: %s", secret, stdout)
+		}
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("oauth flow ran %d time(s), want 1", len(*calls))
+	}
+	if got := (*calls)[0]; got.clientID != "stored-client-id" || got.clientSecret != "stored-secret" {
+		t.Fatalf("oauth flow client config = %+v, want the stored values", got)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load credential: %v", err)
+	}
+	if got.AccessToken != "new-access" || got.RefreshToken != "new-refresh" {
+		t.Fatalf("tokens = %+v, want fresh access and refresh tokens", got)
+	}
+	if want := expiry.Format(time.RFC3339); got.TokenExpiry != want {
+		t.Fatalf("token expiry = %q, want %q", got.TokenExpiry, want)
+	}
+	if got.Username != "me@gmail.com" ||
+		got.OAuthClientID != "stored-client-id" || got.OAuthClientSecret != "stored-secret" {
+		t.Fatalf("stored identity changed: %+v", got)
+	}
+}
+
+func TestAccountReauthKeepsRefreshTokenWhenGoogleOmitsIt(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Personal Google", ServerURL: "https://apidata.googleusercontent.com/caldav",
+		Username: "me@gmail.com", AuthType: "oauth2",
+	}, auth.Credential{
+		Username: "me@gmail.com", AccessToken: "old-access", RefreshToken: "old-refresh",
+		OAuthClientID: "stored-client-id", OAuthClientSecret: "stored-secret",
+	}, store)
+	if err != nil {
+		t.Fatalf("create oauth account: %v", err)
+	}
+	a.Close()
+	t.Setenv("GOOGLE_CLIENT_SECRET", "")
+
+	stubGoogleOAuthFlow(t, &auth.GoogleOAuthResult{
+		AccessToken: "new-access", Expiry: time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC),
+	})
+	if _, _, err := runAccountCommandInProcess(t,
+		"account", "reauth", "Personal Google",
+		"--output", "json", "--allow-plaintext",
+	); err != nil {
+		t.Fatalf("account reauth: %v", err)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load credential: %v", err)
+	}
+	if got.AccessToken != "new-access" {
+		t.Fatalf("access token = %q, want new-access", got.AccessToken)
+	}
+	if got.RefreshToken != "old-refresh" {
+		t.Fatalf("refresh token = %q, want old-refresh kept", got.RefreshToken)
+	}
+}
+
+func TestAccountReauthRefusesBasicAndBearer(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	basic, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/dav/",
+		Username: "alice", AuthType: "basic",
+	}, auth.Credential{Username: "alice", Password: "old-password"}, store)
+	if err != nil {
+		t.Fatalf("create basic account: %v", err)
+	}
+	bearer, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "API Token", ServerURL: "https://cal.example.test/dav/",
+		Username: "bob", AuthType: "bearer",
+	}, auth.Credential{Username: "bob", AccessToken: "old-token"}, store)
+	if err != nil {
+		t.Fatalf("create bearer account: %v", err)
+	}
+	a.Close()
+
+	for _, ref := range []string{"Work", "API Token"} {
+		_, stderr, err := runChroncalCommand(t,
+			"account", "reauth", ref,
+			"--output", "json", "--allow-plaintext",
+		)
+		if err == nil {
+			t.Fatalf("account reauth should refuse %s accounts", ref)
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("decode error %q: %v", stderr, jerr)
+		}
+		if payload.Code != "invalid_input" {
+			t.Fatalf("code = %q, want invalid_input", payload.Code)
+		}
+		if !strings.Contains(strings.ToLower(payload.Error), "account credentials") {
+			t.Fatalf("error = %q, want account credentials guidance", payload.Error)
+		}
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	gotBasic, err := a.Accounts.LoadCredential(ctx, basic.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load basic credential: %v", err)
+	}
+	if gotBasic.Password != "old-password" {
+		t.Fatalf("basic password = %q, want old-password unchanged", gotBasic.Password)
+	}
+	gotBearer, err := a.Accounts.LoadCredential(ctx, bearer.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load bearer credential: %v", err)
+	}
+	if gotBearer.AccessToken != "old-token" {
+		t.Fatalf("bearer token = %q, want old-token unchanged", gotBearer.AccessToken)
+	}
+}
+
+func TestAccountReauthOverridesClientConfigFromFlagAndEnv(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Personal Google", ServerURL: "https://apidata.googleusercontent.com/caldav",
+		Username: "me@gmail.com", AuthType: "oauth2",
+	}, auth.Credential{
+		Username: "me@gmail.com", AccessToken: "old-access", RefreshToken: "old-refresh",
+		OAuthClientID: "stored-client-id", OAuthClientSecret: "stored-secret",
+	}, store)
+	if err != nil {
+		t.Fatalf("create oauth account: %v", err)
+	}
+	a.Close()
+	t.Setenv("GOOGLE_CLIENT_SECRET", "env-secret")
+
+	calls := stubGoogleOAuthFlow(t, &auth.GoogleOAuthResult{
+		AccessToken: "new-access", RefreshToken: "new-refresh",
+		Expiry: time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC),
+	})
+	if _, _, err := runAccountCommandInProcess(t,
+		"account", "reauth", "Personal Google",
+		"--oauth-client-id", "flag-client-id",
+		"--output", "json", "--allow-plaintext",
+	); err != nil {
+		t.Fatalf("account reauth: %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("oauth flow ran %d time(s), want 1", len(*calls))
+	}
+	if got := (*calls)[0]; got.clientID != "flag-client-id" || got.clientSecret != "env-secret" {
+		t.Fatalf("oauth flow client config = %+v, want flag client ID and env secret", got)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load credential: %v", err)
+	}
+	if got.OAuthClientID != "flag-client-id" || got.OAuthClientSecret != "env-secret" {
+		t.Fatalf("client config = %+v, want overrides persisted", got)
+	}
+}
+
+func TestAccountReauthRequiresOAuthClientID(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Personal Google", ServerURL: "https://apidata.googleusercontent.com/caldav",
+		Username: "me@gmail.com", AuthType: "oauth2",
+	}, auth.Credential{Username: "me@gmail.com", AccessToken: "access", RefreshToken: "refresh"}, store)
+	if err != nil {
+		t.Fatalf("create oauth account: %v", err)
+	}
+	a.Close()
+	t.Setenv("GOOGLE_CLIENT_SECRET", "env-secret")
+
+	calls := stubGoogleOAuthFlow(t, &auth.GoogleOAuthResult{
+		AccessToken: "new-access", RefreshToken: "new-refresh",
+		Expiry: time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC),
+	})
+	_, _, err = runAccountCommandInProcess(t,
+		"account", "reauth", "Personal Google", "--allow-plaintext",
+	)
+	if err == nil {
+		t.Fatal("reauth without a client ID should fail")
+	}
+	var cliErr *cliError
+	if !errors.As(err, &cliErr) || cliErr.Code != "invalid_input" {
+		t.Fatalf("error = %v, want invalid_input", err)
+	}
+	if !strings.Contains(cliErr.Msg, "--oauth-client-id") {
+		t.Fatalf("error = %q, want --oauth-client-id guidance", cliErr.Msg)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("oauth flow ran %d time(s), want 0", len(*calls))
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load credential: %v", err)
+	}
+	if got.AccessToken != "access" || got.RefreshToken != "refresh" {
+		t.Fatalf("oauth credential mutated: %+v", got)
+	}
+}
+
+// oauthFlowCall records the client config one stubbed OAuth flow run used.
+type oauthFlowCall struct {
+	clientID     string
+	clientSecret string
+}
+
+// stubGoogleOAuthFlow swaps the OAuth flow seam for a canned result so tests
+// exercise reauth without binding a loopback listener or opening a browser.
+// The returned slice pointer records the client config every run used.
+func stubGoogleOAuthFlow(t *testing.T, result *auth.GoogleOAuthResult) *[]oauthFlowCall {
+	t.Helper()
+	var calls []oauthFlowCall
+	prev := runGoogleOAuthFlow
+	runGoogleOAuthFlow = func(_ context.Context, clientID, clientSecret string) (*auth.GoogleOAuthResult, error) {
+		calls = append(calls, oauthFlowCall{clientID: clientID, clientSecret: clientSecret})
+		return result, nil
+	}
+	t.Cleanup(func() { runGoogleOAuthFlow = prev })
+	return &calls
+}
+
+// runAccountCommandInProcess executes one account command tree in this
+// process so package-var seams (the stubbed OAuth flow) apply. It mirrors
+// TestHelperProcess: a fresh root whose PersistentPreRunE reloads cfg from
+// CHRONCAL_DB, with the real --output/--allow-plaintext flag closures.
+func runAccountCommandInProcess(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
+	prevFmt, prevPlaintext := outputFmt, allowPlaintext
+	t.Cleanup(func() { outputFmt, allowPlaintext = prevFmt, prevPlaintext })
+
+	root := &cobra.Command{
+		Use: "chroncal-test",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			cfg, err = config.Load()
+			return err
+		},
+	}
+	root.PersistentFlags().StringVarP(&outputFmt, "output", "o", "text", "output format (text, json)")
+	root.PersistentFlags().BoolVar(&allowPlaintext, "allow-plaintext", false, "permit storing credentials in plaintext when no OS keyring is available")
+	root.AddCommand(accountCmd())
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs(args)
+	err := root.Execute()
+	return out.String(), errBuf.String(), err
 }
 
 func openPlaintextApp(t *testing.T, dbPath string) *app.App {

--- a/cmd/chroncal/account_cli_test.go
+++ b/cmd/chroncal/account_cli_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/douglasdemoura/chroncal/internal/account"
 	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
@@ -486,6 +487,235 @@ func setupAccountCalendarSelectionTest(t *testing.T) string {
 		t.Fatalf("reduce initial account selection: %v", err)
 	}
 	return dbPath
+}
+
+func TestAccountCredentialsRotatesBearerAndBasic(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+
+	bearer, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "API Token", ServerURL: "https://cal.example.test/dav/",
+		Username: "alice", AuthType: "bearer",
+	}, auth.Credential{AccessToken: "old-token"}, store)
+	if err != nil {
+		t.Fatalf("create bearer account: %v", err)
+	}
+	basic, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/dav/",
+		Username: "bob", AuthType: "basic",
+	}, auth.Credential{Password: "old-password"}, store)
+	if err != nil {
+		t.Fatalf("create basic account: %v", err)
+	}
+	a.Close()
+
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "new-token")
+	stdout, _, err := runChroncalCommand(t,
+		"account", "credentials", "API Token",
+		"--output", "json", "--allow-plaintext",
+	)
+	if err != nil {
+		t.Fatalf("account credentials bearer: %v", err)
+	}
+	assertAccountJSONWithoutSecrets(t, stdout, "API Token", "bearer")
+	if strings.Contains(stdout, "new-token") || strings.Contains(stdout, "old-token") {
+		t.Fatalf("json leaked a bearer token: %s", stdout)
+	}
+
+	t.Setenv("CHRONCAL_PASSWORD", "new-password")
+	stdout, _, err = runChroncalCommand(t,
+		"account", "credentials", "Work",
+		"--output", "json", "--allow-plaintext",
+	)
+	if err != nil {
+		t.Fatalf("account credentials basic: %v", err)
+	}
+	assertAccountJSONWithoutSecrets(t, stdout, "Work", "basic")
+	if strings.Contains(stdout, "new-password") || strings.Contains(stdout, "old-password") {
+		t.Fatalf("json leaked a password: %s", stdout)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	store = openPlaintextStore(t, a)
+	gotBearer, err := a.Accounts.LoadCredential(ctx, bearer.ID, store)
+	if err != nil {
+		t.Fatalf("load bearer credential: %v", err)
+	}
+	if gotBearer.AccessToken != "new-token" || gotBearer.Password != "" {
+		t.Fatalf("bearer credential = %+v, want access_token new-token", gotBearer)
+	}
+	gotBasic, err := a.Accounts.LoadCredential(ctx, basic.ID, store)
+	if err != nil {
+		t.Fatalf("load basic credential: %v", err)
+	}
+	if gotBasic.Password != "new-password" || gotBasic.AccessToken != "" {
+		t.Fatalf("basic credential = %+v, want password new-password", gotBasic)
+	}
+	if gotBearer.Username != "alice" || gotBasic.Username != "bob" {
+		t.Fatalf("usernames changed: bearer=%q basic=%q", gotBearer.Username, gotBasic.Username)
+	}
+}
+
+func TestAccountCredentialsRefusesOAuth(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Personal Google", ServerURL: "https://apidata.googleusercontent.com/caldav",
+		Username: "me@gmail.com", AuthType: "oauth2",
+	}, auth.Credential{AccessToken: "access", RefreshToken: "refresh"}, store)
+	if err != nil {
+		t.Fatalf("create oauth account: %v", err)
+	}
+	a.Close()
+
+	t.Setenv("CHRONCAL_PASSWORD", "should-not-apply")
+	_, stderr, err := runChroncalCommand(t,
+		"account", "credentials", "Personal Google",
+		"--output", "json", "--allow-plaintext",
+	)
+	if err == nil {
+		t.Fatal("account credentials should refuse oauth2")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error %q: %v", stderr, jerr)
+	}
+	if payload.Code != "invalid_input" {
+		t.Fatalf("code = %q, want invalid_input", payload.Code)
+	}
+	lower := strings.ToLower(payload.Error)
+	oauthHint := strings.Contains(lower, "oauth")
+	reauthHint := strings.Contains(lower, "reauth")
+	if !oauthHint && !reauthHint {
+		t.Fatalf("error = %q, want oauth/reauth guidance", payload.Error)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load oauth credential: %v", err)
+	}
+	if got.AccessToken != "access" || got.RefreshToken != "refresh" {
+		t.Fatalf("oauth credential mutated: %+v", got)
+	}
+}
+
+func TestAccountCredentialsMissingEnvLeavesPreviousSecret(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/dav/",
+		Username: "alice", AuthType: "basic",
+	}, auth.Credential{Password: "old-password"}, store)
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	a.Close()
+
+	t.Setenv("CHRONCAL_PASSWORD", "")
+	_, stderr, err := runChroncalCommand(t,
+		"account", "credentials", "Work",
+		"--output", "json", "--allow-plaintext",
+	)
+	if err == nil {
+		t.Fatal("credentials without CHRONCAL_PASSWORD should fail")
+	}
+	if !strings.Contains(stderr, "CHRONCAL_PASSWORD") {
+		t.Fatalf("missing-env error = %q, want CHRONCAL_PASSWORD guidance", stderr)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load credential: %v", err)
+	}
+	if got.Password != "old-password" {
+		t.Fatalf("password = %q, want old-password left unchanged", got.Password)
+	}
+}
+
+func TestAccountCredentialsRepairsBrokenKeyring(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/dav/",
+		Username: "alice", AuthType: "bearer",
+	}, auth.Credential{AccessToken: "old-token"}, store)
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatalf("delete credential: %v", err)
+	}
+	a.Close()
+
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "repaired-token")
+	if _, _, err := runChroncalCommand(t,
+		"account", "credentials", "Work",
+		"--output", "json", "--allow-plaintext",
+	); err != nil {
+		t.Fatalf("credentials with missing keyring entry: %v", err)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load repaired credential: %v", err)
+	}
+	if got.AccessToken != "repaired-token" {
+		t.Fatalf("access token = %q, want repaired-token", got.AccessToken)
+	}
+}
+
+func openPlaintextApp(t *testing.T, dbPath string) *app.App {
+	t.Helper()
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	a.AllowPlaintext = true
+	return a
+}
+
+func openPlaintextStore(t *testing.T, a *app.App) auth.CredentialStore {
+	t.Helper()
+	store, err := auth.NewCredentialStore(
+		a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, true,
+	)
+	if err != nil {
+		t.Fatalf("credential store: %v", err)
+	}
+	return store
+}
+
+func assertAccountJSONWithoutSecrets(t *testing.T, stdout, displayName, authType string) {
+	t.Helper()
+	var got jsonAccount
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode account json: %v\n%s", err, stdout)
+	}
+	if got.DisplayName != displayName || got.AuthType != authType || got.ID == 0 {
+		t.Fatalf("account json = %+v, want %s %s", got, displayName, authType)
+	}
+	if strings.Contains(stdout, `"password"`) || strings.Contains(stdout, `"access_token"`) ||
+		strings.Contains(stdout, `"refresh_token"`) {
+		t.Fatalf("account json includes secret keys: %s", stdout)
+	}
 }
 
 func setupDiscoveredAccountCLI(t *testing.T, name string) (string, string) {

--- a/cmd/chroncal/calendar.go
+++ b/cmd/chroncal/calendar.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/douglasdemoura/chroncal/internal/app"
 	calendarpkg "github.com/douglasdemoura/chroncal/internal/calendar"
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/textsafe"
 )
 
@@ -77,7 +78,11 @@ Exactly one calendar is default at any time.`,
 			if target.IsDefault {
 				w := cmd.OutOrStdout()
 				if outputFmt != "text" {
-					return printOutput(w, toJSONCalendar(target))
+					item, err := jsonCalendarDecorated(ctx, a, target)
+					if err != nil {
+						return err
+					}
+					return printOutput(w, item)
 				}
 				fmt.Fprintf(w, "Calendar %q is already the default.\n", target.Name)
 				return nil
@@ -94,7 +99,11 @@ Exactly one calendar is default at any time.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONCalendar(updated))
+				item, err := jsonCalendarDecorated(ctx, a, updated)
+				if err != nil {
+					return err
+				}
+				return printOutput(w, item)
 			}
 			fmt.Fprintf(w, "Default calendar set to %q.\n", updated.Name)
 			return nil
@@ -126,9 +135,9 @@ func calendarListCmd() *cobra.Command {
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				items := make([]jsonCalendar, len(cals))
-				for i, c := range cals {
-					items[i] = toJSONCalendar(c)
+				items, err := jsonCalendars(context.Background(), a, cals)
+				if err != nil {
+					return err
 				}
 				return printOutput(w, items)
 			}
@@ -190,7 +199,11 @@ func calendarGetCmd() *cobra.Command {
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONCalendar(c))
+				item, err := jsonCalendarDecorated(context.Background(), a, c)
+				if err != nil {
+					return err
+				}
+				return printOutput(w, item)
 			}
 			printCalendar(w, c)
 			return nil
@@ -265,7 +278,11 @@ behavior.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONCalendar(c))
+				item, err := jsonCalendarDecorated(context.Background(), a, c)
+				if err != nil {
+					return err
+				}
+				return printOutput(w, item)
 			}
 			fmt.Fprintf(w, "Created calendar %d: %s\n", c.ID, c.Name)
 			return nil
@@ -392,7 +409,11 @@ Only the flags you pass are changed.`,
 
 			w := cmd.OutOrStdout()
 			if outputFmt != "text" {
-				return printOutput(w, toJSONCalendar(c))
+				item, err := jsonCalendarDecorated(ctx, a, c)
+				if err != nil {
+					return err
+				}
+				return printOutput(w, item)
 			}
 			fmt.Fprintf(w, "Updated calendar %d: %s\n", c.ID, c.Name)
 			return nil
@@ -603,4 +624,55 @@ func findCalendarByRef(cals []calendarpkg.Calendar, ref string) (calendarpkg.Cal
 	default:
 		return calendarpkg.Calendar{}, fmt.Errorf("calendar name %q is ambiguous; use its numeric ID instead", ref)
 	}
+}
+
+func jsonCalendars(ctx context.Context, a *app.App, cals []calendarpkg.Calendar) ([]jsonCalendar, error) {
+	hidden := hiddenCalendarSet()
+	names, err := accountDisplayNames(ctx, a)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]jsonCalendar, len(cals))
+	for i, c := range cals {
+		items[i] = decorateJSONCalendar(c, names, hidden)
+	}
+	return items, nil
+}
+
+func jsonCalendarDecorated(ctx context.Context, a *app.App, c calendarpkg.Calendar) (jsonCalendar, error) {
+	items, err := jsonCalendars(ctx, a, []calendarpkg.Calendar{c})
+	if err != nil {
+		return jsonCalendar{}, err
+	}
+	return items[0], nil
+}
+
+func decorateJSONCalendar(c calendarpkg.Calendar, names map[int64]string, hidden map[int64]struct{}) jsonCalendar {
+	item := toJSONCalendar(c)
+	if c.AccountID != 0 {
+		item.AccountName = names[c.AccountID]
+	}
+	_, item.Hidden = hidden[c.ID]
+	return item
+}
+
+func hiddenCalendarSet() map[int64]struct{} {
+	ids := config.LoadUIState().HiddenCalendars
+	out := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+func accountDisplayNames(ctx context.Context, a *app.App) (map[int64]string, error) {
+	accounts, err := a.Accounts.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+	names := make(map[int64]string, len(accounts))
+	for _, item := range accounts {
+		names[item.ID] = item.DisplayName
+	}
+	return names, nil
 }

--- a/cmd/chroncal/calendar.go
+++ b/cmd/chroncal/calendar.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -31,6 +32,8 @@ Calendars can stay local-only, or they can be linked to a remote CalDAV
 calendar for sync.`,
 		Example: `  chroncal calendar list
   chroncal calendar create "Work"
+  chroncal calendar hide Work
+  chroncal calendar show Work
   chroncal calendar create "Work" --remote-url https://cal.example.com/dav/calendars/work/ --username alice --auth bearer
   chroncal calendar update Work --remote-url https://cal.example.com/dav/calendars/work/ --username alice --auth bearer`,
 		Args: rejectUnknownSubcommand,
@@ -43,6 +46,8 @@ calendar for sync.`,
 		calendarUpdateCmd(),
 		calendarDeleteCmd(),
 		calendarSetDefaultCmd(),
+		calendarHideCmd(),
+		calendarShowCmd(),
 	)
 	return cmd
 }
@@ -106,6 +111,74 @@ Exactly one calendar is default at any time.`,
 				return printOutput(w, item)
 			}
 			fmt.Fprintf(w, "Default calendar set to %q.\n", updated.Name)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func calendarHideCmd() *cobra.Command {
+	return calendarVisibilityCmd("hide", true)
+}
+
+func calendarShowCmd() *cobra.Command {
+	return calendarVisibilityCmd("show", false)
+}
+
+func calendarVisibilityCmd(use string, hide bool) *cobra.Command {
+	short := "Show a calendar in the TUI sidebar"
+	long := `Show a calendar that was hidden from the TUI sidebar.
+
+Hidden calendars stay in the database. Events still sync. Only the
+sidebar (and consumers that honor hidden_calendars) omit them.`
+	example := `  chroncal calendar show Work
+  chroncal calendar show 2`
+	textLine := "Showing calendar %q.\n"
+	if hide {
+		short = "Hide a calendar from the TUI sidebar"
+		long = `Hide a calendar from the TUI sidebar without deleting it.
+
+Events stay in the database and still sync. The bar and TUI treat
+hidden calendars as opted out of the sidebar.`
+		example = `  chroncal calendar hide Work
+  chroncal calendar hide 2`
+		textLine = "Hidden calendar %q.\n"
+	}
+	cmd := &cobra.Command{
+		Use:     use + " <id|name>",
+		Short:   short,
+		Long:    long,
+		Example: example,
+		Args:    exactOneArg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			a, err := initApp()
+			if err != nil {
+				return err
+			}
+			defer a.Close()
+			ctx := context.Background()
+
+			cals, err := a.Calendars.List(ctx)
+			if err != nil {
+				return fmt.Errorf("list calendars: %w", err)
+			}
+			target, err := findCalendarByRef(cals, args[0])
+			if err != nil {
+				return errInvalidInputf("%v", err)
+			}
+			if err := setCalendarHidden(target.ID, hide); err != nil {
+				return err
+			}
+
+			w := cmd.OutOrStdout()
+			if outputFmt != "text" {
+				item, err := jsonCalendarDecorated(ctx, a, target)
+				if err != nil {
+					return err
+				}
+				return printOutput(w, item)
+			}
+			fmt.Fprintf(w, textLine, target.Name)
 			return nil
 		},
 	}
@@ -675,4 +748,29 @@ func accountDisplayNames(ctx context.Context, a *app.App) (map[int64]string, err
 		names[item.ID] = item.DisplayName
 	}
 	return names, nil
+}
+
+func setCalendarHidden(id int64, hide bool) error {
+	state := config.LoadUIState()
+	next := make([]int64, 0, len(state.HiddenCalendars)+1)
+	found := false
+	for _, existing := range state.HiddenCalendars {
+		if existing == id {
+			found = true
+			if !hide {
+				continue
+			}
+		}
+		next = append(next, existing)
+	}
+	if hide && !found {
+		next = append(next, id)
+	}
+	slices.Sort(next)
+	if len(next) == 0 {
+		state.HiddenCalendars = nil
+	} else {
+		state.HiddenCalendars = next
+	}
+	return config.SaveUIState(state)
 }

--- a/cmd/chroncal/calendar_cli_test.go
+++ b/cmd/chroncal/calendar_cli_test.go
@@ -244,10 +244,61 @@ func TestCalendarListJSONIncludesOwnerEmail(t *testing.T) {
 			if got.OwnerEmail != "me@example.com" {
 				t.Fatalf("owner_email = %q, want %q", got.OwnerEmail, "me@example.com")
 			}
+			if got.AccountID != 0 {
+				t.Fatalf("account_id = %d, want 0 for local calendar", got.AccountID)
+			}
+			if got.Hidden {
+				t.Fatal("hidden = true, want false for a new calendar")
+			}
 			return
 		}
 	}
 	t.Fatalf("calendar list did not include Work: %s", stdout)
+}
+
+func TestCalendarListJSONIncludesAccountForRemoteCalendar(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "test-token")
+
+	_, _, err := runChroncalCommand(t,
+		"calendar", "create", "Work",
+		"--remote-url", "https://cal.example.com/dav/calendars/work/",
+		"--username", "alice",
+		"--auth", "bearer",
+		"--allow-plaintext",
+		"--output", "json",
+	)
+	if err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	stdout, _, err := runChroncalCommand(t, "calendar", "list", "--output", "json")
+	if err != nil {
+		t.Fatalf("calendar list json: %v", err)
+	}
+	var cals []jsonCalendar
+	if err := json.Unmarshal([]byte(stdout), &cals); err != nil {
+		t.Fatalf("decode: %v\n%s", err, stdout)
+	}
+	var got *jsonCalendar
+	for i := range cals {
+		if cals[i].Name == "Work" {
+			got = &cals[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("Work missing: %s", stdout)
+	}
+	if got.AccountID == 0 {
+		t.Fatalf("account_id omitted/zero, want linked account: %s", stdout)
+	}
+	if got.AccountName == "" {
+		t.Fatalf("account_name empty, want derived display name: %s", stdout)
+	}
+	if got.RemoteURL != "https://cal.example.com/dav/calendars/work/" {
+		t.Fatalf("remote_url = %q", got.RemoteURL)
+	}
 }
 
 func setupCalendarCLITestEnv(t *testing.T) string {
@@ -261,6 +312,8 @@ func setupCalendarCLITestEnv(t *testing.T) string {
 	// hermetically and don't depend on the host OS keyring, which is absent on
 	// the Linux CI runner (no org.freedesktop.secrets) — see issue #474.
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg-config"))
+	// Isolate hidden_calendars from the developer's real TUI state.
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "xdg-state"))
 	return dbPath
 }
 

--- a/cmd/chroncal/calendar_cli_test.go
+++ b/cmd/chroncal/calendar_cli_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
 
@@ -299,6 +300,119 @@ func TestCalendarListJSONIncludesAccountForRemoteCalendar(t *testing.T) {
 	if got.RemoteURL != "https://cal.example.com/dav/calendars/work/" {
 		t.Fatalf("remote_url = %q", got.RemoteURL)
 	}
+}
+
+func TestCalendarHideShowJSON(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if err := config.SaveUIState(config.UIState{
+		ShowSidebar: false,
+		ViewMode:    "week",
+	}); err != nil {
+		t.Fatalf("seed ui state: %v", err)
+	}
+
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	work := calendarJSONByName(t, "Work")
+
+	stdout, _, err := runChroncalCommand(t, "calendar", "hide", fmt.Sprintf("%d", work.ID), "--output", "json")
+	if err != nil {
+		t.Fatalf("calendar hide: %v", err)
+	}
+	var hidden jsonCalendar
+	if err := json.Unmarshal([]byte(stdout), &hidden); err != nil {
+		t.Fatalf("decode hide: %v\n%s", err, stdout)
+	}
+	if !hidden.Hidden || hidden.ID != work.ID {
+		t.Fatalf("hide json = %+v, want hidden id %d", hidden, work.ID)
+	}
+
+	state := config.LoadUIState()
+	if state.ShowSidebar || state.ViewMode != "week" {
+		t.Fatalf("ui state scalars lost: %+v", state)
+	}
+	if len(state.HiddenCalendars) != 1 || state.HiddenCalendars[0] != work.ID {
+		t.Fatalf("hidden_calendars = %v, want [%d]", state.HiddenCalendars, work.ID)
+	}
+
+	// Hide is idempotent and does not duplicate the id.
+	if _, _, err := runChroncalCommand(t, "calendar", "hide", "Work", "--output", "json"); err != nil {
+		t.Fatalf("calendar hide again: %v", err)
+	}
+	state = config.LoadUIState()
+	if len(state.HiddenCalendars) != 1 || state.HiddenCalendars[0] != work.ID {
+		t.Fatalf("hidden_calendars after second hide = %v", state.HiddenCalendars)
+	}
+
+	listed := calendarJSONByName(t, "Work")
+	if !listed.Hidden {
+		t.Fatal("list json hidden = false after hide")
+	}
+
+	stdout, _, err = runChroncalCommand(t, "calendar", "show", "Work", "--output", "json")
+	if err != nil {
+		t.Fatalf("calendar show: %v", err)
+	}
+	var shown jsonCalendar
+	if err := json.Unmarshal([]byte(stdout), &shown); err != nil {
+		t.Fatalf("decode show: %v\n%s", err, stdout)
+	}
+	if shown.Hidden {
+		t.Fatal("show json hidden = true, want false")
+	}
+	state = config.LoadUIState()
+	if len(state.HiddenCalendars) != 0 {
+		t.Fatalf("hidden_calendars after show = %v, want empty", state.HiddenCalendars)
+	}
+	if state.ViewMode != "week" || state.ShowSidebar {
+		t.Fatalf("ui state scalars lost after show: %+v", state)
+	}
+
+	if _, _, err := runChroncalCommand(t, "calendar", "show", fmt.Sprintf("%d", work.ID), "--output", "json"); err != nil {
+		t.Fatalf("calendar show again: %v", err)
+	}
+}
+
+func TestCalendarHideUnknownIDIsInvalidInput(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	_, stderr, err := runChroncalCommand(t, "calendar", "hide", "99999", "--output", "json")
+	if err == nil {
+		t.Fatal("calendar hide 99999 should fail")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error payload %q: %v", stderr, jerr)
+	}
+	if payload.Code != "invalid_input" {
+		t.Fatalf("code = %q, want invalid_input", payload.Code)
+	}
+	if !strings.Contains(payload.Error, "99999") {
+		t.Fatalf("error = %q, want it to mention the unknown id", payload.Error)
+	}
+}
+
+func calendarJSONByName(t *testing.T, name string) jsonCalendar {
+	t.Helper()
+	stdout, _, err := runChroncalCommand(t, "calendar", "list", "--output", "json")
+	if err != nil {
+		t.Fatalf("calendar list: %v", err)
+	}
+	var cals []jsonCalendar
+	if err := json.Unmarshal([]byte(stdout), &cals); err != nil {
+		t.Fatalf("decode list: %v\n%s", err, stdout)
+	}
+	for _, c := range cals {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("calendar %q missing: %s", name, stdout)
+	return jsonCalendar{}
 }
 
 func setupCalendarCLITestEnv(t *testing.T) string {

--- a/cmd/chroncal/calendar_remote.go
+++ b/cmd/chroncal/calendar_remote.go
@@ -17,6 +17,11 @@ import (
 
 var newCalendarCredentialStore = auth.NewCredentialStore
 
+// runGoogleOAuthFlow is the seam over auth.GoogleOAuthFlow. Tests stub it so
+// OAuth code paths run without binding a loopback listener or opening a
+// browser.
+var runGoogleOAuthFlow = auth.GoogleOAuthFlow
+
 type calendarRemoteFlags struct {
 	RemoteURL     string
 	Username      string
@@ -127,7 +132,7 @@ func buildCalendarCredential(ctx context.Context, flags calendarRemoteFlags) (au
 		if err != nil {
 			return auth.Credential{}, err
 		}
-		result, err := auth.GoogleOAuthFlow(ctx, flags.OAuthClientID, clientSecret)
+		result, err := runGoogleOAuthFlow(ctx, flags.OAuthClientID, clientSecret)
 		if err != nil {
 			return auth.Credential{}, fmt.Errorf("OAuth flow: %w", err)
 		}

--- a/cmd/chroncal/calendar_remote.go
+++ b/cmd/chroncal/calendar_remote.go
@@ -161,9 +161,9 @@ func readBasicPassword() (string, error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return "", fmt.Errorf("a password is required: set CHRONCAL_PASSWORD or run interactively")
 	}
-	fmt.Print("Password: ")
+	fmt.Fprint(os.Stderr, "Password: ")
 	passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	if err != nil {
 		return "", fmt.Errorf("read password: %w", err)
 	}
@@ -187,9 +187,9 @@ func readBearerToken() (string, error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return "", fmt.Errorf("a bearer token is required: set CHRONCAL_BEARER_TOKEN or run interactively")
 	}
-	fmt.Print("Bearer token: ")
+	fmt.Fprint(os.Stderr, "Bearer token: ")
 	tokenBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	if err != nil {
 		return "", fmt.Errorf("read bearer token: %w", err)
 	}
@@ -214,9 +214,9 @@ func readGoogleClientSecret() (string, error) {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return "", fmt.Errorf("a Google OAuth client secret is required: set GOOGLE_CLIENT_SECRET or run interactively")
 	}
-	fmt.Print("Google OAuth client secret: ")
+	fmt.Fprint(os.Stderr, "Google OAuth client secret: ")
 	secretBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
 	if err != nil {
 		return "", fmt.Errorf("read client secret: %w", err)
 	}

--- a/cmd/chroncal/output.go
+++ b/cmd/chroncal/output.go
@@ -99,14 +99,21 @@ func toJSONAlarmAttendees(attendees []model.AlarmAttendee) []jsonAlarmAttendee {
 }
 
 type jsonCalendar struct {
-	ID          int64  `json:"id"`
-	Name        string `json:"name"`
-	Color       string `json:"color"`
-	Description string `json:"description,omitempty"`
-	OwnerEmail  string `json:"owner_email,omitempty"`
-	IsDefault   bool   `json:"is_default,omitempty"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
+	ID            int64  `json:"id"`
+	Name          string `json:"name"`
+	Color         string `json:"color"`
+	Description   string `json:"description,omitempty"`
+	OwnerEmail    string `json:"owner_email,omitempty"`
+	IsDefault     bool   `json:"is_default,omitempty"`
+	AccountID     int64  `json:"account_id,omitempty"`
+	AccountName   string `json:"account_name,omitempty"`
+	RemoteURL     string `json:"remote_url,omitempty"`
+	RemoteAccess  string `json:"remote_access,omitempty"`
+	LastSyncAt    string `json:"last_sync_at,omitempty"`
+	LastSyncError string `json:"last_sync_error,omitempty"`
+	Hidden        bool   `json:"hidden,omitempty"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
 }
 
 func toJSONEvent(e event.Event) jsonEvent {
@@ -166,14 +173,19 @@ func toJSONEvent(e event.Event) jsonEvent {
 
 func toJSONCalendar(c calendar.Calendar) jsonCalendar {
 	return jsonCalendar{
-		ID:          c.ID,
-		Name:        c.Name,
-		Color:       c.Color,
-		Description: c.Description,
-		OwnerEmail:  c.OwnerEmail,
-		IsDefault:   c.IsDefault,
-		CreatedAt:   c.CreatedAt.UTC().Format(time.RFC3339),
-		UpdatedAt:   c.UpdatedAt.UTC().Format(time.RFC3339),
+		ID:            c.ID,
+		Name:          c.Name,
+		Color:         c.Color,
+		Description:   c.Description,
+		OwnerEmail:    c.OwnerEmail,
+		IsDefault:     c.IsDefault,
+		AccountID:     c.AccountID,
+		RemoteURL:     c.RemoteURL,
+		RemoteAccess:  c.RemoteAccess,
+		LastSyncAt:    c.LastSyncAt,
+		LastSyncError: c.LastSyncError,
+		CreatedAt:     c.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:     c.UpdatedAt.UTC().Format(time.RFC3339),
 	}
 }
 

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -139,13 +139,6 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 			ctx, cancel := context.WithTimeout(context.Background(), syncRunTimeout)
 			defer cancel()
 
-			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			if err != nil {
-				return fmt.Errorf("credential store: %w", err)
-			}
-
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, stderrSyncLogger(os.Stderr))
-
 			// Look up names for every calendar up front so both the JSON and
 			// text views can label results without re-querying per result.
 			cals, err := a.Calendars.List(ctx)
@@ -157,26 +150,53 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 				calNames[c.ID] = c.Name
 			}
 
-			var results []*syncPkg.SyncResult
+			// Resolve --calendar / --account before opening the credential
+			// store. An unknown name is not_found; an account with no linked
+			// calendars is a clean no-op. Neither needs a keyring, and CI has
+			// none (see issue #474).
+			var targetCalendarID, targetAccountID int64
 			if calendarName != "" {
 				target, err := findCalendarByRef(cals, calendarName)
 				if err != nil {
 					return &cliError{Code: "not_found", Msg: err.Error()}
 				}
-				r, err := svc.SyncCalendar(ctx, target.ID, strategy)
-				if err != nil {
-					return classifySyncError(err)
-				}
-				results = []*syncPkg.SyncResult{r}
+				targetCalendarID = target.ID
 			} else if accountName != "" {
 				acct, err := resolveAccount(ctx, a.Accounts, accountName)
 				if err != nil {
 					return err
 				}
+				targetAccountID = acct.ID
+				linked := false
+				for _, c := range cals {
+					if c.AccountID == acct.ID {
+						linked = true
+						break
+					}
+				}
+				if !linked {
+					return renderSyncRunResults(cmd, nil, calNames)
+				}
+			}
+
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
+
+			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, stderrSyncLogger(os.Stderr))
+
+			var results []*syncPkg.SyncResult
+			if targetCalendarID != 0 {
+				r, err := svc.SyncCalendar(ctx, targetCalendarID, strategy)
+				if err != nil {
+					return classifySyncError(err)
+				}
+				results = []*syncPkg.SyncResult{r}
+			} else if targetAccountID != 0 {
 				// SyncAccount runs the account's calendars in series: they
 				// share one credential, so a refresh must not race itself.
-				// An account with no linked calendars is a clean no-op.
-				results, err = svc.SyncAccount(ctx, acct.ID, strategy)
+				results, err = svc.SyncAccount(ctx, targetAccountID, strategy)
 				if err != nil {
 					return classifySyncError(err)
 				}

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -106,6 +106,7 @@ conflicts for calendars connected to remote CalDAV calendars.`,
 func syncRunCmd() *cobra.Command {
 	var (
 		calendarName string
+		accountName  string
 		conflict     string
 	)
 	cmd := &cobra.Command{
@@ -114,9 +115,11 @@ func syncRunCmd() *cobra.Command {
 		Long: `Push local changes and pull remote changes for connected calendars.
 
 By default every connected calendar is synced. Use --calendar to limit the
-run to a single local calendar.`,
+run to a single local calendar, or --account to limit it to every calendar
+linked to one CalDAV account. The two flags are mutually exclusive.`,
 		Example: `  chroncal sync run
   chroncal sync run --calendar Work
+  chroncal sync run --account Work
   chroncal sync run --conflict prompt`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validate the flag up front so a typo (e.g. "Prompt", "ask")
@@ -165,6 +168,18 @@ run to a single local calendar.`,
 					return classifySyncError(err)
 				}
 				results = []*syncPkg.SyncResult{r}
+			} else if accountName != "" {
+				acct, err := resolveAccount(ctx, a.Accounts, accountName)
+				if err != nil {
+					return err
+				}
+				// SyncAccount runs the account's calendars in series: they
+				// share one credential, so a refresh must not race itself.
+				// An account with no linked calendars is a clean no-op.
+				results, err = svc.SyncAccount(ctx, acct.ID, strategy)
+				if err != nil {
+					return classifySyncError(err)
+				}
 			} else {
 				results, err = svc.SyncAll(ctx, strategy)
 				if err != nil {
@@ -176,7 +191,9 @@ run to a single local calendar.`,
 		},
 	}
 	cmd.Flags().StringVar(&calendarName, "calendar", "", "Sync only this calendar")
+	cmd.Flags().StringVar(&accountName, "account", "", "Sync only calendars linked to this account")
 	cmd.Flags().StringVar(&conflict, "conflict", "server-wins", "Conflict strategy: server-wins or prompt")
+	mutuallyExclusive(cmd, "calendar", "account")
 	return cmd
 }
 

--- a/cmd/chroncal/sync_cli_test.go
+++ b/cmd/chroncal/sync_cli_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/storage"
 )
 
 // TestSyncResetMatchesCalendarCaseInsensitively guards against issue #112.
@@ -56,5 +61,126 @@ func TestSyncRunMatchesCalendarCaseInsensitively(t *testing.T) {
 	}
 	if strings.Contains(stderr, `calendar "work" not found`) {
 		t.Fatalf("sync run --calendar work failed to resolve %q case-insensitively; stderr = %q", "Work", stderr)
+	}
+}
+
+// TestSyncRunRejectsAccountWithCalendar pins the flag contract of the
+// account-scoped run. --calendar picks one local calendar while --account
+// narrows the run to every calendar of one CalDAV account, so passing both
+// is ambiguous. Reject the pair up front with invalid_input rather than
+// silently honoring one of them.
+func TestSyncRunRejectsAccountWithCalendar(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	createLinkedCalendarForTest(t, dbPath)
+
+	_, stderr, err := runChroncalCommand(t, "sync", "run",
+		"--account", "__calendar_test", "--calendar", "Work", "--output", "json")
+	if err == nil {
+		t.Fatalf("sync run --account with --calendar was accepted; expected an invalid_input error")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode stderr: %v\n%s", jerr, stderr)
+	}
+	if payload.Code != "invalid_input" || !strings.Contains(payload.Error, "mutually exclusive") {
+		t.Fatalf("sync run --account + --calendar: code = %q, error = %q; want the mutually-exclusive invalid_input",
+			payload.Code, payload.Error)
+	}
+}
+
+// TestSyncRunScopesToRequestedAccount checks that --account narrows the run
+// to that account's calendars only. The linked Work calendar belongs to the
+// "__calendar_test" account, so a run scoped to a second, empty account must
+// be a clean no-op (synced 0) rather than touch Work. A run scoped to the
+// owning account — by case-mismatched name, matching every other account
+// command — must resolve and report only Work, never a not_found error.
+func TestSyncRunScopesToRequestedAccount(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	createLinkedCalendarForTest(t, dbPath)
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	_, err = a.Queries.CreateAccount(context.Background(), storage.CreateAccountParams{
+		Name:      "Empty",
+		ServerUrl: "https://empty.example.com/dav",
+		AuthType:  "bearer",
+		Username:  "bob",
+	})
+	if err != nil {
+		t.Fatalf("create empty account: %v", err)
+	}
+	a.Close()
+
+	// An account with no linked calendars: the run is a no-op, not an error.
+	stdout, _, err := runChroncalCommand(t, "sync", "run", "--account", "empty", "--output", "json")
+	if err != nil {
+		t.Fatalf("sync run --account empty: %v", err)
+	}
+	var emptyRun struct {
+		Synced  int `json:"synced"`
+		Results []struct {
+			CalendarName string `json:"calendar_name"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &emptyRun); err != nil {
+		t.Fatalf("decode sync run --account empty output: %v\n%s", err, stdout)
+	}
+	if emptyRun.Synced != 0 || len(emptyRun.Results) != 0 {
+		t.Fatalf("sync run --account empty synced %d calendar(s) (%v); want a no-op that leaves Work alone",
+			emptyRun.Synced, emptyRun.Results)
+	}
+
+	// The owning account resolves case-insensitively. Without live CalDAV the
+	// cycle may fail or never render; that is fine as long as the failure is
+	// not account-not-found, and any rendered results stay inside the
+	// account: Work is its only calendar, so anything else in results would
+	// mean the run ignored --account.
+	stdout, stderr, err := runChroncalCommand(t, "sync", "run", "--account", "__CALENDAR_TEST", "--output", "json")
+	if err != nil && strings.Contains(stderr, "not_found") {
+		t.Fatalf("sync run --account __CALENDAR_TEST failed to resolve the account case-insensitively; stderr = %q", stderr)
+	}
+	if !strings.Contains(stdout, "results") {
+		return // failed before rendering; resolution already proved above
+	}
+	var scopedRun struct {
+		Results []struct {
+			CalendarName string `json:"calendar_name"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &scopedRun); err != nil {
+		t.Fatalf("decode sync run --account __CALENDAR_TEST output: %v\n%s", err, stdout)
+	}
+	for _, r := range scopedRun.Results {
+		if r.CalendarName != "Work" {
+			t.Fatalf("sync run --account __CALENDAR_TEST synced %q; want only calendars of the requested account", r.CalendarName)
+		}
+	}
+}
+
+// TestSyncRunUnknownAccountIsNotFound keeps the account reference error in
+// the same taxonomy as every other account command: an unknown name is a
+// not_found cliError, so --output json consumers can dispatch on the code.
+func TestSyncRunUnknownAccountIsNotFound(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	_, stderr, err := runChroncalCommand(t, "sync", "run", "--account", "ghost", "--output", "json")
+	if err == nil {
+		t.Fatalf("sync run --account ghost was accepted; expected a not_found error")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode stderr: %v\n%s", jerr, stderr)
+	}
+	if payload.Code != "not_found" || payload.Error != `account "ghost" not found` {
+		t.Fatalf("sync run --account ghost: code = %q, error = %q; want the account not_found error",
+			payload.Code, payload.Error)
 	}
 }

--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -251,7 +252,7 @@ func GoogleOAuthFlow(ctx context.Context, clientID, clientSecret string) (*Googl
 	if err != nil {
 		return nil, err
 	}
-	fmt.Print(flowBanner(flow.AuthURL, flow.BrowserOpened))
+	fmt.Fprint(os.Stderr, flowBanner(flow.AuthURL, flow.BrowserOpened))
 	return flow.Wait(ctx)
 }
 

--- a/internal/auth/google_flow_test.go
+++ b/internal/auth/google_flow_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -183,6 +184,31 @@ func TestPendingOAuthFlow_CancelUnblocksWait(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Wait did not unblock on cancel")
+	}
+}
+
+func TestGoogleOAuthFlow_DoesNotWriteBannerToStdout(t *testing.T) {
+	stubBrowser(t, errors.New("no browser"))
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = old
+		_ = w.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_, _ = GoogleOAuthFlow(ctx, "cid", "secret")
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	got := string(out)
+	if strings.Contains(got, "Open this URL") || strings.Contains(got, "Browser opened") {
+		t.Fatalf("OAuth banner leaked onto stdout (breaks --output json): %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fill the CLI gaps Chroncal Bar needs to manage accounts and calendars in-plugin, matching the TUI Calendars manager.

- Keep OAuth banners and secret prompts on stderr so `--output json` stays a single object.
- Include `account_id`, `account_name`, `remote_url`, `remote_access`, `last_sync_at`, `last_sync_error`, and `hidden` on calendar JSON.
- Add `calendar hide` / `calendar show` (same `hidden_calendars` / `state.json` contract as the TUI).
- Add `account credentials` for basic and bearer (`CHRONCAL_PASSWORD` / `CHRONCAL_BEARER_TOKEN`) and `account reauth` for oauth2.
- Add `sync run --account` to run CalDAV sync for one account.

Secrets stay in the environment, never flags or argv. OAuth reauth keeps the stored refresh token when Google returns empty, and keeps username plus client config.

No `VERSION` bump (stays 0.7.7). Companion: [DouglasdeMoura/chroncal-bar#1](https://github.com/DouglasdeMoura/chroncal-bar/pull/1) (`feat/account-setup`).

## Test Plan

- [x] `mise exec go@1.26.6 -- go test ./cmd/chroncal ./internal/auth -count=1 -timeout 900s`
- [x] `go vet ./cmd/chroncal ./internal/auth`
- [ ] `go test ./...` before any version tag
- [ ] `account credentials` / `account reauth` against a real account
- [ ] `calendar hide` / `calendar show` round-trip in TUI and JSON
- [ ] `sync run --account` for one CalDAV account