### PR TITLE
fix(account): apply live discovery metadata on calendar re-link

### DIFF
--- a/internal/account/service.go
+++ b/internal/account/service.go
@@ -381,19 +381,7 @@ func (s *Service) discoverLocked(ctx context.Context, accountID int64, store aut
 		if local, ok := existingByURL[key]; ok {
 			item.Imported = true
 			item.CalendarID = local.ID
-			if err := qtx.AdoptCalendarRemoteName(ctx, storage.AdoptCalendarRemoteNameParams{
-				Name: remote.Name,
-				ID:   local.ID,
-			}); err != nil {
-				return Discovery{}, fmt.Errorf("adopt discovered calendar name %q: %w", remote.Name, err)
-			}
-			if _, err := qtx.UpdateCalendarDiscovery(ctx, storage.UpdateCalendarDiscoveryParams{
-				RemoteName:       remote.Name,
-				RemoteColor:      remote.Color,
-				RemoteAccess:     string(remote.Access),
-				RemoteComponents: strings.Join(remote.SupportedComponentSet, ","),
-				ID:               local.ID,
-			}); err != nil {
+			if err := applyDiscoveredCalendarMetadata(ctx, qtx, item, local.ID); err != nil {
 				return Discovery{}, fmt.Errorf("update discovered calendar %q: %w", remote.Name, err)
 			}
 		}
@@ -964,10 +952,30 @@ func uniqueUnlinkedByRemoteIdentity(rows []storage.Calendar, serverURL string) m
 	return byKey
 }
 
+// applyDiscoveredCalendarMetadata writes live discovery color, name, access,
+// and components onto a local calendar. AdoptCalendarRemoteName keeps a
+// user-chosen display name. UpdateCalendarDiscovery is the one write of the
+// remote_* mirrors and the color CASE rules.
+func applyDiscoveredCalendarMetadata(ctx context.Context, qtx *storage.Queries, item DiscoveredCalendar, calendarID int64) error {
+	remoteName := remoteCalendarName(item.RemoteCalendar)
+	if err := qtx.AdoptCalendarRemoteName(ctx, storage.AdoptCalendarRemoteNameParams{
+		Name: remoteName,
+		ID:   calendarID,
+	}); err != nil {
+		return err
+	}
+	_, err := qtx.UpdateCalendarDiscovery(ctx, storage.UpdateCalendarDiscoveryParams{
+		RemoteName:       remoteName,
+		RemoteColor:      item.Color,
+		RemoteAccess:     string(normalizedAccess(item.Access)),
+		RemoteComponents: strings.Join(normalizedComponents(item.SupportedComponentSet), ","),
+		ID:               calendarID,
+	})
+	return err
+}
+
 // relinkDiscoveredCalendar attaches one unlinked local calendar to the account.
-// It writes live discovery color, name, access, and components onto the row.
-// Account remove clears remote_color. The live collection can also carry a new
-// remote_name. A later metadata sync then has a current remote baseline.
+// It writes the live collection onto the row through applyDiscoveredCalendarMetadata.
 func relinkDiscoveredCalendar(ctx context.Context, qtx *storage.Queries, acct Account, item DiscoveredCalendar, calendarID int64) error {
 	accountID := acct.ID
 	if err := qtx.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
@@ -977,20 +985,7 @@ func relinkDiscoveredCalendar(ctx context.Context, qtx *storage.Queries, acct Ac
 	}); err != nil {
 		return err
 	}
-	remoteName := remoteCalendarName(item.RemoteCalendar)
-	if err := qtx.AdoptCalendarRemoteName(ctx, storage.AdoptCalendarRemoteNameParams{
-		Name: remoteName,
-		ID:   calendarID,
-	}); err != nil {
-		return err
-	}
-	if _, err := qtx.UpdateCalendarDiscovery(ctx, storage.UpdateCalendarDiscoveryParams{
-		RemoteName:       remoteName,
-		RemoteColor:      item.Color,
-		RemoteAccess:     string(normalizedAccess(item.Access)),
-		RemoteComponents: strings.Join(normalizedComponents(item.SupportedComponentSet), ","),
-		ID:               calendarID,
-	}); err != nil {
+	if err := applyDiscoveredCalendarMetadata(ctx, qtx, item, calendarID); err != nil {
 		return err
 	}
 	return qtx.UpdateCalendarOwnerEmail(ctx, storage.UpdateCalendarOwnerEmailParams{

--- a/internal/account/service.go
+++ b/internal/account/service.go
@@ -938,8 +938,8 @@ func normalizedComponents(components []string) []string {
 }
 
 // uniqueUnlinkedByRemoteIdentity maps a remote identity to one unlinked local
-// calendar. Duplicate keys are dropped so Import creates a fresh row instead
-// of picking an arbitrary snapshot.
+// calendar. Duplicate keys are dropped so Import and ReconcileSelection create
+// a fresh row. They must not pick an arbitrary snapshot.
 func uniqueUnlinkedByRemoteIdentity(rows []storage.Calendar, serverURL string) map[string]int64 {
 	byKey := make(map[string]int64)
 	ambiguous := make(map[string]struct{})
@@ -964,6 +964,10 @@ func uniqueUnlinkedByRemoteIdentity(rows []storage.Calendar, serverURL string) m
 	return byKey
 }
 
+// relinkDiscoveredCalendar attaches one unlinked local calendar to the account.
+// It writes live discovery color, name, access, and components onto the row.
+// Account remove clears remote_color. The live collection can also carry a new
+// remote_name. A later metadata sync then has a current remote baseline.
 func relinkDiscoveredCalendar(ctx context.Context, qtx *storage.Queries, acct Account, item DiscoveredCalendar, calendarID int64) error {
 	accountID := acct.ID
 	if err := qtx.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
@@ -973,7 +977,16 @@ func relinkDiscoveredCalendar(ctx context.Context, qtx *storage.Queries, acct Ac
 	}); err != nil {
 		return err
 	}
-	if err := qtx.UpdateCalendarCapabilitiesFromLink(ctx, storage.UpdateCalendarCapabilitiesFromLinkParams{
+	remoteName := remoteCalendarName(item.RemoteCalendar)
+	if err := qtx.AdoptCalendarRemoteName(ctx, storage.AdoptCalendarRemoteNameParams{
+		Name: remoteName,
+		ID:   calendarID,
+	}); err != nil {
+		return err
+	}
+	if _, err := qtx.UpdateCalendarDiscovery(ctx, storage.UpdateCalendarDiscoveryParams{
+		RemoteName:       remoteName,
+		RemoteColor:      item.Color,
 		RemoteAccess:     string(normalizedAccess(item.Access)),
 		RemoteComponents: strings.Join(normalizedComponents(item.SupportedComponentSet), ","),
 		ID:               calendarID,

--- a/internal/account/service_test.go
+++ b/internal/account/service_test.go
@@ -508,6 +508,177 @@ func TestServiceImportRelinksCalendarsAfterAccountRemove(t *testing.T) {
 	}
 }
 
+// Import must write live discovery color and name onto a re-linked row. Account
+// remove clears remote_color. Metadata sync then has a current remote baseline
+// instead of an empty mirror.
+func TestServiceImportRelinksAppliesLiveRemoteMetadata(t *testing.T) {
+	db, q, err := storage.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	store := newMemoryCredentialStore()
+	svc := NewService(db, q)
+	remote := []caldav.RemoteCalendar{{
+		Path: "/cal/work/", Name: "Work", Color: "#112233",
+		Access: caldav.CalendarAccessOwner, SupportedComponentSet: []string{"VEVENT"},
+	}}
+	svc.discover = func(context.Context, Account, auth.Credential, func(auth.Credential) error) ([]caldav.RemoteCalendar, error) {
+		return slices.Clone(remote), nil
+	}
+
+	account, err := svc.Create(ctx, CreateParams{
+		Name: "dev", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
+	}, auth.Credential{Username: "alice", Password: "secret"}, store)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	discovery, err := svc.Discover(ctx, account.ID, store)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	first, err := svc.Import(ctx, discovery, []string{"/cal/work/"})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if len(first.CreatedIDs) != 1 {
+		t.Fatalf("first import = %+v, want one created", first)
+	}
+	calID := first.CreatedIDs[0]
+
+	if err := svc.Delete(ctx, account.ID, store); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	unlinked, err := q.GetCalendar(ctx, calID)
+	if err != nil {
+		t.Fatalf("get unlinked calendar: %v", err)
+	}
+	if storage.NullableToString(unlinked.RemoteColor) != "" {
+		t.Fatalf("account remove should clear remote_color: %+v", unlinked)
+	}
+	if unlinked.RemoteName != "Work" || unlinked.Color != "#112233" {
+		t.Fatalf("account remove should keep remote_name and local color: %+v", unlinked)
+	}
+
+	remote[0].Name = "Work Live"
+	remote[0].Color = "#AABBCC"
+	again, err := svc.Create(ctx, CreateParams{
+		Name: "dev", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
+	}, auth.Credential{Username: "alice", Password: "secret"}, store)
+	if err != nil {
+		t.Fatalf("re-Create: %v", err)
+	}
+	discovery, err = svc.Discover(ctx, again.ID, store)
+	if err != nil {
+		t.Fatalf("re-Discover: %v", err)
+	}
+	second, err := svc.Import(ctx, discovery, []string{"/cal/work/"})
+	if err != nil {
+		t.Fatalf("re-Import: %v", err)
+	}
+	if len(second.CreatedIDs) != 1 || second.CreatedIDs[0] != calID {
+		t.Fatalf("re-import = %+v, want re-link of %d", second, calID)
+	}
+
+	got, err := q.GetCalendar(ctx, calID)
+	if err != nil {
+		t.Fatalf("get re-linked calendar: %v", err)
+	}
+	if got.RemoteName != "Work Live" {
+		t.Errorf("remote_name = %q, want live discovery name", got.RemoteName)
+	}
+	if storage.NullableToString(got.RemoteColor) != "#AABBCC" {
+		t.Errorf("remote_color = %q, want live discovery color", storage.NullableToString(got.RemoteColor))
+	}
+	if got.Color != "#AABBCC" {
+		t.Errorf("color = %q, want live discovery color", got.Color)
+	}
+	if got.Name != "Work Live" {
+		t.Errorf("name = %q, want adopted live remote name", got.Name)
+	}
+	if got.ColorDirty != 0 {
+		t.Errorf("color_dirty = %d, want 0", got.ColorDirty)
+	}
+}
+
+// Two unlinked rows with the same remote identity are ambiguous. Import must
+// create a new calendar. It must not pick one snapshot at random.
+func TestServiceImportSkipsAmbiguousUnlinkedRemoteIdentity(t *testing.T) {
+	db, q, err := storage.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	store := newMemoryCredentialStore()
+	svc := NewService(db, q)
+	snapA, err := q.CreateCalendar(ctx, storage.CreateCalendarParams{Name: "Snap A", Color: "#111111"})
+	if err != nil {
+		t.Fatalf("create snapshot A: %v", err)
+	}
+	snapB, err := q.CreateCalendar(ctx, storage.CreateCalendarParams{Name: "Snap B", Color: "#222222"})
+	if err != nil {
+		t.Fatalf("create snapshot B: %v", err)
+	}
+	origin := remoteIdentityKey("/cal/work/", "https://cal.example.test/")
+	if _, err := db.ExecContext(ctx,
+		"UPDATE calendars SET remote_url = ?, remote_name = 'Work' WHERE id IN (?, ?)",
+		origin, snapA.ID, snapB.ID,
+	); err != nil {
+		t.Fatalf("seed duplicate origins: %v", err)
+	}
+
+	svc.discover = func(context.Context, Account, auth.Credential, func(auth.Credential) error) ([]caldav.RemoteCalendar, error) {
+		return []caldav.RemoteCalendar{{
+			Path: "/cal/work/", Name: "Work", Color: "#112233", SupportedComponentSet: []string{"VEVENT"},
+		}}, nil
+	}
+	account, err := svc.Create(ctx, CreateParams{
+		Name: "dev", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
+	}, auth.Credential{Username: "alice", Password: "secret"}, store)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	discovery, err := svc.Discover(ctx, account.ID, store)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	result, err := svc.Import(ctx, discovery, []string{"/cal/work/"})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if len(result.CreatedIDs) != 1 {
+		t.Fatalf("import = %+v, want one new calendar", result)
+	}
+	newID := result.CreatedIDs[0]
+	if newID == snapA.ID || newID == snapB.ID {
+		t.Fatalf("import re-linked snapshot %d, want a new row", newID)
+	}
+
+	for _, snap := range []storage.Calendar{snapA, snapB} {
+		got, err := q.GetCalendar(ctx, snap.ID)
+		if err != nil {
+			t.Fatalf("get snapshot %d: %v", snap.ID, err)
+		}
+		if got.AccountID != nil {
+			t.Fatalf("ambiguous snapshot %d was re-linked: %+v", snap.ID, got)
+		}
+	}
+	created, err := q.GetCalendar(ctx, newID)
+	if err != nil {
+		t.Fatalf("get created calendar: %v", err)
+	}
+	if created.AccountID == nil || *created.AccountID != account.ID {
+		t.Fatalf("new calendar account_id = %v, want %d", created.AccountID, account.ID)
+	}
+	if created.Name != "Work" {
+		t.Fatalf("new calendar name = %q, want Work", created.Name)
+	}
+}
+
 func TestServiceDeleteRollsBackWhenCredentialRemovalFails(t *testing.T) {
 	db, q, err := storage.Open(":memory:")
 	if err != nil {
@@ -1683,6 +1854,94 @@ func TestServiceRemoveWithCalendarsRefusesLastCalendar(t *testing.T) {
 	}
 }
 
+// ReconcileSelection must re-link the same local rows after account remove.
+// Events stay on the original calendar IDs.
+func TestReconcileSelectionRelinksCalendarsAfterAccountRemove(t *testing.T) {
+	f := newSelectionFixture(t)
+	imported, _ := f.importAndRefresh(t, "/cal/a/", "/cal/b/")
+	if len(imported.CreatedIDs) != 2 {
+		t.Fatalf("first import = %+v, want two created", imported)
+	}
+	aID, bID := imported.CreatedIDs[0], imported.CreatedIDs[1]
+	ctx := context.Background()
+
+	evtSvc := event.NewService(f.db, f.q)
+	stay, err := evtSvc.Create(ctx, event.CreateParams{
+		CalendarID: aID,
+		Title:      "Stay here",
+		StartTime:  time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	if err := f.svc.Delete(ctx, f.discovery.Account.ID, f.store); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	again, err := f.svc.Create(ctx, CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/dav/",
+		Username: "alice", AuthType: "basic",
+	}, auth.Credential{Username: "alice", Password: "secret"}, f.store)
+	if err != nil {
+		t.Fatalf("re-Create: %v", err)
+	}
+	discovery, err := f.svc.Discover(ctx, again.ID, f.store)
+	if err != nil {
+		t.Fatalf("re-Discover: %v", err)
+	}
+	result, err := f.svc.ReconcileSelection(ctx, discovery, SelectionParams{
+		SelectedPaths: []string{"/cal/a/", "/cal/b/"},
+	}, f.store)
+	if err != nil {
+		t.Fatalf("ReconcileSelection: %v", err)
+	}
+	if !slices.Equal(result.CreatedIDs, []int64{aID, bID}) || len(result.RemovedIDs) != 0 || result.AccountRemoved {
+		t.Fatalf("selection result = %+v, want re-link of %d and %d", result, aID, bID)
+	}
+
+	linked, err := f.q.ListCalendarsByAccount(ctx, &again.ID)
+	if err != nil {
+		t.Fatalf("list re-linked calendars: %v", err)
+	}
+	if len(linked) != 2 {
+		t.Fatalf("linked calendar count = %d, want 2; names = %v", len(linked), calendarNames(linked))
+	}
+	byID := map[int64]storage.Calendar{}
+	for _, row := range linked {
+		byID[row.ID] = row
+	}
+	gotA, ok := byID[aID]
+	if !ok {
+		t.Fatalf("A id %d was not re-linked; linked = %v", aID, calendarNames(linked))
+	}
+	gotB, ok := byID[bID]
+	if !ok {
+		t.Fatalf("B id %d was not re-linked; linked = %v", bID, calendarNames(linked))
+	}
+	if gotA.Name != "A" || strings.Contains(gotA.Name, "(2)") {
+		t.Fatalf("A name = %q, want original without suffix", gotA.Name)
+	}
+	if gotB.Name != "B" || strings.Contains(gotB.Name, "(2)") {
+		t.Fatalf("B name = %q, want original without suffix", gotB.Name)
+	}
+	if storage.NullableToString(gotA.RemoteColor) != "#112233" {
+		t.Errorf("A remote_color = %q, want discovery color", storage.NullableToString(gotA.RemoteColor))
+	}
+	if storage.NullableToString(gotB.RemoteColor) != "#445566" {
+		t.Errorf("B remote_color = %q, want discovery color", storage.NullableToString(gotB.RemoteColor))
+	}
+
+	gotEvent, err := evtSvc.Get(ctx, stay.ID)
+	if err != nil {
+		t.Fatalf("get event: %v", err)
+	}
+	if gotEvent.CalendarID != aID {
+		t.Fatalf("event calendar_id = %d, want original %d", gotEvent.CalendarID, aID)
+	}
+}
+
 func TestReconcileSelectionAddsAndRemovesInOneFinalState(t *testing.T) {
 	f := newSelectionFixture(t)
 	imported, discovery := f.importAndRefresh(t, "/cal/a/")
@@ -1994,5 +2253,27 @@ func TestUniqueUnlinkedByRemoteIdentity_RequiresSameOrigin(t *testing.T) {
 	got := uniqueUnlinkedByRemoteIdentity(rows, "https://cal.example.test/")
 	if got[key] != 7 {
 		t.Fatalf("same origin = %v, want id 7 at %q", got, key)
+	}
+}
+
+func TestUniqueUnlinkedByRemoteIdentity_DropsDuplicates(t *testing.T) {
+	t.Parallel()
+	server := "https://cal.example.test/"
+	key := remoteIdentityKey("/cal/work/", server)
+	other := remoteIdentityKey("/cal/other/", server)
+	linkedID := int64(9)
+	rows := []storage.Calendar{
+		{ID: 1, RemoteUrl: storage.StringToNullable(key)},
+		{ID: 2, RemoteUrl: storage.StringToNullable(key)},
+		{ID: 3, RemoteUrl: storage.StringToNullable(other)},
+		{ID: 4, RemoteUrl: storage.StringToNullable(key)},
+		{ID: 5, AccountID: &linkedID, RemoteUrl: storage.StringToNullable(other)},
+	}
+	got := uniqueUnlinkedByRemoteIdentity(rows, server)
+	if _, ok := got[key]; ok {
+		t.Fatalf("ambiguous key present: %v", got)
+	}
+	if got[other] != 3 {
+		t.Fatalf("unique key = %v, want id 3 at %q", got, other)
 	}
 }

--- a/internal/account/service_test.go
+++ b/internal/account/service_test.go
@@ -393,6 +393,10 @@ func TestServiceDeletePreservesCalendarsAsLocal(t *testing.T) {
 	}
 }
 
+// Import must re-link the same local rows after account remove. Events stay
+// on the original calendar IDs. The re-link writes a live discovery color
+// and name onto the row. Account remove clears remote_color. Metadata sync
+// then has a current remote baseline.
 func TestServiceImportRelinksCalendarsAfterAccountRemove(t *testing.T) {
 	db, q, err := storage.Open(":memory:")
 	if err != nil {
@@ -404,8 +408,8 @@ func TestServiceImportRelinksCalendarsAfterAccountRemove(t *testing.T) {
 	store := newMemoryCredentialStore()
 	svc := NewService(db, q)
 	remote := []caldav.RemoteCalendar{
-		{Path: "/cal/second/", Name: "Second Remote", SupportedComponentSet: []string{"VEVENT"}},
-		{Path: "/cal/seeded/", Name: "Seeded Calendar", SupportedComponentSet: []string{"VEVENT"}},
+		{Path: "/cal/second/", Name: "Second Remote", Color: "#112233", SupportedComponentSet: []string{"VEVENT"}},
+		{Path: "/cal/seeded/", Name: "Seeded Calendar", Color: "#445566", SupportedComponentSet: []string{"VEVENT"}},
 	}
 	svc.discover = func(context.Context, Account, auth.Credential, func(auth.Credential) error) ([]caldav.RemoteCalendar, error) {
 		return slices.Clone(remote), nil
@@ -444,6 +448,21 @@ func TestServiceImportRelinksCalendarsAfterAccountRemove(t *testing.T) {
 	if err := svc.Delete(ctx, account.ID, store); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
+	unlinked, err := q.GetCalendar(ctx, seededID)
+	if err != nil {
+		t.Fatalf("get unlinked calendar: %v", err)
+	}
+	if storage.NullableToString(unlinked.RemoteColor) != "" {
+		t.Fatalf("account remove should clear remote_color: %+v", unlinked)
+	}
+	if unlinked.RemoteName != "Seeded Calendar" || unlinked.Color != "#445566" {
+		t.Fatalf("account remove should keep remote_name and local color: %+v", unlinked)
+	}
+
+	remote[0].Name = "Second Live"
+	remote[0].Color = "#AABBCC"
+	remote[1].Name = "Seeded Live"
+	remote[1].Color = "#DDEEFF"
 
 	again, err := svc.Create(ctx, CreateParams{
 		Name: "dev", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
@@ -486,17 +505,38 @@ func TestServiceImportRelinksCalendarsAfterAccountRemove(t *testing.T) {
 	}
 	gotSecond, ok := byID[secondID]
 	if !ok {
-		t.Fatalf("Second Remote id %d was not re-linked; linked = %v", secondID, calendarNames(linked))
+		t.Fatalf("Second Live id %d was not re-linked; linked = %v", secondID, calendarNames(linked))
 	}
 	gotSeeded, ok := byID[seededID]
 	if !ok {
-		t.Fatalf("Seeded Calendar id %d was not re-linked; linked = %v", seededID, calendarNames(linked))
+		t.Fatalf("Seeded Live id %d was not re-linked; linked = %v", seededID, calendarNames(linked))
 	}
-	if gotSecond.Name != "Second Remote" || strings.Contains(gotSecond.Name, "(2)") {
-		t.Fatalf("Second Remote name = %q, want original without suffix", gotSecond.Name)
+	if gotSecond.Name != "Second Live" || strings.Contains(gotSecond.Name, "(2)") {
+		t.Fatalf("Second Live name = %q, want live discovery name without suffix", gotSecond.Name)
 	}
-	if gotSeeded.Name != "Seeded Calendar" || strings.Contains(gotSeeded.Name, "(2)") {
-		t.Fatalf("Seeded Calendar name = %q, want original without suffix", gotSeeded.Name)
+	if gotSeeded.Name != "Seeded Live" || strings.Contains(gotSeeded.Name, "(2)") {
+		t.Fatalf("Seeded Live name = %q, want live discovery name without suffix", gotSeeded.Name)
+	}
+	if gotSecond.RemoteName != "Second Live" {
+		t.Errorf("Second remote_name = %q, want live discovery name", gotSecond.RemoteName)
+	}
+	if gotSeeded.RemoteName != "Seeded Live" {
+		t.Errorf("Seeded remote_name = %q, want live discovery name", gotSeeded.RemoteName)
+	}
+	if storage.NullableToString(gotSecond.RemoteColor) != "#AABBCC" {
+		t.Errorf("Second remote_color = %q, want live discovery color", storage.NullableToString(gotSecond.RemoteColor))
+	}
+	if storage.NullableToString(gotSeeded.RemoteColor) != "#DDEEFF" {
+		t.Errorf("Seeded remote_color = %q, want live discovery color", storage.NullableToString(gotSeeded.RemoteColor))
+	}
+	if gotSecond.Color != "#AABBCC" {
+		t.Errorf("Second color = %q, want live discovery color", gotSecond.Color)
+	}
+	if gotSeeded.Color != "#DDEEFF" {
+		t.Errorf("Seeded color = %q, want live discovery color", gotSeeded.Color)
+	}
+	if gotSecond.ColorDirty != 0 || gotSeeded.ColorDirty != 0 {
+		t.Errorf("color_dirty = %d/%d, want 0/0", gotSecond.ColorDirty, gotSeeded.ColorDirty)
 	}
 
 	gotEvent, err := evtSvc.Get(ctx, stay.ID)
@@ -505,101 +545,6 @@ func TestServiceImportRelinksCalendarsAfterAccountRemove(t *testing.T) {
 	}
 	if gotEvent.CalendarID != seededID {
 		t.Fatalf("event calendar_id = %d, want original %d", gotEvent.CalendarID, seededID)
-	}
-}
-
-// Import must write live discovery color and name onto a re-linked row. Account
-// remove clears remote_color. Metadata sync then has a current remote baseline
-// instead of an empty mirror.
-func TestServiceImportRelinksAppliesLiveRemoteMetadata(t *testing.T) {
-	db, q, err := storage.Open(":memory:")
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	defer db.Close()
-
-	ctx := context.Background()
-	store := newMemoryCredentialStore()
-	svc := NewService(db, q)
-	remote := []caldav.RemoteCalendar{{
-		Path: "/cal/work/", Name: "Work", Color: "#112233",
-		Access: caldav.CalendarAccessOwner, SupportedComponentSet: []string{"VEVENT"},
-	}}
-	svc.discover = func(context.Context, Account, auth.Credential, func(auth.Credential) error) ([]caldav.RemoteCalendar, error) {
-		return slices.Clone(remote), nil
-	}
-
-	account, err := svc.Create(ctx, CreateParams{
-		Name: "dev", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
-	}, auth.Credential{Username: "alice", Password: "secret"}, store)
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	discovery, err := svc.Discover(ctx, account.ID, store)
-	if err != nil {
-		t.Fatalf("Discover: %v", err)
-	}
-	first, err := svc.Import(ctx, discovery, []string{"/cal/work/"})
-	if err != nil {
-		t.Fatalf("Import: %v", err)
-	}
-	if len(first.CreatedIDs) != 1 {
-		t.Fatalf("first import = %+v, want one created", first)
-	}
-	calID := first.CreatedIDs[0]
-
-	if err := svc.Delete(ctx, account.ID, store); err != nil {
-		t.Fatalf("Delete: %v", err)
-	}
-	unlinked, err := q.GetCalendar(ctx, calID)
-	if err != nil {
-		t.Fatalf("get unlinked calendar: %v", err)
-	}
-	if storage.NullableToString(unlinked.RemoteColor) != "" {
-		t.Fatalf("account remove should clear remote_color: %+v", unlinked)
-	}
-	if unlinked.RemoteName != "Work" || unlinked.Color != "#112233" {
-		t.Fatalf("account remove should keep remote_name and local color: %+v", unlinked)
-	}
-
-	remote[0].Name = "Work Live"
-	remote[0].Color = "#AABBCC"
-	again, err := svc.Create(ctx, CreateParams{
-		Name: "dev", ServerURL: "https://cal.example.test/", Username: "alice", AuthType: "basic",
-	}, auth.Credential{Username: "alice", Password: "secret"}, store)
-	if err != nil {
-		t.Fatalf("re-Create: %v", err)
-	}
-	discovery, err = svc.Discover(ctx, again.ID, store)
-	if err != nil {
-		t.Fatalf("re-Discover: %v", err)
-	}
-	second, err := svc.Import(ctx, discovery, []string{"/cal/work/"})
-	if err != nil {
-		t.Fatalf("re-Import: %v", err)
-	}
-	if len(second.CreatedIDs) != 1 || second.CreatedIDs[0] != calID {
-		t.Fatalf("re-import = %+v, want re-link of %d", second, calID)
-	}
-
-	got, err := q.GetCalendar(ctx, calID)
-	if err != nil {
-		t.Fatalf("get re-linked calendar: %v", err)
-	}
-	if got.RemoteName != "Work Live" {
-		t.Errorf("remote_name = %q, want live discovery name", got.RemoteName)
-	}
-	if storage.NullableToString(got.RemoteColor) != "#AABBCC" {
-		t.Errorf("remote_color = %q, want live discovery color", storage.NullableToString(got.RemoteColor))
-	}
-	if got.Color != "#AABBCC" {
-		t.Errorf("color = %q, want live discovery color", got.Color)
-	}
-	if got.Name != "Work Live" {
-		t.Errorf("name = %q, want adopted live remote name", got.Name)
-	}
-	if got.ColorDirty != 0 {
-		t.Errorf("color_dirty = %d, want 0", got.ColorDirty)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #622.

Follow-ups from the review of #618.

`relinkDiscoveredCalendar` restored the account link but left `remote_color` empty and `remote_name` stale. Metadata sync could then treat the local color as the remote baseline until a later discover.

This change writes the live collection color, name, access, and components onto the re-linked row. Tests cover ReconcileSelection remove-then-add of the same collections, and skip auto-relink when two unlinked rows share one remote identity.

## Checklist

- [x] Tests pass (`make test`) — ran `go test ./internal/account/ -count=1`
- [x] Lint reports no issues (`make lint`) — ran `golangci-lint run ./internal/account/`
- [x] Add new tests for new functions
- [ ] Update the documentation when the change needs it

## Test plan

- [ ] Remove an account, change the remote collection color/name, add the account again, and confirm the re-linked calendar shows the live color and name
- [ ] In the TUI calendar manager, uncheck and re-check the same collections after an account remove/add and confirm events stay on the original calendar IDs
- [ ] Confirm a local rename still survives re-link when the local name no longer matches `remote_name`