### PR TITLE
chore(test): add a CalDAV account lifecycle lab

### DIFF
--- a/scripts/caldav-lab/README.md
+++ b/scripts/caldav-lab/README.md
@@ -1,0 +1,68 @@
+# CalDAV account lab
+
+This lab runs the `chroncal account` commands against a real CalDAV server.
+The unit tests use fake transports. The Radicale round-trip tests in
+`internal/ical` cover the iCal layer. Neither one covers the account
+lifecycle end to end. This lab covers that gap.
+
+## What the lab needs
+
+- Docker with the `compose` plugin
+- `curl`
+- A Go toolchain, for `make build`
+
+## How to run the lab
+
+```bash
+scripts/caldav-lab/run-account-lab.sh
+```
+
+The script starts the server, seeds the collections, builds the binary, and
+runs the full lifecycle. Set `KEEP_DB=1` to keep the temporary database for
+inspection.
+
+To stop the server and to delete its data:
+
+```bash
+docker compose -f scripts/caldav-lab/docker-compose.yml down -v
+```
+
+## What the lab covers
+
+The seed script creates five collections:
+
+| Collection           | Component  | Purpose                                  |
+| -------------------- | ---------- | ---------------------------------------- |
+| `Personal`           | `VEVENT`   | A usable event collection                |
+| `Holidays in Brazil` | `VEVENT`   | A second event collection, with a space  |
+| `Família`            | `VEVENT`   | A non-ASCII display name                 |
+| `Tasks`              | `VTODO`    | A todo collection                        |
+| `Availability`       | `VFREEBUSY`| An unusable collection, to skip          |
+
+The lab script then runs this sequence:
+
+1. `account add` discovers the collections and imports the four usable ones.
+   It skips the `VFREEBUSY` collection as unsupported.
+2. `account calendars list` refreshes the complete inventory.
+3. The initial sync pulls the three seeded events. The script asserts this.
+4. `event add` plus `sync run` pushes a local event to the server.
+5. `account calendars set` reduces the local selection to two calendars. The
+   script asserts which remote paths stay and which ones go.
+6. `account remove` deletes the credential and keeps the local copies.
+
+The remote `Personal` collection arrives with the local name `Personal (2)`,
+because the local default calendar already holds the name `Personal`. The
+assertions match on the remote path for that reason.
+
+The script exits with a non-zero status when an assertion fails.
+
+## The port
+
+The lab server listens on port 5233. The anonymous server for the
+`internal/ical` round-trip tests listens on port 5232. The two servers can
+run at the same time.
+
+## Warning
+
+Do not expose this server to a network. The credential is `alice:secret`
+and the transport is HTTP.

--- a/scripts/caldav-lab/docker-compose.yml
+++ b/scripts/caldav-lab/docker-compose.yml
@@ -1,0 +1,26 @@
+# Radicale CalDAV server for the account lab.
+#
+# The server needs authentication (alice:secret) and holds several
+# collections. The lab uses it to run `chroncal account` against a real
+# CalDAV server.
+#
+# The port is 5233. The anonymous round-trip server for the
+# internal/ical tests uses 5232. Both servers can run at the same time.
+#
+# Usage:
+#   docker compose -f scripts/caldav-lab/docker-compose.yml up -d
+#   docker compose -f scripts/caldav-lab/docker-compose.yml down -v
+services:
+  radicale:
+    image: tomsquest/docker-radicale:3.2.0.0
+    container_name: chroncal-caldav-lab
+    ports:
+      - "5233:5232"
+    environment:
+      RADICALE_USERS: alice:secret
+    volumes:
+      - radicale-lab-data:/data
+    restart: unless-stopped
+
+volumes:
+  radicale-lab-data:

--- a/scripts/caldav-lab/run-account-lab.sh
+++ b/scripts/caldav-lab/run-account-lab.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Run the account lifecycle against the lab CalDAV server.
+#
+# The script covers this sequence:
+#
+# 1. `account add` discovers and imports the usable collections.
+# 2. `account calendars list` shows the complete inventory.
+# 3. `sync run` pulls the seeded events.
+# 4. `event add` plus `sync run` pushes a local event to the server.
+# 5. `account calendars set` reduces the selection.
+# 6. `account remove` deletes the credential and keeps the local copies.
+#
+# The script uses a temporary database. It does not touch the calendar data
+# of the user.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+COMPOSE_FILE="scripts/caldav-lab/docker-compose.yml"
+SERVER="${CALDAV_URL:-http://127.0.0.1:5233}/"
+KEEP_DB="${KEEP_DB:-0}"
+
+LAB_DB="$(mktemp /tmp/chroncal-lab-XXXXXX.db)"
+cleanup() {
+  if [ "$KEEP_DB" = "0" ]; then
+    rm -f "$LAB_DB" "$LAB_DB"-wal "$LAB_DB"-shm
+  fi
+}
+trap cleanup EXIT
+
+docker compose -f "$COMPOSE_FILE" up -d
+scripts/caldav-lab/seed-calendars.sh
+
+make build
+
+export CHRONCAL_DB="$LAB_DB"
+export CHRONCAL_PASSWORD=secret
+BIN="./chroncal"
+FLAGS=(--allow-plaintext)
+
+echo "== account add =="
+"$BIN" "${FLAGS[@]}" account add "Work Lab" \
+  --server "$SERVER" --username alice --auth basic --allow-insecure
+
+echo "== account calendars list =="
+"$BIN" "${FLAGS[@]}" account calendars list "Work Lab"
+
+echo "== the initial sync pulled the seeded events =="
+events="$("$BIN" "${FLAGS[@]}" event list --from 2026-01-01 --to 2027-12-31)"
+printf '%s\n' "$events"
+for want in "Lab standup" "Independence Day" "Family dinner"; do
+  case "$events" in
+    *"$want"*) ;;
+    *)
+      echo "the initial sync did not pull \"$want\"" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "== sync run =="
+"$BIN" "${FLAGS[@]}" sync run
+
+echo "== push a local event =="
+"$BIN" "${FLAGS[@]}" event add "Radicale push test" \
+  --date "$(date -u -d '+1 day' +%Y-%m-%d)" --time 10:00 --duration 1h \
+  --calendar "Holidays in Brazil"
+"$BIN" "${FLAGS[@]}" sync run
+
+echo "== reduce the selection =="
+"$BIN" "${FLAGS[@]}" account calendars set "Work Lab" \
+  --calendar "Holidays in Brazil" --calendar "Família" --yes
+
+echo "== the reduced selection kept two calendars =="
+# Match on remote_url. The remote "Personal" collection arrives as
+# "Personal (2)", because the local default calendar already holds the name.
+kept="$("$BIN" "${FLAGS[@]}" -o json calendar list)"
+"$BIN" "${FLAGS[@]}" calendar list
+for gone in "/alice/personal/" "/alice/tasks/"; do
+  case "$kept" in
+    *"$gone"*)
+      echo "account calendars set kept the deselected ${gone}" >&2
+      exit 1
+      ;;
+  esac
+done
+for stays in "/alice/holidays-brazil/" "/alice/familia/"; do
+  case "$kept" in
+    *"$stays"*) ;;
+    *)
+      echo "account calendars set dropped the selected ${stays}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "== account remove =="
+"$BIN" "${FLAGS[@]}" account remove "Work Lab" --yes
+
+echo "== account remove kept the local copies =="
+"$BIN" "${FLAGS[@]}" calendar list
+
+echo "The account lab passed. DB=$LAB_DB"

--- a/scripts/caldav-lab/seed-calendars.sh
+++ b/scripts/caldav-lab/seed-calendars.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Create the lab collections on the Radicale server.
+#
+# The set covers a VEVENT collection, a VTODO collection, a VFREEBUSY
+# collection, and a non-ASCII display name. Chroncal discovery must
+# separate the usable collections from the unusable ones.
+set -euo pipefail
+
+BASE_URL="${CALDAV_URL:-http://127.0.0.1:5233}"
+USER="${CALDAV_USER:-alice}"
+PASS="${CALDAV_PASS:-secret}"
+AUTH="${USER}:${PASS}"
+
+mkcalendar() {
+  local path="$1" display="$2" components="$3" color="${4:-#4285f4}"
+  local status
+  status=$(curl -sS -u "$AUTH" -o /dev/null -w '%{http_code}' -X MKCALENDAR \
+    -H 'Content-Type: application/xml; charset=utf-8' --data-binary @- "${BASE_URL}${path}" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<C:mkcalendar xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:ICAL="http://apple.com/ns/ical/">
+  <D:set><D:prop>
+    <D:displayname>${display}</D:displayname>
+    <C:supported-calendar-component-set>${components}</C:supported-calendar-component-set>
+    <ICAL:calendar-color>${color}</ICAL:calendar-color>
+  </D:prop></D:set>
+</C:mkcalendar>
+XML
+)
+  # 405 and 409 mean the collection is already present. The script is idempotent.
+  case "$status" in
+    201 | 405 | 409) ;;
+    *)
+      echo "mkcalendar ${path} failed with HTTP ${status}" >&2
+      return 1
+      ;;
+  esac
+}
+
+put_event() {
+  local path="$1" uid="$2" summary="$3"
+  local status
+  status=$(curl -sS -u "$AUTH" -o /dev/null -w '%{http_code}' -X PUT \
+    -H 'Content-Type: text/calendar; charset=utf-8' --data-binary @- "${BASE_URL}${path}" <<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Chroncal Lab//EN
+BEGIN:VEVENT
+UID:${uid}
+DTSTAMP:20260721T120000Z
+DTSTART:20260722T140000Z
+DTEND:20260722T150000Z
+SUMMARY:${summary}
+END:VEVENT
+END:VCALENDAR
+ICS
+)
+  case "$status" in
+    201 | 204 | 409 | 412) ;;
+    *)
+      echo "put_event ${path} failed with HTTP ${status}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Wait a maximum of 15 seconds for the server.
+for _ in $(seq 1 30); do
+  curl -fsS -u "$AUTH" "${BASE_URL}/" > /dev/null 2>&1 && break
+  sleep 0.5
+done
+
+mkcalendar "/${USER}/personal/" "Personal" '<C:comp name="VEVENT"/>' '#112233'
+mkcalendar "/${USER}/holidays-brazil/" "Holidays in Brazil" '<C:comp name="VEVENT"/>' '#445566'
+mkcalendar "/${USER}/familia/" "Família" '<C:comp name="VEVENT"/>' '#228B22'
+mkcalendar "/${USER}/tasks/" "Tasks" '<C:comp name="VTODO"/>' '#AA5500'
+mkcalendar "/${USER}/availability/" "Availability" '<C:comp name="VFREEBUSY"/>' '#778899'
+
+put_event "/${USER}/personal/lab-meeting.ics" "lab-personal-1" "Lab standup"
+put_event "/${USER}/holidays-brazil/independence-day.ics" "lab-holiday-1" "Independence Day"
+put_event "/${USER}/familia/dinner.ics" "lab-family-1" "Family dinner"
+
+echo "Seeded the collections for ${USER} at ${BASE_URL}"


### PR DESCRIPTION
Salvaged from a stale worktree (`feat/caldav-calendar-discovery`, PR #540 merged) during a worktree cleanup. The lab was an untracked scratch directory that never landed. It has been hardened with real assertions and verified end to end.

## Gap

Three layers of CalDAV testing exist, and none covers the account lifecycle against a real server:

| Layer | Covers | Server |
| --- | --- | --- |
| unit tests | request/response shapes | fake transport |
| `internal/ical/radicale_test.go` (46 tests) | iCal round-trip fidelity | anonymous Radicale on `:5232` |
| **this lab** | **`chroncal account` lifecycle** | **authenticated Radicale on `:5233`** |

Discovery, selective import, access metadata, and the deselect/remove paths are only reachable through a server that needs authentication and holds several collections.

## What it does

`scripts/caldav-lab/run-account-lab.sh` starts the server, seeds five collections, builds the binary, and runs:

1. `account add` — discovers the collections, imports the four usable ones, skips the `VFREEBUSY` one as unsupported
2. `account calendars list` — refreshes the complete inventory
3. the initial sync pulls the three seeded events — **asserted**
4. `event add` plus `sync run` — pushes a local event to the server
5. `account calendars set` — reduces the selection; which remote paths stay and which go is **asserted**
6. `account remove` — deletes the credential, keeps the local copies

The seeded collections cover `VEVENT`, `VTODO`, and `VFREEBUSY` component sets, a name with a space, and a non-ASCII name (`Família`).

The script uses a temporary database and never touches the calendar data of the user. It exits non-zero when an assertion fails.

## Notes

- The port is **5233**, so this server and the anonymous `:5232` one for the `internal/ical` tests can run at the same time. This does not conflict with the open #31.
- Nothing here runs in CI. It is an on-demand lab; `make test` stays hermetic.

## Verification

- Ran end to end against a clean server: passes, exit 0
- Negative test: corrupting one expected remote path makes the run exit 1 with a clear message
- `bash -n` on both scripts

https://claude.ai/code/session_01UHcC7MGM76HYMgysbW4umj
