### PR TITLE
fix(sync): keep event sync when calendar-color PROPFIND 403s

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ Google limitations:
 - Google CalDAV only supports `VEVENT`. Use Nextcloud, Radicale, or Fastmail for `VTODO` and `VJOURNAL`.
 - Google paginates large `sync-collection` REPORT responses (RFC 6578 §3.6). It returns a `507` marker plus a continuation token. chroncal follows the pages and applies the union. The first sync of a large calendar then pulls every event.
 - If account add lists calendars but the first sync returns HTTP 403, enable `caldav.googleapis.com` on the Google Cloud project. The Calendar JSON API is not enough.
-- A failed calendar-color PROPFIND does not block event sync. Google colors come from CalendarList.
+- A failed calendar-color PROPFIND does not block event sync. Google colors come from CalendarList. Local Google color edits are written back through CalendarList, not Apple `calendar-color`.
 
 ### Free/busy
 

--- a/README.md
+++ b/README.md
@@ -494,6 +494,8 @@ Google limitations:
 
 - Google CalDAV only supports `VEVENT`. Use Nextcloud, Radicale, or Fastmail for `VTODO` and `VJOURNAL`.
 - Google paginates large `sync-collection` REPORT responses (RFC 6578 §3.6). It returns a `507` marker plus a continuation token. chroncal follows the pages and applies the union. The first sync of a large calendar then pulls every event.
+- If account add lists calendars but the first sync returns HTTP 403, enable `caldav.googleapis.com` on the Google Cloud project. The Calendar JSON API is not enough.
+- A failed calendar-color PROPFIND does not block event sync. Google colors come from CalendarList.
 
 ### Free/busy
 

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -593,7 +593,33 @@ func statusErrorf(status int, format string, args ...any) error {
 	return retry.NewHTTPError(status, fmt.Errorf(format, args...))
 }
 
+const httpErrorBodyLimit = 1024
+
+// googleCalDAVForbiddenHint tells the user how to fix a Google CalDAV 403.
+// CalendarList uses the Calendar JSON API. Event sync uses CalDAV. Google
+// returns 403 from apidata.googleusercontent.com when caldav.googleapis.com
+// is off on the OAuth client project (issue #628).
+const googleCalDAVForbiddenHint = "enable caldav.googleapis.com on the Google Cloud project (the Calendar JSON API is not enough)"
+
 func httpError(resp *http.Response) error {
+	if resp == nil {
+		return fmt.Errorf("HTTP 0")
+	}
+
+	var body []byte
+	truncated := false
+	if resp.Body != nil {
+		lr := &io.LimitedReader{R: resp.Body, N: httpErrorBodyLimit}
+		body, _ = io.ReadAll(lr)
+		truncated = lr.N == 0
+	}
+	return httpErrorFromBody(resp, body, truncated)
+}
+
+// httpErrorFromBody builds the same typed HTTP error as httpError when the
+// caller already consumed the response body. Sync-collection sniffs a 403
+// for valid-sync-token and must still show the body (issue #628).
+func httpErrorFromBody(resp *http.Response, body []byte, truncated bool) error {
 	if resp == nil {
 		return fmt.Errorf("HTTP 0")
 	}
@@ -603,21 +629,20 @@ func httpError(resp *http.Response) error {
 		status = fmt.Sprintf("%d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
-	var bodyText string
-	if resp.Body != nil {
-		lr := &io.LimitedReader{R: resp.Body, N: 1024}
-		body, _ := io.ReadAll(lr)
-		bodyText = strings.TrimSpace(string(body))
-		if lr.N == 0 {
-			bodyText += " […]"
-		}
+	bodyText := strings.TrimSpace(string(body))
+	if !truncated && len(bodyText) > httpErrorBodyLimit {
+		bodyText = bodyText[:httpErrorBodyLimit]
+		truncated = true
+	}
+	if truncated && bodyText != "" && !strings.HasSuffix(bodyText, " […]") {
+		bodyText += " […]"
 	}
 
 	msg := fmt.Sprintf("HTTP %s", status)
 	if bodyText != "" {
 		msg = fmt.Sprintf("HTTP %s: %s", status, bodyText)
 	}
-	err := retry.NewHTTPError(resp.StatusCode, errors.New(msg))
+	err := annotateGoogleCalDAVForbidden(resp, retry.NewHTTPError(resp.StatusCode, errors.New(msg)))
 
 	// Servers ask clients to back off via Retry-After (typically on 429 or
 	// 503). Thread that hint out as a typed transient error so the retry
@@ -628,6 +653,19 @@ func httpError(resp *http.Response) error {
 		}
 	}
 	return err
+}
+
+func annotateGoogleCalDAVForbidden(resp *http.Response, err error) error {
+	if err == nil || resp == nil || resp.StatusCode != http.StatusForbidden {
+		return err
+	}
+	if resp.Request == nil || resp.Request.URL == nil {
+		return err
+	}
+	if !IsGoogleCalendarEndpoint(resp.Request.URL.String()) {
+		return err
+	}
+	return fmt.Errorf("%w; %s", err, googleCalDAVForbiddenHint)
 }
 
 // parseRetryAfter parses an HTTP Retry-After header value, which is either a

--- a/internal/caldav/google_calendar_list.go
+++ b/internal/caldav/google_calendar_list.go
@@ -1,6 +1,7 @@
 package caldav
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -137,6 +138,105 @@ func fetchGoogleCalendarListPage(ctx context.Context, client googleHTTPClient, p
 
 func googleCalDAVCollectionURL(calendarID string) string {
 	return googleCalDAVBaseURL + "/" + url.PathEscape(strings.TrimSpace(calendarID)) + "/events"
+}
+
+// googleCalendarIDFromCollectionURL reverses googleCalDAVCollectionURL.
+func googleCalendarIDFromCollectionURL(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if !IsGoogleCalendarEndpoint(raw) {
+		return "", false
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", false
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 4 || parts[0] != "caldav" || parts[1] != "v2" || parts[len(parts)-1] != "events" {
+		return "", false
+	}
+	id := strings.TrimSpace(strings.Join(parts[2:len(parts)-1], "/"))
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+type googleCalendarListColorPatch struct {
+	BackgroundColor string `json:"backgroundColor"`
+	ForegroundColor string `json:"foregroundColor"`
+}
+
+func googleCalendarListForeground(background string) string {
+	hex := strings.TrimPrefix(NormalizeCalendarColor(background), "#")
+	if len(hex) != 6 {
+		return "#ffffff"
+	}
+	var r, g, b int
+	if _, err := fmt.Sscanf(hex, "%02x%02x%02x", &r, &g, &b); err != nil {
+		return "#ffffff"
+	}
+	if 0.2126*float64(r)+0.7152*float64(g)+0.0722*float64(b) > 140 {
+		return "#000000"
+	}
+	return "#ffffff"
+}
+
+// SetGoogleCalendarListColor writes a calendar's display color through the
+// Calendar JSON API. Google CalDAV does not implement Apple calendar-color.
+func SetGoogleCalendarListColor(ctx context.Context, client googleHTTPClient, calendarURL, color string) error {
+	calendarID, ok := googleCalendarIDFromCollectionURL(calendarURL)
+	if !ok {
+		return fmt.Errorf("google calendar id: not a Google CalDAV collection URL")
+	}
+	color = NormalizeCalendarColor(color)
+	if color == "" {
+		return fmt.Errorf("google calendar color is empty")
+	}
+
+	endpoint, err := url.Parse(googleCalendarListURL)
+	if err != nil {
+		return fmt.Errorf("parse Google CalendarList URL: %w", err)
+	}
+	if endpoint.Path == "" {
+		endpoint.Path = "/"
+	}
+	endpoint = endpoint.JoinPath(calendarID)
+	query := endpoint.Query()
+	query.Set("colorRgbFormat", "true")
+	endpoint.RawQuery = query.Encode()
+
+	body, err := json.Marshal(googleCalendarListColorPatch{
+		BackgroundColor: color,
+		ForegroundColor: googleCalendarListForeground(color),
+	})
+	if err != nil {
+		return fmt.Errorf("encode Google CalendarList color: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create Google CalendarList color request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("google CalendarList color request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.Request == nil {
+		resp.Request = req
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("google CalendarList color: %w", httpError(resp))
+	}
+	return nil
+}
+
+// SetGoogleCalendarListColor writes the calendar's display color through the
+// Calendar JSON API using this client's credentials.
+func (c *Client) SetGoogleCalendarListColor(ctx context.Context, calendarURL, color string) error {
+	return SetGoogleCalendarListColor(ctx, c.httpClient, calendarURL, color)
 }
 
 func googleCalendarAccess(role string) CalendarAccess {

--- a/internal/caldav/google_calendar_list_test.go
+++ b/internal/caldav/google_calendar_list_test.go
@@ -3,9 +3,11 @@ package caldav
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/auth"
@@ -106,5 +108,89 @@ func TestDiscoverGoogleCalendarsSkipsDeletedAndMapsFreeBusyReader(t *testing.T) 
 	}
 	if got := calendars[0].SupportedComponentSet; !slices.Equal(got, []string{"VFREEBUSY"}) {
 		t.Fatalf("freeBusyReader SupportedComponentSet = %v, want VFREEBUSY-only", got)
+	}
+}
+
+func TestGoogleCalendarIDFromCollectionURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		id string
+	}{
+		{"me@example.com"},
+		{"en.brazilian#holiday@group.v.calendar.google.com"},
+	}
+	for _, tc := range cases {
+		got, ok := googleCalendarIDFromCollectionURL(googleCalDAVCollectionURL(tc.id))
+		if !ok || got != tc.id {
+			t.Errorf("googleCalendarIDFromCollectionURL(%q) = %q, %v", tc.id, got, ok)
+		}
+	}
+	if _, ok := googleCalendarIDFromCollectionURL("https://cal.example.com/dav/work"); ok {
+		t.Fatal("non-Google URL parsed as a Google calendar id")
+	}
+	if _, ok := googleCalendarIDFromCollectionURL("https://apidata.googleusercontent.com/caldav"); ok {
+		t.Fatal("account root parsed as a Google calendar id")
+	}
+}
+
+func TestSetGoogleCalendarListColorPatchesRGB(t *testing.T) {
+	calendarID := "en.brazilian#holiday@group.v.calendar.google.com"
+	var gotPath, gotQuery, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s", r.Method)
+		}
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"backgroundColor":"#112233"}`))
+	}))
+	defer server.Close()
+
+	oldListURL := googleCalendarListURL
+	googleCalendarListURL = server.URL
+	defer func() { googleCalendarListURL = oldListURL }()
+
+	collection := googleCalDAVCollectionURL(calendarID)
+	if err := SetGoogleCalendarListColor(context.Background(), http.DefaultClient, collection, "#112233"); err != nil {
+		t.Fatalf("SetGoogleCalendarListColor: %v", err)
+	}
+	if strings.Trim(gotPath, "/") != calendarID {
+		t.Fatalf("path = %q, want calendar id %q", gotPath, calendarID)
+	}
+	if !strings.Contains(gotQuery, "colorRgbFormat=true") {
+		t.Fatalf("query = %q", gotQuery)
+	}
+	if !strings.Contains(gotBody, `"backgroundColor":"#112233"`) {
+		t.Fatalf("body = %s", gotBody)
+	}
+	if !strings.Contains(gotBody, `"foregroundColor":"#ffffff"`) {
+		t.Fatalf("body missing foreground: %s", gotBody)
+	}
+}
+
+func TestSetGoogleCalendarListColorForbiddenIncludesBody(t *testing.T) {
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"reason":"forbidden"}}`, http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	oldListURL := googleCalendarListURL
+	googleCalendarListURL = server.URL
+	defer func() { googleCalendarListURL = oldListURL }()
+
+	err := SetGoogleCalendarListColor(context.Background(), http.DefaultClient, googleCalDAVCollectionURL("me@example.com"), "#112233")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "forbidden") {
+		t.Fatalf("error = %v, want body", err)
 	}
 }

--- a/internal/caldav/properties.go
+++ b/internal/caldav/properties.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -48,9 +47,12 @@ func GetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 		return "", err
 	}
 	defer resp.Body.Close()
+	if resp.Request == nil {
+		resp.Request = req
+	}
 
 	if resp.StatusCode != http.StatusMultiStatus {
-		return "", statusErrorf(resp.StatusCode, "PROPFIND calendar-color: HTTP %d", resp.StatusCode)
+		return "", fmt.Errorf("PROPFIND calendar-color: %w", httpError(resp))
 	}
 
 	var ms calendarColorMultiStatus
@@ -64,7 +66,10 @@ func GetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 			switch {
 			case code >= 200 && code < 300:
 				return NormalizeCalendarColor(propstat.Prop.CalendarColor), nil
-			case code == http.StatusNotFound:
+			case code == http.StatusNotFound, code == http.StatusForbidden:
+				// The collection exists. The server does not advertise
+				// calendar-color. Keep the call successful so sync can
+				// still pull events (issue #628).
 				return "", nil
 			case code != 0:
 				return "", statusErrorf(code, "PROPFIND calendar-color: HTTP %d", code)
@@ -155,8 +160,10 @@ func SetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 		}
 		return nil
 	default:
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return statusErrorf(resp.StatusCode, "PROPPATCH calendar-color: HTTP %d", resp.StatusCode)
+		if resp.Request == nil {
+			resp.Request = req
+		}
+		return fmt.Errorf("PROPPATCH calendar-color: %w", httpError(resp))
 	}
 }
 

--- a/internal/caldav/properties_test.go
+++ b/internal/caldav/properties_test.go
@@ -55,6 +55,92 @@ func TestGetCalendarColor(t *testing.T) {
 	}
 }
 
+func TestGetCalendarColorForbiddenIncludesBody(t *testing.T) {
+	t.Parallel()
+
+	client := testHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Status:     "403 Forbidden",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"reason":"accessNotConfigured"}}`)),
+				Request:    req,
+			}, nil
+		},
+	}
+
+	_, err := GetCalendarColor(context.Background(), client, "https://example.com/cal/work")
+	if err == nil {
+		t.Fatal("err = nil, want 403")
+	}
+	if !strings.Contains(err.Error(), "accessNotConfigured") {
+		t.Fatalf("err = %q, want the response body", err)
+	}
+	if strings.Contains(err.Error(), googleCalDAVForbiddenHint) {
+		t.Fatalf("err = %q, must not hint at Google CalDAV on a generic host", err)
+	}
+}
+
+func TestGetCalendarColorGoogleForbiddenHintsCalDAVAPI(t *testing.T) {
+	t.Parallel()
+
+	client := testHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Status:     "403 Forbidden",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"reason":"accessNotConfigured"}}`)),
+				Request:    req,
+			}, nil
+		},
+	}
+
+	_, err := GetCalendarColor(context.Background(), client, "https://apidata.googleusercontent.com/caldav/v2/me@example.com/events")
+	if err == nil {
+		t.Fatal("err = nil, want 403")
+	}
+	if !strings.Contains(err.Error(), "accessNotConfigured") {
+		t.Fatalf("err = %q, want the response body", err)
+	}
+	if !strings.Contains(err.Error(), googleCalDAVForbiddenHint) {
+		t.Fatalf("err = %q, want the caldav.googleapis.com hint", err)
+	}
+}
+
+func TestGetCalendarColorPropstatForbiddenIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	client := testHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusMultiStatus,
+				Header:     http.Header{"Content-Type": []string{"application/xml"}},
+				Body: io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:ic="http://apple.com/ns/ical/">
+  <d:response>
+    <d:href>/cal/work</d:href>
+    <d:propstat>
+      <d:prop><ic:calendar-color/></d:prop>
+      <d:status>HTTP/1.1 403 Forbidden</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)),
+				Request: req,
+			}, nil
+		},
+	}
+
+	color, err := GetCalendarColor(context.Background(), client, "https://example.com/cal/work")
+	if err != nil {
+		t.Fatalf("GetCalendarColor: %v", err)
+	}
+	if color != "" {
+		t.Fatalf("color = %q, want empty when the property is forbidden", color)
+	}
+}
+
 func TestNormalizeCalendarColor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/caldav/retry_after_test.go
+++ b/internal/caldav/retry_after_test.go
@@ -2,7 +2,9 @@ package caldav
 
 import (
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,5 +80,31 @@ func TestHTTPErrorNoRetryAfterStaysPlain(t *testing.T) {
 	// Still retryable via status-code classification.
 	if !retry.IsTransient(err) {
 		t.Fatalf("httpError(503) should still be transient: %v", err)
+	}
+}
+
+func TestHTTPErrorAnnotatesGoogleCalDAVForbidden(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://apidata.googleusercontent.com/caldav/v2/me@example.com/events/", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Status:     "403 Forbidden",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"reason":"accessNotConfigured"}}`)),
+		Request:    req,
+	}
+	got := httpError(resp)
+	if got == nil {
+		t.Fatal("httpError = nil, want 403")
+	}
+	if !strings.Contains(got.Error(), "accessNotConfigured") {
+		t.Fatalf("err = %q, want the response body", got)
+	}
+	if !strings.Contains(got.Error(), googleCalDAVForbiddenHint) {
+		t.Fatalf("err = %q, want the caldav.googleapis.com hint", got)
 	}
 }

--- a/internal/caldav/sync_collection.go
+++ b/internal/caldav/sync_collection.go
@@ -85,7 +85,7 @@ func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncTo
 		if bytes.Contains(raw, []byte("valid-sync-token")) {
 			return nil, ErrSyncTokenInvalid
 		}
-		return nil, statusErrorf(resp.StatusCode, "REPORT sync-collection: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("REPORT sync-collection: %w", httpErrorFromBody(resp, raw, false))
 	case http.StatusBadRequest, http.StatusMethodNotAllowed,
 		http.StatusUnsupportedMediaType, http.StatusUnprocessableEntity,
 		http.StatusNotImplemented:

--- a/internal/caldav/sync_collection_test.go
+++ b/internal/caldav/sync_collection_test.go
@@ -139,6 +139,40 @@ func TestSyncCollectionForbiddenWithoutPreconditionIsGenericError(t *testing.T) 
 	if errors.Is(err, ErrSyncCollectionUnsupported) {
 		t.Fatalf("err = %v, must not be ErrSyncCollectionUnsupported on 403", err)
 	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("err = %q, want the response body", err)
+	}
+}
+
+func TestSyncCollectionGoogleForbiddenHintsCalDAVAPI(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(putTestHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"reason":"accessNotConfigured"}}`)),
+			Request:    req,
+		}, nil
+	}}, "https://apidata.googleusercontent.com/caldav/v2")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = client.SyncCollection(context.Background(), "/me@example.com/events/", "")
+	if err == nil {
+		t.Fatal("err = nil, want 403")
+	}
+	if errors.Is(err, ErrSyncTokenInvalid) {
+		t.Fatalf("err = %v, must not be ErrSyncTokenInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "accessNotConfigured") {
+		t.Fatalf("err = %q, want the response body", err)
+	}
+	if !strings.Contains(err.Error(), googleCalDAVForbiddenHint) {
+		t.Fatalf("err = %q, want the caldav.googleapis.com hint", err)
+	}
 }
 
 func TestSyncCollectionUnsupportedOnNotImplemented(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1674,6 +1674,13 @@ func (e *Engine) syncCalendarMetadata(ctx context.Context, client *caldav.Client
 		return fmt.Errorf("get calendar for metadata sync: %w", err)
 	}
 
+	// Google CalendarList already supplies the color at discovery. Apple
+	// calendar-color is not a Google CalDAV property. Skip both the fetch
+	// and the push. A PROPFIND 403 must not fail event sync (issue #628).
+	if caldav.IsGoogleCalendarEndpoint(remoteURL) {
+		return nil
+	}
+
 	// A dirty local color wins: push it and clear the flag. Skip the remote
 	// fetch entirely — its value would be discarded, and a failed fetch must
 	// not block the pending push or strand ColorDirty (issue #419).
@@ -1693,7 +1700,15 @@ func (e *Engine) syncCalendarMetadata(ctx context.Context, client *caldav.Client
 		return client.GetCalendarColor(ctx, remoteURL)
 	})
 	if err != nil {
-		return fmt.Errorf("get remote calendar color: %w", err)
+		// Color is decorative. A server that refuses calendar-color must
+		// not fail the rest of the calendar sync (issue #628).
+		e.logger.Warn("get remote calendar color failed", "calendar_id", calendarID, "error", err)
+		return nil
+	}
+	if remoteColor == "" {
+		// The server does not advertise a color. Keep the color that
+		// discovery or the user already set.
+		return nil
 	}
 
 	if remoteColor != storage.NullableToString(cal.RemoteColor) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1675,9 +1675,25 @@ func (e *Engine) syncCalendarMetadata(ctx context.Context, client *caldav.Client
 	}
 
 	// Google CalendarList already supplies the color at discovery. Apple
-	// calendar-color is not a Google CalDAV property. Skip both the fetch
-	// and the push. A PROPFIND 403 must not fail event sync (issue #628).
+	// calendar-color is not a Google CalDAV property, so never PROPFIND
+	// it. A dirty local color still has to be written: CalendarList PATCH
+	// is the Google equivalent of Apple calendar-color PROPPATCH. Clearing
+	// ColorDirty after a successful write lets later Discover rounds adopt
+	// CalendarList again. A failed write must not fail event sync
+	// (issue #628); the dirty latch then keeps the local override.
 	if caldav.IsGoogleCalendarEndpoint(remoteURL) {
+		if cal.ColorDirty == 0 {
+			return nil
+		}
+		if _, err := caldav.Retry(ctx, syncRetryOptions, func(ctx context.Context) (struct{}, error) {
+			return struct{}{}, client.SetGoogleCalendarListColor(ctx, remoteURL, cal.Color)
+		}); err != nil {
+			e.logger.Warn("set google calendar color failed", "calendar_id", calendarID, "error", err)
+			return nil
+		}
+		if err := e.calendars.ClearColorDirty(ctx, calendarID, cal.Color); err != nil {
+			return fmt.Errorf("clear calendar color dirty: %w", err)
+		}
 		return nil
 	}
 

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2570,6 +2570,264 @@ func TestEngineSyncCalendarMetadataAdoptsRemoteColor(t *testing.T) {
 	}
 }
 
+func seedCalendarColorState(t *testing.T, db *sql.DB, q *storage.Queries, remoteURL, color, remoteColor string, dirty int) {
+	t.Helper()
+	ctx := context.Background()
+	account, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      "test",
+		ServerUrl: "https://example.com",
+		AuthType:  "basic",
+		Username:  "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		ID:        1,
+		AccountID: &account.ID,
+		RemoteUrl: storage.StringToNullable(remoteURL),
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE calendars
+		SET color = ?, remote_color = ?, color_dirty = ?
+		WHERE id = 1
+	`, color, remoteColor, dirty); err != nil {
+		t.Fatalf("seed calendar color state: %v", err)
+	}
+}
+
+// TestEngineSyncCalendarMetadataIgnoresColorFetchForbidden reproduces
+// issue #628. A PROPFIND 403 for calendar-color must not fail metadata
+// sync. Event pull can then continue. The local color stays in place.
+func TestEngineSyncCalendarMetadataIgnoresColorFetchForbidden(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	seedCalendarColorState(t, db, q, "https://example.com/cal/work", "#9e69af", "#9e69af", 0)
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Method != "PROPFIND" {
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Header:     http.Header{"Content-Type": []string{"text/plain"}},
+			Body:       io.NopCloser(strings.NewReader("nope")),
+			Request:    r,
+		}, nil
+	})
+
+	if err := engine.syncCalendarMetadata(context.Background(), client, 1, "https://example.com/cal/work"); err != nil {
+		t.Fatalf("syncCalendarMetadata: %v", err)
+	}
+
+	cal, err := q.GetCalendar(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if cal.Color != "#9e69af" {
+		t.Fatalf("Color = %q, want #9e69af", cal.Color)
+	}
+	if got := storage.NullableToString(cal.RemoteColor); got != "#9e69af" {
+		t.Fatalf("RemoteColor = %q, want #9e69af", got)
+	}
+}
+
+// TestEngineSyncCalendarMetadataSkipsGoogleColorRequests reproduces
+// issue #628. Google colors come from CalendarList. Apple calendar-color
+// traffic must not run against CalDAV.
+func TestEngineSyncCalendarMetadataSkipsGoogleColorRequests(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	seedCalendarColorState(t, db, q,
+		"https://apidata.googleusercontent.com/caldav/v2/me@example.com/events",
+		"#9e69af", "#9e69af", 1)
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		return nil, nil
+	})
+
+	if err := engine.syncCalendarMetadata(context.Background(), client, 1,
+		"https://apidata.googleusercontent.com/caldav/v2/me@example.com/events"); err != nil {
+		t.Fatalf("syncCalendarMetadata: %v", err)
+	}
+
+	cal, err := q.GetCalendar(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if cal.Color != "#9e69af" {
+		t.Fatalf("Color = %q, want #9e69af", cal.Color)
+	}
+	if cal.ColorDirty != 1 {
+		t.Fatalf("ColorDirty = %d, want 1", cal.ColorDirty)
+	}
+}
+
+// TestEngineSyncCalendarMetadataKeepsColorWhenRemoteOmitsIt reproduces
+// issue #628. A 404 propstat for calendar-color must not wipe a color
+// that discovery already stored.
+func TestEngineSyncCalendarMetadataKeepsColorWhenRemoteOmitsIt(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	seedCalendarColorState(t, db, q, "https://example.com/cal/work", "#9e69af", "#9e69af", 0)
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Method != "PROPFIND" {
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusMultiStatus,
+			Header:     http.Header{"Content-Type": []string{"application/xml"}},
+			Body: io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:ic="http://apple.com/ns/ical/">
+  <d:response>
+    <d:href>/cal/work</d:href>
+    <d:propstat>
+      <d:prop><ic:calendar-color/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)),
+			Request: r,
+		}, nil
+	})
+
+	if err := engine.syncCalendarMetadata(context.Background(), client, 1, "https://example.com/cal/work"); err != nil {
+		t.Fatalf("syncCalendarMetadata: %v", err)
+	}
+
+	cal, err := q.GetCalendar(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if cal.Color != "#9e69af" {
+		t.Fatalf("Color = %q, want #9e69af", cal.Color)
+	}
+}
+
+// TestEngineSyncCalendarPullsEventsWhenColorForbidden reproduces issue
+// #628. Initial sync must pull events even when calendar-color PROPFIND
+// returns HTTP 403.
+func TestEngineSyncCalendarPullsEventsWhenColorForbidden(t *testing.T) {
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	const eventICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//chroncal//tests//EN
+BEGIN:VEVENT
+UID:color-403-event
+DTSTAMP:20260820T120000Z
+DTSTART:20260820T120000Z
+DTEND:20260820T130000Z
+SUMMARY:Still synced
+END:VEVENT
+END:VCALENDAR
+`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PROPFIND":
+			http.Error(w, `{"error":{"reason":"accessNotConfigured"}}`, http.StatusForbidden)
+			return
+		case "REPORT":
+			body, _ := io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusMultiStatus)
+			if strings.Contains(string(body), "calendar-multiget") {
+				_, _ = io.WriteString(w, `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/calendar/color-403-event.ics</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>&quot;etag-1&quot;</d:getetag>
+        <cal:calendar-data>`+eventICS+`</cal:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)
+				return
+			}
+			_, _ = io.WriteString(w, `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/calendar/color-403-event.ics</d:href>
+    <d:propstat>
+      <d:prop><d:getetag>&quot;etag-1&quot;</d:getetag></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:sync-token>https://example.com/sync/1</d:sync-token>
+</d:multistatus>`)
+			return
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			http.Error(w, "unexpected", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	remoteAccount, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name: "color-403", ServerUrl: server.URL, AuthType: "basic", Username: "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	calendars, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := calendars[0].ID
+	remoteURL := server.URL + "/calendar"
+	if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		ID: calendarID, AccountID: &remoteAccount.ID, RemoteUrl: &remoteURL,
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE calendars SET color = '#9e69af', remote_color = '#9e69af', color_dirty = 0 WHERE id = ?
+	`, calendarID); err != nil {
+		t.Fatalf("seed calendar color: %v", err)
+	}
+	engine.credStore.(*mockCredStore).creds[remoteAccount.ID] = auth.Credential{
+		AccountID: remoteAccount.ID, Username: "user", Password: "secret",
+	}
+
+	result, err := engine.SyncCalendar(ctx, calendarID, ConflictServerWins)
+	if err != nil {
+		t.Fatalf("SyncCalendar: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("sync errors = %v, want none after a color 403", result.Errors)
+	}
+	if result.Pulled != 1 {
+		t.Fatalf("Pulled = %d, want 1", result.Pulled)
+	}
+	evt, err := q.GetEventByUID(ctx, "color-403-event")
+	if err != nil {
+		t.Fatalf("GetEventByUID: %v", err)
+	}
+	if evt.Title != "Still synced" {
+		t.Fatalf("Title = %q, want Still synced", evt.Title)
+	}
+	cal, err := q.GetCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if cal.Color != "#9e69af" {
+		t.Fatalf("Color = %q, want #9e69af", cal.Color)
+	}
+}
+
 // TestEnginePullPaginatesTruncatedSyncCollection reproduces the Google
 // initial-snapshot data loss. The server truncates the sync-collection
 // response (RFC 6578 §3.6 — a 507 marker on the collection plus a

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2636,16 +2636,16 @@ func TestEngineSyncCalendarMetadataIgnoresColorFetchForbidden(t *testing.T) {
 	}
 }
 
-// TestEngineSyncCalendarMetadataSkipsGoogleColorRequests reproduces
+// TestEngineSyncCalendarMetadataSkipsGoogleColorFetch reproduces
 // issue #628. Google colors come from CalendarList. Apple calendar-color
-// traffic must not run against CalDAV.
-func TestEngineSyncCalendarMetadataSkipsGoogleColorRequests(t *testing.T) {
+// traffic must not run against CalDAV when there is nothing to push.
+func TestEngineSyncCalendarMetadataSkipsGoogleColorFetch(t *testing.T) {
 	t.Parallel()
 
 	engine, db, q := newTestEngine(t)
 	seedCalendarColorState(t, db, q,
 		"https://apidata.googleusercontent.com/caldav/v2/me@example.com/events",
-		"#9e69af", "#9e69af", 1)
+		"#9e69af", "#9e69af", 0)
 
 	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
 		t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
@@ -2663,6 +2663,106 @@ func TestEngineSyncCalendarMetadataSkipsGoogleColorRequests(t *testing.T) {
 	}
 	if cal.Color != "#9e69af" {
 		t.Fatalf("Color = %q, want #9e69af", cal.Color)
+	}
+	if cal.ColorDirty != 0 {
+		t.Fatalf("ColorDirty = %d, want 0", cal.ColorDirty)
+	}
+}
+
+// TestEngineSyncCalendarMetadataPushesGoogleColorViaCalendarList writes a
+// dirty Google color through CalendarList, not Apple calendar-color.
+func TestEngineSyncCalendarMetadataPushesGoogleColorViaCalendarList(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	const remoteURL = "https://apidata.googleusercontent.com/caldav/v2/me@example.com/events"
+	seedCalendarColorState(t, db, q, remoteURL, "#112233", "#9e69af", 1)
+
+	var sawPatch bool
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Host != "www.googleapis.com" {
+			t.Fatalf("PATCH host = %q, want www.googleapis.com", r.URL.Host)
+		}
+		if !strings.Contains(r.URL.Path, "/calendar/v3/users/me/calendarList/") {
+			t.Fatalf("PATCH path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("colorRgbFormat") != "true" {
+			t.Fatalf("colorRgbFormat = %q", r.URL.Query().Get("colorRgbFormat"))
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if !strings.Contains(string(body), `"backgroundColor":"#112233"`) {
+			t.Fatalf("PATCH body = %s", body)
+		}
+		sawPatch = true
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"backgroundColor":"#112233"}`)),
+			Request:    r,
+		}, nil
+	})
+
+	if err := engine.syncCalendarMetadata(context.Background(), client, 1, remoteURL); err != nil {
+		t.Fatalf("syncCalendarMetadata: %v", err)
+	}
+	if !sawPatch {
+		t.Fatal("expected CalendarList color PATCH")
+	}
+
+	cal, err := q.GetCalendar(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if cal.Color != "#112233" {
+		t.Fatalf("Color = %q, want #112233", cal.Color)
+	}
+	if got := storage.NullableToString(cal.RemoteColor); got != "#112233" {
+		t.Fatalf("RemoteColor = %q, want #112233", got)
+	}
+	if cal.ColorDirty != 0 {
+		t.Fatalf("ColorDirty = %d, want 0", cal.ColorDirty)
+	}
+}
+
+// TestEngineSyncCalendarMetadataKeepsGoogleColorDirtyWhenPatchFails keeps
+// the local Google color override when CalendarList PATCH is refused.
+// Event sync must still proceed (issue #628).
+func TestEngineSyncCalendarMetadataKeepsGoogleColorDirtyWhenPatchFails(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	const remoteURL = "https://apidata.googleusercontent.com/caldav/v2/me@example.com/events"
+	seedCalendarColorState(t, db, q, remoteURL, "#112233", "#9e69af", 1)
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"reason":"forbidden"}}`)),
+			Request:    r,
+		}, nil
+	})
+
+	if err := engine.syncCalendarMetadata(context.Background(), client, 1, remoteURL); err != nil {
+		t.Fatalf("syncCalendarMetadata: %v", err)
+	}
+
+	cal, err := q.GetCalendar(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if cal.Color != "#112233" {
+		t.Fatalf("Color = %q, want #112233", cal.Color)
 	}
 	if cal.ColorDirty != 1 {
 		t.Fatalf("ColorDirty = %d, want 1", cal.ColorDirty)


### PR DESCRIPTION
Fixes #628.

## The problem

Google CalendarList uses the Calendar JSON API, so account add can list calendars. Event sync uses CalDAV. A 403 from `apidata.googleusercontent.com` usually means `caldav.googleapis.com` is off on the OAuth client project.

Two things combined into a dead initial sync:

1. A failed Apple `calendar-color` PROPFIND was treated as a hard calendar metadata error. That aborted the calendar pass before events could pull.
2. CalDAV 403s dropped the response body. The log led with color and hid `accessNotConfigured`.

## The change

- Color fetch is best-effort. A 403/404 on `calendar-color` no longer fails calendar sync, so events can still pull.
- Google calendars skip Apple `calendar-color` entirely. Color already comes from CalendarList.
- CalDAV 403 responses keep the body. On `apidata.googleusercontent.com` they also hint to enable `caldav.googleapis.com` (the Calendar JSON API is not enough).

After this, `account add` still fails initial sync if CalDAV is disabled, but the error names the missing API instead of color. Enable CalDAV, then `chroncal sync run`.

## Tests

- Color PROPFIND 403 includes the body. Google 403s add the CalDAV API hint. A 403 propstat for `calendar-color` is treated as no color.
- `sync-collection` 403s include the body and the Google hint.
- Metadata sync ignores a color 403, skips Google color traffic, and keeps a discovery color when the remote omits the property.
- Full calendar sync still pulls events when color PROPFIND returns 403.

`go test ./...` is clean.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Add new tests for new functions
- [x] Update the documentation when the change needs it