### PR TITLE
feat(tui): add Sunday/Monday week-start toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ chroncal --event standup-uid --at 2026-04-17T14:00:00Z
 
 `--at` accepts an RFC 3339 timestamp or `YYYY-MM-DD`. It selects a generated occurrence of a recurring series. The details show the times of that occurrence, not the series start. Stored overrides take `--recurrence-id` with the series UID. `--at` requires `--event` and excludes `--recurrence-id`.
 
-**Views**: month, week, day, agenda. Switch with `m`, `w`, `d`, `a`.
+**Views**: month, week, day, agenda. Switch with `m`, `w`, `d`, `a`. Press `W` to switch the first day of the week between Sunday and Monday. The TUI stores the choice. You can also set `ui.week_start` in `config.toml`.
 
 The TUI can create, edit, view, and delete events. Event details include alarms, attendees, and attachments. Use `p` to copy event details. Use `u` to undo a delete.
 
@@ -672,13 +672,14 @@ Configuration loads in this order of precedence:
 | `db` | Path to SQLite database | `$XDG_DATA_HOME/chroncal/chroncal.db` |
 | `product_id` | iCal PRODID for export | `-//chroncal//chroncal//EN` |
 | `ui.theme` | Built-in TUI theme name under `internal/tui/themes/` (`system` or `default`; see [TUI themes](#tui-themes)) | `system` |
+| `ui.week_start` | First day of the week in the TUI month view, week view, and mini-calendar (`sunday` or `monday`) | `sunday` |
 | `soft_delete.purge_days` | Days to keep soft-deleted rows before the background purge. `0` disables automatic purge. | `30` |
 | `sync.interval` | Minimum interval between background CalDAV syncs that `chroncal service run` performs. `service install` defaults to `15m` when this is unset. | (unset — no sync unless the installed service sets `CHRONCAL_SYNC_INTERVAL`) |
 | `sync.conflict_strategy` | Default conflict-resolution mode when you do not pass `sync run --conflict` | (unset) |
 | `security.allow_unsafe_alarm_audio_attach` | Allow AUDIO alarms to attach arbitrary URIs. Off by default. | `false` |
 | `security.allow_unsafe_alarm_email_attendees` | Allow EMAIL alarms to send to unverified attendee addresses. Off by default. | `false` |
 
-Every key is also available as an environment variable (`CHRONCAL_` prefix, dots become underscores). Examples: `CHRONCAL_UI_THEME`, `CHRONCAL_SOFT_DELETE_PURGE_DAYS`, `CHRONCAL_SYNC_INTERVAL`.
+Every key is also available as an environment variable (`CHRONCAL_` prefix, dots become underscores). Examples: `CHRONCAL_UI_THEME`, `CHRONCAL_UI_WEEK_START`, `CHRONCAL_SOFT_DELETE_PURGE_DAYS`, `CHRONCAL_SYNC_INTERVAL`.
 
 ### TUI themes
 

--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ chroncal --event standup-uid --at 2026-04-17T14:00:00Z
 
 `--at` accepts an RFC 3339 timestamp or `YYYY-MM-DD`. It selects a generated occurrence of a recurring series. The details show the times of that occurrence, not the series start. Stored overrides take `--recurrence-id` with the series UID. `--at` requires `--event` and excludes `--recurrence-id`.
 
-**Views**: month, week, day, agenda. Switch with `m`, `w`, `d`, `a`. Press `W` to switch the first day of the week between Sunday and Monday. The TUI stores the choice. You can also set `ui.week_start` in `config.toml`.
+**Views**: month, week, day, agenda. Switch with `m`, `w`, `d`, `a`. Press `W` to switch the first day of the week between Sunday and Monday. The TUI stores the choice, the same way it stores the view. `ui.week_start` in `config.toml` sets the default before a stored choice exists.
 
 The TUI can create, edit, view, and delete events. Event details include alarms, attendees, and attachments. Use `p` to copy event details. Use `u` to undo a delete.
 

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -245,7 +245,11 @@ Helpful conventions:
 			}
 		}
 
-		return tui.Run(a, cfg.UI.Theme, tui.RunOptions{Event: openEvent})
+		weekStart := time.Sunday
+		if w, ok := config.ParseWeekStart(cfg.UI.WeekStart); ok {
+			weekStart = w
+		}
+		return tui.Run(a, cfg.UI.Theme, tui.RunOptions{Event: openEvent, WeekStart: weekStart})
 	},
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,9 @@ type UIConfig struct {
 	// Theme is the name of a built-in theme under internal/tui/themes/
 	// (e.g. "default", "system"). Empty falls back to the default.
 	Theme string `mapstructure:"theme"`
+	// WeekStart is the first day of the week in the TUI month view, week
+	// view, and mini-calendar. Valid values: "sunday" (default), "monday".
+	WeekStart string `mapstructure:"week_start"`
 }
 
 type Config struct {
@@ -145,6 +148,7 @@ func newViper() *viper.Viper {
 	v.BindEnv("security.allow_plaintext")
 	v.BindEnv("soft_delete.purge_days")
 	v.BindEnv("ui.theme")
+	v.BindEnv("ui.week_start")
 
 	return v
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -260,3 +260,26 @@ func TestLoad_NoFileNoError(t *testing.T) {
 		t.Fatalf("Load() error = %v, want nil when config file is absent", err)
 	}
 }
+
+func TestLoad_UIWeekStartFromFile(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "chroncal")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[ui]\nweek_start = \"monday\"\n"), 0o644)
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_UI_WEEK_START", "")
+
+	cfg := mustLoad(t)
+	if cfg.UI.WeekStart != "monday" {
+		t.Errorf("UI.WeekStart = %q, want monday", cfg.UI.WeekStart)
+	}
+}
+
+func TestLoad_UIWeekStartFromEnv(t *testing.T) {
+	t.Setenv("CHRONCAL_UI_WEEK_START", "monday")
+	cfg := mustLoad(t)
+	if cfg.UI.WeekStart != "monday" {
+		t.Errorf("UI.WeekStart = %q, want monday from env", cfg.UI.WeekStart)
+	}
+}

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -15,6 +15,9 @@ type UIState struct {
 	HiddenCalendars     []int64 `json:"hidden_calendars,omitempty"`
 	AgendaShowEmptyDays bool    `json:"agenda_show_empty_days,omitempty"`
 	ShowWeekNumbers     bool    `json:"show_week_numbers,omitempty"`
+	// WeekStart is "sunday" or "monday". Empty means the TUI has not stored
+	// a choice, so the ui.week_start config value (or Sunday) applies.
+	WeekStart string `json:"week_start,omitempty"`
 }
 
 func defaultUIState() UIState {

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -15,8 +15,8 @@ type UIState struct {
 	HiddenCalendars     []int64 `json:"hidden_calendars,omitempty"`
 	AgendaShowEmptyDays bool    `json:"agenda_show_empty_days,omitempty"`
 	ShowWeekNumbers     bool    `json:"show_week_numbers,omitempty"`
-	// WeekStart is "sunday" or "monday". Empty means the TUI has not stored
-	// a choice, so the ui.week_start config value (or Sunday) applies.
+	// WeekStart is "sunday" or "monday". Empty means no stored TUI choice
+	// yet, so the ui.week_start config value (or Sunday) applies.
 	WeekStart string `json:"week_start,omitempty"`
 }
 

--- a/internal/config/state_test.go
+++ b/internal/config/state_test.go
@@ -51,3 +51,35 @@ func TestUIStateLoad_OldFileWithoutHiddenCalendars(t *testing.T) {
 		t.Errorf("HiddenCalendars should be nil for old file, got %v", out.HiddenCalendars)
 	}
 }
+
+func TestUIStateRoundTrip_WeekStart(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	in := UIState{ShowSidebar: true, WeekStart: "monday"}
+	if err := SaveUIState(in); err != nil {
+		t.Fatalf("SaveUIState: %v", err)
+	}
+	out := LoadUIState()
+	if out.WeekStart != "monday" {
+		t.Errorf("WeekStart = %q, want monday", out.WeekStart)
+	}
+}
+
+func TestUIStateLoad_OldFileWithoutWeekStart(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	path := filepath.Join(dir, "chroncal", "state.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"show_sidebar":true,"view_mode":"month"}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	out := LoadUIState()
+	if out.WeekStart != "" {
+		t.Errorf("WeekStart = %q, want empty for old file", out.WeekStart)
+	}
+}

--- a/internal/config/weekstart.go
+++ b/internal/config/weekstart.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"strings"
+	"time"
+)
+
+// Canonical ui.week_start values.
+const (
+	WeekStartSunday = "sunday"
+	WeekStartMonday = "monday"
+)
+
+// ParseWeekStart maps a config or UI-state value to a weekday.
+// It accepts "sunday" and "monday" in any case, plus the short forms
+// "sun" and "mon". An empty or unknown value returns Sunday and false.
+func ParseWeekStart(s string) (time.Weekday, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case WeekStartSunday, "sun", "su":
+		return time.Sunday, true
+	case WeekStartMonday, "mon", "mo":
+		return time.Monday, true
+	default:
+		return time.Sunday, false
+	}
+}
+
+// FormatWeekStart returns the canonical config value for w.
+// Any weekday other than Monday maps to sunday.
+func FormatWeekStart(w time.Weekday) string {
+	if w == time.Monday {
+		return WeekStartMonday
+	}
+	return WeekStartSunday
+}

--- a/internal/config/weekstart_test.go
+++ b/internal/config/weekstart_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseWeekStart(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   time.Weekday
+		wantOK bool
+	}{
+		{"", time.Sunday, false},
+		{"   ", time.Sunday, false},
+		{"bogus", time.Sunday, false},
+		{"sunday", time.Sunday, true},
+		{"Sunday", time.Sunday, true},
+		{"SUN", time.Sunday, true},
+		{" su ", time.Sunday, true},
+		{"monday", time.Monday, true},
+		{"Monday", time.Monday, true},
+		{"MON", time.Monday, true},
+		{"mo", time.Monday, true},
+	}
+	for _, tc := range tests {
+		got, ok := ParseWeekStart(tc.in)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("ParseWeekStart(%q) = %v, %v; want %v, %v",
+				tc.in, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+func TestFormatWeekStart(t *testing.T) {
+	if got := FormatWeekStart(time.Monday); got != WeekStartMonday {
+		t.Errorf("Monday = %q, want %q", got, WeekStartMonday)
+	}
+	if got := FormatWeekStart(time.Sunday); got != WeekStartSunday {
+		t.Errorf("Sunday = %q, want %q", got, WeekStartSunday)
+	}
+	if got := FormatWeekStart(time.Saturday); got != WeekStartSunday {
+		t.Errorf("Saturday = %q, want %q", got, WeekStartSunday)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -5293,6 +5293,7 @@ func (m Model) toggleWeekNumbers() (tea.Model, tea.Cmd) {
 }
 
 // toggleWeekStart switches the first day of the week between Sunday and Monday.
+// Month and week query ranges follow the new grid, so events reload.
 func (m Model) toggleWeekStart() (tea.Model, tea.Cmd) {
 	if m.weekStart == time.Monday {
 		m.weekStart = time.Sunday
@@ -5304,10 +5305,7 @@ func (m Model) toggleWeekStart() (tea.Model, tea.Cmd) {
 	m.week = m.week.SetWeekStart(m.weekStart)
 	m.sidebar = m.sidebar.SetWeekStart(m.weekStart)
 	m.saveUIState()
-	if m.viewMode == viewWeek {
-		return m, m.loadEvents()
-	}
-	return m, nil
+	return m, m.loadEvents()
 }
 
 // toggleSidebar toggles the sidebar panel and resyncs view sizes.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -55,6 +55,7 @@ type appKeyMap struct {
 	AgendaView   key.Binding
 	Sidebar      key.Binding
 	WeekNumbers  key.Binding
+	WeekStart    key.Binding
 	Create       key.Binding
 	SwitchFocus  key.Binding
 	Help         key.Binding
@@ -74,6 +75,7 @@ func defaultAppKeys() appKeyMap {
 		AgendaView:   key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "agenda")),
 		Sidebar:      key.NewBinding(key.WithKeys("\\"), key.WithHelp("\\", "sidebar")),
 		WeekNumbers:  key.NewBinding(key.WithKeys("#"), key.WithHelp("#", "week numbers")),
+		WeekStart:    key.NewBinding(key.WithKeys("W", "shift+w"), key.WithHelp("W", "week start")),
 		Create:       key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "new")),
 		SwitchFocus:  key.NewBinding(key.WithKeys("tab", "shift+tab"), key.WithHelp("tab", "switch focus")),
 		Help:         key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
@@ -447,6 +449,11 @@ type Model struct {
 	ready            bool
 	showSidebar      bool
 	showWeekNumbers  bool
+	weekStart        time.Weekday
+	// persistWeekStart is true when the first day of the week came from
+	// UI state or from a TUI toggle. Config then stays the default until
+	// the user sets the day in the TUI.
+	persistWeekStart bool
 	focus            appFocus
 	hiddenCalendars  map[int64]bool
 	clickedEventID   int64
@@ -552,6 +559,12 @@ type Model struct {
 // (see internal/tui/themes/*.toml); empty or unknown names fall back to
 // DefaultThemeName.
 func NewModel(a *app.App, themeName string) Model {
+	return newModel(a, themeName, time.Sunday)
+}
+
+// newModel builds the root TUI model. configWeekStart is the value from
+// config.toml / CHRONCAL_UI_WEEK_START. A stored UI-state choice overrides it.
+func newModel(a *app.App, themeName string, configWeekStart time.Weekday) Model {
 	ui := config.LoadUIState()
 	hidden := make(map[int64]bool, len(ui.HiddenCalendars))
 	for _, id := range ui.HiddenCalendars {
@@ -567,7 +580,13 @@ func NewModel(a *app.App, themeName string) Model {
 	case "agenda":
 		vm = viewAgenda
 	}
-	sb := NewSidebarModel(NewMiniMonthModel(now), NewCalendarListModel(nil, hidden))
+	weekStart := configWeekStart
+	persistWeekStart := false
+	if w, ok := config.ParseWeekStart(ui.WeekStart); ok {
+		weekStart = w
+		persistWeekStart = true
+	}
+	sb := NewSidebarModel(NewMiniMonthModel(now).SetWeekStart(weekStart), NewCalendarListModel(nil, hidden))
 	sp := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	theme := LoadTheme(themeName, true)
 	SetActiveTheme(theme)
@@ -576,12 +595,14 @@ func NewModel(a *app.App, themeName string) Model {
 		themeName:          themeName,
 		keys:               defaultAppKeys(),
 		viewMode:           vm,
-		calendar:           NewCalendarModel(now).SetShowWeekNumbers(ui.ShowWeekNumbers),
-		week:               NewWeekModel(now).SetShowWeekNumbers(ui.ShowWeekNumbers),
+		calendar:           NewCalendarModel(now).SetShowWeekNumbers(ui.ShowWeekNumbers).SetWeekStart(weekStart),
+		week:               NewWeekModel(now).SetShowWeekNumbers(ui.ShowWeekNumbers).SetWeekStart(weekStart),
 		day:                NewDayModel(now),
 		agenda:             newAgendaForStartup(now, vm, ui.AgendaShowEmptyDays),
 		showSidebar:        ui.ShowSidebar,
 		showWeekNumbers:    ui.ShowWeekNumbers,
+		weekStart:          weekStart,
+		persistWeekStart:   persistWeekStart,
 		hiddenCalendars:    hidden,
 		focus:              focusCalendar,
 		sidebar:            sb,
@@ -2800,7 +2821,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case EventCreateMsg:
 		var cmd tea.Cmd
 		m.form, cmd = NewEventFormModel(msg.Day, eventFormCalendars(m.calendars), m.theme)
-		m.form = m.form.SetSize(m.width, m.height)
+		m.form = m.form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
 		m.formOpen = true
 		return m, cmd
 
@@ -2856,7 +2877,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		var cmd tea.Cmd
 		m.form, cmd = NewEventFormModelForEditInstance(msg.event, msg.instanceTime, eventFormCalendars(m.calendars), m.theme)
-		m.form = m.form.SetSize(m.width, m.height)
+		m.form = m.form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
 		m.formOpen = true
 		m.dialogOpen = false
 		if m.viewDialogOpen {
@@ -2905,7 +2926,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case EventDuplicateMsg:
 		var cmd tea.Cmd
 		m.form, cmd = NewEventFormModelForDuplicate(msg.Event, eventFormCalendars(m.calendars), m.theme)
-		m.form = m.form.SetSize(m.width, m.height)
+		m.form = m.form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
 		m.formOpen = true
 		if m.viewDialogOpen {
 			m.viewReturnEvent = msg.Event
@@ -3045,6 +3066,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ToggleWeekNumbersMsg:
 		return m.toggleWeekNumbers()
+
+	case ToggleWeekStartMsg:
+		return m.toggleWeekStart()
 
 	case eventCreatedMsg:
 		if msg.err != nil {
@@ -4850,6 +4874,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.toggleSidebar()
 		case key.Matches(msg, m.keys.WeekNumbers):
 			return m.toggleWeekNumbers()
+		case key.Matches(msg, m.keys.WeekStart):
+			return m.toggleWeekStart()
 		case key.Matches(msg, m.keys.CalendarList):
 			return m, func() tea.Msg { return CalendarManagerRequestedMsg{Target: CalendarManagerTargetRoot} }
 		case key.Matches(msg, m.keys.Sync):
@@ -4887,7 +4913,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			var cmd tea.Cmd
 			m.form, cmd = NewEventFormModel(cursor, eventFormCalendars(m.calendars), m.theme)
-			m.form = m.form.SetSize(m.width, m.height)
+			m.form = m.form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
 			m.formOpen = true
 			return m, cmd
 		}
@@ -5266,6 +5292,24 @@ func (m Model) toggleWeekNumbers() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// toggleWeekStart switches the first day of the week between Sunday and Monday.
+func (m Model) toggleWeekStart() (tea.Model, tea.Cmd) {
+	if m.weekStart == time.Monday {
+		m.weekStart = time.Sunday
+	} else {
+		m.weekStart = time.Monday
+	}
+	m.persistWeekStart = true
+	m.calendar = m.calendar.SetWeekStart(m.weekStart)
+	m.week = m.week.SetWeekStart(m.weekStart)
+	m.sidebar = m.sidebar.SetWeekStart(m.weekStart)
+	m.saveUIState()
+	if m.viewMode == viewWeek {
+		return m, m.loadEvents()
+	}
+	return m, nil
+}
+
 // toggleSidebar toggles the sidebar panel and resyncs view sizes.
 func (m Model) toggleSidebar() (tea.Model, tea.Cmd) {
 	m.showSidebar = !m.showSidebar
@@ -5302,6 +5346,13 @@ func (m *Model) switchView() tea.Cmd {
 	return m.loadEvents()
 }
 
+func (m Model) persistedWeekStart() string {
+	if !m.persistWeekStart {
+		return ""
+	}
+	return config.FormatWeekStart(m.weekStart)
+}
+
 func (m Model) saveUIState() {
 	var vm string
 	switch m.viewMode {
@@ -5327,13 +5378,15 @@ func (m Model) saveUIState() {
 		HiddenCalendars:     ids,
 		AgendaShowEmptyDays: m.agenda.ShowEmptyDays(),
 		ShowWeekNumbers:     m.showWeekNumbers,
+		WeekStart:           m.persistedWeekStart(),
 	})
 }
 
 // RunOptions configures a TUI session. A non-zero Event jumps to that
 // occurrence and opens its view dialog after the first load.
 type RunOptions struct {
-	Event event.Event
+	Event     event.Event
+	WeekStart time.Weekday
 }
 
 func Run(a *app.App, themeName string, opts RunOptions) error {
@@ -5354,7 +5407,7 @@ func Run(a *app.App, themeName string, opts RunOptions) error {
 	bg, palette := detectTerminalState(os.Stdin, os.Stdout)
 	SetActivePalette(palette)
 
-	model := NewModel(a, themeName)
+	model := newModel(a, themeName, opts.WeekStart)
 	if opts.Event.ID != 0 {
 		model = model.WithOpenEvent(opts.Event)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -450,10 +450,6 @@ type Model struct {
 	showSidebar      bool
 	showWeekNumbers  bool
 	weekStart        time.Weekday
-	// persistWeekStart is true when the first day of the week came from
-	// UI state or from a TUI toggle. Config then stays the default until
-	// the user sets the day in the TUI.
-	persistWeekStart bool
 	focus            appFocus
 	hiddenCalendars  map[int64]bool
 	clickedEventID   int64
@@ -581,10 +577,8 @@ func newModel(a *app.App, themeName string, configWeekStart time.Weekday) Model 
 		vm = viewAgenda
 	}
 	weekStart := configWeekStart
-	persistWeekStart := false
 	if w, ok := config.ParseWeekStart(ui.WeekStart); ok {
 		weekStart = w
-		persistWeekStart = true
 	}
 	sb := NewSidebarModel(NewMiniMonthModel(now).SetWeekStart(weekStart), NewCalendarListModel(nil, hidden))
 	sp := spinner.New(spinner.WithSpinner(spinner.MiniDot))
@@ -602,7 +596,6 @@ func newModel(a *app.App, themeName string, configWeekStart time.Weekday) Model 
 		showSidebar:        ui.ShowSidebar,
 		showWeekNumbers:    ui.ShowWeekNumbers,
 		weekStart:          weekStart,
-		persistWeekStart:   persistWeekStart,
 		hiddenCalendars:    hidden,
 		focus:              focusCalendar,
 		sidebar:            sb,
@@ -2819,11 +2812,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case EventCreateMsg:
-		var cmd tea.Cmd
-		m.form, cmd = NewEventFormModel(msg.Day, eventFormCalendars(m.calendars), m.theme)
-		m.form = m.form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
-		m.formOpen = true
-		return m, cmd
+		form, cmd := NewEventFormModel(msg.Day, eventFormCalendars(m.calendars), m.theme)
+		return m.openEventForm(form, cmd)
 
 	case EventEditMsg:
 		if cmd, blocked := m.blockReadOnlyCalendarMutation(msg.Event.CalendarID); blocked {
@@ -2875,16 +2865,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			return m, nil
 		}
-		var cmd tea.Cmd
-		m.form, cmd = NewEventFormModelForEditInstance(msg.event, msg.instanceTime, eventFormCalendars(m.calendars), m.theme)
-		m.form = m.form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
-		m.formOpen = true
+		form, cmd := NewEventFormModelForEditInstance(msg.event, msg.instanceTime, eventFormCalendars(m.calendars), m.theme)
 		m.dialogOpen = false
 		if m.viewDialogOpen {
 			m.viewReturnEvent = msg.event
 		}
 		m.viewDialogOpen = false
-		return m, cmd
+		return m.openEventForm(form, cmd)
 
 	case EventViewRequestedMsg:
 		ev := msg.Event
@@ -2924,15 +2911,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case EventDuplicateMsg:
-		var cmd tea.Cmd
-		m.form, cmd = NewEventFormModelForDuplicate(msg.Event, eventFormCalendars(m.calendars), m.theme)
-		m.form = m.form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
-		m.formOpen = true
+		form, cmd := NewEventFormModelForDuplicate(msg.Event, eventFormCalendars(m.calendars), m.theme)
 		if m.viewDialogOpen {
 			m.viewReturnEvent = msg.Event
 		}
 		m.viewDialogOpen = false
-		return m, cmd
+		return m.openEventForm(form, cmd)
 
 	case EventFormSaveMsg:
 		if cmd, blocked := m.blockReadOnlyCalendarMutation(msg.CalendarID); blocked {
@@ -4911,11 +4895,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			default:
 				cursor = m.calendar.Cursor()
 			}
-			var cmd tea.Cmd
-			m.form, cmd = NewEventFormModel(cursor, eventFormCalendars(m.calendars), m.theme)
-			m.form = m.form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
-			m.formOpen = true
-			return m, cmd
+			form, cmd := NewEventFormModel(cursor, eventFormCalendars(m.calendars), m.theme)
+			return m.openEventForm(form, cmd)
 		}
 		if m.focus == focusCalendar {
 			switch m.viewMode {
@@ -5300,7 +5281,6 @@ func (m Model) toggleWeekStart() (tea.Model, tea.Cmd) {
 	} else {
 		m.weekStart = time.Monday
 	}
-	m.persistWeekStart = true
 	m.calendar = m.calendar.SetWeekStart(m.weekStart)
 	m.week = m.week.SetWeekStart(m.weekStart)
 	m.sidebar = m.sidebar.SetWeekStart(m.weekStart)
@@ -5323,6 +5303,13 @@ func (m Model) toggleSidebar() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// openEventForm mounts an event form with the session week start and size.
+func (m Model) openEventForm(form EventFormModel, cmd tea.Cmd) (Model, tea.Cmd) {
+	m.form = form.SetWeekStart(m.weekStart).SetSize(m.width, m.height)
+	m.formOpen = true
+	return m, cmd
+}
+
 // openPalette initializes and shows the command palette.
 func (m Model) openPalette() (tea.Model, tea.Cmd) {
 	cmds := buildPaletteCommands(m)
@@ -5342,13 +5329,6 @@ func (m *Model) switchView() tea.Cmd {
 	m.agenda = m.agenda.SetSize(iw, ih)
 	m.saveUIState()
 	return m.loadEvents()
-}
-
-func (m Model) persistedWeekStart() string {
-	if !m.persistWeekStart {
-		return ""
-	}
-	return config.FormatWeekStart(m.weekStart)
 }
 
 func (m Model) saveUIState() {
@@ -5376,7 +5356,7 @@ func (m Model) saveUIState() {
 		HiddenCalendars:     ids,
 		AgendaShowEmptyDays: m.agenda.ShowEmptyDays(),
 		ShowWeekNumbers:     m.showWeekNumbers,
-		WeekStart:           m.persistedWeekStart(),
+		WeekStart:           config.FormatWeekStart(m.weekStart),
 	})
 }
 

--- a/internal/tui/event_form.go
+++ b/internal/tui/event_form.go
@@ -192,11 +192,12 @@ type EventFormModel struct {
 	// fieldKeys maps form item index → field key for OnFieldEnter
 	fieldKeys []string
 
-	keys   eventFormKeyMap
-	help   help.Model
-	width  int
-	height int
-	theme  Theme
+	keys      eventFormKeyMap
+	help      help.Model
+	width     int
+	height    int
+	theme     Theme
+	weekStart time.Weekday
 }
 
 type eventFormKeyMap struct {
@@ -811,7 +812,7 @@ func (m *EventFormModel) tryOpenOverlay() tea.Cmd {
 		return noopCmd
 	case efKeyRepeat:
 		if m.repeatField.Selected() == repeatCustomIdx {
-			m.rruleEditor = NewRecurrenceEditorModel(m.day, m.width, m.height, m.theme)
+			m.rruleEditor = NewRecurrenceEditorModel(m.day, m.width, m.height, m.theme).SetWeekStart(m.weekStart)
 			if m.customRule != "" {
 				m.rruleEditor.LoadRule(m.customRule)
 			}
@@ -837,7 +838,8 @@ func (m *EventFormModel) tryOpenOverlay() tea.Cmd {
 func (m *EventFormModel) openDatePicker() {
 	m.datePicker = NewMiniMonthModel(m.day).Focus().FocusGrid().
 		SetTheme(m.theme.Selected, m.theme.Today, m.theme.Text, m.theme.Muted).
-		SetRangeColor(m.theme.Selected)
+		SetRangeColor(m.theme.Selected).
+		SetWeekStart(m.weekStart)
 	m.rangeMode = m.rangeHasEnd
 	m.rangeStart = time.Time{}
 	m.rangeEnd = time.Time{}
@@ -855,7 +857,8 @@ func (m *EventFormModel) openDatePicker() {
 // openEndsDatePicker initialises the ends-date MiniMonthModel and opens the overlay.
 func (m *EventFormModel) openEndsDatePicker() {
 	m.endsDatePickerModel = NewMiniMonthModel(m.endsDate).Focus().FocusGrid().
-		SetTheme(m.theme.Selected, m.theme.Today, m.theme.Text, m.theme.Muted)
+		SetTheme(m.theme.Selected, m.theme.Today, m.theme.Text, m.theme.Muted).
+		SetWeekStart(m.weekStart)
 	m.endsDatePicker = true
 	m.dpBtnFocus = -1
 }
@@ -865,6 +868,12 @@ func (m *EventFormModel) openEndsDatePicker() {
 // This callback exists for non-overlay field-enter behavior.
 func (m *EventFormModel) handleFieldEnter(fieldKey string) tea.Cmd {
 	return nil // nil = proceed with default focus-next
+}
+
+// SetWeekStart sets the first day of the week for date-picker grids.
+func (m EventFormModel) SetWeekStart(w time.Weekday) EventFormModel {
+	m.weekStart = w
+	return m
 }
 
 func (m EventFormModel) SetSize(w, h int) EventFormModel {

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -396,12 +396,16 @@ func isoWeekForRow(anchor time.Time, weekStart time.Weekday, week int) int {
 	return w
 }
 
+// weekdayOffset returns how many days d falls after weekStart, in 0..6.
+func weekdayOffset(d time.Time, weekStart time.Weekday) int {
+	return (int(d.Weekday()) - int(weekStart) + 7) % 7
+}
+
 // calendarGridAnchor returns the date of the top-left cell of the calendar
 // grid for the given month and week start.
 func calendarGridAnchor(month time.Time, weekStart time.Weekday) time.Time {
 	first := time.Date(month.Year(), month.Month(), 1, 0, 0, 0, 0, time.Local)
-	offset := (int(first.Weekday()) - int(weekStart) + 7) % 7
-	return first.AddDate(0, 0, -offset)
+	return first.AddDate(0, 0, -weekdayOffset(first, weekStart))
 }
 
 // distributeCells splits avail into n cell sizes each >= minSize. It spreads

--- a/internal/tui/help_dialog.go
+++ b/internal/tui/help_dialog.go
@@ -211,6 +211,7 @@ func (m HelpDialogModel) sections() []helpSection {
 				{"?", "this help"},
 				{"\\", "toggle sidebar"},
 				{"#", "toggle week numbers"},
+				{"W", "toggle week start"},
 				{"tab · shift+tab", "move focus"},
 				{"esc · q", "close (read-only dialogs)"},
 				{"esc", "close (forms)"},

--- a/internal/tui/minicalendar.go
+++ b/internal/tui/minicalendar.go
@@ -66,6 +66,7 @@ type MiniMonthModel struct {
 	rangeActive bool
 	rangeStart  time.Time // zero if not yet pinned
 	rangeEnd    time.Time // zero if only start is pinned
+	weekStart   time.Weekday
 }
 
 func NewMiniMonthModel(initial time.Time) MiniMonthModel {
@@ -90,6 +91,12 @@ func (m MiniMonthModel) SetTheme(accent, today, text, muted color.Color) MiniMon
 // when range mode is active. Endpoints continue to use the accent color.
 func (m MiniMonthModel) SetRangeColor(c color.Color) MiniMonthModel {
 	m.rangeColor = c
+	return m
+}
+
+// SetWeekStart sets the first column of the day grid. Sunday is the default.
+func (m MiniMonthModel) SetWeekStart(w time.Weekday) MiniMonthModel {
+	m.weekStart = w
 	return m
 }
 
@@ -232,7 +239,7 @@ func (m MiniMonthModel) Update(msg tea.Msg) (MiniMonthModel, tea.Cmd) {
 }
 
 // miniMonthHeaderWidth is the header row width in display columns. It matches
-// the weekday row ("Su Mo Tu We Th Fr Sa") and the seven day cells below it.
+// the weekday row (seven 2-letter labels) and the seven day cells below it.
 // The chevrons then align with the right edge of the grid.
 const miniMonthHeaderWidth = 20
 
@@ -285,7 +292,7 @@ func (m MiniMonthModel) HandleClick(x, y int) (MiniMonthModel, tea.Cmd) {
 	if col < 0 || col > 6 {
 		return m, nil
 	}
-	leading := int(m.displayMonth.Weekday())
+	leading := weekdayOffset(m.displayMonth, m.weekStart)
 	dayIndex := gridY*7 + col - leading
 	if dayIndex < 0 {
 		return m, nil
@@ -334,12 +341,12 @@ func (m MiniMonthModel) View() string {
 	b.WriteString(rightChev)
 	b.WriteString("\n")
 	// Weekday row dimmed so the day numbers carry the hierarchy.
-	b.WriteString(mutedStyle.Render("Su Mo Tu We Th Fr Sa"))
+	b.WriteString(mutedStyle.Render(miniWeekdayHeader(m.weekStart)))
 	b.WriteString("\n")
 
 	first := m.displayMonth
 	// Pad to align first-of-month under its weekday column.
-	leading := int(first.Weekday())
+	leading := weekdayOffset(first, m.weekStart)
 	for range leading {
 		b.WriteString("   ")
 	}
@@ -496,19 +503,19 @@ func addMonthClamped(t time.Time, months int) time.Time {
 }
 
 // renderMiniCalendar draws a compact month grid.
-func renderMiniCalendar(selected, today time.Time, indent int, theme Theme) string {
+func renderMiniCalendar(selected, today time.Time, indent int, theme Theme, weekStart time.Weekday) string {
 	y, mo, _ := selected.Date()
 	loc := selected.Location()
 
 	first := time.Date(y, mo, 1, 0, 0, 0, 0, loc)
-	startDow := int(first.Weekday())
+	startDow := weekdayOffset(first, weekStart)
 	daysInMonth := time.Date(y, mo+1, 0, 0, 0, 0, 0, loc).Day()
 
 	pad := strings.Repeat(" ", indent)
 	faint := lipgloss.NewStyle().Faint(true)
 
 	var lines []string
-	lines = append(lines, pad+faint.Render("Su Mo Tu We Th Fr Sa"))
+	lines = append(lines, pad+faint.Render(miniWeekdayHeader(weekStart)))
 
 	dayNum := 1
 	for week := range 6 {
@@ -546,4 +553,20 @@ func sameDay(a, b time.Time) bool {
 	ay, am, ad := a.Date()
 	by, bm, bd := b.Date()
 	return ay == by && am == bm && ad == bd
+}
+
+var miniWeekdayLabels = [7]string{"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+
+// miniWeekdayHeader returns the compact weekday row for weekStart.
+// Sunday yields "Su Mo Tu We Th Fr Sa". The width is always 20 columns.
+func miniWeekdayHeader(weekStart time.Weekday) string {
+	var b strings.Builder
+	b.Grow(20)
+	for i := range 7 {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(miniWeekdayLabels[(int(weekStart)+i)%7])
+	}
+	return b.String()
 }

--- a/internal/tui/palette_commands.go
+++ b/internal/tui/palette_commands.go
@@ -1,6 +1,10 @@
 package tui
 
-import tea "charm.land/bubbletea/v2"
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
 
 // Palette action messages. The palette emits these via a selected command's
 // Action func; the app-level Update handles them like any other tea.Msg.
@@ -17,11 +21,14 @@ type ToggleSidebarMsg struct{}
 // ToggleWeekNumbersMsg toggles the ISO week-number gutter in month/week views.
 type ToggleWeekNumbersMsg struct{}
 
+// ToggleWeekStartMsg switches the first day of the week between Sunday and Monday.
+type ToggleWeekStartMsg struct{}
+
 // buildPaletteCommands returns the default commands exposed through the
 // palette, with bindings to the current app state (cursor, etc.).
 func buildPaletteCommands(m Model) []PaletteCommand {
 	cursor, _ := m.viewCursorAndToday()
-	commands := make([]PaletteCommand, 0, 17)
+	commands := make([]PaletteCommand, 0, 18)
 	commands = append(commands,
 		PaletteCommand{
 			ID:       "nav.today",
@@ -106,6 +113,13 @@ func buildPaletteCommands(m Model) []PaletteCommand {
 			Action:   func() tea.Msg { return ToggleWeekNumbersMsg{} },
 		},
 		PaletteCommand{
+			ID:       "ui.week_start",
+			Title:    weekStartPaletteTitle(m.weekStart),
+			Category: "View",
+			Shortcut: "W",
+			Action:   func() tea.Msg { return ToggleWeekStartMsg{} },
+		},
+		PaletteCommand{
 			ID:       "trash.view",
 			Title:    "Recently Deleted",
 			Category: "View",
@@ -128,4 +142,11 @@ func buildPaletteCommands(m Model) []PaletteCommand {
 		},
 	)
 	return commands
+}
+
+func weekStartPaletteTitle(weekStart time.Weekday) string {
+	if weekStart == time.Monday {
+		return "Start Week on Sunday"
+	}
+	return "Start Week on Monday"
 }

--- a/internal/tui/recurrence_editor.go
+++ b/internal/tui/recurrence_editor.go
@@ -64,10 +64,17 @@ type RecurrenceEditorModel struct {
 	done      bool
 	cancelled bool
 
-	help   help.Model
-	width  int
-	height int
-	theme  Theme
+	help      help.Model
+	width     int
+	height    int
+	theme     Theme
+	weekStart time.Weekday
+}
+
+// SetWeekStart sets the first day of the week for the ends-date mini-calendar.
+func (m RecurrenceEditorModel) SetWeekStart(w time.Weekday) RecurrenceEditorModel {
+	m.weekStart = w
+	return m
 }
 
 // NewRecurrenceEditorModel creates a new editor pre-configured from the event date.
@@ -547,7 +554,7 @@ func (m RecurrenceEditorModel) HandleEndsDateMouse(msg tea.MouseClickMsg, picker
 	y, mo, _ := m.endsDate.Date()
 	loc := m.endsDate.Location()
 	first := time.Date(y, mo, 1, 0, 0, 0, 0, loc)
-	startDow := int(first.Weekday())
+	startDow := weekdayOffset(first, m.weekStart)
 	daysInMonth := time.Date(y, mo+1, 0, 0, 0, 0, 0, loc).Day()
 
 	dayNum := ry*7 + dow - startDow + 1
@@ -673,7 +680,7 @@ func (m RecurrenceEditorModel) EndsDatePickerView() string {
 	bold := lipgloss.NewStyle().Bold(true)
 
 	monthStr := m.endsDate.Format("January 2006")
-	calGrid := renderMiniCalendar(m.endsDate, time.Now(), 0, m.theme)
+	calGrid := renderMiniCalendar(m.endsDate, time.Now(), 0, m.theme, m.weekStart)
 	gridLines := strings.Split(calGrid, "\n")
 	calLines := make([]string, 0, len(gridLines)+1)
 	calLines = append(calLines, bold.Render(monthStr))

--- a/internal/tui/sidebar_model.go
+++ b/internal/tui/sidebar_model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
@@ -12,6 +13,12 @@ import (
 func (m SidebarModel) SetTheme(t Theme) SidebarModel {
 	m.miniMonth = m.miniMonth.SetTheme(t.Selected, t.Today, t.Text, t.Muted)
 	m.list = m.list.SetTheme(t.Selected, t.Muted, t.Text, t.SelectedText, t.Error)
+	return m
+}
+
+// SetWeekStart propagates the first day of the week to the mini-month grid.
+func (m SidebarModel) SetWeekStart(w time.Weekday) SidebarModel {
+	m.miniMonth = m.miniMonth.SetWeekStart(w)
 	return m
 }
 

--- a/internal/tui/week_model.go
+++ b/internal/tui/week_model.go
@@ -80,8 +80,8 @@ func NewWeekModel(today time.Time) WeekModel {
 }
 
 func (m WeekModel) WeekStartDate() time.Time {
-	offset := (int(m.cursor.Weekday()) - int(m.weekStart) + 7) % 7
-	return time.Date(m.cursor.Year(), m.cursor.Month(), m.cursor.Day()-offset, 0, 0, 0, 0, m.cursor.Location())
+	d := m.cursor
+	return time.Date(d.Year(), d.Month(), d.Day()-weekdayOffset(d, m.weekStart), 0, 0, 0, 0, d.Location())
 }
 
 func (m WeekModel) Cursor() time.Time { return m.cursor }

--- a/internal/tui/week_model.go
+++ b/internal/tui/week_model.go
@@ -107,6 +107,14 @@ func (m WeekModel) SetShowWeekNumbers(show bool) WeekModel {
 	return m
 }
 
+// SetWeekStart sets the first day of the displayed week. Sunday is the default.
+func (m WeekModel) SetWeekStart(w time.Weekday) WeekModel {
+	m.weekStart = w
+	return m
+}
+
+func (m WeekModel) WeekStart() time.Weekday { return m.weekStart }
+
 func (m WeekModel) allDayRowCount() int {
 	anchor := m.WeekStartDate()
 	maxPerCol := 0

--- a/internal/tui/weekstart_test.go
+++ b/internal/tui/weekstart_test.go
@@ -93,8 +93,8 @@ func TestToggleWeekStart_PersistsMonday(t *testing.T) {
 
 	next, cmd := m.toggleWeekStart()
 	m = next.(Model)
-	if cmd != nil {
-		t.Fatal("month view toggle must not reload events")
+	if cmd == nil {
+		t.Fatal("month view toggle must reload events for the shifted grid")
 	}
 	if m.weekStart != time.Monday {
 		t.Fatalf("toggled weekStart = %v, want Monday", m.weekStart)
@@ -114,6 +114,36 @@ func TestToggleWeekStart_PersistsMonday(t *testing.T) {
 	reloaded := NewModel(nil, "")
 	if reloaded.weekStart != time.Monday {
 		t.Fatalf("reloaded weekStart = %v, want Monday", reloaded.weekStart)
+	}
+}
+
+func TestToggleWeekStart_MonthViewReloadsShiftedRange(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	m := NewModel(nil, "")
+	m.viewMode = viewMonth
+	// January 2023 starts on Sunday. Sunday-start grid is 1 Jan;
+	// Monday-start grid is 26 Dec.
+	m.calendar.month = time.Date(2023, 1, 1, 0, 0, 0, 0, time.Local)
+	m.calendar.cursor = time.Date(2023, 1, 15, 0, 0, 0, 0, time.Local)
+
+	beforeFrom, beforeTo := m.expectedEventRange()
+	next, cmd := m.toggleWeekStart()
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("month view toggle must reload events for the shifted grid")
+	}
+	afterFrom, afterTo := m.expectedEventRange()
+	if afterFrom.Equal(beforeFrom) && afterTo.Equal(beforeTo) {
+		t.Fatalf("expectedEventRange did not change: %v–%v", afterFrom, afterTo)
+	}
+	wantFrom, wantTo := localSpanQueryRange(
+		time.Date(2022, 12, 26, 0, 0, 0, 0, time.Local),
+		time.Date(2023, 2, 6, 0, 0, 0, 0, time.Local),
+	)
+	if !afterFrom.Equal(wantFrom) || !afterTo.Equal(wantTo) {
+		t.Fatalf("expectedEventRange = %v–%v, want %v–%v", afterFrom, afterTo, wantFrom, wantTo)
 	}
 }
 

--- a/internal/tui/weekstart_test.go
+++ b/internal/tui/weekstart_test.go
@@ -1,0 +1,171 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/config"
+)
+
+func TestCalendarGridAnchor_WeekStart(t *testing.T) {
+	// April 2026 starts on Wednesday.
+	month := time.Date(2026, 4, 1, 0, 0, 0, 0, time.Local)
+
+	sun := calendarGridAnchor(month, time.Sunday)
+	if got := sun.Format("2006-01-02"); got != "2026-03-29" {
+		t.Errorf("Sunday start anchor = %s, want 2026-03-29", got)
+	}
+	if sun.Weekday() != time.Sunday {
+		t.Errorf("Sunday start weekday = %s, want Sunday", sun.Weekday())
+	}
+
+	mon := calendarGridAnchor(month, time.Monday)
+	if got := mon.Format("2006-01-02"); got != "2026-03-30" {
+		t.Errorf("Monday start anchor = %s, want 2026-03-30", got)
+	}
+	if mon.Weekday() != time.Monday {
+		t.Errorf("Monday start weekday = %s, want Monday", mon.Weekday())
+	}
+}
+
+func TestMiniWeekdayHeader(t *testing.T) {
+	if got := miniWeekdayHeader(time.Sunday); got != "Su Mo Tu We Th Fr Sa" {
+		t.Errorf("Sunday header = %q", got)
+	}
+	if got := miniWeekdayHeader(time.Monday); got != "Mo Tu We Th Fr Sa Su" {
+		t.Errorf("Monday header = %q", got)
+	}
+	if w := len("Su Mo Tu We Th Fr Sa"); w != miniMonthHeaderWidth {
+		t.Fatalf("fixture width %d != miniMonthHeaderWidth %d", w, miniMonthHeaderWidth)
+	}
+	if got := len(miniWeekdayHeader(time.Monday)); got != miniMonthHeaderWidth {
+		t.Errorf("Monday header width = %d, want %d", got, miniMonthHeaderWidth)
+	}
+}
+
+func TestMiniMonth_MondayWeekStartHeaderAndClick(t *testing.T) {
+	// April 2026 starts on Wednesday. Monday-first layout of week row 0:
+	//   Mo Tu We Th Fr Sa Su
+	//         1  2  3  4  5
+	day := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	m := NewMiniMonthModel(day).SetWeekStart(time.Monday)
+	out := stripANSI(m.View())
+	if !strings.Contains(out, "Mo Tu We Th Fr Sa Su") {
+		t.Fatalf("View missing Monday-first header:\n%s", out)
+	}
+	if strings.Contains(out, "Su Mo Tu We Th Fr Sa") {
+		t.Fatalf("View still has Sunday-first header:\n%s", out)
+	}
+
+	// Click column 2 (Wednesday) of the first grid row (y=2) → April 1.
+	got, cmd := m.HandleClick(2*3, 2)
+	if cmd == nil {
+		t.Fatal("click on April 1 returned no command")
+	}
+	if got.cursor.Format("2006-01-02") != "2026-04-01" {
+		t.Errorf("cursor = %s, want 2026-04-01", got.cursor.Format("2006-01-02"))
+	}
+}
+
+func TestWeekModel_SetWeekStartShiftsAnchor(t *testing.T) {
+	// Sunday 5 April 2026.
+	cursor := time.Date(2026, 4, 5, 12, 0, 0, 0, time.Local)
+	m := NewWeekModel(cursor)
+	m.cursor = cursor
+	if got := m.WeekStartDate().Format("2006-01-02"); got != "2026-04-05" {
+		t.Errorf("Sunday-start week = %s, want 2026-04-05", got)
+	}
+	m = m.SetWeekStart(time.Monday)
+	if got := m.WeekStartDate().Format("2006-01-02"); got != "2026-03-30" {
+		t.Errorf("Monday-start week = %s, want 2026-03-30", got)
+	}
+}
+
+func TestToggleWeekStart_PersistsMonday(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	m := NewModel(nil, "")
+	if m.weekStart != time.Sunday {
+		t.Fatalf("default weekStart = %v, want Sunday", m.weekStart)
+	}
+
+	next, cmd := m.toggleWeekStart()
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatal("month view toggle must not reload events")
+	}
+	if m.weekStart != time.Monday {
+		t.Fatalf("toggled weekStart = %v, want Monday", m.weekStart)
+	}
+	if m.calendar.WeekStart() != time.Monday {
+		t.Fatal("calendar weekStart was not applied")
+	}
+	if m.week.WeekStart() != time.Monday {
+		t.Fatal("week view weekStart was not applied")
+	}
+
+	state := config.LoadUIState()
+	if state.WeekStart != config.WeekStartMonday {
+		t.Fatalf("persisted week_start = %q, want monday", state.WeekStart)
+	}
+
+	reloaded := NewModel(nil, "")
+	if reloaded.weekStart != time.Monday {
+		t.Fatalf("reloaded weekStart = %v, want Monday", reloaded.weekStart)
+	}
+}
+
+func TestNewModel_ConfigWeekStartAppliesWhenStateEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	m := newModel(nil, "", time.Monday)
+	if m.weekStart != time.Monday {
+		t.Fatalf("weekStart = %v, want Monday from config", m.weekStart)
+	}
+	if m.persistWeekStart {
+		t.Fatal("config week start must not lock UI state until the user toggles")
+	}
+	m.saveUIState()
+	if got := config.LoadUIState().WeekStart; got != "" {
+		t.Fatalf("saved week_start = %q, want empty so config remains the source", got)
+	}
+}
+
+func TestNewModel_UIStateOverridesConfigWeekStart(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	if err := config.SaveUIState(config.UIState{ShowSidebar: true, WeekStart: "sunday"}); err != nil {
+		t.Fatalf("SaveUIState: %v", err)
+	}
+
+	m := newModel(nil, "", time.Monday)
+	if m.weekStart != time.Sunday {
+		t.Fatalf("weekStart = %v, want Sunday from UI state", m.weekStart)
+	}
+}
+
+func TestPaletteWeekStartTitleFollowsState(t *testing.T) {
+	if got := weekStartPaletteTitle(time.Sunday); got != "Start Week on Monday" {
+		t.Errorf("Sunday title = %q", got)
+	}
+	if got := weekStartPaletteTitle(time.Monday); got != "Start Week on Sunday" {
+		t.Errorf("Monday title = %q", got)
+	}
+
+	cmd := paletteCommandByID(t, buildPaletteCommands(Model{weekStart: time.Monday}), "ui.week_start")
+	if cmd.Title != "Start Week on Sunday" || cmd.Shortcut != "W" {
+		t.Fatalf("palette command = %+v", cmd)
+	}
+	if _, ok := cmd.Action().(ToggleWeekStartMsg); !ok {
+		t.Fatalf("action = %T, want ToggleWeekStartMsg", cmd.Action())
+	}
+}
+
+func TestHelpDialog_WindowsSectionDocumentsWeekStart(t *testing.T) {
+	if got := findHelpEntry(t, "Windows", "toggle week start"); got != "W" {
+		t.Fatalf("week-start key = %q, want W", got)
+	}
+}

--- a/internal/tui/weekstart_test.go
+++ b/internal/tui/weekstart_test.go
@@ -155,12 +155,9 @@ func TestNewModel_ConfigWeekStartAppliesWhenStateEmpty(t *testing.T) {
 	if m.weekStart != time.Monday {
 		t.Fatalf("weekStart = %v, want Monday from config", m.weekStart)
 	}
-	if m.persistWeekStart {
-		t.Fatal("config week start must not lock UI state until the user toggles")
-	}
 	m.saveUIState()
-	if got := config.LoadUIState().WeekStart; got != "" {
-		t.Fatalf("saved week_start = %q, want empty so config remains the source", got)
+	if got := config.LoadUIState().WeekStart; got != config.WeekStartMonday {
+		t.Fatalf("saved week_start = %q, want monday", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #629.

## Summary

The month view, week view, and mini-calendar always started on Sunday. This change adds a Sunday/Monday toggle.

## How to use it

- Press **`W`** in the TUI to switch Sunday ↔ Monday.
- Use the command palette (`/`): **Start Week on Monday** / **Start Week on Sunday**.
- Set a default in config:

```toml
[ui]
week_start = "monday"
```

Or `CHRONCAL_UI_WEEK_START=monday`. Default remains Sunday.

A TUI toggle is stored in session state. Later launches keep it. Config applies until the user changes the day in the TUI. After that, the TUI choice wins.

Month view, week view, the sidebar mini-calendar, and date pickers all follow the choice.

## Tests

- Config load from file and env.
- UI-state round-trip and old-file compatibility.
- Grid anchor, mini-calendar header/click, week-view shift, persist, and palette/help.

`go test ./internal/config ./internal/tui ./cmd/chroncal` is clean.

## Checklist

- [x] Tests pass (`go test ./internal/config ./internal/tui ./cmd/chroncal`)
- [x] Add new tests for new functions
- [x] Update the documentation when the change needs it