### PR TITLE
fix(sync): do not withhold the token on uncanonical multiget misses

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1261,7 +1261,8 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 		// Per-resource 404s here are NOT deletions. Google can list an href
 		// that 404s on multiget for a reason other than a real delete.
 		// classifyMultigetMiss splits a known miss (local row: incomplete)
-		// from an unknown miss (no local row: record and retry). See pullView.
+		// from an unknown miss (no local row: record and retry). An
+		// uncanonical href carries neither risk: skip it. See pullView.
 		for _, miss := range multi.Missing {
 			canonical, hrefErr := client.CanonicalObjectRef(remoteURL, miss)
 			kind, local := classifyMultigetMiss(canonical, hrefErr, localByPath)
@@ -1276,7 +1277,14 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 				// even though we have no actual evidence of deletion.
 				seenUIDs[local.Uid] = true
 			case multigetMissUncanonical:
-				view.knownMisses++
+				// CanonicalObjectRef rejected this href (query or fragment,
+				// another origin, a collection path). localByPath holds
+				// canonical paths only, so no local row maps to this miss
+				// and there is no data to lose. A retry obligation cannot
+				// converge either: the resource loop below discards any body
+				// served under an uncanonical path. Log and move on so a
+				// broken or hostile server cannot wedge the calendar with a
+				// permanent token withhold. See issue #625.
 			case multigetMissUnknown:
 				if recErr := pending.noteMiss(ctx, canonical); recErr != nil {
 					e.logger.Warn("record unknown multiget miss", "calendar_id", calendarID, "href", miss, "error", recErr)

--- a/internal/sync/pending_href.go
+++ b/internal/sync/pending_href.go
@@ -158,6 +158,15 @@ const (
 	multigetMissUnknown     multigetMissKind = "unknown"
 )
 
+// classifyMultigetMiss sorts one multiget 404 by the risk it carries.
+//
+//	multigetMissUncanonical: CanonicalObjectRef rejected the href. No
+//	local row can map to it, so it is not a data-loss signal. The caller
+//	skips it or takes the unknown-miss budget path.
+//	multigetMissKnown: the path maps to a local row. The caller must
+//	treat the pull as incomplete.
+//	multigetMissUnknown: no local row maps to the path. The caller may
+//	record a retry obligation and advance the token.
 func classifyMultigetMiss(canonical string, hrefErr error, localByPath map[string]storage.SyncResource) (multigetMissKind, storage.SyncResource) {
 	if hrefErr != nil {
 		return multigetMissUncanonical, storage.SyncResource{}

--- a/internal/sync/pending_href_test.go
+++ b/internal/sync/pending_href_test.go
@@ -384,6 +384,138 @@ func TestEnginePullDropsUnknownMultigetMissAfterBudget(t *testing.T) {
 	}
 }
 
+// TestEnginePullUncanonicalMultigetMissAdvancesToken covers issue #625.
+// A server can report a 404 under an href that CanonicalObjectRef rejects:
+// a query string, another origin, or a collection path. No local row can
+// map to such an href, so the miss carries no data-loss signal. The engine
+// must skip it: no known-miss count, no pending row, and the token
+// advances. The same table pins the old rules for canonical 404s: an
+// unknown miss takes the budget path, and a miss for a local row still
+// withholds the token.
+func TestEnginePullUncanonicalMultigetMissAdvancesToken(t *testing.T) {
+	t.Parallel()
+
+	const (
+		token1  = "https://example.com/sync/t1"
+		alive   = "/calendar/alive.ics"
+		phantom = "/calendar/phantom-invite.ics"
+		racey   = "/calendar/racey.ics"
+	)
+
+	cases := []struct {
+		name        string
+		seedLocal   string   // non-empty seeds a local row for this UID at racey
+		missing     []string // hrefs the multiget response reports as 404
+		wantToken   string
+		wantErrors  bool
+		wantPulled  int
+		wantDeleted int
+		wantPending int
+	}{
+		{
+			name:        "query string",
+			missing:     []string{phantom + "?rev=2"},
+			wantToken:   token1,
+			wantPulled:  1,
+			wantPending: 0,
+		},
+		{
+			name:        "other origin",
+			missing:     []string{"https://evil.example.com/calendar/phantom-invite.ics"},
+			wantToken:   token1,
+			wantPulled:  1,
+			wantPending: 0,
+		},
+		{
+			name:        "root collection path",
+			missing:     []string{"/"},
+			wantToken:   token1,
+			wantPulled:  1,
+			wantPending: 0,
+		},
+		{
+			name:        "canonical unknown miss still records and advances",
+			missing:     []string{phantom},
+			wantToken:   token1,
+			wantPulled:  1,
+			wantPending: 1,
+		},
+		{
+			name:        "canonical known miss still withholds the token",
+			seedLocal:   "racey",
+			missing:     []string{racey},
+			wantToken:   "",
+			wantErrors:  true,
+			wantPulled:  1,
+			wantDeleted: 0,
+			wantPending: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			engine, db, q := newTestEngine(t)
+			ctx := context.Background()
+			calendarID := firstCalendarID(t, q)
+
+			listed := []string{alive, phantom}
+			if tc.seedLocal != "" {
+				insertTestEvent(t, db, calendarID, tc.seedLocal)
+				if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+					CalendarID: calendarID, Uid: tc.seedLocal, OwnerType: "event",
+					RemoteUrl: racey, Etag: "old", Dirty: 0, SyncStrategy: "sync-token",
+				}); err != nil {
+					t.Fatalf("UpsertSyncResource %s: %v", tc.seedLocal, err)
+				}
+				listed = append(listed, racey)
+			}
+
+			client := newScriptedClient(t,
+				func(string) string { return syncCollectionXML(token1, listed...) },
+				func(int, string) string {
+					return multigetXML(map[string]string{alive: testEventICS("alive-uid", "Alive")}, tc.missing)
+				},
+			)
+
+			result, err := engine.pull(ctx, client, calendarID, "/calendar/")
+			if err != nil {
+				t.Fatalf("pull: %v", err)
+			}
+			if result.pulled != tc.wantPulled {
+				t.Fatalf("pulled = %d, want %d", result.pulled, tc.wantPulled)
+			}
+			if result.deleted != tc.wantDeleted {
+				t.Fatalf("deleted = %d, want %d", result.deleted, tc.wantDeleted)
+			}
+			if (len(result.errors) > 0) != tc.wantErrors {
+				t.Fatalf("errors = %v, wantErrors = %v", result.errors, tc.wantErrors)
+			}
+			if tok := calendarToken(t, q, calendarID); tok != tc.wantToken {
+				t.Fatalf("sync_token = %q, want %q", tok, tc.wantToken)
+			}
+			rows := listPendingHrefs(t, q, calendarID)
+			if len(rows) != tc.wantPending {
+				t.Fatalf("pending hrefs = %+v, want %d row(s)", rows, tc.wantPending)
+			}
+			if tc.wantPending == 1 {
+				if rows[0].Href != phantom || rows[0].MissCount != 1 {
+					t.Fatalf("pending hrefs = %+v, want one row for %s with miss_count 1", rows, phantom)
+				}
+			}
+			if _, err := q.GetEventByUID(ctx, "alive-uid"); err != nil {
+				t.Fatalf("alive event missing: %v", err)
+			}
+			if tc.seedLocal != "" {
+				if _, err := q.GetEventByUID(ctx, tc.seedLocal); err != nil {
+					t.Fatalf("%s row (known miss) was wrongly deleted: %v", tc.seedLocal, err)
+				}
+			}
+		})
+	}
+}
+
 // TestEnginePullMixedKnownAndUnknownMultigetMissWithholdsToken pins the
 // split completeness rule. A known miss still withholds the token and
 // absence deletion. An unknown phantom in the same REPORT does not


### PR DESCRIPTION
## Summary

Unclassified calendar-multiget 404s whose href fails `CanonicalObjectRef` (query/fragment, other origin, collection path) no longer increment `knownMisses`. They are skipped entirely, so the sync token advances and a server echoing out-of-scope hrefs on every REPORT can no longer wedge a calendar.

## Rationale

- No local row can map to an uncanonical path (`localByPath` holds canonical paths only), so there is no data-loss signal to protect.
- A pending retry row could never converge: response bodies served under uncanonical paths are already discarded downstream, so record-or-drop would burn fetches and budget on garbage forever.
- This matches the change-list loop, which already skips out-of-scope hrefs with a warning.

Canonical known misses still withhold the token; canonical unknown misses still take the budget path. Behavior for real data-loss signals is unchanged.

## Tests

Table-driven `TestEnginePullUncanonicalMultigetMissAdvancesToken`: query-string / other-origin / root-collection hrefs → token advances, zero pending rows; canonical unknown → budget row recorded + token advances; canonical known → token withheld, local row survives.

`go test ./internal/sync/... ./internal/caldav/...` pass.

Fixes #625
