### PR TITLE
feat(nix): add home-manager module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,21 @@ jobs:
       - name: Build via the flake
         run: nix build .#chroncal --no-link --print-build-logs
 
+  flake-eval:
+    name: Nix flake eval
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+
+      # Verify that the flake outputs and the Home Manager module still
+      # evaluate. Do not build anything. The flake job builds the package.
+      - name: Evaluate flake outputs
+        run: |
+          nix flake check --no-build
+          nix eval .#homeModules.default
+
   release-config:
     name: Release config
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -741,6 +741,8 @@ from = "you@example.com"
 
 The environment variable is `CHRONCAL_SMTP_PASSWORD_CMD`.
 
+Do not put a literal `password` in a Nix-managed config through the Home Manager module. The generated file lands in the world-readable Nix store. Use `password_cmd` there instead.
+
 ### Desktop notification backends
 
 `chroncal alarm check` records fired alarms even in headless environments. `DISPLAY` and `AUDIO` notifications still need an OS notification backend. On Linux that backend is a D-Bus notification daemon. GNOME and KDE include one. Lighter setups can use a standalone daemon such as `mako` or `dunst`.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,27 @@ Build the package from a clone:
 nix build .#chroncal
 ```
 
-The flake exposes `packages.default`, `packages.chroncal`, `apps.default`, and a developer shell with Go, GoReleaser, golangci-lint, govulncheck, and sqlc.
+The flake exposes `packages.default`, `packages.chroncal`, `apps.default`, a developer shell with Go, GoReleaser, golangci-lint, govulncheck, and sqlc, and a Home Manager module under `homeModules.default` (also aliased as `homeManagerModules.default`).
+
+The Home Manager module installs chroncal and writes `$XDG_CONFIG_HOME/chroncal/config.toml` from `programs.chroncal.settings`. Import it and set options:
+
+```nix
+# In your flake inputs:
+# chroncal.url = "github:DouglasdeMoura/chroncal";
+
+# In your Home Manager modules:
+imports = [ inputs.chroncal.homeManagerModules.default ];
+
+programs.chroncal = {
+  enable = true;
+  settings = {
+    ui.week_start = "monday";
+    smtp.password_cmd = "pass show smtp/app-password";
+  };
+};
+```
+
+chroncal stores accounts in its database and the OS keyring. The module has no account options for that reason. Use `settings` for every documented config key.
 
 ### Scoop (Windows)
 
@@ -708,6 +728,18 @@ from = "you@example.com"
 ```
 
 Or via environment: `CHRONCAL_SMTP_HOST`, `CHRONCAL_SMTP_PORT`, `CHRONCAL_SMTP_USERNAME`, `CHRONCAL_SMTP_PASSWORD`, `CHRONCAL_SMTP_FROM`.
+
+To avoid a hardcoded password, set `password_cmd` instead of `password`. chroncal runs the command at send time and reads the password from its stdout. The output loses one trailing newline. Set one of the two keys, never both:
+
+```toml
+[smtp]
+host = "smtp.example.com"
+username = "you@example.com"
+password_cmd = "pass show smtp/app-password"
+from = "you@example.com"
+```
+
+The environment variable is `CHRONCAL_SMTP_PASSWORD_CMD`.
 
 ### Desktop notification backends
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,12 @@ imports = [ inputs.chroncal.homeManagerModules.default ];
 programs.chroncal = {
   enable = true;
   settings = {
-    ui.week_start = "monday";
-    smtp.password_cmd = "pass show smtp/app-password";
+    ui = {
+      week_start = "monday";
+    };
+    smtp = {
+      password_cmd = "pass show smtp/app-password";
+    };
   };
 };
 ```
@@ -379,11 +383,11 @@ Journal flags: `--date`, `--description`, `--calendar`, `--status`, `--class`, `
 ### CalDAV accounts
 
 ```
-chroncal account add              "<name>" --server URL --username USER [--auth {basic,bearer,oauth2}] [--oauth-client-id ID] [--allow-insecure]
+chroncal account add              "<name>" --server URL --username USER [--auth {basic,bearer,oauth2}] [--oauth-client-id ID] [--password-cmd CMD] [--allow-insecure]
 chroncal account get              <name|id>
 chroncal account list
 chroncal account update           <name|id> --name NAME
-chroncal account credentials      <name|id>
+chroncal account credentials      <name|id> [--password-cmd CMD]
 chroncal account reauth           <name|id> [--oauth-client-id ID]
 chroncal account calendars list   <name|id>
 chroncal account calendars add    <name|id> (--calendar NAME_OR_URL ... | --all)
@@ -399,7 +403,7 @@ An account stores one credential. It discovers every CalDAV calendar collection 
 
 If you select none, the command also removes the empty account and credential. `account remove` deletes the credential and remote links. It keeps downloaded calendars as local copies.
 
-`account credentials` rotates the stored secret of a basic or bearer account. It reads the new value from `CHRONCAL_PASSWORD` (basic) or `CHRONCAL_BEARER_TOKEN` (bearer). `account reauth` repeats the Google OAuth consent flow for an oauth2 account; the client secret comes from `GOOGLE_CLIENT_SECRET` or the stored value, and `--oauth-client-id` replaces the stored client ID. Neither command accepts a secret as a CLI flag.
+`account credentials` rotates the stored secret of a basic or bearer account. For basic auth it reads `CHRONCAL_PASSWORD`, or it stores `--password-cmd` / `CHRONCAL_PASSWORD_CMD` and runs that command at request time. The secret is the first stdout line. The command has a 30-second deadline. Stderr is discarded. For bearer auth it reads `CHRONCAL_BEARER_TOKEN`. `account reauth` repeats the Google OAuth consent flow for an oauth2 account; the client secret comes from `GOOGLE_CLIENT_SECRET` or the stored value, and `--oauth-client-id` replaces the stored client ID. Neither command accepts the password itself as a CLI flag.
 
 You can open read-only collections locally and sync them pull-only. Chroncal does not send metadata changes, resources, or tombstones to them.
 
@@ -427,10 +431,11 @@ You can still use remote flags with `create` or `update` to attach one local cal
 --username <user>
 --auth {basic,bearer,oauth2}
 --oauth-client-id <id>
+--password-cmd <command>
 --allow-insecure
 ```
 
-For script setup, the commands read credentials from environment variables, not from prompts: `CHRONCAL_PASSWORD` (basic), `CHRONCAL_BEARER_TOKEN` (bearer), and `GOOGLE_CLIENT_SECRET` (oauth2). The commands do not accept these values as CLI flags.
+For script setup, the commands read credentials from environment variables, not from prompts: `CHRONCAL_PASSWORD` or `CHRONCAL_PASSWORD_CMD` (basic), `CHRONCAL_BEARER_TOKEN` (bearer), and `GOOGLE_CLIENT_SECRET` (oauth2). `--password-cmd` stores the command. The commands do not accept the password itself as a CLI flag.
 
 Pass `--disconnect-remote` on `update` to remove the remote link of a calendar.
 
@@ -729,7 +734,7 @@ from = "you@example.com"
 
 Or via environment: `CHRONCAL_SMTP_HOST`, `CHRONCAL_SMTP_PORT`, `CHRONCAL_SMTP_USERNAME`, `CHRONCAL_SMTP_PASSWORD`, `CHRONCAL_SMTP_FROM`.
 
-To avoid a hardcoded password, set `password_cmd` instead of `password`. chroncal runs the command at send time and reads the password from its stdout. The output loses one trailing newline. Set one of the two keys, never both:
+To avoid a hardcoded password, set `password_cmd` instead of `password`. chroncal runs the command at send time. The secret is the first stdout line. The command has a 30-second deadline. Stderr is discarded. Set one of the two keys, never both:
 
 ```toml
 [smtp]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,6 @@ chroncal stores data in a local SQLite database. The main security areas are:
 - **iCal import** -- The import path parses untrusted `.ics` files. chroncal enforces payload and inline attachment size limits on import.
 - **Account credentials** -- The OS keyring stores credentials by default. Plaintext storage is opt-in only for environments without a usable keyring.
 - **OAuth tokens** -- Google CalDAV uses PKCE. The configured credential store keeps access tokens after a refresh.
-- **SMTP credentials** -- Config files store SMTP credentials.
+- **SMTP credentials** -- Config files store SMTP credentials. The `smtp.password_cmd` option runs a command at send time and keeps the secret out of the config file.
 - **Remote CalDAV servers** -- Sync, discovery, and free/busy requests use bounded HTTP clients and command deadlines.
 - **Desktop notifications** -- D-Bus on Linux.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ You should receive an acknowledgment within 48 hours. We will work with you to u
 chroncal stores data in a local SQLite database. The main security areas are:
 
 - **iCal import** -- The import path parses untrusted `.ics` files. chroncal enforces payload and inline attachment size limits on import.
-- **Account credentials** -- The OS keyring stores credentials by default. Plaintext storage is opt-in only for environments without a usable keyring.
+- **Account credentials** -- The OS keyring stores credentials by default. Plaintext storage is opt-in only for environments without a usable keyring. A basic-auth `password_cmd` stores the command, not the secret. chroncal runs the command at request time.
 - **OAuth tokens** -- Google CalDAV uses PKCE. The configured credential store keeps access tokens after a refresh.
-- **SMTP credentials** -- Config files store SMTP credentials. The `smtp.password_cmd` option runs a command at send time and keeps the secret out of the config file.
+- **SMTP credentials** -- Config files store SMTP credentials. The `smtp.password_cmd` option runs a command at send time. The secret is the first stdout line. The command has a 30-second deadline. Stderr is discarded.
 - **Remote CalDAV servers** -- Sync, discovery, and free/busy requests use bounded HTTP clients and command deadlines.
 - **Desktop notifications** -- D-Bus on Linux.

--- a/cmd/chroncal/account.go
+++ b/cmd/chroncal/account.go
@@ -48,6 +48,7 @@ func accountAddCmd() *cobra.Command {
 		username      string
 		authType      string
 		oauthClientID string
+		passwordCmd   string
 		allowInsecure bool
 	)
 	cmd := &cobra.Command{
@@ -70,6 +71,7 @@ exposes, import every usable collection, and complete their initial sync.`,
 			}
 			cred, err := buildCalendarCredential(ctx, calendarRemoteFlags{
 				Username: username, AuthType: authType, OAuthClientID: oauthClientID,
+				PasswordCommand: passwordCmd,
 			})
 			if err != nil {
 				return err
@@ -123,6 +125,7 @@ exposes, import every usable collection, and complete their initial sync.`,
 	cmd.Flags().StringVar(&username, "username", "", "username or account email (required)")
 	cmd.Flags().StringVar(&authType, "auth", "basic", "authentication type: basic, bearer, oauth2")
 	cmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "Google OAuth desktop client ID")
+	cmd.Flags().StringVar(&passwordCmd, "password-cmd", "", "command whose first stdout line is the basic-auth password")
 	cmd.Flags().BoolVar(&allowInsecure, "allow-insecure", false, "allow an HTTP endpoint for local development")
 	_ = cmd.MarkFlagRequired("server")
 	_ = cmd.MarkFlagRequired("username")
@@ -230,6 +233,7 @@ authentication type, or stored credential.`,
 }
 
 func accountCredentialsCmd() *cobra.Command {
+	var passwordCmd string
 	cmd := &cobra.Command{
 		Use:   "credentials <name|id>",
 		Short: "Rotate a basic or bearer account secret",
@@ -238,13 +242,14 @@ func accountCredentialsCmd() *cobra.Command {
 The server URL, username, and authentication type stay the same. OAuth
 accounts must use "chroncal account reauth" instead.
 
-Secrets come from the environment, never from flags:
-  basic   CHRONCAL_PASSWORD
+Do not pass the password as a CLI flag.
+  basic   CHRONCAL_PASSWORD, --password-cmd, or CHRONCAL_PASSWORD_CMD
   bearer  CHRONCAL_BEARER_TOKEN
 
 A missing or identity-mismatched keyring entry is repaired. Other
 backend failures leave the previous secret unchanged.`,
 		Example: `  CHRONCAL_PASSWORD=... chroncal account credentials Work --output json
+  chroncal account credentials Work --password-cmd "pass show caldav_password"
   CHRONCAL_BEARER_TOKEN=... chroncal account credentials 3 --output json`,
 		Args: exactOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -260,7 +265,7 @@ backend failures leave the previous secret unchanged.`,
 			}
 
 			authType := strings.ToLower(strings.TrimSpace(configured.AuthType))
-			var secret string
+			var secret, passwordCmdValue string
 			switch authType {
 			case "oauth2":
 				return errInvalidInputf(
@@ -270,7 +275,7 @@ backend failures leave the previous secret unchanged.`,
 			case "bearer":
 				secret, err = readBearerToken()
 			case "basic", "":
-				secret, err = readBasicPassword()
+				secret, passwordCmdValue, err = readBasicSecret(passwordCmd)
 			default:
 				return errInvalidInputf("unsupported auth type %q", configured.AuthType)
 			}
@@ -292,8 +297,12 @@ backend failures leave the previous secret unchanged.`,
 			}
 			if authType == "bearer" {
 				cred.AccessToken = secret
+			} else if passwordCmdValue != "" {
+				cred.Password = ""
+				cred.PasswordCommand = passwordCmdValue
 			} else {
 				cred.Password = secret
+				cred.PasswordCommand = ""
 			}
 			if err := a.Accounts.StoreCredential(ctx, configured.ID, fingerprint, cred, store); err != nil {
 				return err
@@ -307,6 +316,7 @@ backend failures leave the previous secret unchanged.`,
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&passwordCmd, "password-cmd", "", "command whose first stdout line is the basic-auth password")
 	return cmd
 }
 

--- a/cmd/chroncal/account_cli_test.go
+++ b/cmd/chroncal/account_cli_test.go
@@ -565,6 +565,46 @@ func TestAccountCredentialsRotatesBearerAndBasic(t *testing.T) {
 	}
 }
 
+func TestAccountCredentialsStoresPasswordCmd(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/dav/",
+		Username: "bob", AuthType: "basic",
+	}, auth.Credential{Password: "old-password"}, store)
+	if err != nil {
+		t.Fatalf("create basic account: %v", err)
+	}
+	a.Close()
+
+	t.Setenv("CHRONCAL_PASSWORD", "")
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "")
+	stdout, _, err := runChroncalCommand(t,
+		"account", "credentials", "Work",
+		"--password-cmd", "pass show caldav_password",
+		"--output", "json", "--allow-plaintext",
+	)
+	if err != nil {
+		t.Fatalf("account credentials password-cmd: %v", err)
+	}
+	assertAccountJSONWithoutSecrets(t, stdout, "Work", "basic")
+	if strings.Contains(stdout, "old-password") {
+		t.Fatalf("json leaked a password: %s", stdout)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load credential: %v", err)
+	}
+	if got.Password != "" || got.PasswordCommand != "pass show caldav_password" {
+		t.Fatalf("credential = %+v, want password_cmd stored and password cleared", got)
+	}
+}
+
 func TestAccountCredentialsRefusesOAuth(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	ctx := context.Background()

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -232,7 +232,8 @@ To enable EMAIL notifications, configure SMTP via environment variables:
   CHRONCAL_SMTP_PORT       SMTP server port (default: 587)
   CHRONCAL_SMTP_USERNAME   SMTP authentication username
   CHRONCAL_SMTP_PASSWORD   SMTP authentication password
-  CHRONCAL_SMTP_PASSWORD_CMD   command whose stdout is the password (alternative to CHRONCAL_SMTP_PASSWORD)
+  CHRONCAL_SMTP_PASSWORD_CMD command whose stdout is the password (alternative to
+  CHRONCAL_SMTP_PASSWORD)
   CHRONCAL_SMTP_FROM       sender address for alarm emails
 
 Or in the config file ($XDG_CONFIG_HOME/chroncal/config.toml):

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -232,8 +232,8 @@ To enable EMAIL notifications, configure SMTP via environment variables:
   CHRONCAL_SMTP_PORT       SMTP server port (default: 587)
   CHRONCAL_SMTP_USERNAME   SMTP authentication username
   CHRONCAL_SMTP_PASSWORD   SMTP authentication password
-  CHRONCAL_SMTP_PASSWORD_CMD command whose stdout is the password (alternative to
-  CHRONCAL_SMTP_PASSWORD)
+  CHRONCAL_SMTP_PASSWORD_CMD command whose first stdout line is the password
+                         (alternative to CHRONCAL_SMTP_PASSWORD)
   CHRONCAL_SMTP_FROM       sender address for alarm emails
 
 Or in the config file ($XDG_CONFIG_HOME/chroncal/config.toml):

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -232,6 +232,7 @@ To enable EMAIL notifications, configure SMTP via environment variables:
   CHRONCAL_SMTP_PORT       SMTP server port (default: 587)
   CHRONCAL_SMTP_USERNAME   SMTP authentication username
   CHRONCAL_SMTP_PASSWORD   SMTP authentication password
+  CHRONCAL_SMTP_PASSWORD_CMD   command whose stdout is the password (alternative to CHRONCAL_SMTP_PASSWORD)
   CHRONCAL_SMTP_FROM       sender address for alarm emails
 
 Or in the config file ($XDG_CONFIG_HOME/chroncal/config.toml):
@@ -240,6 +241,8 @@ Or in the config file ($XDG_CONFIG_HOME/chroncal/config.toml):
   port = 587
   username = "user@example.com"
   password = "app-password"
+  # or retrieve the password with a command instead of hardcoding it:
+  # password_cmd = "pass show smtp/app-password"
   from = "noreply@example.com"
 
 Environment variables override config file values.

--- a/cmd/chroncal/calendar.go
+++ b/cmd/chroncal/calendar.go
@@ -294,6 +294,7 @@ func calendarCreateCmd() *cobra.Command {
 		username      string
 		authType      string
 		oauthClientID string
+		passwordCmd   string
 		allowInsecure bool
 	)
 	cmd := &cobra.Command{
@@ -311,7 +312,7 @@ behavior.`,
 			if strings.TrimSpace(args[0]) == "" {
 				return errInvalidInputf("calendar name must not be empty")
 			}
-			if err := validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID, allowInsecure, false); err != nil {
+			if err := validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID, passwordCmd, allowInsecure, false); err != nil {
 				return err
 			}
 
@@ -334,11 +335,12 @@ behavior.`,
 
 			if strings.TrimSpace(remoteURL) != "" {
 				if err := connectCalendarRemote(cmd.Context(), a, c, calendarRemoteFlags{
-					RemoteURL:     remoteURL,
-					Username:      username,
-					AuthType:      authType,
-					OAuthClientID: oauthClientID,
-					AllowInsecure: allowInsecure,
+					RemoteURL:       remoteURL,
+					Username:        username,
+					AuthType:        authType,
+					OAuthClientID:   oauthClientID,
+					PasswordCommand: passwordCmd,
+					AllowInsecure:   allowInsecure,
 				}); err != nil {
 					return err
 				}
@@ -368,6 +370,7 @@ behavior.`,
 	cmd.Flags().StringVar(&username, "username", "", "Username for remote authentication")
 	cmd.Flags().StringVar(&authType, "auth", "basic", "Auth type: basic, bearer, oauth2")
 	cmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "OAuth 2.0 client ID")
+	cmd.Flags().StringVar(&passwordCmd, "password-cmd", "", "command whose first stdout line is the basic-auth password")
 	cmd.Flags().BoolVar(&allowInsecure, "allow-insecure", false, "Allow HTTP (non-HTTPS) remote URLs")
 	return cmd
 }
@@ -382,6 +385,7 @@ func calendarUpdateCmd() *cobra.Command {
 		username         string
 		authType         string
 		oauthClientID    string
+		passwordCmd      string
 		allowInsecure    bool
 		disconnectRemote bool
 	)
@@ -430,7 +434,7 @@ Only the flags you pass are changed.`,
 				}
 			}
 
-			if err := validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID, allowInsecure, disconnectRemote); err != nil {
+			if err := validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID, passwordCmd, allowInsecure, disconnectRemote); err != nil {
 				return err
 			}
 
@@ -466,11 +470,12 @@ Only the flags you pass are changed.`,
 				}
 			} else if strings.TrimSpace(remoteURL) != "" {
 				if err := connectCalendarRemote(ctx, a, c, calendarRemoteFlags{
-					RemoteURL:     remoteURL,
-					Username:      username,
-					AuthType:      authType,
-					OAuthClientID: oauthClientID,
-					AllowInsecure: allowInsecure,
+					RemoteURL:       remoteURL,
+					Username:        username,
+					AuthType:        authType,
+					OAuthClientID:   oauthClientID,
+					PasswordCommand: passwordCmd,
+					AllowInsecure:   allowInsecure,
 				}); err != nil {
 					return err
 				}
@@ -500,6 +505,7 @@ Only the flags you pass are changed.`,
 	cmd.Flags().StringVar(&username, "username", "", "Username for remote authentication")
 	cmd.Flags().StringVar(&authType, "auth", "basic", "Auth type: basic, bearer, oauth2")
 	cmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "OAuth 2.0 client ID")
+	cmd.Flags().StringVar(&passwordCmd, "password-cmd", "", "command whose first stdout line is the basic-auth password")
 	cmd.Flags().BoolVar(&allowInsecure, "allow-insecure", false, "Allow HTTP (non-HTTPS) remote URLs")
 	cmd.Flags().BoolVar(&disconnectRemote, "disconnect-remote", false, "Remove the remote CalDAV link from this calendar")
 	return cmd

--- a/cmd/chroncal/calendar_remote.go
+++ b/cmd/chroncal/calendar_remote.go
@@ -23,28 +23,30 @@ var newCalendarCredentialStore = auth.NewCredentialStore
 var runGoogleOAuthFlow = auth.GoogleOAuthFlow
 
 type calendarRemoteFlags struct {
-	RemoteURL     string
-	Username      string
-	AuthType      string
-	OAuthClientID string
-	AllowInsecure bool
+	RemoteURL       string
+	Username        string
+	AuthType        string
+	OAuthClientID   string
+	PasswordCommand string
+	AllowInsecure   bool
 }
 
-func validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID string, allowInsecure, disconnectRemote bool) error {
+func validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID, passwordCmd string, allowInsecure, disconnectRemote bool) error {
 	remoteURL = strings.TrimSpace(remoteURL)
 	username = strings.TrimSpace(username)
 	authType = strings.ToLower(strings.TrimSpace(authType))
 	oauthClientID = strings.TrimSpace(oauthClientID)
+	passwordCmd = strings.TrimSpace(passwordCmd)
 
 	if disconnectRemote {
-		if remoteURL != "" || username != "" || oauthClientID != "" || allowInsecure || authType != "" && authType != "basic" {
+		if remoteURL != "" || username != "" || oauthClientID != "" || passwordCmd != "" || allowInsecure || authType != "" && authType != "basic" {
 			return fmt.Errorf("--disconnect-remote cannot be combined with remote connection flags like --remote-url")
 		}
 		return nil
 	}
 
 	if remoteURL == "" {
-		if username != "" || oauthClientID != "" || allowInsecure || authType != "" && authType != "basic" {
+		if username != "" || oauthClientID != "" || passwordCmd != "" || allowInsecure || authType != "" && authType != "basic" {
 			return fmt.Errorf("remote flags require --remote-url")
 		}
 		return nil
@@ -85,6 +87,10 @@ func connectCalendarRemote(ctx context.Context, a *app.App, cal calendarpkg.Cale
 	metaPassword := cred.Password
 	if cred.AccessToken != "" {
 		metaPassword = cred.AccessToken
+	} else if cred.PasswordCommand != "" {
+		if resolved, resolveErr := cred.ResolvePassword(); resolveErr == nil {
+			metaPassword = resolved
+		}
 	}
 	metaCtx, metaCancel := context.WithTimeout(ctx, 10*time.Second)
 	meta, _ := caldav.FetchCalendarMetadata(metaCtx, flags.RemoteURL, flags.Username, metaPassword, flags.AuthType, flags.AllowInsecure)
@@ -122,11 +128,15 @@ func buildCalendarCredential(ctx context.Context, flags calendarRemoteFlags) (au
 		}
 		return auth.Credential{Username: flags.Username, AccessToken: token}, nil
 	case "basic":
-		password, err := readBasicPassword()
+		password, passwordCmd, err := readBasicSecret(flags.PasswordCommand)
 		if err != nil {
 			return auth.Credential{}, err
 		}
-		return auth.Credential{Username: flags.Username, Password: password}, nil
+		return auth.Credential{
+			Username:        flags.Username,
+			Password:        password,
+			PasswordCommand: passwordCmd,
+		}, nil
 	case "oauth2":
 		clientSecret, err := readGoogleClientSecret()
 		if err != nil {
@@ -153,18 +163,39 @@ func normalizeAuthType(authType string) string {
 	return calendarpkg.NormalizeAuthType(authType)
 }
 
-// readBasicPassword obtains the password for --auth basic. We never accept it
-// as a CLI flag. That keeps secrets out of /proc/<pid>/cmdline and shell
-// history. Sources, in order:
+// readBasicSecret obtains the basic-auth secret. We never accept the
+// password itself as a CLI flag. That keeps secrets out of
+// /proc/<pid>/cmdline and shell history. Sources, in order:
 //
-//  1. CHRONCAL_PASSWORD env var (handy for scripted/CI setup).
-//  2. Interactive prompt via terminal (echo disabled).
+//  1. --password-cmd flag (the command is not a secret).
+//  2. CHRONCAL_PASSWORD_CMD env var.
+//  3. CHRONCAL_PASSWORD env var.
+//  4. Interactive prompt via terminal (echo disabled).
+//
+// A password command and CHRONCAL_PASSWORD together are an error.
+func readBasicSecret(passwordCmdFlag string) (password, passwordCmd string, err error) {
+	cmd := strings.TrimSpace(passwordCmdFlag)
+	if cmd == "" {
+		cmd = strings.TrimSpace(os.Getenv("CHRONCAL_PASSWORD_CMD"))
+	}
+	envPassword := os.Getenv("CHRONCAL_PASSWORD")
+	if cmd != "" && envPassword != "" {
+		return "", "", fmt.Errorf("CHRONCAL_PASSWORD and password_cmd are mutually exclusive; set one of them")
+	}
+	if cmd != "" {
+		return "", cmd, nil
+	}
+	password, err = readBasicPassword()
+	return password, "", err
+}
+
+// readBasicPassword obtains a literal password for --auth basic.
 func readBasicPassword() (string, error) {
 	if s := os.Getenv("CHRONCAL_PASSWORD"); s != "" {
 		return s, nil
 	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return "", fmt.Errorf("a password is required: set CHRONCAL_PASSWORD or run interactively")
+		return "", fmt.Errorf("a password is required: set CHRONCAL_PASSWORD, CHRONCAL_PASSWORD_CMD, --password-cmd, or run interactively")
 	}
 	fmt.Fprint(os.Stderr, "Password: ")
 	passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/cmd/chroncal/calendar_remote_test.go
+++ b/cmd/chroncal/calendar_remote_test.go
@@ -21,3 +21,35 @@ func TestReadBasicPasswordRequiresEnvWhenNonInteractive(t *testing.T) {
 		t.Fatal("expected error when stdin is not a terminal and env is unset")
 	}
 }
+
+func TestReadBasicSecretUsesPasswordCmdFlag(t *testing.T) {
+	t.Setenv("CHRONCAL_PASSWORD", "")
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "env-cmd")
+	password, cmd, err := readBasicSecret("pass show caldav_password")
+	if err != nil {
+		t.Fatalf("readBasicSecret: %v", err)
+	}
+	if password != "" || cmd != "pass show caldav_password" {
+		t.Fatalf("password=%q cmd=%q, want empty password and flag command", password, cmd)
+	}
+}
+
+func TestReadBasicSecretUsesEnvCmd(t *testing.T) {
+	t.Setenv("CHRONCAL_PASSWORD", "")
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "secret-tool lookup caldav host")
+	password, cmd, err := readBasicSecret("")
+	if err != nil {
+		t.Fatalf("readBasicSecret: %v", err)
+	}
+	if password != "" || cmd != "secret-tool lookup caldav host" {
+		t.Fatalf("password=%q cmd=%q, want env command", password, cmd)
+	}
+}
+
+func TestReadBasicSecretRejectsPasswordAndCmd(t *testing.T) {
+	t.Setenv("CHRONCAL_PASSWORD", "literal")
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "echo from-cmd")
+	if _, _, err := readBasicSecret(""); err == nil {
+		t.Fatal("expected error when password and password_cmd are both set")
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,15 @@
       nixpkgs,
       flake-utils,
     }:
-    flake-utils.lib.eachDefaultSystem (
+    {
+      # Home Manager module. It sits outside eachDefaultSystem because a
+      # module must not pin one build system; the consumer's pkgs picks it.
+      homeModules.default = import ./home-manager.nix { inherit self; };
+
+      # Alias under the historical attribute name.
+      homeManagerModules.default = self.homeModules.default;
+    }
+    // flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -50,6 +50,8 @@ in
         Settings for chroncal's config.toml.
         The module writes them to {file}`$XDG_CONFIG_HOME/chroncal/config.toml`.
         See the chroncal README for the supported keys.
+        Do not put a literal smtp.password here. The Nix store is
+        world-readable; use password_cmd for the secret instead.
       '';
       example = {
         ui = {

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -1,0 +1,76 @@
+# Home Manager module for chroncal.
+#
+# The shape follows the khal module in home-manager, scoped to what chroncal
+# reads from $XDG_CONFIG_HOME/chroncal/config.toml. chroncal stores accounts
+# in its database and the OS keyring, so this module exposes no account
+# options. Use the freeform settings option for every documented config key,
+# including smtp.password_cmd for command-retrieved passwords.
+{ self }:
+
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    optional
+    types
+    ;
+
+  cfg = config.programs.chroncal;
+  settingsFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.chroncal = {
+    enable = mkEnableOption "chroncal";
+
+    package = mkOption {
+      type = types.nullOr types.package;
+      # `or null` covers systems outside the flake's default systems.
+      default = self.packages.${pkgs.system}.default or null;
+      defaultText = lib.literalExpression "chroncal.packages.\${pkgs.system}.default";
+      description = ''
+        The chroncal package to install.
+        Set it to null to use a chroncal from another source.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+      };
+      default = { };
+      description = ''
+        Settings for chroncal's config.toml.
+        The module writes them to {file}`$XDG_CONFIG_HOME/chroncal/config.toml`.
+        See the chroncal README for the supported keys.
+      '';
+      example = {
+        ui = {
+          theme = "default";
+          week_start = "monday";
+        };
+        smtp = {
+          host = "smtp.example.com";
+          username = "me@example.com";
+          from = "me@example.com";
+          password_cmd = "pass show smtp/app-password";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = optional (cfg.package != null) cfg.package;
+
+    xdg.configFile."chroncal/config.toml" = mkIf (cfg.settings != { }) {
+      source = settingsFormat.generate "chroncal-config.toml" cfg.settings;
+    };
+  };
+}

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -12,14 +12,20 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/douglasdemoura/chroncal/internal/secretcmd"
 	"github.com/zalando/go-keyring"
 )
 
 // Credential holds authentication secrets for an account.
 type Credential struct {
-	AccountID          int64  `json:"account_id"`
-	Username           string `json:"username,omitempty"`
-	Password           string `json:"password,omitempty"`
+	AccountID int64  `json:"account_id"`
+	Username  string `json:"username,omitempty"`
+	Password  string `json:"password,omitempty"`
+	// PasswordCommand is a shell command whose first stdout line is the
+	// CalDAV basic-auth password. It is an alternative to a stored
+	// Password. The command runs at request time, not at store time. Set
+	// one of the two fields, never both. Example: "pass show caldav_password".
+	PasswordCommand    string `json:"password_cmd,omitempty"`
 	AccessToken        string `json:"access_token,omitempty"`
 	RefreshToken       string `json:"refresh_token,omitempty"`
 	TokenExpiry        string `json:"token_expiry,omitempty"` // RFC 3339
@@ -27,6 +33,28 @@ type Credential struct {
 	// OAuth client config (stored with credential, not in DB)
 	OAuthClientID     string `json:"oauth_client_id,omitempty"`
 	OAuthClientSecret string `json:"oauth_client_secret,omitempty"`
+}
+
+// errPasswordConflict reports a credential that sets both Password and
+// PasswordCommand. The source of the secret must stay unambiguous.
+var errPasswordConflict = errors.New("password and password_cmd are mutually exclusive; set one of them")
+
+// ResolvePassword returns the CalDAV basic-auth password for this credential.
+// A set PasswordCommand runs at call time. The secret is the first line of
+// stdout. Setting both Password and PasswordCommand is an error.
+func (c Credential) ResolvePassword() (string, error) {
+	switch {
+	case c.Password != "" && c.PasswordCommand != "":
+		return "", errPasswordConflict
+	case c.PasswordCommand != "":
+		secret, err := secretcmd.Run(c.PasswordCommand)
+		if err != nil {
+			return "", fmt.Errorf("password_cmd: %w", err)
+		}
+		return secret, nil
+	default:
+		return c.Password, nil
+	}
 }
 
 // CredentialStore provides read/write access to account credentials.

--- a/internal/auth/credential_password_cmd_test.go
+++ b/internal/auth/credential_password_cmd_test.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+)
+
+func TestCredential_ResolvePassword_Literal(t *testing.T) {
+	got, err := (Credential{Password: "secret123"}).ResolvePassword()
+	if err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	if got != "secret123" {
+		t.Errorf("ResolvePassword() = %q, want %q", got, "secret123")
+	}
+}
+
+func TestCredential_ResolvePassword_CommandKeepsFirstLine(t *testing.T) {
+	command := "printf 'from-cmd\\nmetadata\\n'"
+	if runtime.GOOS == "windows" {
+		command = "echo from-cmd"
+	}
+	got, err := (Credential{PasswordCommand: command}).ResolvePassword()
+	if err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	if got != "from-cmd" {
+		t.Errorf("ResolvePassword() = %q, want %q", got, "from-cmd")
+	}
+}
+
+func TestCredential_ResolvePassword_BothSetIsError(t *testing.T) {
+	_, err := (Credential{Password: "literal", PasswordCommand: "echo from-cmd"}).ResolvePassword()
+	if err == nil {
+		t.Fatal("ResolvePassword() error = nil, want an error when both password sources are set")
+	}
+	if !errors.Is(err, errPasswordConflict) {
+		t.Errorf("ResolvePassword() error = %v, want the mutual-exclusion error", err)
+	}
+}
+
+func TestCredential_ResolvePassword_CommandError(t *testing.T) {
+	command := "exit 3"
+	if runtime.GOOS == "windows" {
+		command = "exit /b 3"
+	}
+	if _, err := (Credential{PasswordCommand: command}).ResolvePassword(); err == nil {
+		t.Fatal("ResolvePassword() error = nil, want an error for a failing password command")
+	}
+}

--- a/internal/caldav/auth.go
+++ b/internal/caldav/auth.go
@@ -56,10 +56,15 @@ func httpClientFromCredential(cred auth.Credential, persist func(auth.Credential
 			}
 		}
 		return httpClient, nil
-	case cred.Password != "":
-		return webdav.HTTPClientWithBasicAuth(defaultHTTPClient, cred.Username, cred.Password), nil
 	default:
-		return nil, fmt.Errorf("credential has no password or access token")
+		password, err := cred.ResolvePassword()
+		if err != nil {
+			return nil, err
+		}
+		if password == "" {
+			return nil, fmt.Errorf("credential has no password, password_cmd, or access token")
+		}
+		return webdav.HTTPClientWithBasicAuth(defaultHTTPClient, cred.Username, password), nil
 	}
 }
 

--- a/internal/caldav/auth_test.go
+++ b/internal/caldav/auth_test.go
@@ -2,9 +2,11 @@ package caldav
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"io"
 	"net/http"
+	"runtime"
 	"testing"
 	"time"
 
@@ -214,5 +216,60 @@ func TestNewClientFromCredential_UsesBoundedHTTPClient(t *testing.T) {
 	}
 	if oauthClient.inner.Timeout != defaultHTTPTimeout {
 		t.Fatalf("inner timeout = %s, want %s", oauthClient.inner.Timeout, defaultHTTPTimeout)
+	}
+}
+
+func TestNewClientFromCredential_RunsPasswordCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX password command")
+	}
+
+	prevDefaultClient := defaultHTTPClient
+	var gotAuth string
+	defaultHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			gotAuth = r.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(http.NoBody),
+				Header:     make(http.Header),
+				Request:    r,
+			}, nil
+		}),
+	}
+	t.Cleanup(func() { defaultHTTPClient = prevDefaultClient })
+
+	client, err := NewClientFromCredential("https://example.com", auth.Credential{
+		Username:        "alice",
+		PasswordCommand: "printf 'from-cmd\\nmetadata\\n'",
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewClientFromCredential: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/resource", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("alice:from-cmd"))
+	if gotAuth != want {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, want)
+	}
+}
+
+func TestNewClientFromCredential_PasswordCommandConflict(t *testing.T) {
+	_, err := NewClientFromCredential("https://example.com", auth.Credential{
+		Username:        "alice",
+		Password:        "literal",
+		PasswordCommand: "echo from-cmd",
+	}, nil)
+	if err == nil {
+		t.Fatal("NewClientFromCredential error = nil, want mutual-exclusion error")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,16 +1,14 @@
 package config
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/secretcmd"
 	"github.com/spf13/viper"
 )
 
@@ -21,10 +19,10 @@ type SMTPConfig struct {
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
 	From     string `mapstructure:"from"`
-	// PasswordCommand is a shell command whose stdout is the SMTP password.
-	// It is an alternative to a hardcoded Password in the config file. The
-	// command runs at send time, not at load time. Set one of the two
-	// fields, never both. Example: "pass show smtp/app-password".
+	// PasswordCommand is a shell command whose first stdout line is the SMTP
+	// password. It is an alternative to a hardcoded Password in the config
+	// file. The command runs at send time, not at load time. Set one of the
+	// two fields, never both. Example: "pass show smtp/app-password".
 	PasswordCommand string `mapstructure:"password_cmd"`
 	// TLSMode controls how TLS is established for the SMTP connection.
 	// Valid values:
@@ -44,52 +42,23 @@ type SMTPConfig struct {
 var errSMTPPasswordConflict = errors.New("smtp.password and smtp.password_cmd are mutually exclusive; set one of them")
 
 // ResolvePassword returns the SMTP password for this configuration.
-// A set PasswordCommand runs at call time and its stdout becomes the
-// password. The output loses one trailing newline. The command runs through
-// the system shell, so it accepts arguments and pipes. Setting both
-// Password and PasswordCommand is an error: the source of the secret must
-// stay unambiguous.
+// A set PasswordCommand runs at call time. The secret is the first line of
+// stdout. The command runs through the system shell, so it accepts arguments
+// and pipes. Setting both Password and PasswordCommand is an error: the
+// source of the secret must stay unambiguous.
 func (c SMTPConfig) ResolvePassword() (string, error) {
 	switch {
 	case c.Password != "" && c.PasswordCommand != "":
 		return "", errSMTPPasswordConflict
 	case c.PasswordCommand != "":
-		return runPasswordCommand(c.PasswordCommand)
+		secret, err := secretcmd.Run(c.PasswordCommand)
+		if err != nil {
+			return "", fmt.Errorf("smtp.password_cmd: %w", err)
+		}
+		return secret, nil
 	default:
 		return c.Password, nil
 	}
-}
-
-// defaultPasswordCmdTimeout bounds how long smtp.password_cmd may run. A
-// helper that blocks must not stop the alarm email forever. notify.Email
-// runs from `alarm check` and from the installed service tick.
-const defaultPasswordCmdTimeout = 30 * time.Second
-
-// passwordCmdTimeout holds the active bound. A test sets it to a shorter
-// value.
-var passwordCmdTimeout = defaultPasswordCmdTimeout
-
-// runPasswordCommand executes a password-retrieval command and returns its
-// stdout. The error message omits stderr on purpose. Helper programs such as
-// password managers can print secrets there.
-func runPasswordCommand(command string) (string, error) {
-	shell, flag := "sh", "-c"
-	if runtime.GOOS == "windows" {
-		shell, flag = "cmd", "/c"
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), passwordCmdTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, shell, flag, command)
-	// A killed shell can leave a helper child that holds the output pipe.
-	// WaitDelay bounds that wait, so the deadline holds even when the
-	// shell forked its command instead of replacing itself.
-	cmd.WaitDelay = time.Second
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("run smtp.password_cmd %q: %w", command, err)
-	}
-	password := strings.TrimSuffix(string(out), "\n")
-	return strings.TrimSuffix(password, "\r"), nil
 }
 
 type SyncConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -18,6 +20,11 @@ type SMTPConfig struct {
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
 	From     string `mapstructure:"from"`
+	// PasswordCommand is a shell command whose stdout is the SMTP password.
+	// It is an alternative to a hardcoded Password in the config file. The
+	// command runs at send time, not at load time. Set one of the two
+	// fields, never both. Example: "pass show smtp/app-password".
+	PasswordCommand string `mapstructure:"password_cmd"`
 	// TLSMode controls how TLS is established for the SMTP connection.
 	// Valid values:
 	//   ""           – auto-detect: port 465 uses implicit TLS (SMTPS), all
@@ -29,6 +36,39 @@ type SMTPConfig struct {
 	//   "none"       – skip implicit TLS; delegates to smtp.SendMail which
 	//                  still negotiates STARTTLS when the server offers it.
 	TLSMode string `mapstructure:"tls"`
+}
+
+// ResolvePassword returns the SMTP password for this configuration.
+// A set PasswordCommand runs at call time and its stdout becomes the
+// password. The output loses one trailing newline. The command runs through
+// the system shell, so it accepts arguments and pipes. Setting both
+// Password and PasswordCommand is an error: the source of the secret must
+// stay unambiguous.
+func (c SMTPConfig) ResolvePassword() (string, error) {
+	switch {
+	case c.Password != "" && c.PasswordCommand != "":
+		return "", errors.New("smtp.password and smtp.password_cmd are mutually exclusive; set one of them")
+	case c.PasswordCommand != "":
+		return runPasswordCommand(c.PasswordCommand)
+	default:
+		return c.Password, nil
+	}
+}
+
+// runPasswordCommand executes a password-retrieval command and returns its
+// stdout. The error message omits stderr on purpose. Helper programs such as
+// password managers can print secrets there.
+func runPasswordCommand(command string) (string, error) {
+	shell, flag := "sh", "-c"
+	if runtime.GOOS == "windows" {
+		shell, flag = "cmd", "/c"
+	}
+	out, err := exec.CommandContext(context.Background(), shell, flag, command).Output()
+	if err != nil {
+		return "", fmt.Errorf("run smtp.password_cmd %q: %w", command, err)
+	}
+	password := strings.TrimSuffix(string(out), "\n")
+	return strings.TrimSuffix(password, "\r"), nil
 }
 
 type SyncConfig struct {
@@ -139,6 +179,7 @@ func newViper() *viper.Viper {
 	v.BindEnv("smtp.port")
 	v.BindEnv("smtp.username")
 	v.BindEnv("smtp.password")
+	v.BindEnv("smtp.password_cmd")
 	v.BindEnv("smtp.from")
 	v.BindEnv("smtp.tls")
 	v.BindEnv("sync.interval")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ import (
 // SMTPConfig holds SMTP connection settings for EMAIL action alarms.
 type SMTPConfig struct {
 	Host     string `mapstructure:"host"`
-	Port     int `mapstructure:"port"`
+	Port     int    `mapstructure:"port"`
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
 	From     string `mapstructure:"from"`
@@ -79,7 +79,12 @@ func runPasswordCommand(command string) (string, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), passwordCmdTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, shell, flag, command).Output()
+	cmd := exec.CommandContext(ctx, shell, flag, command)
+	// A killed shell can leave a helper child that holds the output pipe.
+	// WaitDelay bounds that wait, so the deadline holds even when the
+	// shell forked its command instead of replacing itself.
+	cmd.WaitDelay = time.Second
+	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("run smtp.password_cmd %q: %w", command, err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -16,7 +17,7 @@ import (
 // SMTPConfig holds SMTP connection settings for EMAIL action alarms.
 type SMTPConfig struct {
 	Host     string `mapstructure:"host"`
-	Port     int    `mapstructure:"port"`
+	Port     int `mapstructure:"port"`
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
 	From     string `mapstructure:"from"`
@@ -38,6 +39,10 @@ type SMTPConfig struct {
 	TLSMode string `mapstructure:"tls"`
 }
 
+// errSMTPPasswordConflict reports a config that sets both smtp.password and
+// smtp.password_cmd. The source of the secret must stay unambiguous.
+var errSMTPPasswordConflict = errors.New("smtp.password and smtp.password_cmd are mutually exclusive; set one of them")
+
 // ResolvePassword returns the SMTP password for this configuration.
 // A set PasswordCommand runs at call time and its stdout becomes the
 // password. The output loses one trailing newline. The command runs through
@@ -47,13 +52,22 @@ type SMTPConfig struct {
 func (c SMTPConfig) ResolvePassword() (string, error) {
 	switch {
 	case c.Password != "" && c.PasswordCommand != "":
-		return "", errors.New("smtp.password and smtp.password_cmd are mutually exclusive; set one of them")
+		return "", errSMTPPasswordConflict
 	case c.PasswordCommand != "":
 		return runPasswordCommand(c.PasswordCommand)
 	default:
 		return c.Password, nil
 	}
 }
+
+// defaultPasswordCmdTimeout bounds how long smtp.password_cmd may run. A
+// helper that blocks must not stop the alarm email forever. notify.Email
+// runs from `alarm check` and from the installed service tick.
+const defaultPasswordCmdTimeout = 30 * time.Second
+
+// passwordCmdTimeout holds the active bound. A test sets it to a shorter
+// value.
+var passwordCmdTimeout = defaultPasswordCmdTimeout
 
 // runPasswordCommand executes a password-retrieval command and returns its
 // stdout. The error message omits stderr on purpose. Helper programs such as
@@ -63,7 +77,9 @@ func runPasswordCommand(command string) (string, error) {
 	if runtime.GOOS == "windows" {
 		shell, flag = "cmd", "/c"
 	}
-	out, err := exec.CommandContext(context.Background(), shell, flag, command).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), passwordCmdTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, shell, flag, command).Output()
 	if err != nil {
 		return "", fmt.Errorf("run smtp.password_cmd %q: %w", command, err)
 	}
@@ -148,6 +164,12 @@ func Load() (Config, error) {
 	var cfg Config
 	if err := v.Unmarshal(&cfg); err != nil {
 		return Config{}, fmt.Errorf("parse config file: %w", err)
+	}
+	// Reject an ambiguous password source at load time. The error would
+	// otherwise surface only at send time, when an alarm fires. The check
+	// in ResolvePassword stays as a second guard.
+	if cfg.SMTP.Password != "" && cfg.SMTP.PasswordCommand != "" {
+		return Config{}, errSMTPPasswordConflict
 	}
 	if cfg.SMTP.Port == 0 {
 		cfg.SMTP.Port = DefaultSMTPPort

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"time"
 )
 
 // mustLoad calls Load and fails the test on error. Use it in tests that
@@ -176,8 +175,8 @@ func TestSMTPConfig_ResolvePassword_Literal(t *testing.T) {
 	}
 }
 
-func TestSMTPConfig_ResolvePassword_CommandTrimsTrailingNewline(t *testing.T) {
-	command := "printf 'from-cmd\\n'"
+func TestSMTPConfig_ResolvePassword_CommandKeepsFirstLine(t *testing.T) {
+	command := "printf 'from-cmd\\nmetadata\\n'"
 	if runtime.GOOS == "windows" {
 		command = "echo from-cmd"
 	}
@@ -187,7 +186,7 @@ func TestSMTPConfig_ResolvePassword_CommandTrimsTrailingNewline(t *testing.T) {
 		t.Fatalf("ResolvePassword() error = %v", err)
 	}
 	if got != "from-cmd" {
-		t.Errorf("ResolvePassword() = %q, want %q (trailing newline must be trimmed)", got, "from-cmd")
+		t.Errorf("ResolvePassword() = %q, want %q (first stdout line is the secret)", got, "from-cmd")
 	}
 }
 
@@ -213,34 +212,6 @@ func TestSMTPConfig_ResolvePassword_BothSetIsError(t *testing.T) {
 	cfg := SMTPConfig{Password: "literal", PasswordCommand: "echo from-cmd"}
 	if _, err := cfg.ResolvePassword(); err == nil {
 		t.Fatal("ResolvePassword() error = nil, want an error when both password sources are set")
-	}
-}
-
-// TestRunPasswordCommandTimeout checks that a helper which blocks cannot
-// hold the alarm email forever. The test shortens passwordCmdTimeout, so it
-// stays fast and deterministic.
-func TestRunPasswordCommandTimeout(t *testing.T) {
-	oldTimeout := passwordCmdTimeout
-	passwordCmdTimeout = 200 * time.Millisecond
-	t.Cleanup(func() { passwordCmdTimeout = oldTimeout })
-
-	// The background job forces the shell to fork instead of replace
-	// itself, so the killed shell leaves a helper child behind. That child
-	// holds the output pipe, which is the exact shape the deadline must
-	// survive (it hung the ubuntu CI runner once). The Windows variant has
-	// no pipe-holding grandchild; it exercises the plain deadline only.
-	command := "sleep 60 & wait"
-	if runtime.GOOS == "windows" {
-		command = "ping -n 60 127.0.0.1"
-	}
-
-	start := time.Now()
-	_, err := runPasswordCommand(command)
-	if err == nil {
-		t.Fatal("runPasswordCommand error = nil, want a timeout error")
-	}
-	if elapsed := time.Since(start); elapsed > 5*time.Second {
-		t.Fatalf("runPasswordCommand took %v, want a return before the command ends", elapsed)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -103,6 +104,87 @@ from = "noreply@example.com"
 	}
 	if cfg.SMTP.From != "noreply@example.com" {
 		t.Errorf("SMTP.From = %q, want %q", cfg.SMTP.From, "noreply@example.com")
+	}
+}
+
+func TestLoad_SMTPPasswordCmdFromFile(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "chroncal")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`
+[smtp]
+host = "smtp.example.com"
+password_cmd = "pass show smtp/app-password"
+`), 0o644)
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_SMTP_HOST", "")
+	t.Setenv("CHRONCAL_SMTP_PASSWORD", "")
+	t.Setenv("CHRONCAL_SMTP_PASSWORD_CMD", "")
+
+	cfg := mustLoad(t)
+	if cfg.SMTP.PasswordCommand != "pass show smtp/app-password" {
+		t.Errorf("SMTP.PasswordCommand = %q, want %q", cfg.SMTP.PasswordCommand, "pass show smtp/app-password")
+	}
+}
+
+func TestLoad_SMTPPasswordCmdFromEnv(t *testing.T) {
+	t.Setenv("CHRONCAL_SMTP_PASSWORD_CMD", "secret-tool lookup smtp host")
+
+	cfg := mustLoad(t)
+	if cfg.SMTP.PasswordCommand != "secret-tool lookup smtp host" {
+		t.Errorf("SMTP.PasswordCommand = %q, want %q", cfg.SMTP.PasswordCommand, "secret-tool lookup smtp host")
+	}
+}
+
+func TestSMTPConfig_ResolvePassword_Literal(t *testing.T) {
+	cfg := SMTPConfig{Password: "secret123"}
+	got, err := cfg.ResolvePassword()
+	if err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	if got != "secret123" {
+		t.Errorf("ResolvePassword() = %q, want %q", got, "secret123")
+	}
+}
+
+func TestSMTPConfig_ResolvePassword_CommandTrimsTrailingNewline(t *testing.T) {
+	command := "printf 'from-cmd\\n'"
+	if runtime.GOOS == "windows" {
+		command = "echo from-cmd"
+	}
+	cfg := SMTPConfig{PasswordCommand: command}
+	got, err := cfg.ResolvePassword()
+	if err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	if got != "from-cmd" {
+		t.Errorf("ResolvePassword() = %q, want %q (trailing newline must be trimmed)", got, "from-cmd")
+	}
+}
+
+func TestSMTPConfig_ResolvePassword_CommandError(t *testing.T) {
+	command := "exit 3"
+	if runtime.GOOS == "windows" {
+		command = "exit /b 3"
+	}
+	cfg := SMTPConfig{PasswordCommand: command}
+	if _, err := cfg.ResolvePassword(); err == nil {
+		t.Fatal("ResolvePassword() error = nil, want an error for a failing password command")
+	}
+}
+
+func TestSMTPConfig_ResolvePassword_MissingCommand(t *testing.T) {
+	cfg := SMTPConfig{PasswordCommand: "chroncal-definitely-not-a-real-binary-1234"}
+	if _, err := cfg.ResolvePassword(); err == nil {
+		t.Fatal("ResolvePassword() error = nil, want an error for a missing password command")
+	}
+}
+
+func TestSMTPConfig_ResolvePassword_BothSetIsError(t *testing.T) {
+	cfg := SMTPConfig{Password: "literal", PasswordCommand: "echo from-cmd"}
+	if _, err := cfg.ResolvePassword(); err == nil {
+		t.Fatal("ResolvePassword() error = nil, want an error when both password sources are set")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -227,7 +227,8 @@ func TestRunPasswordCommandTimeout(t *testing.T) {
 	// The background job forces the shell to fork instead of replace
 	// itself, so the killed shell leaves a helper child behind. That child
 	// holds the output pipe, which is the exact shape the deadline must
-	// survive (it hung the ubuntu CI runner once).
+	// survive (it hung the ubuntu CI runner once). The Windows variant has
+	// no pipe-holding grandchild; it exercises the plain deadline only.
 	command := "sleep 60 & wait"
 	if runtime.GOOS == "windows" {
 		command = "ping -n 60 127.0.0.1"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 // mustLoad calls Load and fails the test on error. Use it in tests that
@@ -137,6 +139,32 @@ func TestLoad_SMTPPasswordCmdFromEnv(t *testing.T) {
 	}
 }
 
+// TestLoad_SMTPPasswordAndPasswordCmdBothSetIsError checks that Load rejects
+// a config with both password sources. The error must surface at load time,
+// not at send time when an alarm fires.
+func TestLoad_SMTPPasswordAndPasswordCmdBothSetIsError(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "chroncal")
+	os.MkdirAll(configDir, 0o755)
+	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`
+[smtp]
+password = "literal-secret"
+password_cmd = "pass show smtp/app-password"
+`), 0o644)
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_SMTP_PASSWORD", "")
+	t.Setenv("CHRONCAL_SMTP_PASSWORD_CMD", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want an error when both password sources are set")
+	}
+	if !errors.Is(err, errSMTPPasswordConflict) {
+		t.Errorf("Load() error = %v, want the mutual-exclusion error", err)
+	}
+}
+
 func TestSMTPConfig_ResolvePassword_Literal(t *testing.T) {
 	cfg := SMTPConfig{Password: "secret123"}
 	got, err := cfg.ResolvePassword()
@@ -185,6 +213,29 @@ func TestSMTPConfig_ResolvePassword_BothSetIsError(t *testing.T) {
 	cfg := SMTPConfig{Password: "literal", PasswordCommand: "echo from-cmd"}
 	if _, err := cfg.ResolvePassword(); err == nil {
 		t.Fatal("ResolvePassword() error = nil, want an error when both password sources are set")
+	}
+}
+
+// TestRunPasswordCommandTimeout checks that a helper which blocks cannot
+// hold the alarm email forever. The test shortens passwordCmdTimeout, so it
+// stays fast and deterministic.
+func TestRunPasswordCommandTimeout(t *testing.T) {
+	oldTimeout := passwordCmdTimeout
+	passwordCmdTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { passwordCmdTimeout = oldTimeout })
+
+	command := "sleep 60"
+	if runtime.GOOS == "windows" {
+		command = "ping -n 60 127.0.0.1"
+	}
+
+	start := time.Now()
+	_, err := runPasswordCommand(command)
+	if err == nil {
+		t.Fatal("runPasswordCommand error = nil, want a timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("runPasswordCommand took %v, want a return before the command ends", elapsed)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -224,7 +224,11 @@ func TestRunPasswordCommandTimeout(t *testing.T) {
 	passwordCmdTimeout = 200 * time.Millisecond
 	t.Cleanup(func() { passwordCmdTimeout = oldTimeout })
 
-	command := "sleep 60"
+	// The background job forces the shell to fork instead of replace
+	// itself, so the killed shell leaves a helper child behind. That child
+	// holds the output pipe, which is the exact shape the deadline must
+	// survive (it hung the ubuntu CI runner once).
+	command := "sleep 60 & wait"
 	if runtime.GOOS == "windows" {
 		command = "ping -n 60 127.0.0.1"
 	}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -262,7 +262,11 @@ func Email(da alarm.DueAlarm, smtpCfg config.SMTPConfig, policy ExecutionPolicy)
 
 	var auth smtp.Auth
 	if smtpCfg.Username != "" {
-		auth = smtp.PlainAuth("", smtpCfg.Username, smtpCfg.Password, smtpCfg.Host)
+		password, err := smtpCfg.ResolvePassword()
+		if err != nil {
+			return err
+		}
+		auth = smtp.PlainAuth("", smtpCfg.Username, password, smtpCfg.Host)
 	}
 
 	if useImplicitTLS(smtpCfg) {

--- a/internal/secretcmd/secretcmd.go
+++ b/internal/secretcmd/secretcmd.go
@@ -1,0 +1,58 @@
+package secretcmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// DefaultTimeout bounds how long a password command may run. A helper that
+// blocks must not stop an alarm email or a CalDAV request forever.
+const DefaultTimeout = 30 * time.Second
+
+// timeout holds the active bound. A test sets it to a shorter value.
+var timeout = DefaultTimeout
+
+// Run executes command through the system shell and returns the secret.
+// The secret is the first line of stdout. A trailing CR on that line is
+// removed. Later lines are ignored. Helper programs such as pass print
+// metadata after the secret.
+//
+// The command has a deadline of timeout. Stderr is discarded so a helper
+// cannot write a secret to the journal.
+func Run(command string) (string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return "", fmt.Errorf("password command is empty")
+	}
+	shell, flag := "sh", "-c"
+	if runtime.GOOS == "windows" {
+		shell, flag = "cmd", "/c"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, shell, flag, command)
+	// A killed shell can leave a helper child that holds the output pipe.
+	// WaitDelay bounds that wait, so the deadline holds even when the
+	// shell forked its command instead of replacing itself.
+	cmd.WaitDelay = time.Second
+	cmd.Stderr = io.Discard
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("run password command %q: %w", command, err)
+	}
+	secret := firstLine(string(out))
+	if secret == "" {
+		return "", fmt.Errorf("password command %q returned an empty secret", command)
+	}
+	return secret, nil
+}
+
+func firstLine(out string) string {
+	line, _, _ := strings.Cut(out, "\n")
+	return strings.TrimSuffix(line, "\r")
+}

--- a/internal/secretcmd/secretcmd_test.go
+++ b/internal/secretcmd/secretcmd_test.go
@@ -1,0 +1,93 @@
+package secretcmd
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestRun_KeepsFirstLine(t *testing.T) {
+	command := "printf 'from-cmd\\nmetadata\\n'"
+	if runtime.GOOS == "windows" {
+		command = "echo from-cmd"
+	}
+	got, err := Run(command)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got != "from-cmd" {
+		t.Errorf("Run() = %q, want %q", got, "from-cmd")
+	}
+}
+
+func TestRun_DiscardsStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX redirection")
+	}
+	got, err := Run("printf 'from-cmd\\n'; printf 'noise\\n' >&2")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got != "from-cmd" {
+		t.Errorf("Run() = %q, want %q", got, "from-cmd")
+	}
+}
+
+func TestRun_CommandError(t *testing.T) {
+	command := "exit 3"
+	if runtime.GOOS == "windows" {
+		command = "exit /b 3"
+	}
+	if _, err := Run(command); err == nil {
+		t.Fatal("Run() error = nil, want an error for a failing command")
+	}
+}
+
+func TestRun_MissingCommand(t *testing.T) {
+	if _, err := Run("chroncal-definitely-not-a-real-binary-1234"); err == nil {
+		t.Fatal("Run() error = nil, want an error for a missing command")
+	}
+}
+
+func TestRun_EmptyCommand(t *testing.T) {
+	if _, err := Run("   "); err == nil {
+		t.Fatal("Run() error = nil, want an error for an empty command")
+	}
+}
+
+func TestRun_EmptySecret(t *testing.T) {
+	command := "printf '\\n'"
+	if runtime.GOOS == "windows" {
+		command = "echo."
+	}
+	if _, err := Run(command); err == nil {
+		t.Fatal("Run() error = nil, want an error for an empty secret")
+	}
+}
+
+// TestRunTimeout checks that a helper which blocks cannot hold the caller
+// forever. The test shortens timeout, so it stays fast and deterministic.
+func TestRunTimeout(t *testing.T) {
+	oldTimeout := timeout
+	timeout = 200 * time.Millisecond
+	t.Cleanup(func() { timeout = oldTimeout })
+
+	// The background job forces the shell to fork instead of replace
+	// itself, so the killed shell leaves a helper child behind. That child
+	// holds the output pipe, which is the exact shape the deadline must
+	// survive (it hung the ubuntu CI runner once). The Windows variant has
+	// no pipe-holding grandchild; it exercises the plain deadline only.
+	command := "sleep 60 & wait"
+	if runtime.GOOS == "windows" {
+		command = "ping -n 60 127.0.0.1"
+	}
+
+	start := time.Now()
+	_, err := Run(command)
+	if err == nil {
+		t.Fatal("Run error = nil, want a timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Run took %v, want a return before the command ends", elapsed)
+	}
+}

--- a/internal/tui/account_settings_dialog.go
+++ b/internal/tui/account_settings_dialog.go
@@ -373,8 +373,9 @@ func (m AccountOAuthConfigDialogModel) View() string {
 // StoreCredential writes; the account identity (server URL, username) is
 // preserved untouched.
 type AccountCredentialsUpdateSubmittedMsg struct {
-	AccountID int64
-	Secret    string
+	AccountID       int64
+	Secret          string
+	PasswordCommand string
 }
 
 // AccountCredentialsUpdateClosedMsg reports a cancel from the credential
@@ -398,7 +399,7 @@ type AccountCredentialsDialogModel struct {
 
 // NewAccountCredentialsDialogModel builds the credential-rotation form for one
 // account. Bearer auth collects a token. Every other basic-or-bearer type
-// collects a password. That matches the field the calendar connect flow uses.
+// collects a password or a password command.
 func NewAccountCredentialsDialogModel(
 	accountID int64,
 	accountName, authType, username string,
@@ -406,23 +407,47 @@ func NewAccountCredentialsDialogModel(
 ) AccountCredentialsDialogModel {
 	var fieldLabel string
 	secret := newPasswordField()
+	var items []FormItem
 	if accountAuthIsBearer(authType) {
 		fieldLabel = "Token"
 		secret.SetPlaceholder("paste your API token")
+		items = []FormItem{{Label: fieldLabel, Field: secret, Required: true}}
 	} else {
 		fieldLabel = "Password"
+		items = []FormItem{
+			{Label: fieldLabel, Field: secret, Required: true},
+			{Label: "Password cmd", Field: newPasswordCmdField("")},
+		}
 	}
 	styles := DefaultFormStyles()
 	styles.LabelLayout = LabelTop
 	form := NewForm(
 		"Update",
 		styles,
-		FormItem{Label: fieldLabel, Field: secret, Required: true},
+		items...,
 	)
+	form.OnRebuild(func(f *Form) {
+		if accountAuthIsBearer(authType) {
+			return
+		}
+		cmdVal := strings.TrimSpace(f.Field(1).(*TextField).Value())
+		f.SetItemRequired(0, cmdVal == "")
+	})
 	form.OnSubmit(func(f *Form) tea.Cmd {
 		msg := AccountCredentialsUpdateSubmittedMsg{
 			AccountID: accountID,
 			Secret:    strings.TrimSpace(f.Field(0).(*TextField).Value()),
+		}
+		if !accountAuthIsBearer(authType) {
+			msg.PasswordCommand = strings.TrimSpace(f.Field(1).(*TextField).Value())
+			if msg.Secret != "" && msg.PasswordCommand != "" {
+				f.SetError(1, "Set password or password cmd, not both")
+				return nil
+			}
+			if msg.Secret == "" && msg.PasswordCommand == "" {
+				f.SetError(0, "Credential is required")
+				return nil
+			}
 		}
 		return func() tea.Msg { return msg }
 	})

--- a/internal/tui/account_settings_dialog_test.go
+++ b/internal/tui/account_settings_dialog_test.go
@@ -213,8 +213,42 @@ func TestAccountCredentialsDialogBasicCollectsPassword(t *testing.T) {
 		t.Fatal("basic credential form did not submit")
 	}
 	msg, ok := cmd().(AccountCredentialsUpdateSubmittedMsg)
-	if !ok || msg.AccountID != 7 || msg.Secret != "hunter2" {
+	if !ok || msg.AccountID != 7 || msg.Secret != "hunter2" || msg.PasswordCommand != "" {
 		t.Fatalf("basic submission = %#v, want account 7 secret hunter2", cmd())
+	}
+}
+
+func TestAccountCredentialsDialogBasicCollectsPasswordCmd(t *testing.T) {
+	m := NewAccountCredentialsDialogModel(7, "Work", "basic", "alice@example.com", NewTheme(true)).
+		SetSize(80, 30)
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "Password cmd") {
+		t.Fatalf("basic dialog missing Password cmd field:\n%s", view)
+	}
+	m.form.Field(1).(*TextField).SetValue("pass show caldav_password")
+	if m.form.onRebuild != nil {
+		m.form.onRebuild(&m.form)
+	}
+	form, cmd := m.form.Submit()
+	m.form = form
+	if cmd == nil {
+		t.Fatal("password cmd form did not submit")
+	}
+	msg, ok := cmd().(AccountCredentialsUpdateSubmittedMsg)
+	if !ok || msg.AccountID != 7 || msg.Secret != "" || msg.PasswordCommand != "pass show caldav_password" {
+		t.Fatalf("password cmd submission = %#v", cmd())
+	}
+}
+
+func TestAccountCredentialsDialogRejectsPasswordAndCmd(t *testing.T) {
+	m := NewAccountCredentialsDialogModel(7, "Work", "basic", "alice@example.com", NewTheme(true)).
+		SetSize(80, 30)
+	m.form.Field(0).(*TextField).SetValue("hunter2")
+	m.form.Field(1).(*TextField).SetValue("pass show caldav_password")
+	form, cmd := m.form.Submit()
+	m.form = form
+	if cmd != nil {
+		t.Fatalf("submit should reject password and password cmd together, got %T", cmd())
 	}
 }
 
@@ -224,6 +258,9 @@ func TestAccountCredentialsDialogBearerCollectsToken(t *testing.T) {
 	view := stripANSI(m.View())
 	if !strings.Contains(view, "Token") || !strings.Contains(view, "New token for API Token Account") {
 		t.Fatalf("bearer dialog missing Token field/context:\n%s", view)
+	}
+	if strings.Contains(view, "Password cmd") {
+		t.Fatalf("bearer dialog should not collect a password cmd:\n%s", view)
 	}
 	m.form.Field(0).(*TextField).SetValue("abc123")
 	form, cmd := m.form.Submit()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1537,11 +1537,11 @@ func (m Model) finishOAuthCredentialStore(msg oauthCredentialStoredMsg) (Model, 
 
 // updateAccountCredentials rotates one account's secret in place. The stored
 // credential is loaded so its non-secret identity (username, client config) is
-// kept. Only the password (basic) or access token (bearer) is replaced.
+// kept. Only the password, password command, or access token is replaced.
 // StoreCredential re-checks the account fingerprint under the lifecycle lock.
 // A concurrent rename or removal then aborts the write instead of a corrupt
 // write.
-func (m Model) updateAccountCredentials(configured account.Account, secret string) tea.Cmd {
+func (m Model) updateAccountCredentials(configured account.Account, secret, passwordCmd string) tea.Cmd {
 	storedMsg := func(err error) accountCredentialStoredMsg {
 		return accountCredentialStoredMsg{
 			accountID: configured.ID,
@@ -1562,8 +1562,12 @@ func (m Model) updateAccountCredentials(configured account.Account, secret strin
 		}
 		if accountAuthIsBearer(configured.AuthType) {
 			cred.AccessToken = secret
+		} else if strings.TrimSpace(passwordCmd) != "" {
+			cred.Password = ""
+			cred.PasswordCommand = strings.TrimSpace(passwordCmd)
 		} else {
 			cred.Password = secret
+			cred.PasswordCommand = ""
 		}
 		err = m.app.Accounts.StoreCredential(ctx, configured.ID, fingerprint, cred, credStore)
 		return storedMsg(err)
@@ -3461,7 +3465,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncStatus = "Updating credentials…"
 		return m, tea.Batch(
 			m.syncSpinner.Tick,
-			m.updateAccountCredentials(configured, msg.Secret),
+			m.updateAccountCredentials(configured, msg.Secret, msg.PasswordCommand),
 		)
 
 	case AccountCredentialsUpdateClosedMsg:
@@ -3527,6 +3531,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cred.AccessToken = msg.Secret
 		} else {
 			cred.Password = msg.Secret
+			cred.PasswordCommand = strings.TrimSpace(msg.PasswordCommand)
 		}
 		m.syncing = true
 		m.syncStatus = "Adding account…"
@@ -4046,7 +4051,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			meta, err := caldav.VerifyCalendarURL(ctx, req.URL, req.Username, req.Password, req.AuthType, req.AllowInsecure)
+			password := req.Password
+			if strings.TrimSpace(req.PasswordCommand) != "" {
+				resolved, resolveErr := auth.Credential{PasswordCommand: req.PasswordCommand}.ResolvePassword()
+				if resolveErr != nil {
+					return CalendarTestResultMsg{Message: resolveErr.Error()}
+				}
+				password = resolved
+			}
+			meta, err := caldav.VerifyCalendarURL(ctx, req.URL, req.Username, password, req.AuthType, req.AllowInsecure)
 			if err != nil {
 				return CalendarTestResultMsg{Message: err.Error()}
 			}

--- a/internal/tui/calendar_dialog.go
+++ b/internal/tui/calendar_dialog.go
@@ -79,6 +79,7 @@ type CalendarDiscoveryRequestedMsg struct {
 	Username          string
 	AuthType          string
 	Secret            string
+	PasswordCommand   string
 	OAuthClientID     string
 	OAuthClientSecret string
 	AllowInsecure     bool
@@ -124,11 +125,12 @@ type CalendarKeepLocalRequestedMsg struct {
 // CalendarTestRequestedMsg is emitted when the user presses Test. The parent
 // runs a CalDAV authenticated ping and replies with CalendarTestResultMsg.
 type CalendarTestRequestedMsg struct {
-	URL           string
-	Username      string
-	AuthType      string
-	Password      string
-	AllowInsecure bool
+	URL             string
+	Username        string
+	AuthType        string
+	Password        string
+	PasswordCommand string
+	AllowInsecure   bool
 }
 
 // CalendarTestResultMsg is the outcome of a CalendarTestRequestedMsg.
@@ -168,13 +170,14 @@ const (
 	calDAVIdxUsername
 	calDAVIdxAuth
 	calDAVIdxSecret
+	calDAVIdxPasswordCmd
 	calDAVIdxAllowInsecure
 )
 
 const (
 	calDAVIdxOAuthClientID      = calDAVIdxSecret
-	calDAVIdxOAuthClientSecret  = calDAVIdxAllowInsecure
-	calDAVIdxOAuthAllowInsecure = calDAVIdxAllowInsecure + 1
+	calDAVIdxOAuthClientSecret  = calDAVIdxPasswordCmd
+	calDAVIdxOAuthAllowInsecure = calDAVIdxAllowInsecure
 )
 
 var authOptions = []SelectOption{
@@ -520,6 +523,7 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 		FormItem{Label: "Username", Field: newUsernameField(usernamePrefill), Required: true},
 		FormItem{Label: "Auth", Field: newAuthField("basic"), Required: true},
 		FormItem{Label: "Password", Field: newPasswordField(), Required: true},
+		FormItem{Label: "Password cmd", Field: newPasswordCmdField("")},
 		FormItem{Label: "HTTP", Field: insecure},
 	)
 	form.SetActionButton("Test", Button, func() tea.Msg {
@@ -530,8 +534,8 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 	})
 
 	var snapshot struct {
-		secret, clientID, clientSecret string
-		allowInsecure                  bool
+		secret, passwordCmd, clientID, clientSecret string
+		allowInsecure                               bool
 	}
 	oauthLayout := new(bool)
 	snapshotTail := func(f *Form) {
@@ -542,6 +546,7 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 			return
 		}
 		snapshot.secret = f.Field(calDAVIdxSecret).(*TextField).Value()
+		snapshot.passwordCmd = f.Field(calDAVIdxPasswordCmd).(*TextField).Value()
 		snapshot.allowInsecure = f.Field(calDAVIdxAllowInsecure).(*CheckboxField).Checked()
 	}
 	appendTail := func(f *Form, authType string) {
@@ -560,8 +565,10 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 		}
 		secret := newPasswordField()
 		secret.SetValue(snapshot.secret)
+		cmdField := newPasswordCmdField(snapshot.passwordCmd)
 		f.AppendItems(
 			FormItem{Label: "Password", Field: secret, Required: true},
+			FormItem{Label: "Password cmd", Field: cmdField},
 			FormItem{Label: "HTTP", Field: allow},
 		)
 		*oauthLayout = false
@@ -576,12 +583,17 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 		}
 		if !*oauthLayout {
 			secret := f.Field(calDAVIdxSecret).(*TextField)
+			cmdField := f.Field(calDAVIdxPasswordCmd).(*TextField)
 			if authType == "bearer" {
 				f.SetItemLabel(calDAVIdxSecret, "Token")
 				secret.SetPlaceholder("paste your API token")
+				cmdField.SetDisabled(true)
+				f.SetItemRequired(calDAVIdxSecret, true)
 			} else {
 				f.SetItemLabel(calDAVIdxSecret, "Password")
 				secret.SetPlaceholder("your password")
+				cmdField.SetDisabled(false)
+				f.SetItemRequired(calDAVIdxSecret, strings.TrimSpace(cmdField.Value()) == "")
 			}
 		}
 
@@ -640,8 +652,18 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 			}
 		} else {
 			msg.Secret = f.Field(calDAVIdxSecret).(*TextField).Value()
+			msg.PasswordCommand = strings.TrimSpace(f.Field(calDAVIdxPasswordCmd).(*TextField).Value())
 			msg.AllowInsecure = f.Field(calDAVIdxAllowInsecure).(*CheckboxField).Checked()
-			if strings.TrimSpace(msg.Secret) == "" {
+			if accountAuthIsBearer(msg.AuthType) {
+				msg.PasswordCommand = ""
+				if strings.TrimSpace(msg.Secret) == "" {
+					f.SetError(calDAVIdxSecret, "Credential is required")
+					return nil
+				}
+			} else if strings.TrimSpace(msg.Secret) != "" && msg.PasswordCommand != "" {
+				f.SetError(calDAVIdxPasswordCmd, "Set password or password cmd, not both")
+				return nil
+			} else if strings.TrimSpace(msg.Secret) == "" && msg.PasswordCommand == "" {
 				f.SetError(calDAVIdxSecret, "Credential is required")
 				return nil
 			}
@@ -763,6 +785,13 @@ func newPasswordField() *TextField {
 	f := NewTextField("your password")
 	f.SetCharLimit(256)
 	f.SetEchoPassword(true)
+	return f
+}
+
+func newPasswordCmdField(value string) *TextField {
+	f := NewTextField("pass show caldav_password")
+	f.SetValue(value)
+	f.SetCharLimit(512)
 	return f
 }
 
@@ -1235,11 +1264,20 @@ func (m CalendarDialogModel) handleTestPressed() (CalendarDialogModel, tea.Cmd) 
 	user := strings.TrimSpace(m.form.Field(calDAVIdxUsername).(*TextField).Value())
 	auth := m.form.Field(calDAVIdxAuth).(*SelectField).Value()
 	pass := m.form.Field(calDAVIdxSecret).(*TextField).Value()
+	passwordCmd := strings.TrimSpace(m.form.Field(calDAVIdxPasswordCmd).(*TextField).Value())
 	ins := m.form.Field(calDAVIdxAllowInsecure).(*CheckboxField).Checked()
+	if accountAuthIsBearer(auth) {
+		passwordCmd = ""
+	}
 
-	if url == "" || user == "" || pass == "" {
+	if url == "" || user == "" || (strings.TrimSpace(pass) == "" && passwordCmd == "") {
 		m.testStatus = lipgloss.NewStyle().Foreground(m.theme.Error).
 			Render("✗ Fill URL, Username, and Password first")
+		return m, nil
+	}
+	if strings.TrimSpace(pass) != "" && passwordCmd != "" {
+		m.testStatus = lipgloss.NewStyle().Foreground(m.theme.Error).
+			Render("✗ Set password or password cmd, not both")
 		return m, nil
 	}
 
@@ -1247,11 +1285,12 @@ func (m CalendarDialogModel) handleTestPressed() (CalendarDialogModel, tea.Cmd) 
 		Render("Testing…")
 	return m, func() tea.Msg {
 		return CalendarTestRequestedMsg{
-			URL:           url,
-			Username:      user,
-			AuthType:      auth,
-			Password:      pass,
-			AllowInsecure: ins,
+			URL:             url,
+			Username:        user,
+			AuthType:        auth,
+			Password:        pass,
+			PasswordCommand: passwordCmd,
+			AllowInsecure:   ins,
 		}
 	}
 }

--- a/internal/tui/calendar_dialog_password_cmd_test.go
+++ b/internal/tui/calendar_dialog_password_cmd_test.go
@@ -1,0 +1,64 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAccountDialog_PasswordCmdSubmit(t *testing.T) {
+	m := oauthDialogFixture(t, "basic")
+	m.form.Field(calDAVIdxServer).(*TextField).SetValue("https://example.com/dav/")
+	m.form.Field(calDAVIdxUsername).(*TextField).SetValue("alice")
+	m.form.Field(calDAVIdxPasswordCmd).(*TextField).SetValue("pass show caldav_password")
+	m.form.onRebuild(&m.form)
+
+	cmd := m.form.onSubmit(&m.form)
+	if cmd == nil {
+		t.Fatal("submit returned nil; password cmd should satisfy the credential")
+	}
+	discovery, ok := cmd().(CalendarDiscoveryRequestedMsg)
+	if !ok {
+		t.Fatalf("expected CalendarDiscoveryRequestedMsg, got %T", cmd())
+	}
+	if discovery.PasswordCommand != "pass show caldav_password" {
+		t.Errorf("PasswordCommand = %q, want pass show caldav_password", discovery.PasswordCommand)
+	}
+	if strings.TrimSpace(discovery.Secret) != "" {
+		t.Errorf("Secret = %q, want empty when password cmd is set", discovery.Secret)
+	}
+}
+
+func TestAccountDialog_PasswordAndCmdConflict(t *testing.T) {
+	m := oauthDialogFixture(t, "basic")
+	m.form.Field(calDAVIdxServer).(*TextField).SetValue("https://example.com/dav/")
+	m.form.Field(calDAVIdxUsername).(*TextField).SetValue("alice")
+	m.form.Field(calDAVIdxSecret).(*TextField).SetValue("hunter2")
+	m.form.Field(calDAVIdxPasswordCmd).(*TextField).SetValue("pass show caldav_password")
+
+	if cmd := m.form.onSubmit(&m.form); cmd != nil {
+		t.Fatalf("submit should reject password and password cmd together, got %T", cmd())
+	}
+}
+
+func TestAccountDialog_BearerIgnoresPasswordCmd(t *testing.T) {
+	m := oauthDialogFixture(t, "bearer")
+	m.form.Field(calDAVIdxServer).(*TextField).SetValue("https://example.com/dav/")
+	m.form.Field(calDAVIdxUsername).(*TextField).SetValue("alice")
+	m.form.Field(calDAVIdxSecret).(*TextField).SetValue("token-value")
+	m.form.Field(calDAVIdxPasswordCmd).(*TextField).SetValue("pass show caldav_password")
+
+	cmd := m.form.onSubmit(&m.form)
+	if cmd == nil {
+		t.Fatal("bearer submit returned nil")
+	}
+	discovery, ok := cmd().(CalendarDiscoveryRequestedMsg)
+	if !ok {
+		t.Fatalf("expected CalendarDiscoveryRequestedMsg, got %T", cmd())
+	}
+	if discovery.Secret != "token-value" {
+		t.Errorf("Secret = %q, want token-value", discovery.Secret)
+	}
+	if discovery.PasswordCommand != "" {
+		t.Errorf("PasswordCommand = %q, want empty for bearer", discovery.PasswordCommand)
+	}
+}

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -2253,6 +2253,14 @@ func (f *Form) SetItemLabel(i int, label string) {
 	f.applyFieldWidths()
 }
 
+// SetItemRequired updates the required flag of the item at index i.
+func (f *Form) SetItemRequired(i int, required bool) {
+	if i < 0 || i >= len(f.items) {
+		return
+	}
+	f.items[i].Required = required
+}
+
 func (f Form) ItemCount() int { return len(f.items) }
 func (f Form) Focused() int   { return f.focused }
 func (f Form) HasError() bool { return f.error != "" }


### PR DESCRIPTION
## Summary

Exposes a Home Manager module as `homeModules.default` (aliased `homeManagerModules.default`) in flake.nix, plus pimsync-style command-retrieved passwords for SMTP.

## Home Manager module

- New `home-manager.nix`, wired into flake outputs outside `eachDefaultSystem`.
- Options: `programs.chroncal.enable`, `programs.chroncal.package` (defaults to the flake's own package), `programs.chroncal.settings` (freeform attrs → `$XDG_CONFIG_HOME/chroncal/config.toml`).
- No per-account options: chroncal stores CalDAV account credentials in the OS keyring and accounts have no config-file representation, so fabricating them would be misleading. Documented in the module.

## Command-retrieved password

- New `smtp.password_cmd` (env: `CHRONCAL_SMTP_PASSWORD_CMD`) resolved at send time via `SMTPConfig.ResolvePassword()`; stdout becomes the password after one trailing-newline trim. Setting both `password` and `password_cmd` is an error.

## Validation

- Go: `go build ./...`, `go vet ./...`, golangci-lint clean; tests pass for config/auth/notify + cmd/chroncal suite.
- Nix: no nix on the dev host, so validated in a `nixos/nix` container — `nix flake check` passed and an end-to-end home-manager evaluation generated the expected `config.toml` with the flake's own package.

## Out of scope

- Arrow-key modal navigation (separate UX request noted in the issue).
- Per-account config-file credentials (keyring already avoids hardcoded account secrets).

Closes #627
