### PR TITLE
fix(sync): record and report conflicts from the opportunistic push

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,8 @@ Sync runs on each connected calendar on its own. Calendars that share an account
 
 Narrow a run with `--calendar NAME` (one local calendar) or `--account NAME` (every calendar linked to one CalDAV account). The two flags are mutually exclusive. An account with no linked calendars is a clean no-op.
 
+Every write command (`event add`, `todo update`, `journal delete`, and so on) pushes your change to the server right after it saves. The push uses server-wins by default. On a conflict, the server version replaces your local change. chroncal records each replaced change as a conflict row and prints a note on stderr. Run `chroncal sync conflicts` to list the rows. Run `chroncal sync resolve <id> --pick local` to restore your version. Set `sync.conflict_strategy` to `prompt` to stop the automatic replace; the push then keeps your change dirty and waits for your decision.
+
 ### Google Calendar via CalDAV
 
 Google Calendar requires OAuth 2.0. It only exposes `VEVENT` over CalDAV.
@@ -677,7 +679,7 @@ Configuration loads in this order of precedence:
 | `ui.week_start` | First day of the week in the TUI month view, week view, and mini-calendar (`sunday` or `monday`) | `sunday` |
 | `soft_delete.purge_days` | Days to keep soft-deleted rows before the background purge. `0` disables automatic purge. | `30` |
 | `sync.interval` | Minimum interval between background CalDAV syncs that `chroncal service run` performs. `service install` defaults to `15m` when this is unset. | (unset — no sync unless the installed service sets `CHRONCAL_SYNC_INTERVAL`) |
-| `sync.conflict_strategy` | Default conflict-resolution mode when you do not pass `sync run --conflict` | (unset) |
+| `sync.conflict_strategy` | Default conflict-resolution mode when you do not pass `sync run --conflict`. Also applies to background syncs and to the automatic push after each write command. | (unset) |
 | `security.allow_unsafe_alarm_audio_attach` | Allow AUDIO alarms to attach arbitrary URIs. Off by default. | `false` |
 | `security.allow_unsafe_alarm_email_attendees` | Allow EMAIL alarms to send to unverified attendee addresses. Off by default. | `false` |
 

--- a/cmd/chroncal/push.go
+++ b/cmd/chroncal/push.go
@@ -57,7 +57,10 @@ var pushCalendarAfterWrite = func(a *app.App, calendarID int64, outW, warnW io.W
 
 	svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
-	result, err := svc.PushCalendar(ctx, calendarID, syncPkg.ConflictServerWins)
+	// syncStrategy() defaults to ConflictServerWins. The config key
+	// sync.conflict_strategy (env CHRONCAL_SYNC_CONFLICT_STRATEGY) set to
+	// "prompt" opts every opportunistic push into prompt mode instead.
+	result, err := svc.PushCalendar(ctx, calendarID, syncStrategy())
 	if err != nil {
 		fmt.Fprintf(outW, "note: auto-sync failed (%v); change will upload on next sync\n", err)
 		return
@@ -70,8 +73,17 @@ var pushCalendarAfterWrite = func(a *app.App, calendarID int64, outW, warnW io.W
 // warnings from a server-wins conflict import surface. They go to warnW, not
 // outW. JSON callers (which pass io.Discard to keep stdout clean) still
 // see them on the ERROR stream. They never mix into stdout.
+//
+// A server-wins conflict replaces the just-written local row with the server
+// version. That overwrite is silent by design (the push converges), so the
+// result's conflict count is the only signal it happened. reportOpportunisticPush
+// prints one note per count on warnW with the resolve command. Without that
+// note an edit appears to save and then vanishes (issue #610).
 func reportOpportunisticPush(outW, warnW io.Writer, calName string, result *syncPkg.SyncResult) {
 	fprintImportWarnings(warnW, result.Warnings)
+	if result.Conflicts > 0 {
+		fmt.Fprintf(warnW, "note: %d local change(s) conflicted with the server and were replaced by server versions; see chroncal sync conflicts\n", result.Conflicts)
+	}
 	if result.Pushed == 0 && result.Deleted == 0 && len(result.Errors) == 0 {
 		return
 	}

--- a/cmd/chroncal/push_conflict_cli_test.go
+++ b/cmd/chroncal/push_conflict_cli_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// TestOpportunisticPushConflictWarnsAndRecords drives the real
+// opportunistic-push seam against a CalDAV stub that answers the PUT with
+// 412. Issue #610: with the default server-wins strategy the push imports
+// the server version over the just-written local row. The seam must keep
+// that convergence behavior and must also (a) record a sync_conflicts row
+// so `chroncal sync conflicts` lists the overwrite and (b) print the
+// conflict note on stderr while stdout stays clean.
+func TestOpportunisticPushConflictWarnsAndRecords(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+
+	var eventUID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/calendars/work/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		switch r.Method {
+		case http.MethodPut:
+			w.WriteHeader(http.StatusPreconditionFailed)
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+			w.Header().Set("ETag", `"etag-server"`)
+			_, _ = w.Write([]byte("BEGIN:VCALENDAR\r\n" +
+				"VERSION:2.0\r\n" +
+				"PRODID:-//chroncal//test//EN\r\n" +
+				"BEGIN:VEVENT\r\n" +
+				"UID:" + eventUID + "\r\n" +
+				"DTSTAMP:20260403T120000Z\r\n" +
+				"DTSTART:20260403T120000Z\r\n" +
+				"DTEND:20260403T130000Z\r\n" +
+				"SUMMARY:Server version\r\n" +
+				"END:VEVENT\r\n" +
+				"END:VCALENDAR\r\n"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+	ctx := context.Background()
+
+	cal, err := a.Calendars.Create(ctx, "Work", "#7C3AED", "")
+	if err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	account, err := a.Queries.CreateAccount(ctx, storage.CreateAccountParams{
+		Name:      "__push_conflict_test",
+		ServerUrl: srv.URL,
+		AuthType:  "bearer",
+		Username:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	if err := a.Calendars.LinkToAccount(ctx, cal.ID, account.ID, srv.URL+"/calendars/work/"); err != nil {
+		t.Fatalf("link calendar: %v", err)
+	}
+
+	// Seed the credential through the same store constructor the seam uses,
+	// so loadCalendarClient resolves it no matter which backend this host
+	// provides (plaintext on CI, OS keyring elsewhere).
+	a.AllowPlaintext = true
+	credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, true)
+	if err != nil {
+		t.Fatalf("credential store: %v", err)
+	}
+	if err := credStore.Set(auth.Credential{
+		AccountID:          account.ID,
+		AccountFingerprint: auth.AccountFingerprint(srv.URL, "bearer", "alice"),
+		AccessToken:        "test-token",
+	}); err != nil {
+		t.Fatalf("seed credential: %v", err)
+	}
+
+	// The write under test. Creating through the service marks the resource
+	// dirty exactly like `chroncal event add` does.
+	start := time.Date(2026, 4, 3, 10, 0, 0, 0, time.UTC)
+	evt, err := a.Events.Create(ctx, event.CreateParams{
+		CalendarID: cal.ID,
+		Title:      "Local edit",
+		StartTime:  start,
+		EndTime:    start.Add(30 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("event create: %v", err)
+	}
+	eventUID = evt.UID
+
+	var out, warn bytes.Buffer
+	pushCalendarAfterWrite(a, cal.ID, &out, &warn)
+
+	if !strings.Contains(warn.String(), "note: 1 local change(s) conflicted with the server") {
+		t.Errorf("stderr = %q, want the conflict note", warn.String())
+	}
+	if !strings.Contains(warn.String(), "see chroncal sync conflicts") {
+		t.Errorf("stderr = %q, want the resolve hint", warn.String())
+	}
+	if strings.Contains(out.String(), "conflicted") || strings.Contains(out.String(), "Synced") {
+		t.Errorf("stdout = %q; a conflicts-only push must keep stdout clean", out.String())
+	}
+
+	conflicts, err := a.Queries.ListSyncConflictsByCalendar(ctx, cal.ID)
+	if err != nil {
+		t.Fatalf("ListSyncConflictsByCalendar: %v", err)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("sync conflicts = %d, want 1", len(conflicts))
+	}
+	if conflicts[0].Uid != evt.UID {
+		t.Fatalf("conflict uid = %q, want %q", conflicts[0].Uid, evt.UID)
+	}
+	if conflicts[0].ServerEtag != "etag-server" {
+		t.Fatalf("conflict ServerEtag = %q, want etag-server", conflicts[0].ServerEtag)
+	}
+	if !strings.Contains(conflicts[0].LocalIcal, "SUMMARY:Local edit") {
+		t.Fatalf("conflict LocalIcal missing the overwritten local summary, got %q", conflicts[0].LocalIcal)
+	}
+
+	got, err := a.Events.GetByUID(ctx, evt.UID)
+	if err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+	if got.Title != "Server version" {
+		t.Fatalf("Title = %q, want Server version (server-wins convergence unchanged)", got.Title)
+	}
+}

--- a/cmd/chroncal/sync_warnings_cli_test.go
+++ b/cmd/chroncal/sync_warnings_cli_test.go
@@ -83,6 +83,56 @@ func TestReportOpportunisticPushEmitsWarningsThroughInjectedWriter(t *testing.T)
 	}
 }
 
+// A server-wins conflict replaces the just-written local row with the server
+// version. The push then reports Pushed=0/Deleted=0, so without a dedicated
+// note the user sees nothing at all while their edit vanishes (issue #610).
+// reportOpportunisticPush must surface result.Conflicts on the warning
+// writer with the resolve command. stdout stays clean so `-o json` output
+// keeps parsing.
+func TestReportOpportunisticPushSurfacesConflicts(t *testing.T) {
+	t.Parallel()
+
+	// Conflicts only: the silent-data-loss case. Nothing pushed, nothing
+	// deleted, no errors — yet stderr must still explain where the local
+	// edit went.
+	var out, warn bytes.Buffer
+	reportOpportunisticPush(&out, &warn, "Work", &syncPkg.SyncResult{Conflicts: 2})
+	want := "note: 2 local change(s) conflicted with the server and were replaced by server versions; see chroncal sync conflicts\n"
+	if warn.String() != want {
+		t.Errorf("warning writer got %q, want %q", warn.String(), want)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout writer got %q; conflicts-only pushes must keep stdout silent", out.String())
+	}
+
+	// A JSON caller discards stdout and still sees the note on stderr.
+	warn.Reset()
+	reportOpportunisticPush(io.Discard, &warn, "Work", &syncPkg.SyncResult{Conflicts: 1})
+	if !strings.Contains(warn.String(), "see chroncal sync conflicts") {
+		t.Errorf("warning writer got %q, want the conflict note despite discarded stdout", warn.String())
+	}
+
+	// Conflicts alongside a normal push keep both messages on their own
+	// streams.
+	out.Reset()
+	warn.Reset()
+	reportOpportunisticPush(&out, &warn, "Work", &syncPkg.SyncResult{Pushed: 1, Conflicts: 1})
+	if !strings.Contains(warn.String(), "1 local change(s) conflicted") {
+		t.Errorf("warning writer got %q, want the conflict note", warn.String())
+	}
+	if !strings.Contains(out.String(), "Synced to Work") {
+		t.Errorf("stdout writer got %q, want the push confirmation", out.String())
+	}
+
+	// Zero conflicts stay silent: this runs after every single write.
+	out.Reset()
+	warn.Reset()
+	reportOpportunisticPush(&out, &warn, "Work", &syncPkg.SyncResult{Conflicts: 0})
+	if out.Len() != 0 || warn.Len() != 0 {
+		t.Errorf("conflict-free push wrote out=%q warn=%q, want silence", out.String(), warn.String())
+	}
+}
+
 // `sync resolve <id> --pick server` imports the recorded server body through
 // the same importICal as the auto server-wins paths. The engine logger is nil
 // (silent). The warnings ResolveConflict returns are then the only place

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -549,10 +549,11 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 		// and records another conflict every sync. Hold off until the user
 		// resolves it via ResolveConflict, which clears the conflict and
 		// refreshes the ETag. See issue #104. ServerWins is excluded: it
-		// never records conflict rows and clears dirty on its own 412, so it
-		// has no loop to break — and skipping it would strand a stale
-		// conflict row left over from a prior prompt-mode run. The condition
-		// mirrors the conflict-recording branch below, which treats every
+		// auto-resolves each 412 by adopting the server version, and
+		// skipping would block that convergence behind a stale conflict row
+		// left over from a prior prompt-mode run or from its own recording
+		// of an earlier overwritten edit (issue #610). The condition mirrors
+		// the conflict-recording branch below, which treats every
 		// non-ServerWins strategy as prompt mode.
 		if strategy != ConflictServerWins {
 			if open, cerr := e.q.CountOpenSyncConflicts(ctx, storage.CountOpenSyncConflictsParams{
@@ -657,6 +658,38 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 							result.errors = append(result.errors, fmt.Errorf("encode server resource %s: %w", res.Uid, err))
 							result.conflicts++
 							continue
+						}
+						// Record the conflict even though server-wins resolves
+						// it automatically. The import below replaces the local
+						// row with the server version and clears dirty, so
+						// without a row the overwritten local edit would vanish
+						// silently (issue #610). The row keeps both bodies:
+						// `chroncal sync conflicts` lists the overwrite and
+						// `chroncal sync resolve <id> --pick local` restores the
+						// local edit. One open row per UID: a retry loop against
+						// an unimportable server body must not insert a fresh
+						// row on every push.
+						if open, cerr := e.q.CountOpenSyncConflicts(ctx, storage.CountOpenSyncConflictsParams{
+							CalendarID: calendarID,
+							Uid:        res.Uid,
+						}); cerr != nil {
+							e.logger.Warn("check open conflict before record", "uid", res.Uid, "error", cerr)
+						} else if open == 0 {
+							ownerID, lookupErr := e.lookupOwnerID(ctx, res.OwnerType, res.Uid)
+							if lookupErr != nil {
+								e.logger.Warn("lookup owner id for conflict record", "uid", res.Uid, "owner_type", res.OwnerType, "error", lookupErr)
+							}
+							if cerr := e.q.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
+								CalendarID: calendarID,
+								OwnerType:  res.OwnerType,
+								OwnerID:    ownerID,
+								Uid:        res.Uid,
+								LocalIcal:  string(icalData),
+								ServerIcal: buf.String(),
+								ServerEtag: serverRes.ETag,
+							}); cerr != nil {
+								e.logger.Warn("record server-wins conflict", "uid", res.Uid, "error", cerr)
+							}
 						}
 						imported, revs, importWarnings, err := e.importICal(ctx, calendarID, buf.String())
 						if err != nil {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1557,8 +1557,164 @@ END:VCALENDAR
 	if err != nil {
 		t.Fatalf("ListSyncConflictsByCalendar: %v", err)
 	}
-	if len(conflicts) != 0 {
-		t.Fatalf("sync conflicts = %d, want 0", len(conflicts))
+	// Server-wins still adopts the server version above. Issue #610 now also
+	// records the overwritten local edit as a conflict row so
+	// `chroncal sync conflicts` lists it and --pick local can restore it.
+	if len(conflicts) != 1 {
+		t.Fatalf("sync conflicts = %d, want 1", len(conflicts))
+	}
+	if conflicts[0].Uid != "server-wins-event" {
+		t.Fatalf("conflict uid = %q, want server-wins-event", conflicts[0].Uid)
+	}
+	if conflicts[0].ServerEtag != "etag-server" {
+		t.Fatalf("conflict ServerEtag = %q, want etag-server", conflicts[0].ServerEtag)
+	}
+	if !strings.Contains(conflicts[0].LocalIcal, "SUMMARY:Test server-wins-event") {
+		t.Fatalf("conflict LocalIcal missing the overwritten local summary, got %q", conflicts[0].LocalIcal)
+	}
+}
+
+// TestEnginePushCalendarServerWinsRecordsConflictRow drives the push phase
+// behind the opportunistic save-time entry point (PushCalendar) through a 412
+// with the default server-wins strategy. Issue #610: the push must keep its
+// convergence behavior (adopt the server version, clear dirty) and must also
+// record a sync_conflicts row so `chroncal sync conflicts` lists the
+// overwritten local edit. The recorded Conflicts count is what
+// reportOpportunisticPush turns into the stderr warning.
+func TestEnginePushCalendarServerWinsRecordsConflictRow(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	insertTestEvent(t, db, calendarID, "push-conflict-event")
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodPut:
+			return &http.Response{
+				StatusCode: http.StatusPreconditionFailed,
+				Status:     "412 Precondition Failed",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("precondition failed")),
+				Request:    r,
+			}, nil
+		case http.MethodGet:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/calendar; charset=utf-8"},
+					"Etag":         []string{`"etag-server"`},
+				},
+				Body: io.NopCloser(strings.NewReader(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//chroncal//tests//EN
+BEGIN:VEVENT
+UID:push-conflict-event
+DTSTAMP:20260403T120000Z
+DTSTART:20260403T120000Z
+DTEND:20260403T130000Z
+SUMMARY:Server version
+END:VEVENT
+END:VCALENDAR
+`)),
+				Request: r,
+			}, nil
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "push-conflict-event",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/push-conflict-event.ics",
+		Etag:         `"etag-before"`,
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	result, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins)
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if result.conflicts != 1 {
+		t.Fatalf("conflicts = %d, want 1 (this count drives the CLI warning)", result.conflicts)
+	}
+	if result.pushed != 0 || len(result.errors) != 0 {
+		t.Fatalf("pushed = %d, errors = %d; want 0/0", result.pushed, len(result.errors))
+	}
+
+	conflicts, err := q.ListSyncConflictsByCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("ListSyncConflictsByCalendar: %v", err)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("sync conflicts = %d, want 1", len(conflicts))
+	}
+	if conflicts[0].Uid != "push-conflict-event" {
+		t.Fatalf("conflict uid = %q, want push-conflict-event", conflicts[0].Uid)
+	}
+	if conflicts[0].ServerEtag != "etag-server" {
+		t.Fatalf("conflict ServerEtag = %q, want etag-server", conflicts[0].ServerEtag)
+	}
+	if !strings.Contains(conflicts[0].LocalIcal, "SUMMARY:Test push-conflict-event") {
+		t.Fatalf("conflict LocalIcal missing the overwritten local summary, got %q", conflicts[0].LocalIcal)
+	}
+	if !strings.Contains(conflicts[0].ServerIcal, "SUMMARY:Server version") {
+		t.Fatalf("conflict ServerIcal missing the server summary, got %q", conflicts[0].ServerIcal)
+	}
+
+	// Convergence is unchanged: the local row holds the server version and
+	// the dirty flag is cleared.
+	evt, err := q.GetEventByUID(ctx, "push-conflict-event")
+	if err != nil {
+		t.Fatalf("GetEventByUID: %v", err)
+	}
+	if evt.Title != "Server version" {
+		t.Fatalf("Title = %q, want Server version", evt.Title)
+	}
+	dirty, err := q.ListDirtySyncResources(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("ListDirtySyncResources: %v", err)
+	}
+	if len(dirty) != 0 {
+		t.Fatalf("dirty resources = %d, want 0", len(dirty))
+	}
+
+	// A later conflicting push for the same UID reuses the open row instead
+	// of inserting a duplicate on every attempt.
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "push-conflict-event",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/push-conflict-event.ics",
+		Etag:         `"etag-server"`,
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("re-mark dirty: %v", err)
+	}
+	if _, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins); err != nil {
+		t.Fatalf("second push: %v", err)
+	}
+	conflicts, err = q.ListSyncConflictsByCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("re-list conflicts: %v", err)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("sync conflicts after second push = %d, want 1 (no duplicate rows)", len(conflicts))
 	}
 }
 


### PR DESCRIPTION
## Summary

The opportunistic push after every CLI write hard-coded `ConflictServerWins`. On a 412 it imported the server version over the just-written local row and cleared the dirty flag — and `reportOpportunisticPush` ignored `result.Conflicts`, so the edit vanished with no message, no conflict row, nothing in `sync status`.

- The server-wins 412 branch now records a `sync_conflicts` row (both iCal bodies + server ETag) before importing; winner behavior unchanged. A `CountOpenSyncConflicts` guard keeps one open row per UID.
- `reportOpportunisticPush` prints `note: N local change(s) conflicted with the server...` to stderr whenever conflicts occurred, including the conflicts-only case (stdout stays clean/JSON-safe).
- The push now passes `syncStrategy()` so `sync.conflict_strategy=prompt` opts into prompt mode; default unchanged.

## Tests

Engine tests assert the recorded row + convergence + dedup on re-push; CLI tests cover the warning rendering and an end-to-end 412 against an httptest CalDAV stub.

`go test ./cmd/... ./internal/sync/...` pass.

Fixes #610
