### PR TITLE
fix(ical): resolve floating TRIGGER against the record timezone on export

### DIFF
--- a/internal/alarm/export_equivalence_test.go
+++ b/internal/alarm/export_equivalence_test.go
@@ -1,0 +1,63 @@
+package alarm
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/ical"
+	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/recurrence"
+)
+
+// The export invariant for absolute triggers: the exported TRIGGER and
+// computeTriggerTimeForInstance must denote the same instant. Export resolves
+// a floating value through model.ParseAbsoluteTime with the record's
+// timezone, and this test reads the engine through the same function, so the
+// two cannot drift (issue #572). A string-suffix check cannot catch drift,
+// which is why the instants are compared here.
+func TestExportedTriggerMatchesEngineFireTime(t *testing.T) {
+	t.Parallel()
+	const floating = "20260401T100000"
+	expEvt := recurrence.ExpandedEvent{
+		Event: event.Event{
+			UID:       "engine-equivalence@example.com",
+			Title:     "Event",
+			Timezone:  "America/New_York",
+			StartTime: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+			Alarms:    []model.Alarm{{Action: "DISPLAY", TriggerValue: floating, Related: "START"}},
+		},
+		InstanceTime: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+	}
+	alarmRow := model.Alarm{Action: "DISPLAY", TriggerValue: floating, Related: "START"}
+
+	engineAt, err := computeTriggerTimeForInstance(expEvt, alarmRow)
+	if err != nil {
+		t.Fatalf("computeTriggerTimeForInstance: %v", err)
+	}
+
+	data, err := ical.ExportEvents([]event.Event{expEvt.Event}, "Work")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	var raw string
+	for _, line := range strings.Split(string(data), "\r\n") {
+		if strings.HasPrefix(line, "TRIGGER") {
+			if i := strings.Index(line, ":"); i >= 0 {
+				raw = line[i+1:]
+			}
+		}
+	}
+	if raw == "" {
+		t.Fatalf("no TRIGGER value in export:\n%s", data)
+	}
+	exportedAt, err := time.Parse("20060102T150405Z", raw)
+	if err != nil {
+		t.Fatalf("exported TRIGGER %q is not UTC date-time: %v", raw, err)
+	}
+	if !exportedAt.Equal(engineAt) {
+		t.Errorf("exported TRIGGER %s and engine fire time %s differ", exportedAt, engineAt)
+	}
+}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -180,7 +180,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 			if alarm.Summary == "" && alarm.Action == "EMAIL" {
 				alarm.Summary = e.Title
 			}
-			if v := buildValarm(alarm); v != nil {
+			if v := buildValarm(alarm, e.Timezone); v != nil {
 				vevent.Children = append(vevent.Children, v)
 			}
 		}
@@ -549,7 +549,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			if alarm.Summary == "" && alarm.Action == "EMAIL" {
 				alarm.Summary = t.Summary
 			}
-			if v := buildValarm(alarm); v != nil {
+			if v := buildValarm(alarm, t.Timezone); v != nil {
 				vtodo.Children = append(vtodo.Children, v)
 			}
 		}
@@ -744,19 +744,21 @@ func emitRecurrenceID(props ical.Props, recurrenceID string, allDay, floating bo
 // server copy. That is why import drops the value up front, where the user
 // gets a warning. Do not let it reach this point in silence.
 //
-// Do not reinstate UTC normalization without the record's timezone. A floating
-// date-time trigger passes here and is emitted verbatim, which is not valid
-// iCal (issue #572). The UTC normalization that used to sit in buildValarm
-// was reverted. It read floating values as UTC while the alarm engine reads
-// them in the record's timezone. That moved reminders by the zone offset.
+// A floating date-time trigger is resolved against the record's timezone in
+// buildValarm. The alarm engine reads the same value through
+// model.ParseAbsoluteTime with the record's timezone, so export and fire time
+// agree by construction (issue #572). Do not read a floating value as UTC
+// without the record's timezone. That normalization was reverted once, and it
+// moved reminders by the zone offset.
 func exportableTrigger(v string) bool {
 	return model.ParseableAlarmTrigger(v)
 }
 
 // buildValarm renders an alarm as a VALARM component, or nil when the alarm
-// carries a TRIGGER that cannot be expressed as valid iCal. Callers must skip
-// a nil result.
-func buildValarm(alarm model.Alarm) *ical.Component {
+// carries a TRIGGER that cannot be expressed as valid iCal. recordTZ is the
+// owning event or todo timezone, and it resolves a floating absolute trigger
+// the way the alarm engine does. Callers must skip a nil result.
+func buildValarm(alarm model.Alarm, recordTZ string) *ical.Component {
 	if !exportableTrigger(alarm.TriggerValue) {
 		return nil
 	}
@@ -806,11 +808,11 @@ func buildValarm(alarm model.Alarm) *ical.Component {
 		// the whole resource. So this guard stays even though import no longer
 		// produces the case.
 		trigger.Params.Set("VALUE", "DATE-TIME")
-		// Normalize legacy RFC 3339 values to iCal format. Import now
-		// normalizes every RFC 3339 trigger to compact UTC on the way in,
-		// so this branch exists only for pre-normalization DB rows that
-		// still hold the raw RFC 3339 string.
-		if t, err := time.Parse(time.RFC3339, alarm.TriggerValue); err == nil {
+		// Resolve every absolute value through ParseAbsoluteTime, the same
+		// function computeTriggerTimeForInstance uses. A floating value then
+		// denotes the same instant here and at fire time (issue #572). The
+		// call also normalizes legacy RFC 3339 rows to compact UTC.
+		if t, err := model.ParseAbsoluteTime(alarm.TriggerValue, recordTZ); err == nil {
 			trigger.Value = t.UTC().Format("20060102T150405Z")
 		}
 	}

--- a/internal/ical/export_trigger_test.go
+++ b/internal/ical/export_trigger_test.go
@@ -136,3 +136,44 @@ func TestExportableTrigger(t *testing.T) {
 		}
 	}
 }
+
+// A floating absolute trigger is invalid iCal on the wire (RFC 5545 §3.8.6.3
+// requires UTC for VALUE=DATE-TIME). Export resolves it in the record's
+// timezone through model.ParseAbsoluteTime, so the emitted instant is what
+// the alarm engine would fire.
+func TestExport_FloatingTriggerResolvesInRecordZone(t *testing.T) {
+	t.Parallel()
+	const floating = "20260401T100000"
+	events := []event.Event{{
+		UID:       "floating-trigger@example.com",
+		Title:     "Event",
+		Timezone:  "America/New_York",
+		StartTime: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		Alarms: []model.Alarm{
+			{Action: "DISPLAY", TriggerValue: floating, Description: "Floating", Related: "START"},
+		},
+	}}
+	data, err := ExportEvents(events, "Work")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	want, err := model.ParseAbsoluteTime(floating, "America/New_York")
+	if err != nil {
+		t.Fatalf("ParseAbsoluteTime: %v", err)
+	}
+	wantStr := want.UTC().Format("20060102T150405Z")
+	var trigger string
+	for _, line := range strings.Split(string(data), "\r\n") {
+		if strings.HasPrefix(line, "TRIGGER") {
+			trigger = line
+			break
+		}
+	}
+	if trigger == "" {
+		t.Fatalf("no TRIGGER line in export:\n%s", data)
+	}
+	if !strings.HasSuffix(trigger, ":"+wantStr) && !strings.Contains(trigger, wantStr) {
+		t.Errorf("TRIGGER = %s, want it to denote %s (the record-zone resolution)", trigger, wantStr)
+	}
+}


### PR DESCRIPTION
## Summary

A floating date-time alarm trigger (`TRIGGER;VALUE=DATE-TIME:20260401T100000`, no `Z`) was exported verbatim as invalid non-UTC iCal. Strict CalDAV servers 400 the VALARM and the whole resource stays dirty forever. The shape is real: `parseAlarm` produces it for VALARMs with unresolvable TZIDs (Exchange "Customized Time Zone").

`buildValarm` now takes the owning record's timezone and resolves every absolute trigger through `model.ParseAbsoluteTime(value, recordTZ)` — the same function `computeTriggerTimeForInstance` uses — so export and fire time agree **by construction**. This is deliberately not the reverted UTC normalization (c8be639), which read floating values as UTC and moved reminders by the zone offset; here a floating value resolves in the record's timezone exactly as the engine does.

## Tests

The issue's invariant, asserted directly: for a non-UTC-zone record with a floating trigger, the exported `TRIGGER` and `computeTriggerTimeForInstance` denote the same instant (`internal/alarm/export_equivalence_test.go`). Plus exporter-side resolution checks and an unresolvable-TZID round-trip.

`go test ./internal/ical/... ./internal/alarm/... ./internal/model/... ./internal/sync/...` pass.

Fixes #572
