### PR TITLE
feat(cli): add --skip-unreadable to ical export

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ chroncal ical export  [--calendar NAME] [--from DATE] [--to DATE] [--category TE
 
 Imports have size limits to reduce resource exhaustion from untrusted calendar data. `chroncal ical import` rejects `.ics` payloads larger than 8 MiB. It also rejects inline base64 attachments larger than 1 MiB decoded.
 
-The export aborts when one relation read fails. It writes no file, so no incomplete backup exists. Pass `--skip-unreadable` to write past such failures. The file then carries a comment header that names each incomplete record. The command also lists those records on stderr.
+The export aborts when one relation read fails. It writes no file, so no incomplete backup exists. Pass `--skip-unreadable` to continue past records with unreadable relations. The file then carries a comment header that names each incomplete record. The command also lists those records on stderr.
 
 ### Sync
 

--- a/README.md
+++ b/README.md
@@ -418,10 +418,12 @@ Pass `--disconnect-remote` on `update` to remove the remote link of a calendar.
 
 ```
 chroncal ical import  <file.ics> [--calendar NAME]
-chroncal ical export  [--calendar NAME] [--from DATE] [--to DATE] [--category TEXT] [--status TEXT] [-f FILE] [--events] [--todos] [--journals]
+chroncal ical export  [--calendar NAME] [--from DATE] [--to DATE] [--category TEXT] [--status TEXT] [-f FILE] [--events] [--todos] [--journals] [--skip-unreadable]
 ```
 
 Imports have size limits to reduce resource exhaustion from untrusted calendar data. `chroncal ical import` rejects `.ics` payloads larger than 8 MiB. It also rejects inline base64 attachments larger than 1 MiB decoded.
+
+The export aborts when one relation read fails. It writes no file, so no incomplete backup exists. Pass `--skip-unreadable` to write past such failures. The file then carries a comment header that names each incomplete record. The command also lists those records on stderr.
 
 ### Sync
 

--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -160,9 +160,10 @@ included. Use --file to write a file, or omit it to print the .ics data
 to stdout.
 
 A failed relation read aborts the export by default. No file is then
-written, so no incomplete backup exists. Pass --skip-unreadable to write
-past such failures. The file then carries a comment header that names
-each incomplete record, and stderr lists them.`,
+written, so no incomplete backup exists. Pass --skip-unreadable to
+continue past records with unreadable relations. The file then carries
+a comment header that names each incomplete record, and stderr lists
+them.`,
 		Example: `  chroncal ical export --calendar Work --file work.ics
   chroncal ical export --events --from 2026-04-01 --to 2026-04-30
   chroncal ical export --todos --category release`,

--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -147,6 +148,7 @@ func icalExportCmd() *cobra.Command {
 		includeEvents   bool
 		includeTodos    bool
 		includeJournals bool
+		skipUnreadable  bool
 	)
 	cmd := &cobra.Command{
 		Use:   "export",
@@ -155,7 +157,12 @@ func icalExportCmd() *cobra.Command {
 
 Without --events, --todos, or --journals, all supported entry types are
 included. Use --file to write a file, or omit it to print the .ics data
-to stdout.`,
+to stdout.
+
+A failed relation read aborts the export by default. No file is then
+written, so no incomplete backup exists. Pass --skip-unreadable to write
+past such failures. The file then carries a comment header that names
+each incomplete record, and stderr lists them.`,
 		Example: `  chroncal ical export --calendar Work --file work.ics
   chroncal ical export --events --from 2026-04-01 --to 2026-04-30
   chroncal ical export --todos --category release`,
@@ -219,6 +226,10 @@ to stdout.`,
 				toDate = toT.Format("2006-01-02")
 			}
 
+			// Records that exported without all their relations. The default
+			// path aborts instead, so this stays empty there.
+			var incomplete []unreadableRecord
+
 			// Load events
 			var events []event.Event
 			if includeEvents {
@@ -263,8 +274,16 @@ to stdout.`,
 					// .ics missing alarms and attendees. Name the offending record
 					// and say no file was written, so the message is actionable
 					// rather than a bare "event 4211 attachments: ...".
+					//
+					// With --skip-unreadable the user chose that trade-off for this
+					// run: keep every readable relation, and mark what went missing.
 					if err := a.Events.Hydrate(ctx, &events[i]); err != nil {
-						return fmt.Errorf("export aborted, no file written: %w (event uid %s)", err, events[i].UID)
+						if !skipUnreadable {
+							return fmt.Errorf("export aborted, no file written: %w (event uid %s)", err, events[i].UID)
+						}
+						if failed := a.Events.HydrateSkipUnreadable(ctx, &events[i]); len(failed) > 0 {
+							incomplete = append(incomplete, unreadableRecord{"event", events[i].ID, events[i].UID, failed})
+						}
 					}
 				}
 			}
@@ -284,7 +303,12 @@ to stdout.`,
 				}
 				for i := range todos {
 					if err := a.Todos.Hydrate(ctx, &todos[i]); err != nil {
-						return fmt.Errorf("export aborted, no file written: %w (todo uid %s)", err, todos[i].UID)
+						if !skipUnreadable {
+							return fmt.Errorf("export aborted, no file written: %w (todo uid %s)", err, todos[i].UID)
+						}
+						if failed := a.Todos.HydrateSkipUnreadable(ctx, &todos[i]); len(failed) > 0 {
+							incomplete = append(incomplete, unreadableRecord{"todo", todos[i].ID, todos[i].UID, failed})
+						}
 					}
 				}
 			}
@@ -304,7 +328,12 @@ to stdout.`,
 				}
 				for i := range journals {
 					if err := a.Journals.Hydrate(ctx, &journals[i]); err != nil {
-						return fmt.Errorf("export aborted, no file written: %w (journal uid %s)", err, journals[i].UID)
+						if !skipUnreadable {
+							return fmt.Errorf("export aborted, no file written: %w (journal uid %s)", err, journals[i].UID)
+						}
+						if failed := a.Journals.HydrateSkipUnreadable(ctx, &journals[i]); len(failed) > 0 {
+							incomplete = append(incomplete, unreadableRecord{"journal", journals[i].ID, journals[i].UID, failed})
+						}
 					}
 				}
 			}
@@ -343,6 +372,14 @@ to stdout.`,
 				data = ical.MergeCalendars(data, p)
 			}
 
+			// The file must self-describe months later without terminal
+			// context, so the caveat goes into the file as comment lines and
+			// not only onto this run's stderr.
+			if len(incomplete) > 0 {
+				reportUnreadable(incomplete)
+				data = ical.PrependComments(data, unreadableCaveatLines(incomplete))
+			}
+
 			if outFile != "" {
 				if err := os.WriteFile(outFile, data, 0o644); err != nil {
 					return fmt.Errorf("write file: %w", err)
@@ -364,5 +401,39 @@ to stdout.`,
 	cmd.Flags().BoolVar(&includeEvents, "events", false, "include only events")
 	cmd.Flags().BoolVar(&includeTodos, "todos", false, "include only todos")
 	cmd.Flags().BoolVar(&includeJournals, "journals", false, "include only journal entries")
+	cmd.Flags().BoolVar(&skipUnreadable, "skip-unreadable", false,
+		"export past unreadable relations and mark incomplete records (default: abort)")
 	return cmd
+}
+
+// unreadableRecord names one record that exported without all its relations.
+type unreadableRecord struct {
+	kind      string
+	id        int64
+	uid       string
+	relations []string
+}
+
+// reportUnreadable prints one line per incomplete record to stderr. The line
+// carries the row id, the uid, and the names of the lost relations.
+func reportUnreadable(records []unreadableRecord) {
+	fmt.Fprintf(os.Stderr, "chroncal: --skip-unreadable: %d record(s) are incomplete:\n", len(records))
+	for _, r := range records {
+		fmt.Fprintf(os.Stderr, "  %s %d (uid %s): %s\n", r.kind, r.id, r.uid, strings.Join(r.relations, ", "))
+	}
+}
+
+// unreadableCaveatLines builds the comment lines that PrependComments writes
+// into the .ics. A reader months later then sees which records are incomplete
+// and what each one misses, with no terminal output to rely on.
+func unreadableCaveatLines(records []unreadableRecord) []string {
+	lines := []string{
+		"chroncal wrote this file with --skip-unreadable.",
+		"The records below are incomplete. Their named relations are absent:",
+	}
+	for _, r := range records {
+		lines = append(lines, fmt.Sprintf("%s %d (uid %s): %s",
+			r.kind, r.id, r.uid, strings.Join(r.relations, ", ")))
+	}
+	return lines
 }

--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -428,10 +428,10 @@ func reportUnreadable(records []unreadableRecord) {
 // into the .ics. A reader months later then sees which records are incomplete
 // and what each one misses, with no terminal output to rely on.
 func unreadableCaveatLines(records []unreadableRecord) []string {
-	lines := []string{
+	lines := make([]string, 0, 2+len(records))
+	lines = append(lines,
 		"chroncal wrote this file with --skip-unreadable.",
-		"The records below are incomplete. Their named relations are absent:",
-	}
+		"The records below are incomplete. Their named relations are absent:")
 	for _, r := range records {
 		lines = append(lines, fmt.Sprintf("%s %d (uid %s): %s",
 			r.kind, r.id, r.uid, strings.Join(r.relations, ", ")))

--- a/cmd/chroncal/ical_export_skip_unreadable_test.go
+++ b/cmd/chroncal/ical_export_skip_unreadable_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/ical"
+)
+
+const skipUnreadableSeedICS = "BEGIN:VCALENDAR\r\n" +
+	"VERSION:2.0\r\n" +
+	"PRODID:-//chroncal//test//EN\r\n" +
+	"BEGIN:VEVENT\r\n" +
+	"UID:broken-relations@test\r\n" +
+	"DTSTART:20260401T100000Z\r\n" +
+	"DTEND:20260401T110000Z\r\n" +
+	"SUMMARY:Broken relations\r\n" +
+	"ATTENDEE;CN=Alice;ROLE=REQ-PARTICIPANT:mailto:alice@example.com\r\n" +
+	"BEGIN:VALARM\r\n" +
+	"ACTION:DISPLAY\r\n" +
+	"TRIGGER:-PT15M\r\n" +
+	"DESCRIPTION:Reminder\r\n" +
+	"END:VALARM\r\n" +
+	"END:VEVENT\r\n" +
+	"BEGIN:VEVENT\r\n" +
+	"UID:healthy-record@test\r\n" +
+	"DTSTART:20260401T120000Z\r\n" +
+	"DTEND:20260401T130000Z\r\n" +
+	"SUMMARY:Healthy record\r\n" +
+	"END:VEVENT\r\n" +
+	"END:VCALENDAR\r\n"
+
+// TestICalExportSkipUnreadable guards issue #571. One unreadable relation
+// table stands in for one SQLITE_BUSY hit from concurrent sync. The default
+// export must still abort and write nothing. With --skip-unreadable the
+// export keeps every readable relation, lists each incomplete record on
+// stderr, carries the caveat inside the file as ";" comment lines, and the
+// result imports cleanly again.
+func TestICalExportSkipUnreadable(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	icsPath := filepath.Join(t.TempDir(), "seed.ics")
+	if err := os.WriteFile(icsPath, []byte(skipUnreadableSeedICS), 0o644); err != nil {
+		t.Fatalf("write seed ics: %v", err)
+	}
+	if _, _, err := runChroncalCommand(t, "ical", "import", icsPath, "--calendar", "Work"); err != nil {
+		t.Fatalf("ical import: %v", err)
+	}
+
+	// Hide one relation table the way internal/event's hydrate tests do. The
+	// reads then fail the way a real I/O error would, for every record.
+	func() {
+		a, err := app.New(dbPath)
+		if err != nil {
+			t.Fatalf("app.New: %v", err)
+		}
+		defer a.Close()
+		if _, err := a.DB.ExecContext(context.Background(),
+			"ALTER TABLE event_attendees RENAME TO event_attendees_hidden"); err != nil {
+			t.Fatalf("hide event_attendees: %v", err)
+		}
+		t.Cleanup(func() {
+			b, berr := app.New(dbPath)
+			if berr != nil {
+				t.Fatalf("app.New for restore: %v", berr)
+			}
+			defer b.Close()
+			if _, err := b.DB.ExecContext(context.Background(),
+				"ALTER TABLE event_attendees_hidden RENAME TO event_attendees"); err != nil {
+				t.Fatalf("restore event_attendees: %v", err)
+			}
+		})
+	}()
+
+	outPath := filepath.Join(t.TempDir(), "backup.ics")
+
+	// Default: abort on the first failed relation read, write nothing.
+	_, stderr, err := runChroncalCommand(t, "ical", "export", "--calendar", "Work", "--file", outPath)
+	if err == nil {
+		t.Fatal("default export must fail when a relation read fails")
+	}
+	if !strings.Contains(stderr, "no file written") || !strings.Contains(stderr, "attendees") {
+		t.Fatalf("abort message must name the failure and that no file was written:\n%s", stderr)
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Fatalf("aborted export wrote %s anyway", outPath)
+	}
+
+	// Flag mode: continue, write the .ics, mark what went missing.
+	_, stderr, err = runChroncalCommand(t, "ical", "export",
+		"--calendar", "Work", "--file", outPath, "--skip-unreadable")
+	if err != nil {
+		t.Fatalf("ical export --skip-unreadable: %v\n%s", err, stderr)
+	}
+
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	out := string(raw)
+
+	// The file self-describes without terminal context: comment header lines
+	// name the run and every incomplete record with its lost relations.
+	if !strings.Contains(out, "\r\n; chroncal wrote this file with --skip-unreadable.\r\n") {
+		t.Fatalf("output missing the caveat comment header:\n%.200s", out)
+	}
+	for _, want := range []string{
+		"; event ", "(uid broken-relations@test): attendees",
+		"(uid healthy-record@test): attendees",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("caveat header missing %q:\n%s", want, out)
+		}
+	}
+
+	// The stderr summary names every incomplete record too.
+	if !strings.Contains(stderr, "2 record(s) are incomplete:") ||
+		!strings.Contains(stderr, "broken-relations@test") ||
+		!strings.Contains(stderr, "healthy-record@test") ||
+		!strings.Contains(stderr, ": attendees") {
+		t.Fatalf("stderr summary incomplete:\n%s", stderr)
+	}
+
+	// Only the broken relation is gone: the alarm survived.
+	f, err := os.Open(outPath)
+	if err != nil {
+		t.Fatalf("open output: %v", err)
+	}
+	defer f.Close()
+	res, err := ical.ImportFile(f)
+	if err != nil {
+		t.Fatalf("round-trip ImportFile: %v", err)
+	}
+	if res.SkippedComponents != 0 || len(res.Warnings) != 0 {
+		t.Fatalf("round-trip not clean: skipped=%d warnings=%v",
+			res.SkippedComponents, res.Warnings)
+	}
+	if len(res.Events) != 2 {
+		t.Fatalf("Events = %d, want 2", len(res.Events))
+	}
+	var brokenOK, healthyOK bool
+	for _, e := range res.Events {
+		switch e.UID {
+		case "broken-relations@test":
+			if len(e.Attendees) != 0 {
+				t.Errorf("broken record kept %d attendees", len(e.Attendees))
+			}
+			if len(e.Alarms) != 1 {
+				t.Errorf("Alarms = %d, want 1; the readable relation must survive", len(e.Alarms))
+			}
+			brokenOK = true
+		case "healthy-record@test":
+			if len(e.Attendees) != 0 || len(e.Alarms) != 0 {
+				t.Errorf("healthy record grew relations: %+v", e)
+			}
+			healthyOK = true
+		}
+	}
+	if !brokenOK || !healthyOK {
+		t.Fatalf("missing records after round-trip: broken=%v healthy=%v", brokenOK, healthyOK)
+	}
+}

--- a/internal/event/hydrate_test.go
+++ b/internal/event/hydrate_test.go
@@ -61,6 +61,47 @@ func hideTable(t *testing.T, svc *Service, table string) {
 	})
 }
 
+// HydrateSkipUnreadable serves the CLI's ical export --skip-unreadable path.
+// It must name exactly the relations that failed and keep Hydrate's abort
+// contract intact.
+func TestEventService_HydrateSkipUnreadable_NamesLostRelations(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	e := createEvent(t, svc)
+
+	// Hide and restore inside the test body. The post-restore check must run
+	// before this test ends, so hideTable's t.Cleanup ordering does not fit.
+	hide := func() {
+		t.Helper()
+		if _, err := svc.db.ExecContext(ctx,
+			"ALTER TABLE event_attendees RENAME TO event_attendees_hidden"); err != nil {
+			t.Fatalf("hide event_attendees: %v", err)
+		}
+	}
+	restore := func() {
+		t.Helper()
+		if _, err := svc.db.ExecContext(ctx,
+			"ALTER TABLE event_attendees_hidden RENAME TO event_attendees"); err != nil {
+			t.Fatalf("restore event_attendees: %v", err)
+		}
+	}
+
+	hide()
+	failed := svc.HydrateSkipUnreadable(ctx, &e)
+	if len(failed) != 1 || failed[0] != "attendees" {
+		t.Fatalf("HydrateSkipUnreadable = %v, want [attendees]", failed)
+	}
+	if err := svc.Hydrate(ctx, &e); err == nil {
+		t.Fatal("Hydrate returned nil with a relation unreadable; the default export must still abort")
+	}
+
+	restore()
+	failed = svc.HydrateSkipUnreadable(ctx, &e)
+	if len(failed) != 0 {
+		t.Fatalf("HydrateSkipUnreadable after restore = %v, want none", failed)
+	}
+}
+
 func TestEventService_Hydrate_PopulatesRelations(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -2445,7 +2445,21 @@ func (s *Service) HydrateBestEffort(ctx context.Context, e *Event) error {
 	return s.hydrate(ctx, e, false)
 }
 
-func (s *Service) hydrate(ctx context.Context, e *Event, failFast bool) error {
+// HydrateSkipUnreadable populates every relation it can and returns the names
+// of the relations it could not load. It never fails.
+//
+// This serves the CLI's ical export --skip-unreadable path. The user chose to
+// keep a backup that misses unreadable relations, so the export names what
+// each record lost. Any path that writes iCal for a push must use Hydrate.
+// A partial record pushed to a server overwrites the complete copy there.
+func (s *Service) HydrateSkipUnreadable(ctx context.Context, e *Event) []string {
+	return s.collect(ctx, e, false).Failed()
+}
+
+// collect loads every relation onto e through one Collector. Hydrate,
+// HydrateBestEffort, and HydrateSkipUnreadable share it, so the relation set
+// stays a single definition.
+func (s *Service) collect(ctx context.Context, e *Event, failFast bool) *hydrate.Collector {
 	c := &hydrate.Collector{Kind: "event", ID: e.ID, FailFast: failFast}
 	hydrate.Rel(ctx, c, &e.Alarms, "alarms", s.ListAlarms)
 	hydrate.Rel(ctx, c, &e.Attendees, "attendees", s.ListAttendees)
@@ -2455,5 +2469,9 @@ func (s *Service) hydrate(ctx context.Context, e *Event, failFast bool) error {
 	hydrate.Rel(ctx, c, &e.Resources, "resources", s.ListResources)
 	hydrate.Rel(ctx, c, &e.Relations, "relations", s.ListRelations)
 	hydrate.Rel(ctx, c, &e.XProperties, "x-properties", s.ListXProperties)
-	return c.Err()
+	return c
+}
+
+func (s *Service) hydrate(ctx context.Context, e *Event, failFast bool) error {
+	return s.collect(ctx, e, failFast).Err()
 }

--- a/internal/hydrate/hydrate.go
+++ b/internal/hydrate/hydrate.go
@@ -42,6 +42,7 @@ type Collector struct {
 	FailFast bool   // stop at the first error instead of loading the rest
 
 	failures []RelFailure
+	failed   []string
 }
 
 // Rel loads one relation via load(ctx, c.ID) and assigns the result to *dst.
@@ -57,6 +58,7 @@ func Rel[T any](ctx context.Context, c *Collector, dst *[]T, rel string, load fu
 	v, err := load(ctx, c.ID)
 	if err != nil {
 		c.failures = append(c.failures, RelFailure{Kind: c.Kind, ID: c.ID, Relation: rel, Cause: err})
+		c.failed = append(c.failed, rel)
 		return
 	}
 	*dst = v
@@ -74,4 +76,17 @@ func (c *Collector) Err() error {
 		errs[i] = fmt.Errorf("%s %d %s: %w", f.Kind, f.ID, f.Relation, f.Cause)
 	}
 	return &HydrationError{Err: errors.Join(errs...), Failures: c.failures}
+}
+
+// Failed returns the names of the relations that could not load, in load
+// order. It returns nil when every relation loaded. A caller that skips
+// unreadable relations uses it to name what a record lost instead of parsing
+// error text.
+func (c *Collector) Failed() []string {
+	if len(c.failed) == 0 {
+		return nil
+	}
+	out := make([]string, len(c.failed))
+	copy(out, c.failed)
+	return out
 }

--- a/internal/hydrate/hydrate_test.go
+++ b/internal/hydrate/hydrate_test.go
@@ -121,4 +121,46 @@ func TestRelBestEffortContinuesAndJoins(t *testing.T) {
 	if got := err.Error(); got != want {
 		t.Fatalf("Err() = %q, want %q", got, want)
 	}
+
+	got := c.Failed()
+	if len(got) != 2 || got[0] != "attendees" || got[1] != "contacts" {
+		t.Fatalf("Failed() = %v, want [attendees contacts] in load order", got)
+	}
+}
+
+func TestFailedNilWhenClean(t *testing.T) {
+	ctx := context.Background()
+	c := &hydrate.Collector{Kind: "event", ID: 1}
+
+	var comments []string
+	var called bool
+	hydrate.Rel(ctx, c, &comments, "comments", loader(&called, nil, []string{"ok"}, nil))
+
+	if err := c.Err(); err != nil {
+		t.Fatalf("Err() = %v, want nil", err)
+	}
+	if got := c.Failed(); got != nil {
+		t.Fatalf("Failed() = %v, want nil when every relation loaded", got)
+	}
+}
+
+// The CLI's export --skip-unreadable names the lost relations per record. In
+// fail-fast mode the run aborts after the first failure, so the later Rel
+// calls never record a second name.
+func TestFailedSingleEntryInFailFastMode(t *testing.T) {
+	ctx := context.Background()
+	c := &hydrate.Collector{Kind: "todo", ID: 4, FailFast: true}
+
+	var attendees, comments []string
+	var c1, c2 bool
+	hydrate.Rel(ctx, c, &attendees, "attendees", loader[string](&c1, nil, nil, errBoom))
+	hydrate.Rel(ctx, c, &comments, "comments", loader[string](&c2, nil, nil, errBoom))
+
+	if c2 {
+		t.Fatal("second loader ran in fail-fast mode")
+	}
+	got := c.Failed()
+	if len(got) != 1 || got[0] != "attendees" {
+		t.Fatalf("Failed() = %v, want [attendees]", got)
+	}
 }

--- a/internal/ical/comment_header_test.go
+++ b/internal/ical/comment_header_test.go
@@ -1,0 +1,126 @@
+package ical
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+)
+
+func sampleExportForComments(t *testing.T) []byte {
+	t.Helper()
+	data, err := ExportEvents([]event.Event{{
+		UID:       "caveat-1",
+		Title:     "Has relations",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 3, 27, 12, 0, 0, 0, time.UTC),
+	}}, "")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	return data
+}
+
+// The --skip-unreadable caveat must sit inside the VCALENDAR as ";" comment
+// lines, right after the opening line, so the file self-describes later.
+func TestPrependComments_InsertsAfterCalendarBegin(t *testing.T) {
+	t.Parallel()
+	data := PrependComments(sampleExportForComments(t), []string{"first note", "second note"})
+
+	s := string(data)
+	// The encoder sorts the calendar properties alphabetically, so only pin
+	// the comments to the opening line and check VERSION separately.
+	if !strings.HasPrefix(s, "BEGIN:VCALENDAR\r\n; first note\r\n; second note\r\n") {
+		t.Fatalf("comments not inserted right after BEGIN:VCALENDAR:\n%.120s", s)
+	}
+	if !strings.Contains(s, "VERSION:2.0") || !strings.Contains(s, "UID:caveat-1") {
+		t.Fatalf("comment insertion damaged the calendar:\n%s", s)
+	}
+}
+
+// A CR or LF inside a comment would split one entry into two physical lines
+// and desynchronize the header. Each entry stays one line.
+func TestPrependComments_SanitizesLineBreaks(t *testing.T) {
+	t.Parallel()
+	data := PrependComments(sampleExportForComments(t), []string{"one\r\ntwo"})
+	for _, line := range strings.Split(string(data), "\r\n") {
+		if strings.HasPrefix(line, "; ") && strings.Contains(line[2:], "\n") {
+			t.Fatalf("comment kept an embedded newline: %q", line)
+		}
+	}
+	if !strings.Contains(string(data), "; one  two\r\n") {
+		t.Fatalf("sanitized comment missing:\n%s", string(data))
+	}
+}
+
+// Non-calendar input has no anchor line; leave it untouched rather than
+// corrupt it.
+func TestPrependComments_NoCalendarUnchanged(t *testing.T) {
+	t.Parallel()
+	data := []byte("not a calendar")
+	got := PrependComments(data, []string{"note"})
+	if string(got) != "not a calendar" {
+		t.Fatalf("data without VCALENDAR changed: %q", got)
+	}
+}
+
+// go-ical's decoder rejects a ";" line ("empty property name"). chroncal's
+// own --skip-unreadable output carries such lines, so the importer strips
+// them before the decoder sees the stream.
+func TestImportFile_AcceptsCommentLines(t *testing.T) {
+	t.Parallel()
+	body := sampleExportForComments(t)
+	body = PrependComments(body, []string{
+		"chroncal wrote this file with --skip-unreadable.",
+		"event 7 (uid caveat-1): attendees",
+	})
+	res, err := ImportFile(strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("ImportFile with comment lines: %v", err)
+	}
+	if len(res.Events) != 1 || res.Events[0].UID != "caveat-1" {
+		t.Fatalf("Events = %+v, want one event with uid caveat-1", res.Events)
+	}
+	if res.SkippedComponents != 0 || len(res.Warnings) != 0 {
+		t.Fatalf("comments leaked into parsing: skipped=%d warnings=%v",
+			res.SkippedComponents, res.Warnings)
+	}
+}
+
+// Full round-trip sanity: an exported file with a caveat header still imports
+// cleanly through the same path the CLI import command uses.
+func TestRoundTrip_ExportWithCaveatHeaderImportsCleanly(t *testing.T) {
+	t.Parallel()
+	data := sampleExportForComments(t)
+	data = PrependComments(data, []string{"event 7 (uid caveat-1): attendees"})
+
+	tmp := t.TempDir() + "/caveat.ics"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	f, err := os.Open(tmp)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	defer f.Close()
+	res, err := ImportFile(f)
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(res.Events) != 1 {
+		t.Fatalf("Events = %d, want 1", len(res.Events))
+	}
+	e := res.Events[0]
+	if e.UID != "caveat-1" || e.Title != "Has relations" {
+		t.Fatalf("round-trip changed the record: %+v", e)
+	}
+	if e.StartTime != (time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC)) {
+		t.Fatalf("StartTime = %v, want the original instant", e.StartTime)
+	}
+}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -616,6 +616,45 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// PrependComments inserts comment lines after the calendar's opening
+// BEGIN:VCALENDAR line and returns the result. Each entry becomes one physical
+// line that starts with "; ". A CR or LF inside an entry is replaced with a
+// space, so one entry stays one line.
+//
+// RFC 5545 does not define a comment production, but readers skip unknown
+// lines that start with "; " in practice, and chroncal's own importer strips
+// them (see stripCommentLines). The CLI export --skip-unreadable path uses
+// this to carry its caveat inside the file, so the file self-describes months
+// later without terminal context. The data stays unchanged when it holds no
+// VCALENDAR opening line.
+func PrependComments(data []byte, comments []string) []byte {
+	if len(comments) == 0 {
+		return data
+	}
+	s := string(data)
+	idx := strings.Index(s, "BEGIN:VCALENDAR")
+	if idx < 0 {
+		return data
+	}
+	eol := strings.IndexAny(s[idx:], "\r\n")
+	var insertAt int
+	if eol < 0 {
+		// No line end after the opening line; append before whatever tail.
+		insertAt = len(s)
+	} else {
+		insertAt = idx + eol
+	}
+	var b strings.Builder
+	b.WriteString(s[:insertAt])
+	repl := strings.NewReplacer("\r", " ", "\n", " ")
+	for _, c := range comments {
+		b.WriteString("\r\n; ")
+		b.WriteString(repl.Replace(c))
+	}
+	b.WriteString(s[insertAt:])
+	return []byte(b.String())
+}
+
 // MergeCalendars combines two iCal byte streams into one VCALENDAR.
 // It takes the header from the first and appends all components from both.
 func MergeCalendars(a, b []byte) []byte {

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -61,6 +61,25 @@ var errImportLimitExceeded = errors.New("ical import exceeds configured limits")
 const xpropOriginalDTEND = model.XPropOriginalDTEND
 
 // ImportFile parses an iCal stream from a file or another local source.
+
+// stripCommentLines removes physical lines that start with ";" and returns the
+// rest. RFC 5545 does not define a comment production, but chroncal's own
+// ical export --skip-unreadable writes a caveat header in this shape, so the
+// importer must accept its own output again. A folded continuation line starts
+// with a space or a tab, so a ";" at column 0 can only be a comment line.
+func stripCommentLines(data []byte) []byte {
+	if !bytes.HasPrefix(data, []byte(";")) && !bytes.Contains(data, []byte("\n;")) {
+		return data
+	}
+	var out []byte
+	for _, line := range bytes.SplitAfter(data, []byte("\n")) {
+		if len(line) > 0 && line[0] == ';' {
+			continue
+		}
+		out = append(out, line...)
+	}
+	return out
+}
 func ImportFile(r io.Reader) (ImportResult, error) {
 	return importFile(r, false)
 }
@@ -91,6 +110,7 @@ func importFile(r io.Reader, remote bool) (ImportResult, error) {
 	if len(data) > maxImportBytes {
 		return result, fmt.Errorf("ical payload exceeds %d bytes", maxImportBytes)
 	}
+	data = stripCommentLines(data)
 
 	dec := ical.NewDecoder(bytes.NewReader(data))
 

--- a/internal/journal/hydrate_test.go
+++ b/internal/journal/hydrate_test.go
@@ -71,3 +71,20 @@ func TestJournalService_HydrateBestEffort_PopulatesPastAFailure(t *testing.T) {
 		t.Errorf("Comments = %d, want 1", len(fetched.Comments))
 	}
 }
+
+// See event.TestEventService_HydrateSkipUnreadable_NamesLostRelations.
+func TestJournalService_HydrateSkipUnreadable_NamesLostRelations(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	j := createJournal(t, svc)
+
+	hideTable(t, svc, "journal_attendees")
+
+	failed := svc.HydrateSkipUnreadable(ctx, &j)
+	if len(failed) != 1 || failed[0] != "attendees" {
+		t.Fatalf("HydrateSkipUnreadable = %v, want [attendees]", failed)
+	}
+	if err := svc.Hydrate(ctx, &j); err == nil {
+		t.Fatal("Hydrate returned nil with a relation unreadable; the default export must still abort")
+	}
+}

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -1061,7 +1061,17 @@ func (s *Service) HydrateBestEffort(ctx context.Context, j *Journal) error {
 	return s.hydrate(ctx, j, false)
 }
 
-func (s *Service) hydrate(ctx context.Context, j *Journal, failFast bool) error {
+// HydrateSkipUnreadable populates every relation it can and returns the names
+// of the relations it could not load. It never fails. See
+// event.Service.HydrateSkipUnreadable for the contract.
+func (s *Service) HydrateSkipUnreadable(ctx context.Context, j *Journal) []string {
+	return s.collect(ctx, j, false).Failed()
+}
+
+// collect loads every relation onto j through one Collector. Hydrate,
+// HydrateBestEffort, and HydrateSkipUnreadable share it, so the relation set
+// stays a single definition.
+func (s *Service) collect(ctx context.Context, j *Journal, failFast bool) *hydrate.Collector {
 	c := &hydrate.Collector{Kind: "journal", ID: j.ID, FailFast: failFast}
 	hydrate.Rel(ctx, c, &j.Attendees, "attendees", s.ListAttendees)
 	hydrate.Rel(ctx, c, &j.Attachments, "attachments", s.ListAttachments)
@@ -1069,5 +1079,9 @@ func (s *Service) hydrate(ctx context.Context, j *Journal, failFast bool) error 
 	hydrate.Rel(ctx, c, &j.Contacts, "contacts", s.ListContacts)
 	hydrate.Rel(ctx, c, &j.Relations, "relations", s.ListRelations)
 	hydrate.Rel(ctx, c, &j.XProperties, "x-properties", s.ListXProperties)
-	return c.Err()
+	return c
+}
+
+func (s *Service) hydrate(ctx context.Context, j *Journal, failFast bool) error {
+	return s.collect(ctx, j, failFast).Err()
 }

--- a/internal/todo/hydrate_test.go
+++ b/internal/todo/hydrate_test.go
@@ -80,3 +80,20 @@ func TestTodoService_HydrateBestEffort_PopulatesPastAFailure(t *testing.T) {
 		t.Errorf("Attendees = %d, want 1", len(fetched.Attendees))
 	}
 }
+
+// See event.TestEventService_HydrateSkipUnreadable_NamesLostRelations.
+func TestTodoService_HydrateSkipUnreadable_NamesLostRelations(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	td := createTodo(t, svc)
+
+	hideTable(t, svc, "todo_alarms")
+
+	failed := svc.HydrateSkipUnreadable(ctx, &td)
+	if len(failed) != 1 || failed[0] != "alarms" {
+		t.Fatalf("HydrateSkipUnreadable = %v, want [alarms]", failed)
+	}
+	if err := svc.Hydrate(ctx, &td); err == nil {
+		t.Fatal("Hydrate returned nil with a relation unreadable; the default export must still abort")
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -1719,7 +1719,17 @@ func (s *Service) HydrateBestEffort(ctx context.Context, t *Todo) error {
 	return s.hydrate(ctx, t, false)
 }
 
-func (s *Service) hydrate(ctx context.Context, t *Todo, failFast bool) error {
+// HydrateSkipUnreadable populates every relation it can and returns the names
+// of the relations it could not load. It never fails. See
+// event.Service.HydrateSkipUnreadable for the contract.
+func (s *Service) HydrateSkipUnreadable(ctx context.Context, t *Todo) []string {
+	return s.collect(ctx, t, false).Failed()
+}
+
+// collect loads every relation onto t through one Collector. Hydrate,
+// HydrateBestEffort, and HydrateSkipUnreadable share it, so the relation set
+// stays a single definition.
+func (s *Service) collect(ctx context.Context, t *Todo, failFast bool) *hydrate.Collector {
 	c := &hydrate.Collector{Kind: "todo", ID: t.ID, FailFast: failFast}
 	hydrate.Rel(ctx, c, &t.Alarms, "alarms", s.ListAlarms)
 	hydrate.Rel(ctx, c, &t.Attendees, "attendees", s.ListAttendees)
@@ -1729,5 +1739,9 @@ func (s *Service) hydrate(ctx context.Context, t *Todo, failFast bool) error {
 	hydrate.Rel(ctx, c, &t.Resources, "resources", s.ListResources)
 	hydrate.Rel(ctx, c, &t.Relations, "relations", s.ListRelations)
 	hydrate.Rel(ctx, c, &t.XProperties, "x-properties", s.ListXProperties)
-	return c.Err()
+	return c
+}
+
+func (s *Service) hydrate(ctx context.Context, t *Todo, failFast bool) error {
+	return s.collect(ctx, t, failFast).Err()
 }

--- a/internal/tui/harness_test.go
+++ b/internal/tui/harness_test.go
@@ -179,7 +179,7 @@ func TestHarness_EditSave_PreservesStoredAlarms(t *testing.T) {
 	updated, ok := next.(eventUpdatedMsg)
 	require.True(t, ok, "expected eventUpdatedMsg, got %T", next)
 	require.NoError(t, updated.err)
-	m, _ = step(t, m, next)
+	_, _ = step(t, m, next)
 
 	fresh, err := a.Events.Get(ctx, seeded.ID)
 	require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestHarness_CreateSave_WritesAlarmRows(t *testing.T) {
 	created, ok := next.(eventCreatedMsg)
 	require.True(t, ok, "expected eventCreatedMsg, got %T", next)
 	require.NoError(t, created.err)
-	m, _ = step(t, m, next)
+	_, _ = step(t, m, next)
 
 	events, err := a.Events.ListByDateRange(ctx, day, day.AddDate(0, 0, 1))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

`chroncal ical export` aborts and writes nothing when one record's relation read fails — for a 5000-event calendar, one `SQLITE_BUSY` from a concurrent sync means no backup at all. Fail-fast stays the **default** (a backup silently missing alarms is dangerous); this adds the explicit opt-out:

- `--skip-unreadable`: continue past per-record relation failures, write the `.ics`, and print a stderr summary naming every incomplete record (id + uid + lost relations).
- The same caveat is prepended as `;` comment lines inside the VCALENDAR, so the file self-describes months later without terminal context.
- `internal/hydrate.Collector` gains structured failed-relation tracking (`Failed()`); services expose `HydrateSkipUnreadable`. Fail-fast contracts untouched.
- The importer strips our own comment lines pre-decode (go-ical rejects `;` lines), so flagged exports round-trip cleanly.

## Tests

Subprocess test: default aborts writing nothing; flag mode writes a parseable `.ics` with the caveat header, keeps readable relations, omits only broken ones; `ImportFile` round-trip clean. Plus collector and per-service hydrate tests.

`go test ./cmd/... ./internal/ical/... ./internal/event/... ./internal/hydrate/...` pass.

Fixes #571
