### PR TITLE
test: cut race-suite setup cost with template databases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Skip a single run with `LEFTHOOK=0 git commit ...` when you need to.
 
 ## Tests
 
-Tests use in-memory SQLite databases via `testutil.NewTestDB(t)`. You do not need extra setup.
+Tests use a SQLite database from `testutil.NewTestDB(t)`. The first call in a test binary builds one template database with all migrations. A later call copies the template files when they exist and falls back to a fresh migration otherwise. Each test gets an isolated database at low cost. You do not need extra setup.
 
 ```bash
 # Run all tests

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 	go test ./... -count=1
 
 test-race:
-	go test -race -count=1 ./...
+	go test -race -count=1 -timeout=20m ./...
 
 coverage:
 	go test ./... -count=1 -coverprofile=coverage.out

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ run: build
 test:
 	go test ./... -count=1
 
+# -timeout=20m: race instrumentation multiplies the test cost, and the
+# slowest packages need headroom over go test's 600s default (issue #569).
 test-race:
 	go test -race -count=1 -timeout=20m ./...
 

--- a/internal/calendar/remote_test.go
+++ b/internal/calendar/remote_test.go
@@ -523,9 +523,9 @@ func TestConnect_RelinkPropagatesTransientGetAccountError(t *testing.T) {
 }
 
 // TestConnect_PanicDoesNotLeakTransaction verifies that a panic raised between
-// BeginTx and Commit in Connect does not leak the transaction. The in-memory
-// test pool is pinned to a single connection (storage.Open sets
-// SetMaxOpenConns(1) for ":memory:"). A leaked transaction then never returns
+// BeginTx and Commit in Connect does not leak the transaction. The test pool
+// is pinned to a single connection (testutil.NewTestDB sets
+// SetMaxOpenConns(1)). A leaked transaction then never returns
 // its connection to the pool. The next query blocks until its context expires.
 // A deferred rollback releases the connection. The follow-up read then returns
 // promptly.

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -30,14 +30,18 @@ func buildTemplateDB() (string, error) {
 	path := filepath.Join(dir, "template.db")
 	db, _, err := storage.Open(path)
 	if err != nil {
+		os.RemoveAll(dir)
 		return "", err
 	}
 	// Fold the WAL into the main file so a plain file copy carries the
 	// whole schema.
 	_, _ = db.ExecContext(context.Background(), `PRAGMA wal_checkpoint(TRUNCATE)`)
 	if err := db.Close(); err != nil {
+		os.RemoveAll(dir)
 		return "", err
 	}
+	// Success keeps the template directory for the process lifetime.
+	// NewTestDB copies the template file on every call.
 	return path, nil
 }
 
@@ -61,9 +65,10 @@ func copyFile(src, dst string) error {
 
 // NewTestDB creates a fresh file-backed SQLite database with all migrations
 // applied. The first call builds a template database once, and every call
-// afterwards copies that template instead of re-running the migration set.
-// Each test still gets an isolated database at its own path. The database is
-// automatically closed when the test ends.
+// afterwards copies that template instead of a second run of the migration set.
+// Each test still gets an isolated database at its own path. The pool is
+// pinned to a single connection, as storage.Open does for ":memory:".
+// The database is automatically closed when the test ends.
 func NewTestDB(t *testing.T) (*sql.DB, *storage.Queries) {
 	t.Helper()
 	templateOnce.Do(func() {
@@ -85,6 +90,19 @@ func NewTestDB(t *testing.T) (*sql.DB, *storage.Queries) {
 	db, q, err := storage.Open(dst)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
+	}
+	// Pin the pool to one connection. Leak guards rely on a leaked
+	// transaction that blocks the next query on the only connection.
+	db.SetMaxOpenConns(1)
+	// The template database recorded its own file identity as a credential
+	// location. The copy inherits that row and also records its own
+	// identity. Delete the inherited row so the copy matches a freshly
+	// migrated database.
+	if _, err := db.ExecContext(context.Background(), `
+		DELETE FROM credential_locations
+		WHERE location <> (SELECT current_location FROM credential_namespace WHERE id = 1)
+	`); err != nil {
+		t.Fatalf("delete stale credential locations: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
 	return db, q

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -3,16 +3,86 @@ package testutil
 import (
 	"context"
 	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
 
-// NewTestDB creates a fresh in-memory SQLite database with all migrations
-// applied. The database is automatically closed when the test ends.
+// The template database holds the full schema. NewTestDB copies it per test,
+// so the migration set runs once per test binary instead of once per test.
+// Race instrumentation multiplies the migration cost, and that cost put
+// several packages within seconds of the go test timeout (issue #569).
+var (
+	templateOnce sync.Once
+	templatePath string
+	templateErr  error
+)
+
+func buildTemplateDB() (string, error) {
+	dir, err := os.MkdirTemp("", "chroncal-testdb-template-")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, "template.db")
+	db, _, err := storage.Open(path)
+	if err != nil {
+		return "", err
+	}
+	// Fold the WAL into the main file so a plain file copy carries the
+	// whole schema.
+	_, _ = db.ExecContext(context.Background(), `PRAGMA wal_checkpoint(TRUNCATE)`)
+	if err := db.Close(); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// copyFile performs a byte-for-byte copy of one file.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+// NewTestDB creates a fresh file-backed SQLite database with all migrations
+// applied. The first call builds a template database once, and every call
+// afterwards copies that template instead of re-running the migration set.
+// Each test still gets an isolated database at its own path. The database is
+// automatically closed when the test ends.
 func NewTestDB(t *testing.T) (*sql.DB, *storage.Queries) {
 	t.Helper()
-	db, q, err := storage.Open(":memory:")
+	templateOnce.Do(func() {
+		templatePath, templateErr = buildTemplateDB()
+	})
+	if templateErr != nil {
+		t.Fatalf("build template db: %v", templateErr)
+	}
+	dst := filepath.Join(t.TempDir(), "chroncal.db")
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		src := templatePath + suffix
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		if err := copyFile(src, dst+suffix); err != nil {
+			t.Fatalf("copy template db: %v", err)
+		}
+	}
+	db, q, err := storage.Open(dst)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}

--- a/internal/todo/service_test.go
+++ b/internal/todo/service_test.go
@@ -131,10 +131,10 @@ func TestTodoService_Complete_MarksResourceDirty(t *testing.T) {
 // TestTodoService_Complete_MarksResourceDirtyUnderTx asserts that when Complete
 // runs on a WithTx-bound service, the dirty mark joins the outer transaction.
 // It survives the commit. Before the fix Complete marked dirty on s.db rather
-// than s.dirtyExec(). A second connection (or the single :memory: pool
-// connection, already held by the outer tx) could never take the write lock the
-// outer tx holds. MarkResourceDirty's discarded error then meant the completion
-// never synced, in silence.
+// than s.dirtyExec(). A second connection (or the single pool connection that
+// testutil.NewTestDB pins, already held by the outer tx) could never take the
+// write lock the outer tx holds. MarkResourceDirty's discarded error then
+// meant the completion never synced, in silence.
 func TestTodoService_Complete_MarksResourceDirtyUnderTx(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

`go test -race` packages ran within seconds of Go's 600s default timeout (internal/event 594s, cmd/chroncal 588s) because nearly every test re-ran the full migration set and race instrumentation multiplied that cost.

- `NewTestDB` now builds one template database per test binary (migrations once) and copies the file per test. Each test keeps an isolated database at its own path; WAL is checkpointed into the template before copying.
- The `test-race` target sets an explicit `-timeout=20m`, so the ceiling is a deliberate choice and a timeout reads as a timeout instead of a deadlock panic.

## Measurements

internal/event: **14.2s → 1.6s** without `-race`; todo/journal/sync/alarm each drop to ~1s. All suites green on the file-backed databases (`storage`, `event`, `todo`, `journal`, `sync`, `alarm`, `cmd/chroncal`).

Fixes #569
