### PR TITLE
feat(sync): add sync doctor escape hatch for wedged resources

### DIFF
--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -99,7 +99,7 @@ conflicts for calendars connected to remote CalDAV calendars.`,
 		Args: rejectUnknownSubcommand,
 		RunE: groupRunE,
 	}
-	cmd.AddCommand(syncRunCmd(), syncStatusCmd(), syncConflictsCmd(), syncResolveCmd(), syncResetCmd())
+	cmd.AddCommand(syncRunCmd(), syncStatusCmd(), syncConflictsCmd(), syncResolveCmd(), syncResetCmd(), syncDoctorCmd())
 	return cmd
 }
 

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+	syncPkg "github.com/douglasdemoura/chroncal/internal/sync"
+)
+
+// syncDoctorCmd lists wedged sync resources and offers the confirmed escape
+// push. A wedged resource fails export on a deterministic hydration error.
+// Every sync then retries it and no edit under its UID reaches the server
+// (issue #568). The push mode omits the unreadable relations from the PUT.
+// The user accepts that loss with an explicit confirmation.
+func syncDoctorCmd() *cobra.Command {
+	var pushUID string
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Find and recover wedged sync resources",
+		Long: `List local resources whose unreadable data wedges the sync.
+
+A wedged resource stays dirty forever. Every sync retries it and fails on
+the same unreadable relation, and no edit under its UID reaches the server.
+With --push, chroncal pushes the resource without the unreadable relations.
+The server copy then loses exactly those fields. The command prints the loss
+before the push and asks for confirmation.`,
+		Example: `  chroncal sync doctor
+  chroncal sync doctor --push 6f2c8e42-...@example.com --yes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			a, err := initApp()
+			if err != nil {
+				return err
+			}
+			defer a.Close()
+
+			ctx := context.Background()
+			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+
+			cals, err := a.Queries.ListCalendars(ctx)
+			if err != nil {
+				return fmt.Errorf("list calendars: %w", err)
+			}
+
+			if pushUID != "" {
+				return runDoctorPush(cmd, svc, cals, pushUID)
+			}
+			return runDoctorList(cmd, svc, cals)
+		},
+	}
+	cmd.Flags().StringVar(&pushUID, "push", "", "push this UID and drop its unreadable relations")
+	addConfirmFlag(cmd)
+	return cmd
+}
+
+// runDoctorList prints one line per wedged resource across all calendars.
+func runDoctorList(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Calendar) error {
+	out := cmd.OutOrStdout()
+	total := 0
+	for _, cal := range cals {
+		wedged, err := svc.DiagnoseCalendar(context.Background(), cal.ID)
+		if err != nil {
+			return fmt.Errorf("diagnose calendar %q: %w", cal.Name, err)
+		}
+		for _, w := range wedged {
+			total++
+			fmt.Fprintf(out, "calendar %q uid %s (%s): unreadable relation(s) %s\n",
+				cal.Name, w.UID, w.OwnerType, strings.Join(w.Relations, ", "))
+		}
+	}
+	if total == 0 {
+		fmt.Fprintln(out, "No wedged resources.")
+		return nil
+	}
+	fmt.Fprintf(out, "\n%d wedged resource(s). Recover one with:\n", total)
+	fmt.Fprintf(cmd.ErrOrStderr(), "  chroncal sync doctor --push <uid> --yes\n")
+	fmt.Fprintf(cmd.ErrOrStderr(), "The push drops the unreadable relations from the server copy.\n")
+	return nil
+}
+
+// runDoctorPush locates the UID among the wedged resources, announces the
+// loss, asks for confirmation, and pushes the incomplete record.
+func runDoctorPush(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Calendar, uid string) error {
+	ctx := context.Background()
+	for _, cal := range cals {
+		wedged, err := svc.DiagnoseCalendar(ctx, cal.ID)
+		if err != nil {
+			return fmt.Errorf("diagnose calendar %q: %w", cal.Name, err)
+		}
+		for _, w := range wedged {
+			if w.UID != uid {
+				continue
+			}
+			question := fmt.Sprintf(
+				"Push %s from calendar %q without relation(s) %s? The server copy loses those fields",
+				uid, cal.Name, strings.Join(w.Relations, ", "))
+			if err := confirmDestructive(cmd, question); err != nil {
+				return err
+			}
+			dropped, err := svc.DoctorPush(ctx, cal.ID, uid)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Pushed %s. Dropped relation(s): %s.\n",
+				uid, strings.Join(dropped, ", "))
+			fmt.Fprintf(cmd.OutOrStdout(), "The resource is no longer dirty. Other edits flow again.\n")
+			return nil
+		}
+	}
+	return &cliError{
+		Code: "not-wedged",
+		Msg:  fmt.Sprintf("no wedged resource with uid %q; run chroncal sync doctor for the list", uid),
+	}
+}

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -30,6 +30,7 @@ With --push, chroncal pushes the resource without the unreadable relations.
 The server copy then loses exactly those fields. The command prints the loss
 before the push and asks for confirmation.`,
 		Example: `  chroncal sync doctor
+  chroncal sync doctor --output json
   chroncal sync doctor --push 6f2c8e42-...@example.com --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a, err := initApp()
@@ -58,28 +59,67 @@ before the push and asks for confirmation.`,
 	return cmd
 }
 
-// runDoctorList prints one line per wedged resource across all calendars.
-func runDoctorList(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Calendar) error {
-	out := cmd.OutOrStdout()
-	total := 0
+// doctorEntry pairs one wedged resource with the calendar that holds it, so
+// both render functions print the calendar name next to the UID.
+type doctorEntry struct {
+	calendarName string
+	wedged       syncPkg.WedgedResource
+}
+
+// diagnoseAll collects the wedged resources of every calendar.
+func diagnoseAll(ctx context.Context, svc *syncPkg.Service, cals []storage.Calendar) ([]doctorEntry, error) {
+	var entries []doctorEntry
 	for _, cal := range cals {
-		wedged, err := svc.DiagnoseCalendar(context.Background(), cal.ID)
+		wedged, err := svc.DiagnoseCalendar(ctx, cal.ID)
 		if err != nil {
-			return fmt.Errorf("diagnose calendar %q: %w", cal.Name, err)
+			return nil, fmt.Errorf("diagnose calendar %q: %w", cal.Name, err)
 		}
 		for _, w := range wedged {
-			total++
-			fmt.Fprintf(out, "calendar %q uid %s (%s): unreadable relation(s) %s\n",
-				cal.Name, w.UID, w.OwnerType, strings.Join(w.Relations, ", "))
+			entries = append(entries, doctorEntry{calendarName: cal.Name, wedged: w})
 		}
 	}
-	if total == 0 {
+	return entries, nil
+}
+
+// runDoctorList prints one line per wedged resource across all calendars.
+// JSON and YAML return an array, [] when no calendar holds a wedge, like
+// every sibling read command.
+func runDoctorList(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Calendar) error {
+	entries, err := diagnoseAll(context.Background(), svc, cals)
+	if err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+
+	if outputFmt != "text" {
+		items := make([]map[string]any, 0, len(entries))
+		for _, en := range entries {
+			items = append(items, map[string]any{
+				"calendar_id":     en.wedged.CalendarID,
+				"calendar_name":   en.calendarName,
+				"uid":             en.wedged.UID,
+				"owner_type":      en.wedged.OwnerType,
+				"relations":       en.wedged.Relations,
+				"push_fail_count": en.wedged.PushFailCount,
+			})
+		}
+		return printOutput(out, items)
+	}
+
+	if len(entries) == 0 {
 		fmt.Fprintln(out, "No wedged resources.")
 		return nil
 	}
-	fmt.Fprintf(out, "\n%d wedged resource(s). Recover one with:\n", total)
-	fmt.Fprintf(cmd.ErrOrStderr(), "  chroncal sync doctor --push <uid> --yes\n")
-	fmt.Fprintf(cmd.ErrOrStderr(), "The push drops the unreadable relations from the server copy.\n")
+	for _, en := range entries {
+		fmt.Fprintf(out, "calendar %q uid %s (%s): unreadable relation(s) %s; %d failed push attempt(s)\n",
+			en.calendarName, en.wedged.UID, en.wedged.OwnerType,
+			strings.Join(en.wedged.Relations, ", "), en.wedged.PushFailCount)
+	}
+	// The whole hint block goes to stdout. A consumer that captures stdout
+	// then also captures the recovery command.
+	fmt.Fprintf(out, "\n%d wedged resource(s). Recover one with:\n", len(entries))
+	fmt.Fprintln(out, "  chroncal sync doctor --push <uid> --yes")
+	fmt.Fprintln(out, "The push drops the unreadable relations from the server copy.")
 	return nil
 }
 
@@ -106,14 +146,28 @@ func runDoctorPush(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Cale
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Pushed %s. Dropped relation(s): %s.\n",
-				uid, strings.Join(dropped, ", "))
-			fmt.Fprintf(cmd.OutOrStdout(), "The resource is no longer dirty. Other edits flow again.\n")
-			return nil
+			return renderDoctorPush(cmd, uid, dropped)
 		}
 	}
 	return &cliError{
-		Code: "not-wedged",
+		Code: "not_found",
 		Msg:  fmt.Sprintf("no wedged resource with uid %q; run chroncal sync doctor for the list", uid),
 	}
+}
+
+// renderDoctorPush confirms the escape push using the active --output
+// format, like the sibling sync resolve command.
+func renderDoctorPush(cmd *cobra.Command, uid string, dropped []string) error {
+	if outputFmt != "text" {
+		return printOutput(cmd.OutOrStdout(), map[string]any{
+			"uid":     uid,
+			"pushed":  true,
+			"dropped": dropped,
+		})
+	}
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Pushed %s. Dropped relation(s): %s.\n",
+		uid, strings.Join(dropped, ", "))
+	fmt.Fprintln(out, "The resource is no longer dirty. Other edits flow again.")
+	return nil
 }

--- a/cmd/chroncal/sync_doctor_cli_test.go
+++ b/cmd/chroncal/sync_doctor_cli_test.go
@@ -1,64 +1,21 @@
 package main
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
-
 	"github.com/douglasdemoura/chroncal/internal/app"
-	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
 
-// runSyncDoctorInProcess executes `sync doctor` against the database that
-// CHRONCAL_DB points at. The confirm helper refuses a non-interactive shell
-// without --yes, which is exactly the behavior under test.
-func runSyncDoctorInProcess(t *testing.T, args ...string) (string, string, error) {
+// seedWedgedCLIResource inserts one dirty event whose relations relation
+// cannot load, then renames that table. The doctor then lists exactly one
+// wedge. event_relations is safe to rename: only hydration reads it, so the
+// helper process still opens the database afterwards.
+func seedWedgedCLIResource(t *testing.T, dbPath string) {
 	t.Helper()
-
-	prevFmt, prevPlaintext := outputFmt, allowPlaintext
-	t.Cleanup(func() { outputFmt, allowPlaintext = prevFmt, prevPlaintext })
-
-	root := &cobra.Command{
-		Use: "chroncal-test",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			cfg, err = config.Load()
-			return err
-		},
-	}
-	root.PersistentFlags().StringVarP(&outputFmt, "output", "o", "text", "output format (text, json)")
-	root.PersistentFlags().BoolVar(&allowPlaintext, "allow-plaintext", false, "permit storing credentials in plaintext when no OS keyring is available")
-	root.AddCommand(syncCmd())
-	var out, errBuf bytes.Buffer
-	root.SetOut(&out)
-	root.SetErr(&errBuf)
-	root.SetArgs(args)
-	err := root.Execute()
-	return out.String(), errBuf.String(), err
-}
-
-func TestSyncDoctorEmptyReportsNone(t *testing.T) {
-	t.Setenv("CHRONCAL_DB", t.TempDir()+"/doctor.db")
-
-	out, _, err := runSyncDoctorInProcess(t, "sync", "doctor")
-	if err != nil {
-		t.Fatalf("sync doctor: %v", err)
-	}
-	if !strings.Contains(out, "No wedged resources.") {
-		t.Errorf("output %q misses the empty report", out)
-	}
-}
-
-func TestSyncDoctorPushRefusesNonInteractiveWithoutYes(t *testing.T) {
-	dbPath := t.TempDir() + "/doctor.db"
-	t.Setenv("CHRONCAL_DB", dbPath)
-
-	// Seed one wedged resource so the push flow reaches its confirmation
-	// gate instead of stopping at the not-found check.
 	a, err := app.New(dbPath)
 	if err != nil {
 		t.Fatalf("app.New: %v", err)
@@ -87,19 +44,157 @@ func TestSyncDoctorPushRefusesNonInteractiveWithoutYes(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertSyncResource: %v", err)
 	}
-	// Wedge the relations relation. app.New must stay able to open the
-	// database afterwards, so the wedge cannot touch a table the startup
-	// maintenance queries (event_alarms, x-properties). event_relations is
-	// safe: only hydration reads it.
 	if _, err := a.DB.ExecContext(ctx, `ALTER TABLE event_relations RENAME TO event_relations_broken`); err != nil {
 		t.Fatalf("rename event_relations: %v", err)
 	}
+}
 
-	_, _, err = runSyncDoctorInProcess(t, "sync", "doctor", "--push", "wedge-cli@example.com")
+// bumpPushFailCount stores a failed-push count on the wedged resource, like
+// the engine bookkeeping does after failed push attempts.
+func bumpPushFailCount(t *testing.T, dbPath string, count int) {
+	t.Helper()
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+	if _, err := a.DB.ExecContext(context.Background(),
+		`UPDATE sync_resources SET push_fail_count = ?, last_push_error = ?`,
+		count, "export wedge-cli@example.com: unreadable relation(s) relations",
+	); err != nil {
+		t.Fatalf("bump push_fail_count: %v", err)
+	}
+}
+
+func TestSyncDoctorEmptyReportsNone(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	stdout, _, err := runChroncalCommand(t, "sync", "doctor")
+	if err != nil {
+		t.Fatalf("sync doctor: %v", err)
+	}
+	if !strings.Contains(stdout, "No wedged resources.") {
+		t.Errorf("output %q misses the empty report", stdout)
+	}
+}
+
+func TestSyncDoctorJSONEmptyIsArray(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	stdout, _, err := runChroncalCommand(t, "sync", "doctor", "--output", "json")
+	if err != nil {
+		t.Fatalf("sync doctor --output json: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &items); err != nil {
+		t.Fatalf("decode %q: %v", stdout, err)
+	}
+	if len(items) != 0 {
+		t.Errorf("items = %v, want an empty array", items)
+	}
+}
+
+func TestSyncDoctorListsWedgedResource(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	seedWedgedCLIResource(t, dbPath)
+
+	stdout, stderr, err := runChroncalCommand(t, "sync", "doctor")
+	if err != nil {
+		t.Fatalf("sync doctor: %v (stderr: %s)", err, stderr)
+	}
+	if !strings.Contains(stdout, "uid wedge-cli@example.com (event): unreadable relation(s) relations; 0 failed push attempt(s)") {
+		t.Errorf("output %q misses the wedged line with its push-failure count", stdout)
+	}
+	// The whole recovery hint belongs to stdout. A consumer that captures
+	// stdout then also captures the command it needs.
+	for _, want := range []string{
+		"1 wedged resource(s). Recover one with:",
+		"chroncal sync doctor --push <uid> --yes",
+		"The push drops the unreadable relations from the server copy.",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout %q misses hint %q", stdout, want)
+		}
+	}
+	if strings.Contains(stderr, "chroncal sync doctor") {
+		t.Errorf("stderr %q carries part of the hint; the hint belongs on stdout", stderr)
+	}
+
+	bumpPushFailCount(t, dbPath, 3)
+	stdout, _, err = runChroncalCommand(t, "sync", "doctor")
+	if err != nil {
+		t.Fatalf("sync doctor after bumps: %v", err)
+	}
+	if !strings.Contains(stdout, "3 failed push attempt(s)") {
+		t.Errorf("output %q misses the recorded push-failure count", stdout)
+	}
+}
+
+func TestSyncDoctorJSONListsWedgedResource(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	seedWedgedCLIResource(t, dbPath)
+	bumpPushFailCount(t, dbPath, 2)
+
+	stdout, _, err := runChroncalCommand(t, "sync", "doctor", "--output", "json")
+	if err != nil {
+		t.Fatalf("sync doctor --output json: %v", err)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &items); err != nil {
+		t.Fatalf("decode %q: %v", stdout, err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %v, want one entry", items)
+	}
+	item := items[0]
+	if item["uid"] != "wedge-cli@example.com" {
+		t.Errorf("uid = %v, want wedge-cli@example.com", item["uid"])
+	}
+	if item["owner_type"] != "event" {
+		t.Errorf("owner_type = %v, want event", item["owner_type"])
+	}
+	relations, _ := item["relations"].([]any)
+	if len(relations) != 1 || relations[0] != "relations" {
+		t.Errorf("relations = %v, want [relations]", item["relations"])
+	}
+	if item["push_fail_count"] != float64(2) {
+		t.Errorf("push_fail_count = %v, want 2", item["push_fail_count"])
+	}
+}
+
+func TestSyncDoctorPushRefusesNonInteractiveWithoutYes(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	seedWedgedCLIResource(t, dbPath)
+
+	// Seed one wedged resource so the push flow reaches its confirmation
+	// gate instead of stopping at the not-found check.
+	_, _, err := runChroncalCommand(t, "sync", "doctor", "--push", "wedge-cli@example.com")
 	if err == nil {
 		t.Fatal("expected refusal without --yes in a non-interactive shell")
 	}
 	if !strings.Contains(err.Error(), "--yes") {
 		t.Errorf("refusal %q does not mention --yes", err.Error())
+	}
+}
+
+func TestSyncDoctorPushUnknownUIDIsNotFound(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	_, stderr, err := runChroncalCommand(t, "sync", "doctor", "--push", "missing@example.com", "--yes", "--output", "json")
+	if err == nil {
+		t.Fatal("push of an unknown uid should fail")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error payload %q: %v", stderr, jerr)
+	}
+	if payload.Code != "not_found" {
+		t.Fatalf("code = %q, want not_found", payload.Code)
+	}
+	if !strings.Contains(payload.Error, "missing@example.com") {
+		t.Fatalf("error = %q, want it to name the uid", payload.Error)
 	}
 }

--- a/cmd/chroncal/sync_doctor_cli_test.go
+++ b/cmd/chroncal/sync_doctor_cli_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/config"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// runSyncDoctorInProcess executes `sync doctor` against the database that
+// CHRONCAL_DB points at. The confirm helper refuses a non-interactive shell
+// without --yes, which is exactly the behavior under test.
+func runSyncDoctorInProcess(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
+	prevFmt, prevPlaintext := outputFmt, allowPlaintext
+	t.Cleanup(func() { outputFmt, allowPlaintext = prevFmt, prevPlaintext })
+
+	root := &cobra.Command{
+		Use: "chroncal-test",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			cfg, err = config.Load()
+			return err
+		},
+	}
+	root.PersistentFlags().StringVarP(&outputFmt, "output", "o", "text", "output format (text, json)")
+	root.PersistentFlags().BoolVar(&allowPlaintext, "allow-plaintext", false, "permit storing credentials in plaintext when no OS keyring is available")
+	root.AddCommand(syncCmd())
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs(args)
+	err := root.Execute()
+	return out.String(), errBuf.String(), err
+}
+
+func TestSyncDoctorEmptyReportsNone(t *testing.T) {
+	t.Setenv("CHRONCAL_DB", t.TempDir()+"/doctor.db")
+
+	out, _, err := runSyncDoctorInProcess(t, "sync", "doctor")
+	if err != nil {
+		t.Fatalf("sync doctor: %v", err)
+	}
+	if !strings.Contains(out, "No wedged resources.") {
+		t.Errorf("output %q misses the empty report", out)
+	}
+}
+
+func TestSyncDoctorPushRefusesNonInteractiveWithoutYes(t *testing.T) {
+	dbPath := t.TempDir() + "/doctor.db"
+	t.Setenv("CHRONCAL_DB", dbPath)
+
+	// Seed one wedged resource so the push flow reaches its confirmation
+	// gate instead of stopping at the not-found check.
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+	ctx := context.Background()
+	cals, err := a.Queries.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	if _, err := a.DB.ExecContext(ctx,
+		`INSERT INTO events (uid, calendar_id, title, start_time, end_time, status, transp, class)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"wedge-cli@example.com", cals[0].ID, "Wedged",
+		"2026-04-03T10:00:00Z", "2026-04-03T11:00:00Z", "CONFIRMED", "OPAQUE", "PUBLIC",
+	); err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	if err := a.Queries.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   cals[0].ID,
+		Uid:          "wedge-cli@example.com",
+		OwnerType:    "event",
+		Etag:         "",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+	// Wedge the relations relation. app.New must stay able to open the
+	// database afterwards, so the wedge cannot touch a table the startup
+	// maintenance queries (event_alarms, x-properties). event_relations is
+	// safe: only hydration reads it.
+	if _, err := a.DB.ExecContext(ctx, `ALTER TABLE event_relations RENAME TO event_relations_broken`); err != nil {
+		t.Fatalf("rename event_relations: %v", err)
+	}
+
+	_, _, err = runSyncDoctorInProcess(t, "sync", "doctor", "--push", "wedge-cli@example.com")
+	if err == nil {
+		t.Fatal("expected refusal without --yes in a non-interactive shell")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("refusal %q does not mention --yes", err.Error())
+	}
+}

--- a/db/migrations/047_sync_push_fail_count.sql
+++ b/db/migrations/047_sync_push_fail_count.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+-- Consecutive failed push attempts per resource. Push increments the counter
+-- and stores the error on every failed export or PUT. A successful push
+-- resets both. A resource that fails the same way on every sync then shows a
+-- growing count: the wedge that 'chroncal sync doctor' reports.
+ALTER TABLE sync_resources ADD COLUMN push_fail_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sync_resources ADD COLUMN last_push_error TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE sync_resources DROP COLUMN last_push_error;
+ALTER TABLE sync_resources DROP COLUMN push_fail_count;

--- a/db/migrations/047_sync_push_fail_count.sql
+++ b/db/migrations/047_sync_push_fail_count.sql
@@ -1,9 +1,10 @@
 -- +goose Up
 
--- Consecutive failed push attempts per resource. Push increments the counter
--- and stores the error on every failed export or PUT. A successful push
--- resets both. A resource that fails the same way on every sync then shows a
--- growing count: the wedge that 'chroncal sync doctor' reports.
+-- Consecutive failed push attempts per resource. The engine and the sync
+-- doctor increment the counter and store the error after every failed
+-- export, parse, or PUT. A successful push resets both. A resource that
+-- fails the same way on every sync then shows a growing count: the wedge
+-- that 'chroncal sync doctor' reports.
 ALTER TABLE sync_resources ADD COLUMN push_fail_count INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE sync_resources ADD COLUMN last_push_error TEXT NOT NULL DEFAULT '';
 

--- a/db/queries/sync_resources.sql
+++ b/db/queries/sync_resources.sql
@@ -40,15 +40,18 @@ WHERE calendar_id = ? AND uid = ?;
 
 -- name: RecordSyncResourcePushFailure :exec
 -- One more consecutive failed push attempt for this resource. The engine
--- calls this after a failed export or PUT. Doctor reads the counter to show
--- how long a resource stayed wedged.
+-- and the sync doctor call this after a push attempt that fails on an
+-- export, a parse, or a PUT. The doctor reads the counter to show how long
+-- a resource stayed wedged.
 UPDATE sync_resources
 SET push_fail_count = push_fail_count + 1,
     last_push_error = ?
 WHERE calendar_id = ? AND uid = ?;
 
 -- name: ClearSyncResourcePushFailure :exec
--- Reset the failure bookkeeping after a successful push.
+-- Reset the failure bookkeeping after a successful push. The engine clears
+-- it next to FinalizePushedResource. The sync doctor clears it after its
+-- escape-hatch PUT lands.
 UPDATE sync_resources SET push_fail_count = 0, last_push_error = ''
 WHERE calendar_id = ? AND uid = ?;
 

--- a/db/queries/sync_resources.sql
+++ b/db/queries/sync_resources.sql
@@ -38,6 +38,20 @@ SET etag = ?,
     dirty = CASE WHEN rev = ? THEN 0 ELSE dirty END
 WHERE calendar_id = ? AND uid = ?;
 
+-- name: RecordSyncResourcePushFailure :exec
+-- One more consecutive failed push attempt for this resource. The engine
+-- calls this after a failed export or PUT. Doctor reads the counter to show
+-- how long a resource stayed wedged.
+UPDATE sync_resources
+SET push_fail_count = push_fail_count + 1,
+    last_push_error = ?
+WHERE calendar_id = ? AND uid = ?;
+
+-- name: ClearSyncResourcePushFailure :exec
+-- Reset the failure bookkeeping after a successful push.
+UPDATE sync_resources SET push_fail_count = 0, last_push_error = ''
+WHERE calendar_id = ? AND uid = ?;
+
 -- name: DeleteSyncResource :exec
 DELETE FROM sync_resources WHERE calendar_id = ? AND uid = ?;
 

--- a/internal/hydrate/hydrate.go
+++ b/internal/hydrate/hydrate.go
@@ -62,11 +62,6 @@ func Rel[T any](ctx context.Context, c *Collector, dst *[]T, rel string, load fu
 	*dst = v
 }
 
-// Failures returns one entry per failed relation load.
-func (c *Collector) Failures() []RelFailure {
-	return c.failures
-}
-
 // Err returns the recorded errors joined via errors.Join, or nil when every
 // relation loaded. A non-nil result is always a *HydrationError, so callers
 // can read the failed relations in structured form via errors.As.

--- a/internal/hydrate/hydrate.go
+++ b/internal/hydrate/hydrate.go
@@ -15,13 +15,33 @@ import (
 	"fmt"
 )
 
+// RelFailure identifies one relation that failed to load.
+type RelFailure struct {
+	Kind     string // record kind: "event", "todo", "journal"
+	ID       int64  // record row ID
+	Relation string // relation name as passed to Rel
+	Cause    error  // loader error
+}
+
+// HydrationError reports one or more failed relation loads. It wraps the
+// joined causes and also carries each failure in structured form, so a
+// caller can name the broken relation without parsing text.
+type HydrationError struct {
+	Err      error
+	Failures []RelFailure
+}
+
+func (h *HydrationError) Error() string { return h.Err.Error() }
+
+func (h *HydrationError) Unwrap() error { return h.Err }
+
 // Collector tracks relation-load errors for a single record.
 type Collector struct {
 	Kind     string // record kind for error messages: "event", "todo", "journal"
 	ID       int64  // record row ID, passed to every loader
 	FailFast bool   // stop at the first error instead of loading the rest
 
-	errs []error
+	failures []RelFailure
 }
 
 // Rel loads one relation via load(ctx, c.ID) and assigns the result to *dst.
@@ -31,19 +51,32 @@ type Collector struct {
 //
 // It is a free function because Go methods cannot have type parameters.
 func Rel[T any](ctx context.Context, c *Collector, dst *[]T, rel string, load func(context.Context, int64) ([]T, error)) {
-	if c.FailFast && len(c.errs) > 0 {
+	if c.FailFast && len(c.failures) > 0 {
 		return
 	}
 	v, err := load(ctx, c.ID)
 	if err != nil {
-		c.errs = append(c.errs, fmt.Errorf("%s %d %s: %w", c.Kind, c.ID, rel, err))
+		c.failures = append(c.failures, RelFailure{Kind: c.Kind, ID: c.ID, Relation: rel, Cause: err})
 		return
 	}
 	*dst = v
 }
 
+// Failures returns one entry per failed relation load.
+func (c *Collector) Failures() []RelFailure {
+	return c.failures
+}
+
 // Err returns the recorded errors joined via errors.Join, or nil when every
-// relation loaded.
+// relation loaded. A non-nil result is always a *HydrationError, so callers
+// can read the failed relations in structured form via errors.As.
 func (c *Collector) Err() error {
-	return errors.Join(c.errs...)
+	if len(c.failures) == 0 {
+		return nil
+	}
+	errs := make([]error, len(c.failures))
+	for i, f := range c.failures {
+		errs[i] = fmt.Errorf("%s %d %s: %w", f.Kind, f.ID, f.Relation, f.Cause)
+	}
+	return &HydrationError{Err: errors.Join(errs...), Failures: c.failures}
 }

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -305,15 +305,17 @@ type SyncPendingHref struct {
 }
 
 type SyncResource struct {
-	ID           int64
-	CalendarID   int64
-	Uid          string
-	OwnerType    string
-	RemoteUrl    string
-	Etag         string
-	Dirty        int64
-	SyncStrategy string
-	Rev          int64
+	ID            int64
+	CalendarID    int64
+	Uid           string
+	OwnerType     string
+	RemoteUrl     string
+	Etag          string
+	Dirty         int64
+	SyncStrategy  string
+	Rev           int64
+	PushFailCount int64
+	LastPushError string
 }
 
 type Timezone struct {

--- a/internal/storage/sync_resources.sql.go
+++ b/internal/storage/sync_resources.sql.go
@@ -34,7 +34,9 @@ type ClearSyncResourcePushFailureParams struct {
 	Uid        string
 }
 
-// Reset the failure bookkeeping after a successful push.
+// Reset the failure bookkeeping after a successful push. The engine clears
+// it next to FinalizePushedResource. The sync doctor clears it after its
+// escape-hatch PUT lands.
 func (q *Queries) ClearSyncResourcePushFailure(ctx context.Context, arg ClearSyncResourcePushFailureParams) error {
 	_, err := q.db.ExecContext(ctx, clearSyncResourcePushFailure, arg.CalendarID, arg.Uid)
 	return err
@@ -349,8 +351,9 @@ type RecordSyncResourcePushFailureParams struct {
 }
 
 // One more consecutive failed push attempt for this resource. The engine
-// calls this after a failed export or PUT. Doctor reads the counter to show
-// how long a resource stayed wedged.
+// and the sync doctor call this after a push attempt that fails on an
+// export, a parse, or a PUT. The doctor reads the counter to show how long
+// a resource stayed wedged.
 func (q *Queries) RecordSyncResourcePushFailure(ctx context.Context, arg RecordSyncResourcePushFailureParams) error {
 	_, err := q.db.ExecContext(ctx, recordSyncResourcePushFailure, arg.LastPushError, arg.CalendarID, arg.Uid)
 	return err

--- a/internal/storage/sync_resources.sql.go
+++ b/internal/storage/sync_resources.sql.go
@@ -24,6 +24,22 @@ func (q *Queries) ClearSyncResourceDirty(ctx context.Context, arg ClearSyncResou
 	return err
 }
 
+const clearSyncResourcePushFailure = `-- name: ClearSyncResourcePushFailure :exec
+UPDATE sync_resources SET push_fail_count = 0, last_push_error = ''
+WHERE calendar_id = ? AND uid = ?
+`
+
+type ClearSyncResourcePushFailureParams struct {
+	CalendarID int64
+	Uid        string
+}
+
+// Reset the failure bookkeeping after a successful push.
+func (q *Queries) ClearSyncResourcePushFailure(ctx context.Context, arg ClearSyncResourcePushFailureParams) error {
+	_, err := q.db.ExecContext(ctx, clearSyncResourcePushFailure, arg.CalendarID, arg.Uid)
+	return err
+}
+
 const createTombstone = `-- name: CreateTombstone :exec
 INSERT INTO tombstones (calendar_id, uid, remote_url) VALUES (?, ?, ?)
 ON CONFLICT(calendar_id, uid) DO UPDATE SET
@@ -152,7 +168,7 @@ func (q *Queries) FinalizePushedResource(ctx context.Context, arg FinalizePushed
 }
 
 const getSyncResource = `-- name: GetSyncResource :one
-SELECT id, calendar_id, uid, owner_type, remote_url, etag, dirty, sync_strategy, rev FROM sync_resources WHERE calendar_id = ? AND uid = ?
+SELECT id, calendar_id, uid, owner_type, remote_url, etag, dirty, sync_strategy, rev, push_fail_count, last_push_error FROM sync_resources WHERE calendar_id = ? AND uid = ?
 `
 
 type GetSyncResourceParams struct {
@@ -173,12 +189,14 @@ func (q *Queries) GetSyncResource(ctx context.Context, arg GetSyncResourceParams
 		&i.Dirty,
 		&i.SyncStrategy,
 		&i.Rev,
+		&i.PushFailCount,
+		&i.LastPushError,
 	)
 	return i, err
 }
 
 const listDirtySyncResources = `-- name: ListDirtySyncResources :many
-SELECT id, calendar_id, uid, owner_type, remote_url, etag, dirty, sync_strategy, rev FROM sync_resources WHERE calendar_id = ? AND dirty = 1 ORDER BY id
+SELECT id, calendar_id, uid, owner_type, remote_url, etag, dirty, sync_strategy, rev, push_fail_count, last_push_error FROM sync_resources WHERE calendar_id = ? AND dirty = 1 ORDER BY id
 `
 
 func (q *Queries) ListDirtySyncResources(ctx context.Context, calendarID int64) ([]SyncResource, error) {
@@ -200,6 +218,8 @@ func (q *Queries) ListDirtySyncResources(ctx context.Context, calendarID int64) 
 			&i.Dirty,
 			&i.SyncStrategy,
 			&i.Rev,
+			&i.PushFailCount,
+			&i.LastPushError,
 		); err != nil {
 			return nil, err
 		}
@@ -215,7 +235,7 @@ func (q *Queries) ListDirtySyncResources(ctx context.Context, calendarID int64) 
 }
 
 const listSyncResourcesByCalendar = `-- name: ListSyncResourcesByCalendar :many
-SELECT id, calendar_id, uid, owner_type, remote_url, etag, dirty, sync_strategy, rev FROM sync_resources WHERE calendar_id = ? ORDER BY id
+SELECT id, calendar_id, uid, owner_type, remote_url, etag, dirty, sync_strategy, rev, push_fail_count, last_push_error FROM sync_resources WHERE calendar_id = ? ORDER BY id
 `
 
 func (q *Queries) ListSyncResourcesByCalendar(ctx context.Context, calendarID int64) ([]SyncResource, error) {
@@ -237,6 +257,8 @@ func (q *Queries) ListSyncResourcesByCalendar(ctx context.Context, calendarID in
 			&i.Dirty,
 			&i.SyncStrategy,
 			&i.Rev,
+			&i.PushFailCount,
+			&i.LastPushError,
 		); err != nil {
 			return nil, err
 		}
@@ -310,6 +332,27 @@ type MarkSyncResourceDirtyWithEtagParams struct {
 
 func (q *Queries) MarkSyncResourceDirtyWithEtag(ctx context.Context, arg MarkSyncResourceDirtyWithEtagParams) error {
 	_, err := q.db.ExecContext(ctx, markSyncResourceDirtyWithEtag, arg.Etag, arg.CalendarID, arg.Uid)
+	return err
+}
+
+const recordSyncResourcePushFailure = `-- name: RecordSyncResourcePushFailure :exec
+UPDATE sync_resources
+SET push_fail_count = push_fail_count + 1,
+    last_push_error = ?
+WHERE calendar_id = ? AND uid = ?
+`
+
+type RecordSyncResourcePushFailureParams struct {
+	LastPushError string
+	CalendarID    int64
+	Uid           string
+}
+
+// One more consecutive failed push attempt for this resource. The engine
+// calls this after a failed export or PUT. Doctor reads the counter to show
+// how long a resource stayed wedged.
+func (q *Queries) RecordSyncResourcePushFailure(ctx context.Context, arg RecordSyncResourcePushFailureParams) error {
+	_, err := q.db.ExecContext(ctx, recordSyncResourcePushFailure, arg.LastPushError, arg.CalendarID, arg.Uid)
 	return err
 }
 

--- a/internal/sync/doctor.go
+++ b/internal/sync/doctor.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/event"
-	"github.com/douglasdemoura/chroncal/internal/journal"
-	"github.com/douglasdemoura/chroncal/internal/todo"
 	"github.com/douglasdemoura/chroncal/internal/hydrate"
 	icalPkg "github.com/douglasdemoura/chroncal/internal/ical"
+	"github.com/douglasdemoura/chroncal/internal/journal"
 	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
 // WedgedResource describes a dirty sync resource whose export fails on a
@@ -24,6 +24,10 @@ type WedgedResource struct {
 	OwnerType  string
 	// Relations names every relation whose load failed.
 	Relations []string
+	// PushFailCount counts the consecutive push attempts that failed
+	// before this diagnosis. The push loop and this doctor increment it
+	// after every failed attempt (issue #646).
+	PushFailCount int64
 }
 
 // DiagnoseCalendar exports every dirty resource of one calendar and returns
@@ -44,10 +48,11 @@ func (e *Engine) DiagnoseCalendar(ctx context.Context, calendarID int64) ([]Wedg
 				rels = append(rels, f.Relation)
 			}
 			wedged = append(wedged, WedgedResource{
-				CalendarID: calendarID,
-				UID:        res.Uid,
-				OwnerType:  res.OwnerType,
-				Relations:  rels,
+				CalendarID:    calendarID,
+				UID:           res.Uid,
+				OwnerType:     res.OwnerType,
+				Relations:     rels,
+				PushFailCount: res.PushFailCount,
 			})
 		}
 	}
@@ -60,7 +65,21 @@ func (e *Engine) DiagnoseCalendar(ctx context.Context, calendarID int64) ([]Wedg
 // this is the one path where chroncal knowingly pushes an incomplete record,
 // and it exists so a deterministic local corruption cannot block every other
 // edit forever (issue #568).
+//
+// The doctor deliberately skips the organizer gate (userOrganizesEvent) that
+// the regular push enforces. The doctor exists to move resources the regular
+// push cannot move. A foreign-organized meeting with an unreadable relation
+// stays wedged without this bypass.
 func (e *Engine) DoctorPush(ctx context.Context, calendarID int64, uid string) (dropped []string, err error) {
+	// Hold the calendar lifecycle lock across the dirty snapshot, the PUT,
+	// and the finalize, like SyncCalendar and PushCalendar do. A concurrent
+	// sync run must not interleave between them (issue #647).
+	release, err := e.lockCalendarLifecycle(ctx, calendarID)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	cal, _, client, remoteURL, err := e.loadCalendarClient(ctx, calendarID)
 	if err != nil {
 		return nil, err
@@ -106,11 +125,32 @@ func (e *Engine) DoctorPush(ctx context.Context, calendarID int64, uid string) (
 		}
 	}
 
+	// A PUT can reach the server and still lose its response, which Retry
+	// classifies as transient. The retried PUT re-sends the stale If-Match
+	// and the server answers 412 forever. Mirror the regular push loop:
+	// when an earlier attempt may have landed and the server now holds the
+	// exact body we sent, adopt the landed ETag. See issues #294 and #647.
+	priorAttemptMayHaveLanded := false
 	newEtag, putErr := caldav.Retry(ctx, syncRetryOptions, func(ctx context.Context) (string, error) {
-		return client.PutResource(ctx, putPath, body, res.Etag)
+		etag, err := client.PutResource(ctx, putPath, body, res.Etag)
+		if err == nil {
+			return etag, nil
+		}
+		// A 412 is never transient, so these branches are exclusive.
+		if caldav.IsTransient(err) {
+			priorAttemptMayHaveLanded = true
+		} else if priorAttemptMayHaveLanded && caldav.IsConflict(err) {
+			if landedEtag, ok := e.putAlreadyLanded(ctx, client, putPath, body); ok {
+				return landedEtag, nil
+			}
+		}
+		return etag, err
 	})
+
 	if putErr != nil {
-		return dropped, fmt.Errorf("put %s: %w", uid, putErr)
+		putErr = fmt.Errorf("put %s: %w", uid, putErr)
+		e.recordPushFailure(ctx, calendarID, uid, putErr)
+		return dropped, putErr
 	}
 
 	if err := e.q.FinalizePushedResource(ctx, storage.FinalizePushedResourceParams{
@@ -121,6 +161,9 @@ func (e *Engine) DoctorPush(ctx context.Context, calendarID int64, uid string) (
 	}); err != nil {
 		return dropped, fmt.Errorf("finalize pushed resource %s: %w", uid, err)
 	}
+	// The incomplete record reached the server. Reset the failure
+	// bookkeeping like a regular successful push does.
+	e.clearPushFailure(ctx, calendarID, uid)
 	if res.RemoteUrl == "" {
 		if err := e.q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
 			CalendarID:   calendarID,

--- a/internal/sync/doctor.go
+++ b/internal/sync/doctor.go
@@ -1,0 +1,237 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/douglasdemoura/chroncal/internal/caldav"
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/journal"
+	"github.com/douglasdemoura/chroncal/internal/todo"
+	"github.com/douglasdemoura/chroncal/internal/hydrate"
+	icalPkg "github.com/douglasdemoura/chroncal/internal/ical"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// WedgedResource describes a dirty sync resource whose export fails on a
+// deterministic hydration error. Every sync retries it and fails the same
+// way, and no edit under its UID reaches the server (issue #568).
+type WedgedResource struct {
+	CalendarID int64
+	UID        string
+	OwnerType  string
+	// Relations names every relation whose load failed.
+	Relations []string
+}
+
+// DiagnoseCalendar exports every dirty resource of one calendar and returns
+// the ones that fail on unreadable relations. Transient export failures are
+// not wedges; they stay out of the list.
+func (e *Engine) DiagnoseCalendar(ctx context.Context, calendarID int64) ([]WedgedResource, error) {
+	dirty, err := e.q.ListDirtySyncResources(ctx, calendarID)
+	if err != nil {
+		return nil, fmt.Errorf("list dirty: %w", err)
+	}
+	var wedged []WedgedResource
+	for _, res := range dirty {
+		_, err := e.exportResource(ctx, res.OwnerType, res.Uid)
+		var hErr *hydrate.HydrationError
+		if err != nil && errors.As(err, &hErr) && len(hErr.Failures) > 0 {
+			rels := make([]string, 0, len(hErr.Failures))
+			for _, f := range hErr.Failures {
+				rels = append(rels, f.Relation)
+			}
+			wedged = append(wedged, WedgedResource{
+				CalendarID: calendarID,
+				UID:        res.Uid,
+				OwnerType:  res.OwnerType,
+				Relations:  rels,
+			})
+		}
+	}
+	return wedged, nil
+}
+
+// DoctorPush pushes one wedged resource with best-effort hydration. The PUT
+// omits every relation named in dropped, so the server copy loses exactly
+// those fields. The caller must obtain explicit user confirmation first:
+// this is the one path where chroncal knowingly pushes an incomplete record,
+// and it exists so a deterministic local corruption cannot block every other
+// edit forever (issue #568).
+func (e *Engine) DoctorPush(ctx context.Context, calendarID int64, uid string) (dropped []string, err error) {
+	cal, _, client, remoteURL, err := e.loadCalendarClient(ctx, calendarID)
+	if err != nil {
+		return nil, err
+	}
+	if remoteCalendarIsReadOnly(cal) {
+		return nil, fmt.Errorf("calendar %d is read-only", calendarID)
+	}
+
+	dirty, err := e.q.ListDirtySyncResources(ctx, calendarID)
+	if err != nil {
+		return nil, fmt.Errorf("list dirty: %w", err)
+	}
+	var res *storage.SyncResource
+	for i := range dirty {
+		if dirty[i].Uid == uid {
+			res = &dirty[i]
+			break
+		}
+	}
+	if res == nil {
+		return nil, fmt.Errorf("no dirty sync resource for uid %q on calendar %d", uid, calendarID)
+	}
+
+	icalData, dropped, err := e.exportResourceBestEffortFor(ctx, res.OwnerType, res.Uid)
+	if err != nil {
+		return nil, fmt.Errorf("best-effort export %s: %w", uid, err)
+	}
+	body, parseErr := parseICalData(icalData)
+	if parseErr != nil {
+		return nil, fmt.Errorf("parse ical for %s: %w", uid, parseErr)
+	}
+
+	putPath := res.RemoteUrl
+	if putPath == "" {
+		putPath, err = client.CanonicalObjectRef(remoteURL, buildRemoteResourcePath(remoteURL, res.Uid))
+		if err != nil {
+			return nil, fmt.Errorf("build remote href for %s: %w", uid, err)
+		}
+	} else {
+		putPath, err = client.CanonicalObjectRef(remoteURL, putPath)
+		if err != nil {
+			return nil, fmt.Errorf("validate remote href for %s: %w", uid, err)
+		}
+	}
+
+	newEtag, putErr := caldav.Retry(ctx, syncRetryOptions, func(ctx context.Context) (string, error) {
+		return client.PutResource(ctx, putPath, body, res.Etag)
+	})
+	if putErr != nil {
+		return dropped, fmt.Errorf("put %s: %w", uid, putErr)
+	}
+
+	if err := e.q.FinalizePushedResource(ctx, storage.FinalizePushedResourceParams{
+		CalendarID: calendarID,
+		Uid:        res.Uid,
+		Etag:       newEtag,
+		Rev:        res.Rev,
+	}); err != nil {
+		return dropped, fmt.Errorf("finalize pushed resource %s: %w", uid, err)
+	}
+	if res.RemoteUrl == "" {
+		if err := e.q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+			CalendarID:   calendarID,
+			Uid:          res.Uid,
+			OwnerType:    res.OwnerType,
+			RemoteUrl:    normalizeRemoteRef(putPath),
+			Etag:         newEtag,
+			Dirty:        0,
+			SyncStrategy: res.SyncStrategy,
+		}); err != nil {
+			return dropped, fmt.Errorf("update sync resource URL %s: %w", uid, err)
+		}
+	}
+	e.logger.Warn("doctor push pushed an incomplete record",
+		"uid", uid, "owner_type", res.OwnerType, "dropped_relations", dropped)
+	return dropped, nil
+}
+
+// exportResourceBestEffort bundles a UID's rows like exportResourceFor, but it
+// hydrates best-effort and reports the relations it had to drop. The payload
+// is incomplete by construction; only DoctorPush may send it.
+func exportResourceBestEffort[T any](
+	ctx context.Context,
+	e *Engine,
+	uid, kind string,
+	get func(context.Context, string) (T, error),
+	listOverrides func(context.Context, string) ([]T, error),
+	hydrateBestEffort func(context.Context, *Engine, *T) ([]string, error),
+	export func([]T, string) ([]byte, error),
+) ([]byte, []string, error) {
+	var rows []T
+	switch row, err := get(ctx, uid); {
+	case err == nil:
+		rows = append(rows, row)
+	case !errors.Is(err, sql.ErrNoRows):
+		return nil, nil, fmt.Errorf("get %s master uid %s: %w", kind, uid, err)
+	}
+	overrides, err := listOverrides(ctx, uid)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list overrides for %s uid %s: %w", kind, uid, err)
+	}
+	rows = append(rows, overrides...)
+	if len(rows) == 0 {
+		return nil, nil, fmt.Errorf("%w: %s uid %s", errResourceMissing, kind, uid)
+	}
+	seen := make(map[string]struct{})
+	var dropped []string
+	for i := range rows {
+		rels, err := hydrateBestEffort(ctx, e, &rows[i])
+		if err != nil {
+			return nil, nil, fmt.Errorf("hydrate %s uid %s: %w", kind, uid, err)
+		}
+		for _, r := range rels {
+			if _, ok := seen[r]; !ok {
+				seen[r] = struct{}{}
+				dropped = append(dropped, r)
+			}
+		}
+	}
+	data, err := export(rows, "")
+	return data, dropped, err
+}
+
+// The per-type best-effort hydrate adapters return the dropped relation names
+// in structured form. HydrateBestEffort returns a *hydrate.HydrationError, so
+// the names come from the collector and no text parsing is involved.
+func hydrateEventBestEffort(ctx context.Context, e *Engine, evt *event.Event) ([]string, error) {
+	return droppedRelations(e.events.HydrateBestEffort(ctx, evt))
+}
+
+func hydrateTodoBestEffort(ctx context.Context, e *Engine, td *todo.Todo) ([]string, error) {
+	return droppedRelations(e.todos.HydrateBestEffort(ctx, td))
+}
+
+func hydrateJournalBestEffort(ctx context.Context, e *Engine, j *journal.Journal) ([]string, error) {
+	return droppedRelations(e.journals.HydrateBestEffort(ctx, j))
+}
+
+func droppedRelations(err error) ([]string, error) {
+	if err == nil {
+		return nil, nil
+	}
+	var hErr *hydrate.HydrationError
+	if !errors.As(err, &hErr) {
+		// Not a structured hydration report. Best-effort hydration has no
+		// answer for it, so it stays fatal.
+		return nil, err
+	}
+	// A HydrationError is the expected best-effort result: the record is
+	// complete except for the named relations.
+	rels := make([]string, 0, len(hErr.Failures))
+	for _, f := range hErr.Failures {
+		rels = append(rels, f.Relation)
+	}
+	return rels, nil
+}
+
+// exportResourceBestEffortFor dispatches on owner type. It mirrors the
+// ownerOpsByType export entries with the best-effort hydrators.
+func (e *Engine) exportResourceBestEffortFor(ctx context.Context, ownerType, uid string) ([]byte, []string, error) {
+	switch ownerType {
+	case ownerTypeEvent:
+		return exportResourceBestEffort(ctx, e, uid, ownerTypeEvent,
+			e.events.GetByUID, e.events.ListOverridesByUID, hydrateEventBestEffort, icalPkg.ExportEvents)
+	case ownerTypeTodo:
+		return exportResourceBestEffort(ctx, e, uid, ownerTypeTodo,
+			e.todos.GetByUID, e.todos.ListOverridesByUID, hydrateTodoBestEffort, icalPkg.ExportTodos)
+	case ownerTypeJournal:
+		return exportResourceBestEffort(ctx, e, uid, ownerTypeJournal,
+			e.journals.GetByUID, e.journals.ListOverridesByUID, hydrateJournalBestEffort, icalPkg.ExportJournals)
+	default:
+		return nil, nil, fmt.Errorf("%w: %q", errUnknownOwnerType, ownerType)
+	}
+}

--- a/internal/sync/doctor_test.go
+++ b/internal/sync/doctor_test.go
@@ -1,0 +1,166 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/douglasdemoura/chroncal/internal/calendar"
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/journal"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+	"github.com/douglasdemoura/chroncal/internal/todo"
+)
+
+// breakEventAlarms makes the alarms relation fail on every load. The rename
+// is deterministic: no retry can fix it, which is exactly the wedge shape
+// issue #568 describes.
+func breakEventAlarms(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `ALTER TABLE event_alarms RENAME TO event_alarms_broken`); err != nil {
+		t.Fatalf("rename event_alarms: %v", err)
+	}
+}
+
+// seedWedgedEvent inserts one dirty event resource whose alarms relation
+// cannot load.
+func seedWedgedEvent(t *testing.T, engine *Engine, db *sql.DB, q *storage.Queries, calendarID int64, uid string) {
+	t.Helper()
+	ctx := context.Background()
+	insertTestEvent(t, db, calendarID, uid)
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          uid,
+		OwnerType:    "event",
+		RemoteUrl:    "",
+		Etag:         "",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource %s: %v", uid, err)
+	}
+	breakEventAlarms(t, db)
+}
+
+func TestExportResourceNamesUnreadableRelations(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	seedWedgedEvent(t, engine, db, q, cals[0].ID, "wedged-export")
+
+	_, err = engine.exportResource(ctx, "event", "wedged-export")
+	if err == nil {
+		t.Fatal("exportResource succeeded on an unreadable relation")
+	}
+	for _, want := range []string{"unreadable relation(s) alarms", "stuck", "chroncal sync doctor"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q misses %q", err.Error(), want)
+		}
+	}
+}
+
+// TestDiagnoseAndDoctorPushRecoverWedgedResource covers the full escape
+// hatch: the diagnosis lists the wedged resource with its broken relation,
+// and the confirmed push converges the calendar while announcing the loss.
+func TestDiagnoseAndDoctorPushRecoverWedgedResource(t *testing.T) {
+	t.Parallel()
+
+	var putBody atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			body, _ := io.ReadAll(r.Body)
+			putBody.Store(string(body))
+			w.Header().Set("ETag", `"etag-doctor"`)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	db, q, err := storage.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	credStore := &mockCredStore{creds: make(map[int64]auth.Credential)}
+	engine := NewEngine(db, q, credStore,
+		calendar.NewService(db, q),
+		event.NewService(db, q),
+		todo.NewService(db, q),
+		journal.NewService(db, q),
+		nil)
+
+	account, err := q.CreateAccount(context.Background(), storage.CreateAccountParams{
+		Name:      "doc",
+		ServerUrl: srv.URL,
+		AuthType:  "basic",
+		Username:  "user-doc",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	credStore.creds[account.ID] = auth.Credential{AccountID: account.ID, Username: "user-doc", Password: "pw"}
+
+	cal, err := q.CreateCalendar(context.Background(), storage.CreateCalendarParams{Name: "doctor"})
+	if err != nil {
+		t.Fatalf("CreateCalendar: %v", err)
+	}
+	if err := q.LinkCalendarToAccount(context.Background(), storage.LinkCalendarToAccountParams{
+		ID:        cal.ID,
+		AccountID: &account.ID,
+		RemoteUrl: storage.StringToNullable(srv.URL + "/cal/doctor/"),
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+
+	seedWedgedEvent(t, engine, db, q, cal.ID, "wedged-doctor")
+
+	wedged, err := engine.DiagnoseCalendar(context.Background(), cal.ID)
+	if err != nil {
+		t.Fatalf("DiagnoseCalendar: %v", err)
+	}
+	if len(wedged) != 1 {
+		t.Fatalf("DiagnoseCalendar returned %d entries, want 1", len(wedged))
+	}
+	if wedged[0].UID != "wedged-doctor" || len(wedged[0].Relations) != 1 || wedged[0].Relations[0] != "alarms" {
+		t.Errorf("unexpected diagnosis: %+v", wedged[0])
+	}
+
+	dropped, err := engine.DoctorPush(context.Background(), cal.ID, "wedged-doctor")
+	if err != nil {
+		t.Fatalf("DoctorPush: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != "alarms" {
+		t.Errorf("dropped = %v, want [alarms]", dropped)
+	}
+
+	stillDirty, err := q.ListDirtySyncResources(context.Background(), cal.ID)
+	if err != nil {
+		t.Fatalf("ListDirtySyncResources: %v", err)
+	}
+	if len(stillDirty) != 0 {
+		t.Errorf("resource still dirty after DoctorPush: %+v", stillDirty)
+	}
+	body, _ := putBody.Load().(string)
+	if body == "" {
+		t.Fatal("the fake server saw no PUT")
+	}
+	if strings.Contains(body, "BEGIN:VALARM") {
+		t.Errorf("the incomplete PUT carried a VALARM anyway:\n%s", body)
+	}
+}

--- a/internal/sync/doctor_test.go
+++ b/internal/sync/doctor_test.go
@@ -164,3 +164,197 @@ func TestDiagnoseAndDoctorPushRecoverWedgedResource(t *testing.T) {
 		t.Errorf("the incomplete PUT carried a VALARM anyway:\n%s", body)
 	}
 }
+
+// newDoctorTestEnv builds an engine whose calendar points at srvURL. The
+// basic credential is already stored.
+func newDoctorTestEnv(t *testing.T, srvURL, name string) (*Engine, *sql.DB, *storage.Queries, storage.Calendar) {
+	t.Helper()
+	db, q, err := storage.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	credStore := &mockCredStore{creds: make(map[int64]auth.Credential)}
+	engine := NewEngine(db, q, credStore,
+		calendar.NewService(db, q),
+		event.NewService(db, q),
+		todo.NewService(db, q),
+		journal.NewService(db, q),
+		nil)
+
+	account, err := q.CreateAccount(context.Background(), storage.CreateAccountParams{
+		Name:      name,
+		ServerUrl: srvURL,
+		AuthType:  "basic",
+		Username:  "user-" + name,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	credStore.creds[account.ID] = auth.Credential{AccountID: account.ID, Username: "user-" + name, Password: "pw"}
+
+	cal, err := q.CreateCalendar(context.Background(), storage.CreateCalendarParams{Name: name})
+	if err != nil {
+		t.Fatalf("CreateCalendar: %v", err)
+	}
+	if err := q.LinkCalendarToAccount(context.Background(), storage.LinkCalendarToAccountParams{
+		ID:        cal.ID,
+		AccountID: &account.ID,
+		RemoteUrl: storage.StringToNullable(srvURL + "/cal/" + name + "/"),
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+	return engine, db, q, cal
+}
+
+// TestPushRecordsFailureAndDoctorResetsCounter pins the push-failure
+// bookkeeping (issue #646). A push attempt that fails on the unreadable
+// relation increments push_fail_count and stores the error. The diagnosis
+// reports the count. A successful doctor push resets both columns.
+func TestPushRecordsFailureAndDoctorResetsCounter(t *testing.T) {
+	t.Parallel()
+
+	var failWrites atomic.Bool
+	failWrites.Store(true)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if failWrites.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("ETag", `"etag-doctor"`)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+
+	engine, db, q, cal := newDoctorTestEnv(t, srv.URL, "counter")
+	ctx := context.Background()
+	seedWedgedEvent(t, engine, db, q, cal.ID, "wedge-count")
+
+	// One push attempt fails on the unreadable relation. The export aborts
+	// before any PUT, so the fake client must stay untouched.
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		return nil, nil
+	})
+	result, err := engine.push(ctx, client, cal.ID, srv.URL, "", ConflictPrompt)
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if len(result.errors) != 1 {
+		t.Fatalf("errors = %v, want one export failure", result.errors)
+	}
+
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: cal.ID, Uid: "wedge-count"})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.PushFailCount != 1 {
+		t.Fatalf("PushFailCount = %d, want 1", res.PushFailCount)
+	}
+	if !strings.Contains(res.LastPushError, "unreadable relation(s)") {
+		t.Fatalf("LastPushError = %q, want it to name the relation", res.LastPushError)
+	}
+
+	wedged, err := engine.DiagnoseCalendar(ctx, cal.ID)
+	if err != nil {
+		t.Fatalf("DiagnoseCalendar: %v", err)
+	}
+	if len(wedged) != 1 || wedged[0].PushFailCount != 1 {
+		t.Fatalf("diagnosis = %+v, want one entry with PushFailCount 1", wedged)
+	}
+
+	// A successful doctor push resets the bookkeeping.
+	failWrites.Store(false)
+	if _, err := engine.DoctorPush(ctx, cal.ID, "wedge-count"); err != nil {
+		t.Fatalf("DoctorPush: %v", err)
+	}
+	res, err = q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: cal.ID, Uid: "wedge-count"})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.PushFailCount != 0 || res.LastPushError != "" {
+		t.Fatalf("bookkeeping after doctor push: count=%d error=%q, want 0 and empty",
+			res.PushFailCount, res.LastPushError)
+	}
+	if res.Dirty != 0 {
+		t.Fatalf("Dirty = %d, want 0", res.Dirty)
+	}
+}
+
+// TestDoctorPushRecoversLostPutResponse mirrors the lost-response recovery
+// of the regular push (issue #294) on the doctor path (issue #647). The
+// first PUT lands and its response fails transiently. The retry sends the
+// stale If-Match and the server answers 412. The doctor adopts the ETag of
+// the landed write instead of failing the same way forever.
+func TestDoctorPushRecoversLostPutResponse(t *testing.T) {
+	t.Parallel()
+
+	var putBody atomic.Value
+	var putCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			putBody.Store(string(body))
+			putCount.Add(1)
+			if putCount.Load() == 1 {
+				// The write landed. The response fails transiently, like a
+				// reset connection would.
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			// The retry carries the stale pre-PUT If-Match.
+			w.WriteHeader(http.StatusPreconditionFailed)
+		case http.MethodGet:
+			// The server holds exactly the body of the first PUT.
+			w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+			w.Header().Set("Etag", `"etag-after"`)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(putBody.Load().(string)))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	engine, db, q, cal := newDoctorTestEnv(t, srv.URL, "lostput")
+	ctx := context.Background()
+
+	// A previously synced wedged resource: it carries a remote URL and an
+	// ETag, so the doctor PUT is conditional.
+	insertTestEvent(t, db, cal.ID, "doctor-lost-put")
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   cal.ID,
+		Uid:          "doctor-lost-put",
+		OwnerType:    "event",
+		RemoteUrl:    "/cal/lostput/doctor-lost-put.ics",
+		Etag:         `"etag-before"`,
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+	breakEventAlarms(t, db)
+
+	dropped, err := engine.DoctorPush(ctx, cal.ID, "doctor-lost-put")
+	if err != nil {
+		t.Fatalf("DoctorPush: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != "alarms" {
+		t.Fatalf("dropped = %v, want [alarms]", dropped)
+	}
+	if got := putCount.Load(); got != 2 {
+		t.Fatalf("PUT count = %d, want 2 (one lost response, one rejected retry)", got)
+	}
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: cal.ID, Uid: "doctor-lost-put"})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Etag != "etag-after" {
+		t.Fatalf("Etag = %q, want the landed write's etag-after", res.Etag)
+	}
+	if res.Dirty != 0 {
+		t.Fatalf("Dirty = %d, want 0", res.Dirty)
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/calendar"
 	"github.com/douglasdemoura/chroncal/internal/event"
+	hydratepkg "github.com/douglasdemoura/chroncal/internal/hydrate"
 	icalPkg "github.com/douglasdemoura/chroncal/internal/ical"
 	"github.com/douglasdemoura/chroncal/internal/journal"
 	"github.com/douglasdemoura/chroncal/internal/model"
@@ -1559,6 +1560,22 @@ func exportResourceFor[T any](
 			// alarms/attendees/attachments/... and the PUT would strip them
 			// from the server copy. Abort instead: the dirty flag stays set, so
 			// the resource is retried whole on the next sync.
+			//
+			// A deterministic failure (a corrupt row a retry can never fix)
+			// wedges the resource: every sync fails identically and no edit
+			// under this UID reaches the server. Name the broken relations and
+			// point at the escape hatch so the user learns what is stuck and
+			// why (issue #568).
+			var hErr *hydratepkg.HydrationError
+			if errors.As(err, &hErr) && len(hErr.Failures) > 0 {
+				rels := make([]string, 0, len(hErr.Failures))
+				for _, f := range hErr.Failures {
+					rels = append(rels, f.Relation)
+				}
+				return nil, fmt.Errorf(
+					"hydrate %s uid %s: unreadable relation(s) %s; the resource is stuck and no edit reaches the server until it is resolved (see chroncal sync doctor): %w",
+					kind, uid, strings.Join(rels, ", "), err)
+			}
 			return nil, fmt.Errorf("hydrate %s uid %s: %w", kind, uid, err)
 		}
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -589,14 +589,18 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 				continue
 			}
 			e.logger.Error("export resource failed", "uid", res.Uid, "error", err)
-			result.errors = append(result.errors, fmt.Errorf("export %s: %w", res.Uid, err))
+			exportErr := fmt.Errorf("export %s: %w", res.Uid, err)
+			result.errors = append(result.errors, exportErr)
+			e.recordPushFailure(ctx, calendarID, res.Uid, exportErr)
 			continue
 		}
 
 		// Parse the iCal data for PUT
 		cal, parseErr := parseICalData(icalData)
 		if parseErr != nil {
-			result.errors = append(result.errors, fmt.Errorf("parse ical for %s: %w", res.Uid, parseErr))
+			parseErr = fmt.Errorf("parse ical for %s: %w", res.Uid, parseErr)
+			result.errors = append(result.errors, parseErr)
+			e.recordPushFailure(ctx, calendarID, res.Uid, parseErr)
 			continue
 		}
 
@@ -605,13 +609,17 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 		if res.RemoteUrl != "" {
 			putPath, err = client.CanonicalObjectRef(remoteURL, res.RemoteUrl)
 			if err != nil {
-				result.errors = append(result.errors, fmt.Errorf("validate remote href for %s: %w", res.Uid, err))
+				err = fmt.Errorf("validate remote href for %s: %w", res.Uid, err)
+				result.errors = append(result.errors, err)
+				e.recordPushFailure(ctx, calendarID, res.Uid, err)
 				continue
 			}
 		} else {
 			putPath, err = client.CanonicalObjectRef(remoteURL, buildRemoteResourcePath(remoteURL, res.Uid))
 			if err != nil {
-				result.errors = append(result.errors, fmt.Errorf("build remote href for %s: %w", res.Uid, err))
+				err = fmt.Errorf("build remote href for %s: %w", res.Uid, err)
+				result.errors = append(result.errors, err)
+				e.recordPushFailure(ctx, calendarID, res.Uid, err)
 				continue
 			}
 		}
@@ -718,7 +726,9 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 				continue
 			}
 			e.logger.Error("PUT failed", "uid", res.Uid, "error", putErr)
-			result.errors = append(result.errors, fmt.Errorf("put %s: %w", res.Uid, putErr))
+			putErr = fmt.Errorf("put %s: %w", res.Uid, putErr)
+			result.errors = append(result.errors, putErr)
+			e.recordPushFailure(ctx, calendarID, res.Uid, putErr)
 			continue
 		}
 
@@ -737,6 +747,9 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 		}); err != nil {
 			e.logger.Error("finalize pushed resource failed", "uid", res.Uid, "error", err)
 		}
+		// The body reached the server, so this attempt succeeded. Reset the
+		// failure bookkeeping even when the finalize write above failed.
+		e.clearPushFailure(ctx, calendarID, res.Uid)
 
 		// Update remote URL if it was newly assigned
 		if res.RemoteUrl == "" {
@@ -758,6 +771,33 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 	}
 
 	return result, nil
+}
+
+// recordPushFailure stores one more consecutive failed push attempt for a
+// resource. The push loop and the sync doctor call it after a push attempt
+// that fails on an export, a parse, or a PUT. The doctor reads the counter
+// to show how long a resource stayed wedged. A failed bookkeeping write
+// only logs: the push error itself stays the reported failure.
+func (e *Engine) recordPushFailure(ctx context.Context, calendarID int64, uid string, err error) {
+	if rerr := e.q.RecordSyncResourcePushFailure(ctx, storage.RecordSyncResourcePushFailureParams{
+		LastPushError: err.Error(),
+		CalendarID:    calendarID,
+		Uid:           uid,
+	}); rerr != nil {
+		e.logger.Warn("record push failure", "uid", uid, "error", rerr)
+	}
+}
+
+// clearPushFailure resets the push-failure bookkeeping after a successful
+// push. A failed bookkeeping write only logs: the pushed body already
+// reached the server.
+func (e *Engine) clearPushFailure(ctx context.Context, calendarID int64, uid string) {
+	if cerr := e.q.ClearSyncResourcePushFailure(ctx, storage.ClearSyncResourcePushFailureParams{
+		CalendarID: calendarID,
+		Uid:        uid,
+	}); cerr != nil {
+		e.logger.Warn("clear push failure", "uid", uid, "error", cerr)
+	}
 }
 
 // putAlreadyLanded reports whether the server's current body for path equals

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -53,6 +53,21 @@ func (s *Service) SyncAll(ctx context.Context, strategy ConflictStrategy) ([]*Sy
 	return s.engine.SyncAll(ctx, strategy)
 }
 
+// DiagnoseCalendar lists the wedged resources of one calendar. A wedged
+// resource fails export on a deterministic hydration error, so every sync
+// retries it and no edit under its UID reaches the server.
+func (s *Service) DiagnoseCalendar(ctx context.Context, calendarID int64) ([]WedgedResource, error) {
+	return s.engine.DiagnoseCalendar(ctx, calendarID)
+}
+
+// DoctorPush pushes one wedged resource with best-effort hydration. The PUT
+// omits every relation in dropped. The caller must obtain explicit user
+// confirmation first; this is the one path that knowingly pushes an
+// incomplete record (issue #568).
+func (s *Service) DoctorPush(ctx context.Context, calendarID int64, uid string) ([]string, error) {
+	return s.engine.DoctorPush(ctx, calendarID, uid)
+}
+
 // SyncStatus returns the current sync status for a calendar.
 type SyncStatus struct {
 	CalendarID          int64


### PR DESCRIPTION
## Summary

A deterministic hydration failure wedges a resource forever: every sync retries the export, fails on the same unreadable relation, and no edit under that UID ever reaches the server — with no way out short of hand-editing the database.

- **Diagnosable error**: the hydrate failure now names the unreadable relations and states the resource is stuck, pointing at `chroncal sync doctor`.
- **Escape hatch** (the actual resolution): `chroncal sync doctor` lists wedged resources per calendar with their broken relations. `--push <uid>` pushes one with best-effort hydration: the PUT omits exactly the diagnosed relations, the loss is announced first, and explicit confirmation is required (`--yes` for non-interactive shells). The normal push's fail-fast convergence behavior does not change.
- Consecutive-failure backoff needs a schema change and is deliberately left out.

## Tests

Engine tests: rename-table wedge → error names the relation; diagnosis lists it; confirmed doctor push converges the calendar (dirty cleared, PUT lacks the broken relation). CLI tests: empty report, and non-interactive `--push` refusal without `--yes`.

`go test ./cmd/... ./internal/sync/... ./internal/hydrate/...` pass.

Fixes #568
