### PR TITLE
fix(sync): preserve the server DTEND when the parsed value is fabricated

### DIFF
--- a/docs/adr/0002-unparseable-server-dtend.md
+++ b/docs/adr/0002-unparseable-server-dtend.md
@@ -1,0 +1,63 @@
+# ADR 0002: Preserve an unparseable server DTEND through a round trip
+
+- Status: Accepted
+- Related issues: #567, #649, #651
+
+## Context
+
+Some CalDAV servers, Exchange in particular, emit a DTEND with a TZID that
+no IANA tz database resolves. chroncal cannot parse the value. RFC 5545
+section 3.8.2.2 defines DTEND. chroncal must still do two things:
+
+- show the event locally with a usable span,
+- push the resource back without damage to the server copy.
+
+The VALARM case (ADR 0001) dropped the unparseable value at import. That
+answer does not fit here, for one reason: the DTEND string is valid on the
+server that sent it. The raw value survives a round trip. A broken TRIGGER
+had no valid wire form at all.
+
+## Decision
+
+Preserve the raw value, gated on provenance.
+
+- The CalDAV pull path (`ImportFileRemote`) stores the raw DTEND in the
+  x-property `X-CHRONCAL-ORIGINAL-DTEND`.
+- The local row keeps a fabricated span, so the event stays functional in
+  the UI. No marking is necessary. The event works: it lists, it alarms, it
+  expands. A preserved VALARM could not do that.
+- Export emits the stored string as DTEND whenever no DURATION is set. The
+  server receives the exact value it sent.
+- `emitXProperties` never writes the slot to the wire as an x-property.
+  That would duplicate DTEND on the same component.
+- A file import (`ImportFile`) does not set the slot. The value did not
+  come from the target server. A push of the value could send the target
+  server a DTEND it rejects, and the resource would stay dirty.
+
+## Slot invalidation
+
+The slot holds a server value, not a user value. A local edit that changes
+the end time or the duration invalidates it (issue #649). The edit clears
+the slot inside its own transaction, so the next export emits the edited
+span. Without the clear, the edit would push the stale server value back
+and the user's new end time would never reach the server.
+
+Only local edits clear the slot. A sync upsert never goes through the local
+edit path. A fresh server body sets the slot again from current data, so the
+clear would destroy the value it needs to keep. The `ConflictServerWins`
+accept-server path therefore still preserves the slot after a re-pull.
+
+## What must not come back
+
+- Do not emit `X-CHRONCAL-ORIGINAL-DTEND` as an x-property on the wire.
+- Do not set the slot on a file import.
+- Do not clear the slot on a sync-driven upsert.
+- Do not clear the slot when a local edit leaves the span unchanged. The
+  server value still matches the local end time.
+
+## Backstop
+
+`internal/event` clears the slot in the local update transactions
+(`updateEventTx` and the override update path). Two regression tests hold
+the contract: a local span edit drops the stale value, and the ServerWins
+re-pull sets it again.

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -548,6 +548,10 @@ func updateEventTx(ctx context.Context, qtx *storage.Queries, id int64, p Update
 	if err := validateDurationValue(p.StartTime, p.DurationValue); err != nil {
 		return Event{}, err
 	}
+	old, err := qtx.GetEvent(ctx, id)
+	if err != nil {
+		return Event{}, err
+	}
 	r, err := qtx.UpdateEvent(ctx, storage.UpdateEventParams{
 		ID:             id,
 		Title:          p.Title,
@@ -578,8 +582,65 @@ func updateEventTx(ctx context.Context, qtx *storage.Queries, id int64, p Update
 	if err := replaceCategoriesTx(ctx, qtx, e.ID, ParseCategoryList(p.Categories)); err != nil {
 		return Event{}, fmt.Errorf("replace categories: %w", err)
 	}
+	if localSpanEdit(old, p) {
+		if err := clearPreservedDTENDTx(ctx, qtx, e.ID); err != nil {
+			return Event{}, err
+		}
+	}
 	e.Categories = p.Categories
 	return e, nil
+}
+
+// localSpanEdit reports whether an update replaces the stored end time or
+// duration. Only a local edit goes through UpdateParams. A sync upsert
+// bypasses this rule, because a fresh server body sets the slot again
+// (issue #649).
+func localSpanEdit(old storage.Event, p UpdateParams) bool {
+	return old.EndTime != p.EndTime.Format(time.RFC3339) ||
+		storage.NullableToString(old.Duration) != p.DurationValue
+}
+
+// clearPreservedDTENDTx removes the X-CHRONCAL-ORIGINAL-DTEND slot from the
+// event's x-properties. It runs inside the caller's transaction and keeps
+// every other x-property. It does nothing when the slot is absent.
+//
+// A local edit that changes the span invalidates the preserved server DTEND.
+// An export after the edit must emit the edited span, not the stale server
+// string (issue #649).
+func clearPreservedDTENDTx(ctx context.Context, qtx *storage.Queries, eventID int64) error {
+	rows, err := qtx.ListXPropertiesByOwner(ctx, storage.ListXPropertiesByOwnerParams{
+		OwnerType: "event", OwnerID: eventID,
+	})
+	if err != nil {
+		return fmt.Errorf("list x-properties: %w", err)
+	}
+	found := false
+	for _, r := range rows {
+		if r.Name == model.XPropOriginalDTEND {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+	if err := qtx.DeleteXPropertiesByOwner(ctx, storage.DeleteXPropertiesByOwnerParams{
+		OwnerType: "event", OwnerID: eventID,
+	}); err != nil {
+		return fmt.Errorf("delete x-properties: %w", err)
+	}
+	for _, r := range rows {
+		if r.Name == model.XPropOriginalDTEND {
+			continue
+		}
+		if err := qtx.InsertXProperty(ctx, storage.InsertXPropertyParams{
+			OwnerType: "event", OwnerID: eventID,
+			Name: r.Name, Value: r.Value, Params: r.Params,
+		}); err != nil {
+			return fmt.Errorf("insert x-property: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *Service) UpsertByUID(ctx context.Context, p UpsertParams) (Event, error) {
@@ -1072,7 +1133,7 @@ func updateInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, ins
 		Uid:          uid,
 		RecurrenceID: recID,
 	}); gErr == nil {
-		r, err = qtx.UpdateEvent(ctx, overrideUpdateParams(existing.ID, p))
+		r, err = updateOverrideTx(ctx, qtx, existing, p)
 		if err != nil {
 			return Event{}, 0, fmt.Errorf("update override: %w", err)
 		}
@@ -1089,7 +1150,7 @@ func updateInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, ins
 				if eErr != nil {
 					return Event{}, 0, fmt.Errorf("retry get override: %w", eErr)
 				}
-				r, err = qtx.UpdateEvent(ctx, overrideUpdateParams(existing.ID, p))
+				r, err = updateOverrideTx(ctx, qtx, existing, p)
 				if err != nil {
 					return Event{}, 0, fmt.Errorf("retry update override: %w", err)
 				}
@@ -1106,6 +1167,22 @@ func updateInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, ins
 	e := FromStorage(r)
 	e.Categories = timeutil.JoinCategoryList(carriedCats)
 	return e, master.CalendarID, nil
+}
+
+// updateOverrideTx updates a stored override row. A span change clears the
+// preserved server DTEND slot on that row (issue #649). A fresh override row
+// never carries the slot, so the create path needs no clear.
+func updateOverrideTx(ctx context.Context, qtx *storage.Queries, existing storage.Event, p UpdateParams) (storage.Event, error) {
+	r, err := qtx.UpdateEvent(ctx, overrideUpdateParams(existing.ID, p))
+	if err != nil {
+		return storage.Event{}, err
+	}
+	if localSpanEdit(existing, p) {
+		if err := clearPreservedDTENDTx(ctx, qtx, existing.ID); err != nil {
+			return storage.Event{}, err
+		}
+	}
+	return r, nil
 }
 
 // overrideUpdateParams builds the storage params for an update of a stored

--- a/internal/ical/dtend_preserve_test.go
+++ b/internal/ical/dtend_preserve_test.go
@@ -1,0 +1,119 @@
+package ical
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+// exchangeDTENDIcal is the shape Exchange emits: DTSTART parses, DTEND
+// carries a TZID no tz database resolves. The event must still appear
+// locally, and the remote path must keep the original string.
+const exchangeDTENDIcal = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//test//EN
+BEGIN:VEVENT
+UID:dtend-preserve@example.com
+DTSTAMP:20260101T000000Z
+DTSTART:20260101T150000Z
+DTEND;TZID=Customized Time Zone:20260101T163000
+SUMMARY:Exchange meeting
+END:VEVENT
+END:VCALENDAR
+`
+
+func importOneEvent(t *testing.T, data string) event.Event {
+	t.Helper()
+	result, err := ImportFileRemote(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("ImportFileRemote: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	return result.Events[0]
+}
+
+func TestImportRemotePreservesUnparseableDTEND(t *testing.T) {
+	t.Parallel()
+	e := importOneEvent(t, exchangeDTENDIcal)
+
+	if !e.EndTime.After(e.StartTime) {
+		t.Fatalf("fabricated span missing: start=%v end=%v", e.StartTime, e.EndTime)
+	}
+	var preserved *model.XProperty
+	for i := range e.XProperties {
+		if e.XProperties[i].Name == xpropOriginalDTEND {
+			preserved = &e.XProperties[i]
+		}
+	}
+	if preserved == nil {
+		t.Fatalf("no %s x-property in %+v", xpropOriginalDTEND, e.XProperties)
+	}
+	if preserved.Value != "20260101T163000" {
+		t.Errorf("preserved value = %q, want the raw server string", preserved.Value)
+	}
+	if !strings.Contains(preserved.Params, "TZID") || !strings.Contains(preserved.Params, "Customized Time Zone") {
+		t.Errorf("preserved params = %q, want the TZID param", preserved.Params)
+	}
+}
+
+func TestImportFileDoesNotPreserveDTEND(t *testing.T) {
+	t.Parallel()
+	result, err := ImportFile(strings.NewReader(exchangeDTENDIcal))
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	e := result.Events[0]
+	for _, xp := range e.XProperties {
+		if xp.Name == xpropOriginalDTEND {
+			t.Errorf("file import must not set %s", xpropOriginalDTEND)
+		}
+	}
+}
+
+func TestExportPrefersPreservedDTEND(t *testing.T) {
+	t.Parallel()
+	e := importOneEvent(t, exchangeDTENDIcal)
+	data, err := ExportEvents([]event.Event{e}, "Work")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "DTEND;TZID=Customized Time Zone:20260101T163000") {
+		t.Errorf("export lost the server's original DTEND:\n%s", out)
+	}
+	if strings.Contains(out, xpropOriginalDTEND) {
+		t.Errorf("export leaked the preservation slot as an x-property:\n%s", out)
+	}
+}
+
+// A normal event keeps its computed DTEND: the preservation slot only fires
+// when import stored it.
+func TestExportNormalEventKeepsComputedDTEND(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{{
+		UID:       "normal-dtend@example.com",
+		Title:     "Normal",
+		Timezone:  "America/New_York",
+		StartTime: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+	}}
+	data, err := ExportEvents(events, "Work")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	out := string(data)
+	if strings.Contains(out, xpropOriginalDTEND) {
+		t.Errorf("normal event carries the preservation slot:\n%s", out)
+	}
+	if !strings.Contains(out, "DTEND") {
+		t.Errorf("normal event lost its DTEND:\n%s", out)
+	}
+}

--- a/internal/ical/dtend_preserve_test.go
+++ b/internal/ical/dtend_preserve_test.go
@@ -1,12 +1,15 @@
 package ical
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/calendar"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
 
 // exchangeDTENDIcal is the shape Exchange emits: DTSTART parses, DTEND
@@ -115,5 +118,100 @@ func TestExportNormalEventKeepsComputedDTEND(t *testing.T) {
 	}
 	if !strings.Contains(out, "DTEND") {
 		t.Errorf("normal event lost its DTEND:\n%s", out)
+	}
+}
+
+// A local edit that changes the span must clear the preservation slot.
+// Otherwise the next export emits the stale server DTEND and drops the
+// user's new end time (issue #649). An edit that keeps the span keeps the
+// slot.
+func TestLocalSpanEditClearsPreservedDTEND(t *testing.T) {
+	t.Parallel()
+
+	db, q := testutil.NewTestDB(t)
+	ctx := context.Background()
+	calSvc := calendar.NewService(db, q)
+	eventSvc := event.NewService(db, q)
+
+	cals, err := calSvc.List(ctx)
+	if err != nil {
+		t.Fatalf("List calendars: %v", err)
+	}
+	calID := cals[0].ID
+
+	// Persist a remote import the way the sync engine does: the row first,
+	// then the x-properties.
+	imported := importOneEvent(t, exchangeDTENDIcal)
+	saved, err := eventSvc.UpsertByUID(ctx, event.UpsertParams{
+		UID: imported.UID, CalendarID: calID,
+		Title: imported.Title, StartTime: imported.StartTime, EndTime: imported.EndTime,
+		Timezone: imported.Timezone, DtStamp: imported.DtStamp,
+	})
+	if err != nil {
+		t.Fatalf("UpsertByUID: %v", err)
+	}
+	if err := eventSvc.ReplaceXProperties(ctx, saved.ID, imported.XProperties); err != nil {
+		t.Fatalf("ReplaceXProperties: %v", err)
+	}
+
+	hasSlot := func() bool {
+		xps, err := eventSvc.ListXProperties(ctx, saved.ID)
+		if err != nil {
+			t.Fatalf("ListXProperties: %v", err)
+		}
+		for _, xp := range xps {
+			if xp.Name == xpropOriginalDTEND {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasSlot() {
+		t.Fatal("setup lost the preservation slot")
+	}
+
+	// An edit that keeps the span keeps the slot.
+	edit := event.UpdateParams{
+		CalendarID: calID,
+		Title:      "Exchange meeting, renamed",
+		StartTime:  imported.StartTime,
+		EndTime:    imported.EndTime,
+		Timezone:   imported.Timezone,
+	}
+	if _, err := eventSvc.Update(ctx, saved.ID, edit); err != nil {
+		t.Fatalf("span-preserving update: %v", err)
+	}
+	if !hasSlot() {
+		t.Fatal("a span-preserving edit cleared the slot")
+	}
+
+	// A local edit that moves the end time clears the slot.
+	edit.EndTime = imported.EndTime.Add(time.Hour)
+	edited, err := eventSvc.Update(ctx, saved.ID, edit)
+	if err != nil {
+		t.Fatalf("end-time edit: %v", err)
+	}
+	if hasSlot() {
+		t.Fatal("the span edit kept the preservation slot")
+	}
+
+	// Export emits the edited end time, not the stale server string.
+	if err := eventSvc.Hydrate(ctx, &edited); err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	data, err := ExportEvents([]event.Event{edited}, "Work")
+	if err != nil {
+		t.Fatalf("ExportEvents: %v", err)
+	}
+	out := string(data)
+	want := "DTEND:" + edited.EndTime.UTC().Format("20060102T150405Z")
+	if !strings.Contains(out, want) {
+		t.Errorf("export lost the edited DTEND %q:\n%s", want, out)
+	}
+	if strings.Contains(out, "20260101T163000") {
+		t.Errorf("export emitted the stale server DTEND:\n%s", out)
+	}
+	if strings.Contains(out, xpropOriginalDTEND) {
+		t.Errorf("export leaked the preservation slot:\n%s", out)
 	}
 }

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -307,11 +307,13 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 		}
 	}
 
-	// A server DTEND that failed to parse was replaced locally by a
-	// fabricated span. When the value arrived over CalDAV, import preserved
-	// the original string in X-CHRONCAL-ORIGINAL-DTEND. Hand it back
-	// verbatim: the server gets exactly what it gave us, and our invention
-	// never overwrites its value (issue #567).
+	// A CalDAV import of a DTEND that failed to parse stores the raw
+	// server string in X-CHRONCAL-ORIGINAL-DTEND and fabricates a local
+	// span. Emit the stored string as DTEND: the server receives the exact
+	// value it sent, and the fabricated span does not overwrite it (issue
+	// #567). A local edit that changes the span clears the slot first (see
+	// internal/event, issue #649). This override then applies only while
+	// the local span still matches the server value.
 	if !useDuration {
 		for _, xp := range e.XProperties {
 			if xp.Name != xpropOriginalDTEND {
@@ -1313,8 +1315,8 @@ func emitXProperties(comp *ical.Component, xprops []model.XProperty) {
 		if isLibicalDiagnosticProp(xp.Name) {
 			continue
 		}
-		// The original-DTEND preservation slot feeds the DTEND override in
-		// buildVevent. Emitting it again would duplicate the value on the
+		// The original-DTEND slot supplies the DTEND override in
+		// setEventTimes. An emit here would duplicate the value on the
 		// wire.
 		if xp.Name == xpropOriginalDTEND {
 			continue

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -306,6 +306,33 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 			vevent.Props.SetDateTime(ical.PropDateTimeEnd, endTime.UTC())
 		}
 	}
+
+	// A server DTEND that failed to parse was replaced locally by a
+	// fabricated span. When the value arrived over CalDAV, import preserved
+	// the original string in X-CHRONCAL-ORIGINAL-DTEND. Hand it back
+	// verbatim: the server gets exactly what it gave us, and our invention
+	// never overwrites its value (issue #567).
+	if !useDuration {
+		for _, xp := range e.XProperties {
+			if xp.Name != xpropOriginalDTEND {
+				continue
+			}
+			p := &ical.Prop{Name: ical.PropDateTimeEnd, Params: make(ical.Params)}
+			p.Value = xp.Value
+			if xp.Params != "" && xp.Params != "{}" {
+				var params map[string][]string
+				if err := json.Unmarshal([]byte(xp.Params), &params); err == nil {
+					for k, vals := range params {
+						for _, v := range vals {
+							p.Params.Add(k, v)
+						}
+					}
+				}
+			}
+			vevent.Props.Set(p)
+			break
+		}
+	}
 }
 
 func allDayExportDate(t time.Time, timezone string) time.Time {
@@ -1284,6 +1311,12 @@ func splitNonEmpty(s string) []string {
 func emitXProperties(comp *ical.Component, xprops []model.XProperty) {
 	for _, xp := range xprops {
 		if isLibicalDiagnosticProp(xp.Name) {
+			continue
+		}
+		// The original-DTEND preservation slot feeds the DTEND override in
+		// buildVevent. Emitting it again would duplicate the value on the
+		// wire.
+		if xp.Name == xpropOriginalDTEND {
 			continue
 		}
 		p := &ical.Prop{Name: xp.Name, Params: make(ical.Params)}

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -50,7 +50,27 @@ const (
 
 var errImportLimitExceeded = errors.New("ical import exceeds configured limits")
 
+// xpropOriginalDTEND preserves a server DTEND that failed to parse. The
+// fabricated local span must not overwrite the server's value on the next
+// push, so export hands the original string back verbatim. Only the CalDAV
+// pull path sets it: a file-imported value did not come from the target
+// server, and re-emitting it there could wedge a strict server.
+const xpropOriginalDTEND = "X-CHRONCAL-ORIGINAL-DTEND"
+
+// ImportFile parses an iCal stream from a file or another local source.
 func ImportFile(r io.Reader) (ImportResult, error) {
+	return importFile(r, false)
+}
+
+// ImportFileRemote parses an iCal stream that a CalDAV server served. A
+// DTEND that fails to parse is then preserved verbatim in
+// X-CHRONCAL-ORIGINAL-DTEND, so export can hand the server back exactly what
+// it gave us (issue #567).
+func ImportFileRemote(r io.Reader) (ImportResult, error) {
+	return importFile(r, true)
+}
+
+func importFile(r io.Reader, remote bool) (ImportResult, error) {
 	var result ImportResult
 	// skipComponent is the one place that defines what "the parser dropped a
 	// persistable component" means: the warning for the user plus the count
@@ -123,7 +143,7 @@ func ImportFile(r io.Reader) (ImportResult, error) {
 			case ical.CompEvent:
 				vevent := ical.Event{Component: child}
 				resolveComponentTZIDs(child, tzMap)
-				e, warns, err := eventFromVEvent(vevent)
+				e, warns, err := eventFromVEvent(vevent, remote)
 				if err != nil {
 					if errors.Is(err, errImportLimitExceeded) {
 						return result, err
@@ -411,7 +431,7 @@ func parseDateProp(props ical.Props, kind, name, uid string) (string, string) {
 	return t.UTC().Format(time.RFC3339), ""
 }
 
-func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
+func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) {
 	uid, err := ve.Props.Text(ical.PropUID)
 	if err != nil || uid == "" {
 		return event.Event{}, nil, fmt.Errorf("missing UID")
@@ -445,6 +465,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 	var dtendWarnings []string
 	explicitEnd := false
 	badDTEND := false
+	var badDTENDRaw *ical.Prop
 	if prop := ve.Props.Get(ical.PropDateTimeEnd); prop != nil {
 		var err error
 		endTime, err = prop.DateTime(nil)
@@ -461,6 +482,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 			// the exact outcome this fallback exists to prevent.
 			endTime = time.Time{}
 			badDTEND = true
+			badDTENDRaw = prop
 			dtendWarnings = append(dtendWarnings, fmt.Sprintf(
 				"event %q: unparseable DTEND %q; ignored, falling back to DURATION or the default span", uid, prop.Value))
 		}
@@ -625,6 +647,24 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 	resources := parseResourcesFromProps(ve.Props)
 	relations := parseRelationsFromProps(ve.Props)
 
+	xprops := extractXPropertiesWithSet(ve.Props, handledEventProps)
+	if remote && badDTENDRaw != nil {
+		// The server's DTEND failed to parse here but parses on the server
+		// (a non-IANA TZID is the usual cause). Keep the raw property so
+		// export hands the value back verbatim instead of pushing the
+		// fabricated span over the server's original (issue #567).
+		params := "{}"
+		if len(badDTENDRaw.Params) > 0 {
+			if b, err := json.Marshal(badDTENDRaw.Params); err == nil {
+				params = string(b)
+			}
+		}
+		xprops = append(xprops, model.XProperty{
+			Name:   xpropOriginalDTEND,
+			Value:  badDTENDRaw.Value,
+			Params: params,
+		})
+	}
 	return event.Event{
 		UID:            uid,
 		Title:          summary,
@@ -656,7 +696,7 @@ func eventFromVEvent(ve ical.Event) (event.Event, []string, error) {
 		Contacts:       contacts,
 		Resources:      resources,
 		Relations:      relations,
-		XProperties:    extractXPropertiesWithSet(ve.Props, handledEventProps),
+		XProperties:    xprops,
 	}, append(childWarnings, dtendWarnings...), nil
 }
 
@@ -1501,7 +1541,8 @@ var handledJournalProps = map[string]bool{
 	ical.PropDateTimeStamp: true, ical.PropCreated: true, ical.PropLastModified: true,
 	ical.PropAttach: true, ical.PropComment: true, ical.PropContact: true,
 	ical.PropRelatedTo: true,
-	ical.PropAttendee:  true, ical.PropOrganizer: true,
+	ical.PropAttendee: true, ical.PropOrganizer: true,
+	xpropOriginalDTEND: true,
 }
 
 // extractXPropertiesWithSet collects properties not in the handled set.

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -50,12 +50,15 @@ const (
 
 var errImportLimitExceeded = errors.New("ical import exceeds configured limits")
 
-// xpropOriginalDTEND preserves a server DTEND that failed to parse. The
-// fabricated local span must not overwrite the server's value on the next
-// push, so export hands the original string back verbatim. Only the CalDAV
-// pull path sets it: a file-imported value did not come from the target
-// server, and re-emitting it there could wedge a strict server.
-const xpropOriginalDTEND = "X-CHRONCAL-ORIGINAL-DTEND"
+// xpropOriginalDTEND preserves a server DTEND that failed to parse. Export
+// emits the stored string as DTEND, so the fabricated local span does not
+// overwrite the server value (issue #567). A local edit that changes the
+// span clears the slot first (see internal/event, issue #649).
+//
+// Only the CalDAV pull path sets the slot. A file import did not receive
+// the value from the target server. An export of such a value could send
+// the target server a DTEND it rejects, and the resource then stays dirty.
+const xpropOriginalDTEND = model.XPropOriginalDTEND
 
 // ImportFile parses an iCal stream from a file or another local source.
 func ImportFile(r io.Reader) (ImportResult, error) {
@@ -63,9 +66,9 @@ func ImportFile(r io.Reader) (ImportResult, error) {
 }
 
 // ImportFileRemote parses an iCal stream that a CalDAV server served. A
-// DTEND that fails to parse is then preserved verbatim in
-// X-CHRONCAL-ORIGINAL-DTEND, so export can hand the server back exactly what
-// it gave us (issue #567).
+// DTEND that fails to parse is stored verbatim in
+// X-CHRONCAL-ORIGINAL-DTEND. Export then returns the exact server value
+// (issue #567).
 func ImportFileRemote(r io.Reader) (ImportResult, error) {
 	return importFile(r, true)
 }
@@ -649,10 +652,10 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 
 	xprops := extractXPropertiesWithSet(ve.Props, handledEventProps)
 	if remote && badDTENDRaw != nil {
-		// The server's DTEND failed to parse here but parses on the server
-		// (a non-IANA TZID is the usual cause). Keep the raw property so
-		// export hands the value back verbatim instead of pushing the
-		// fabricated span over the server's original (issue #567).
+		// The server's DTEND failed to parse here but parses on the
+		// server (a non-IANA TZID is the usual cause). Store the raw
+		// property, so export returns the server value instead of the
+		// fabricated span (issue #567).
 		params := "{}"
 		if len(badDTENDRaw.Params) > 0 {
 			if b, err := json.Marshal(badDTENDRaw.Params); err == nil {
@@ -1541,8 +1544,7 @@ var handledJournalProps = map[string]bool{
 	ical.PropDateTimeStamp: true, ical.PropCreated: true, ical.PropLastModified: true,
 	ical.PropAttach: true, ical.PropComment: true, ical.PropContact: true,
 	ical.PropRelatedTo: true,
-	ical.PropAttendee: true, ical.PropOrganizer: true,
-	xpropOriginalDTEND: true,
+	ical.PropAttendee:  true, ical.PropOrganizer: true,
 }
 
 // extractXPropertiesWithSet collects properties not in the handled set.

--- a/internal/model/xprop.go
+++ b/internal/model/xprop.go
@@ -1,5 +1,12 @@
 package model
 
+// XPropOriginalDTEND names the x-property that preserves a server DTEND
+// which local parsing could not read. The CalDAV pull path stores the raw
+// property under this name. Export emits the stored string as DTEND while
+// no DURATION is set. A local edit that changes the span clears the slot.
+// See internal/ical and docs/adr/0002 (issues #567, #649).
+const XPropOriginalDTEND = "X-CHRONCAL-ORIGINAL-DTEND"
+
 // XProperty represents an iCal extension property (X-* or unhandled IANA
 // property) stored for round-trip fidelity. The Params field is a JSON
 // object mapping parameter names to arrays of values, e.g.:

--- a/internal/sync/dtend_preserve_test.go
+++ b/internal/sync/dtend_preserve_test.go
@@ -1,0 +1,118 @@
+package sync
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// TestPushServerWinsRepullPreservesDTEND drives the ConflictServerWins
+// accept-server path with a server body whose DTEND fails to parse locally.
+// The re-import must store the raw string in the preservation slot again
+// (issue #567). The local-edit clear in the event service must not break
+// this path. A sync upsert never goes through UpdateParams, so it never
+// clears the slot (issue #649).
+func TestPushServerWinsRepullPreservesDTEND(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	insertTestEvent(t, db, calendarID, "srv-wins-dtend")
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodPut:
+			return &http.Response{
+				StatusCode: http.StatusPreconditionFailed,
+				Status:     "412 Precondition Failed",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("precondition failed")),
+				Request:    r,
+			}, nil
+		case http.MethodGet:
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"text/calendar; charset=utf-8"},
+					"Etag":         []string{`"etag-server"`},
+				},
+				Body: io.NopCloser(strings.NewReader("BEGIN:VCALENDAR\r\n" +
+					"VERSION:2.0\r\n" +
+					"PRODID:-//chroncal//tests//EN\r\n" +
+					"BEGIN:VEVENT\r\n" +
+					"UID:srv-wins-dtend\r\n" +
+					"DTSTAMP:20260101T000000Z\r\n" +
+					"DTSTART:20260101T150000Z\r\n" +
+					"DTEND;TZID=Customized Time Zone:20260101T163000\r\n" +
+					"SUMMARY:Server version\r\n" +
+					"END:VEVENT\r\n" +
+					"END:VCALENDAR\r\n")),
+				Request: r,
+			}, nil
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "srv-wins-dtend",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/srv-wins-dtend.ics",
+		Etag:         "etag-before",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	result, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins)
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if result.conflicts != 1 {
+		t.Fatalf("conflicts = %d, want 1", result.conflicts)
+	}
+	if len(result.errors) != 0 {
+		t.Fatalf("errors = %d, want 0: %v", len(result.errors), result.errors)
+	}
+
+	evt, err := q.GetEventByUID(ctx, "srv-wins-dtend")
+	if err != nil {
+		t.Fatalf("GetEventByUID: %v", err)
+	}
+	xps, err := q.ListXPropertiesByOwner(ctx, storage.ListXPropertiesByOwnerParams{
+		OwnerType: "event", OwnerID: evt.ID,
+	})
+	if err != nil {
+		t.Fatalf("ListXPropertiesByOwner: %v", err)
+	}
+	found := false
+	for _, xp := range xps {
+		if xp.Name != model.XPropOriginalDTEND {
+			continue
+		}
+		found = true
+		if xp.Value != "20260101T163000" {
+			t.Errorf("preserved value = %q, want 20260101T163000", xp.Value)
+		}
+	}
+	if !found {
+		t.Fatalf("the ServerWins re-pull did not store %s again in %+v",
+			model.XPropOriginalDTEND, xps)
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -990,7 +990,7 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 			continue
 		}
 
-		importResult, err := icalPkg.ImportFile(strings.NewReader(buf.String()))
+		importResult, err := icalPkg.ImportFileRemote(strings.NewReader(buf.String()))
 		if err != nil {
 			e.logger.Warn("import fetched resource failed", "path", res.Path, "error", err)
 			continue
@@ -1307,7 +1307,7 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 				e.logger.Warn("encode fetched resource failed", "path", res.Path, "error", err)
 				continue
 			}
-			importResult, err := icalPkg.ImportFile(strings.NewReader(buf.String()))
+			importResult, err := icalPkg.ImportFileRemote(strings.NewReader(buf.String()))
 			if err != nil {
 				e.logger.Warn("import fetched resource failed", "path", res.Path, "error", err)
 				continue
@@ -2215,7 +2215,7 @@ func (e *Engine) inTx(ctx context.Context, fn func(*sql.Tx) error) error {
 // They then do not stamp the server ETag onto an unchanged local row in
 // silence.
 func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) (imported bool, revs map[string]int64, warnings []ImportWarning, err error) {
-	importResult, err := icalPkg.ImportFile(strings.NewReader(data))
+	importResult, err := icalPkg.ImportFileRemote(strings.NewReader(data))
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("import ical: %w", err)
 	}


### PR DESCRIPTION
## Summary

When import cannot parse a `DTEND` it fabricates a span (necessary locally — half-open range queries). But the fabrication did not stay local: any later local edit marked the resource dirty and the push replaced the server's original `DTEND` with our invention. Exchange's non-IANA `TZID=Customized Time Zone` makes this reachable from ordinary traffic.

Provenance-gated preservation, per the issue's proposed direction:

- The **CalDAV pull path** (`ImportFileRemote`) stores the raw property in an `X-CHRONCAL-ORIGINAL-DTEND` x-property when `DTEND` fails to parse.
- `buildVevent` hands that value back verbatim (params included) instead of the computed end — the server gets exactly what it gave us.
- **File imports keep today's behavior**: their value did not come from the target server, and re-emitting it there could wedge a strict server (the issue's open question).
- The slot never reaches the wire as an x-property and re-import is idempotent.

## Tests

Exchange-style case: remote import fabricates the local span AND preserves the raw string + TZID param; export emits `DTEND;TZID=Customized Time Zone:20260101T163000` verbatim with no leaked x-prop; file import sets nothing; normal events unaffected.

`go test ./internal/ical/... ./internal/sync/... ./internal/event/...` pass.

Fixes #567
