### PR TITLE
docs: remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![CI](https://github.com/DouglasdeMoura/chroncal/actions/workflows/ci.yml/badge.svg)](https://github.com/DouglasdeMoura/chroncal/actions/workflows/ci.yml)
 [![Release](https://github.com/DouglasdeMoura/chroncal/actions/workflows/release.yml/badge.svg)](https://github.com/DouglasdeMoura/chroncal/actions/workflows/release.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/douglasdemoura/chroncal.svg)](https://pkg.go.dev/github.com/douglasdemoura/chroncal)
-[![Go Report Card](https://goreportcard.com/badge/github.com/douglasdemoura/chroncal)](https://goreportcard.com/report/github.com/douglasdemoura/chroncal)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 chroncal is a terminal calendar. SQLite stores the data. The program supports full iCal import and export, and CalDAV sync. Launch the TUI for an interactive calendar. Use the CLI to script access to events, todos, journals, alarms, free/busy queries, and calendars.


### PR DESCRIPTION
## Summary

Go Report Card retired the public service. The last message on [goreportcard.com](https://goreportcard.com/report/github.com/douglasdemoura/chroncal) asks projects to drop the badge and use [golangci-lint](https://golangci-lint.run/) instead.

This PR removes the README badge. No linter change: chroncal already follows that recommendation.

- CI: `golangci/golangci-lint-action@v9` (v2.11.4) in `.github/workflows/ci.yml`
- Local: `make lint` / `make check`
- Pre-commit: lefthook runs `golangci-lint run ./...`
- Config: `.golangci.yml`