### PR TITLE
fix(sync): harden the sync doctor against false wedges and lost consent

### DIFF
--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -60,7 +60,7 @@ before the push and asks for confirmation.`,
 }
 
 // doctorEntry pairs one wedged resource with the calendar that holds it, so
-// both render functions print the calendar name next to the UID.
+// every view prints the calendar name next to the UID.
 type doctorEntry struct {
 	calendarName string
 	wedged       syncPkg.WedgedResource
@@ -127,27 +127,29 @@ func runDoctorList(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Cale
 // loss, asks for confirmation, and pushes the incomplete record.
 func runDoctorPush(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Calendar, uid string) error {
 	ctx := context.Background()
-	for _, cal := range cals {
-		wedged, err := svc.DiagnoseCalendar(ctx, cal.ID)
+	entries, err := diagnoseAll(ctx, svc, cals)
+	if err != nil {
+		return err
+	}
+	for _, en := range entries {
+		w := en.wedged
+		if w.UID != uid {
+			continue
+		}
+		question := fmt.Sprintf(
+			"Push %s from calendar %q without relation(s) %s? The server copy loses those fields",
+			uid, en.calendarName, strings.Join(w.Relations, ", "))
+		if err := confirmDestructive(cmd, question); err != nil {
+			return err
+		}
+		// The confirmed relation set rides along. DoctorPush re-runs the
+		// export under the lifecycle lock and refuses the push when the
+		// actual drop set differs from what the user accepted.
+		dropped, err := svc.DoctorPush(ctx, w.CalendarID, uid, w.Relations)
 		if err != nil {
-			return fmt.Errorf("diagnose calendar %q: %w", cal.Name, err)
+			return err
 		}
-		for _, w := range wedged {
-			if w.UID != uid {
-				continue
-			}
-			question := fmt.Sprintf(
-				"Push %s from calendar %q without relation(s) %s? The server copy loses those fields",
-				uid, cal.Name, strings.Join(w.Relations, ", "))
-			if err := confirmDestructive(cmd, question); err != nil {
-				return err
-			}
-			dropped, err := svc.DoctorPush(ctx, cal.ID, uid)
-			if err != nil {
-				return err
-			}
-			return renderDoctorPush(cmd, uid, dropped)
-		}
+		return renderDoctorPush(cmd, uid, dropped)
 	}
 	return &cliError{
 		Code: "not_found",

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -252,6 +252,26 @@ func splitNonEmpty(s string) []string {
 	return out
 }
 
+// propFromXProperty converts one stored X-property into a wire property,
+// decoding its JSON-serialized parameters. The DTEND override in setEventTimes
+// and emitXProperties share it, so the wire encoding of the stored params has
+// one definition.
+func propFromXProperty(xp model.XProperty) *ical.Prop {
+	p := &ical.Prop{Name: xp.Name, Params: make(ical.Params)}
+	p.Value = xp.Value
+	if xp.Params != "" && xp.Params != "{}" {
+		var params map[string][]string
+		if err := json.Unmarshal([]byte(xp.Params), &params); err == nil {
+			for k, vals := range params {
+				for _, v := range vals {
+					p.Params.Add(k, v)
+				}
+			}
+		}
+	}
+	return p
+}
+
 // emitXProperties writes X-properties (and other unhandled properties) onto an
 // iCal component for round-trip preservation. libical-internal annotations
 // (X-LIC-ERROR / X-LIC-ERRORTYPE) are skipped. Those are diagnostic markers
@@ -269,19 +289,7 @@ func emitXProperties(comp *ical.Component, xprops []model.XProperty) {
 		if xp.Name == xpropOriginalDTEND {
 			continue
 		}
-		p := &ical.Prop{Name: xp.Name, Params: make(ical.Params)}
-		p.Value = xp.Value
-		if xp.Params != "" && xp.Params != "{}" {
-			var params map[string][]string
-			if err := json.Unmarshal([]byte(xp.Params), &params); err == nil {
-				for k, vals := range params {
-					for _, v := range vals {
-						p.Params.Add(k, v)
-					}
-				}
-			}
-		}
-		comp.Props.Add(p)
+		comp.Props.Add(propFromXProperty(xp))
 	}
 }
 

--- a/internal/ical/export_events.go
+++ b/internal/ical/export_events.go
@@ -2,7 +2,6 @@ package ical
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -308,18 +307,8 @@ func setEventTimes(vevent *ical.Event, e event.Event) {
 			if xp.Name != xpropOriginalDTEND {
 				continue
 			}
-			p := &ical.Prop{Name: ical.PropDateTimeEnd, Params: make(ical.Params)}
-			p.Value = xp.Value
-			if xp.Params != "" && xp.Params != "{}" {
-				var params map[string][]string
-				if err := json.Unmarshal([]byte(xp.Params), &params); err == nil {
-					for k, vals := range params {
-						for _, v := range vals {
-							p.Params.Add(k, v)
-						}
-					}
-				}
-			}
+			p := propFromXProperty(xp)
+			p.Name = ical.PropDateTimeEnd
 			vevent.Props.Set(p)
 			break
 		}

--- a/internal/sync/doctor.go
+++ b/internal/sync/doctor.go
@@ -2,9 +2,10 @@ package sync
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/event"
@@ -32,7 +33,9 @@ type WedgedResource struct {
 
 // DiagnoseCalendar exports every dirty resource of one calendar and returns
 // the ones that fail on unreadable relations. Transient export failures are
-// not wedges; they stay out of the list.
+// not wedges; they stay out of the list. A resource enters the list only
+// when its export names unreadable relations twice in a row, so a busy or
+// cancelled database read never reads as a wedge.
 func (e *Engine) DiagnoseCalendar(ctx context.Context, calendarID int64) ([]WedgedResource, error) {
 	dirty, err := e.q.ListDirtySyncResources(ctx, calendarID)
 	if err != nil {
@@ -40,23 +43,63 @@ func (e *Engine) DiagnoseCalendar(ctx context.Context, calendarID int64) ([]Wedg
 	}
 	var wedged []WedgedResource
 	for _, res := range dirty {
-		_, err := e.exportResource(ctx, res.OwnerType, res.Uid)
-		var hErr *hydrate.HydrationError
-		if err != nil && errors.As(err, &hErr) && len(hErr.Failures) > 0 {
-			rels := make([]string, 0, len(hErr.Failures))
-			for _, f := range hErr.Failures {
-				rels = append(rels, f.Relation)
-			}
-			wedged = append(wedged, WedgedResource{
-				CalendarID:    calendarID,
-				UID:           res.Uid,
-				OwnerType:     res.OwnerType,
-				Relations:     rels,
-				PushFailCount: res.PushFailCount,
-			})
+		rels, ok := e.diagnoseWedge(ctx, res.OwnerType, res.Uid)
+		if !ok {
+			continue
 		}
+		wedged = append(wedged, WedgedResource{
+			CalendarID:    calendarID,
+			UID:           res.Uid,
+			OwnerType:     res.OwnerType,
+			Relations:     rels,
+			PushFailCount: res.PushFailCount,
+		})
 	}
 	return wedged, nil
+}
+
+// diagnoseWedge reports the unreadable relations when the export fails on
+// them twice in a row. One failure is not proof of a wedge: SQLITE_BUSY
+// after the busy timeout, an I/O error, or context cancellation all reach
+// the collector like a corrupt row does. The retry separates a transient
+// load failure from a deterministic one, so the destructive confirmation
+// never fires on a false diagnosis.
+func (e *Engine) diagnoseWedge(ctx context.Context, ownerType, uid string) ([]string, bool) {
+	_, err := e.exportResource(ctx, ownerType, uid)
+	if !wedgeShaped(err) {
+		return nil, false
+	}
+	_, err = e.exportResource(ctx, ownerType, uid)
+	if !wedgeShaped(err) {
+		return nil, false
+	}
+	var hErr *hydrate.HydrationError
+	errors.As(err, &hErr)
+	rels := make([]string, 0, len(hErr.Failures))
+	for _, f := range hErr.Failures {
+		rels = append(rels, f.Relation)
+	}
+	return rels, true
+}
+
+// wedgeShaped reports whether err is a hydration failure that names broken
+// relations and has no cancellation cause. A done context makes every load
+// fail; those failures vanish on the next attempt and never describe a
+// deterministic wedge.
+func wedgeShaped(err error) bool {
+	if err == nil {
+		return false
+	}
+	var hErr *hydrate.HydrationError
+	if !errors.As(err, &hErr) || len(hErr.Failures) == 0 {
+		return false
+	}
+	for _, f := range hErr.Failures {
+		if errors.Is(f.Cause, context.Canceled) || errors.Is(f.Cause, context.DeadlineExceeded) {
+			return false
+		}
+	}
+	return true
 }
 
 // DoctorPush pushes one wedged resource with best-effort hydration. The PUT
@@ -70,7 +113,12 @@ func (e *Engine) DiagnoseCalendar(ctx context.Context, calendarID int64) ([]Wedg
 // the regular push enforces. The doctor exists to move resources the regular
 // push cannot move. A foreign-organized meeting with an unreadable relation
 // stays wedged without this bypass.
-func (e *Engine) DoctorPush(ctx context.Context, calendarID int64, uid string) (dropped []string, err error) {
+//
+// diagnosed holds the relation set the user confirmed. The push re-runs the
+// best-effort export under the lifecycle lock and refuses to send anything
+// when the actual drop set differs: consent for one loss set must not
+// silently cover another.
+func (e *Engine) DoctorPush(ctx context.Context, calendarID int64, uid string, diagnosed []string) (dropped []string, err error) {
 	// Hold the calendar lifecycle lock across the dirty snapshot, the PUT,
 	// and the finalize, like SyncCalendar and PushLocalEdits do. A concurrent
 	// sync run must not interleave between them (issue #647).
@@ -103,10 +151,30 @@ func (e *Engine) DoctorPush(ctx context.Context, calendarID int64, uid string) (
 		return nil, fmt.Errorf("no dirty sync resource for uid %q on calendar %d", uid, calendarID)
 	}
 
+	open, err := e.q.CountOpenSyncConflicts(ctx, storage.CountOpenSyncConflictsParams{
+		CalendarID: calendarID,
+		Uid:        res.Uid,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("count open sync conflicts %s: %w", uid, err)
+	}
+	if open > 0 {
+		// The regular push skips conflicted resources because a PUT under an
+		// open conflict desynchronizes the recorded conflict snapshots (issue
+		// #104). The doctor must not converge the server around them either.
+		return nil, fmt.Errorf("uid %s has an open sync conflict; resolve it first with chroncal sync resolve", uid)
+	}
+
 	icalData, dropped, err := e.exportResourceBestEffortFor(ctx, res.OwnerType, res.Uid)
 	if err != nil {
 		return nil, fmt.Errorf("best-effort export %s: %w", uid, err)
 	}
+	if !sameRelationSet(dropped, diagnosed) {
+		return nil, fmt.Errorf(
+			"the unreadable relation(s) changed since diagnosis: diagnosed [%s], now [%s]; re-run chroncal sync doctor",
+			strings.Join(diagnosed, ", "), strings.Join(dropped, ", "))
+	}
+
 	body, parseErr := parseICalData(icalData)
 	if parseErr != nil {
 		return nil, fmt.Errorf("parse ical for %s: %w", uid, parseErr)
@@ -182,51 +250,6 @@ func (e *Engine) DoctorPush(ctx context.Context, calendarID int64, uid string) (
 	return dropped, nil
 }
 
-// exportResourceBestEffort bundles a UID's rows like exportResourceFor, but it
-// hydrates best-effort and reports the relations it had to drop. The payload
-// is incomplete by construction; only DoctorPush may send it.
-func exportResourceBestEffort[T any](
-	ctx context.Context,
-	e *Engine,
-	uid, kind string,
-	get func(context.Context, string) (T, error),
-	listOverrides func(context.Context, string) ([]T, error),
-	hydrateBestEffort func(context.Context, *Engine, *T) ([]string, error),
-	export func([]T, string) ([]byte, error),
-) ([]byte, []string, error) {
-	var rows []T
-	switch row, err := get(ctx, uid); {
-	case err == nil:
-		rows = append(rows, row)
-	case !errors.Is(err, sql.ErrNoRows):
-		return nil, nil, fmt.Errorf("get %s master uid %s: %w", kind, uid, err)
-	}
-	overrides, err := listOverrides(ctx, uid)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list overrides for %s uid %s: %w", kind, uid, err)
-	}
-	rows = append(rows, overrides...)
-	if len(rows) == 0 {
-		return nil, nil, fmt.Errorf("%w: %s uid %s", errResourceMissing, kind, uid)
-	}
-	seen := make(map[string]struct{})
-	var dropped []string
-	for i := range rows {
-		rels, err := hydrateBestEffort(ctx, e, &rows[i])
-		if err != nil {
-			return nil, nil, fmt.Errorf("hydrate %s uid %s: %w", kind, uid, err)
-		}
-		for _, r := range rels {
-			if _, ok := seen[r]; !ok {
-				seen[r] = struct{}{}
-				dropped = append(dropped, r)
-			}
-		}
-	}
-	data, err := export(rows, "")
-	return data, dropped, err
-}
-
 // The per-type best-effort hydrate adapters return the dropped relation names
 // in structured form. HydrateBestEffort returns a *hydrate.HydrationError, so
 // the names come from the collector and no text parsing is involved.
@@ -261,20 +284,33 @@ func droppedRelations(err error) ([]string, error) {
 	return rels, nil
 }
 
-// exportResourceBestEffortFor dispatches on owner type. It mirrors the
-// ownerOpsByType export entries with the best-effort hydrators.
+// exportResourceBestEffortFor dispatches on owner type. It runs the shared
+// bundling path in exportResourceFor with the best-effort hydrators, so the
+// doctor's payload assembly cannot drift from the regular push's.
 func (e *Engine) exportResourceBestEffortFor(ctx context.Context, ownerType, uid string) ([]byte, []string, error) {
 	switch ownerType {
 	case ownerTypeEvent:
-		return exportResourceBestEffort(ctx, e, uid, ownerTypeEvent,
+		return exportResourceFor(ctx, e, uid, ownerTypeEvent,
 			e.events.GetByUID, e.events.ListOverridesByUID, hydrateEventBestEffort, icalPkg.ExportEvents)
 	case ownerTypeTodo:
-		return exportResourceBestEffort(ctx, e, uid, ownerTypeTodo,
+		return exportResourceFor(ctx, e, uid, ownerTypeTodo,
 			e.todos.GetByUID, e.todos.ListOverridesByUID, hydrateTodoBestEffort, icalPkg.ExportTodos)
 	case ownerTypeJournal:
-		return exportResourceBestEffort(ctx, e, uid, ownerTypeJournal,
+		return exportResourceFor(ctx, e, uid, ownerTypeJournal,
 			e.journals.GetByUID, e.journals.ListOverridesByUID, hydrateJournalBestEffort, icalPkg.ExportJournals)
 	default:
 		return nil, nil, fmt.Errorf("%w: %q", errUnknownOwnerType, ownerType)
 	}
+}
+
+// sameRelationSet compares two relation sets order-insensitively.
+func sameRelationSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sa := slices.Clone(a)
+	sb := slices.Clone(b)
+	slices.Sort(sa)
+	slices.Sort(sb)
+	return slices.Equal(sa, sb)
 }

--- a/internal/sync/doctor_test.go
+++ b/internal/sync/doctor_test.go
@@ -3,12 +3,15 @@ package sync
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/hydrate"
 
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/calendar"
@@ -141,7 +144,7 @@ func TestDiagnoseAndDoctorPushRecoverWedgedResource(t *testing.T) {
 		t.Errorf("unexpected diagnosis: %+v", wedged[0])
 	}
 
-	dropped, err := engine.DoctorPush(context.Background(), cal.ID, "wedged-doctor")
+	dropped, err := engine.DoctorPush(context.Background(), cal.ID, "wedged-doctor", []string{"alarms"})
 	if err != nil {
 		t.Fatalf("DoctorPush: %v", err)
 	}
@@ -265,7 +268,7 @@ func TestPushRecordsFailureAndDoctorResetsCounter(t *testing.T) {
 
 	// A successful doctor push resets the bookkeeping.
 	failWrites.Store(false)
-	if _, err := engine.DoctorPush(ctx, cal.ID, "wedge-count"); err != nil {
+	if _, err := engine.DoctorPush(ctx, cal.ID, "wedge-count", []string{"alarms"}); err != nil {
 		t.Fatalf("DoctorPush: %v", err)
 	}
 	res, err = q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: cal.ID, Uid: "wedge-count"})
@@ -337,7 +340,7 @@ func TestDoctorPushRecoversLostPutResponse(t *testing.T) {
 	}
 	breakEventAlarms(t, db)
 
-	dropped, err := engine.DoctorPush(ctx, cal.ID, "doctor-lost-put")
+	dropped, err := engine.DoctorPush(ctx, cal.ID, "doctor-lost-put", []string{"alarms"})
 	if err != nil {
 		t.Fatalf("DoctorPush: %v", err)
 	}
@@ -356,5 +359,118 @@ func TestDoctorPushRecoversLostPutResponse(t *testing.T) {
 	}
 	if res.Dirty != 0 {
 		t.Fatalf("Dirty = %d, want 0", res.Dirty)
+	}
+}
+
+// wedgeShaped must reject context-driven failures: a cancelled or timed-out
+// context fails every relation load at once, and listing every dirty
+// resource as wedged would invite a destructive confirmation on a healthy
+// database.
+func TestWedgeShapedRejectsContextCauses(t *testing.T) {
+	t.Parallel()
+
+	plain := &hydrate.HydrationError{
+		Err: errors.New("event 1 alarms: db busy"),
+		Failures: []hydrate.RelFailure{
+			{Kind: "event", ID: 1, Relation: "alarms", Cause: errors.New("db busy")},
+		},
+	}
+	if !wedgeShaped(plain) {
+		t.Error("a non-context hydration failure must stay wedge-shaped")
+	}
+	if wedgeShaped(errors.New("not a hydration error")) {
+		t.Error("a non-hydration error is not a wedge shape")
+	}
+	if wedgeShaped(nil) {
+		t.Error("nil is not a wedge shape")
+	}
+	cancelled := &hydrate.HydrationError{
+		Err: errors.New("event 1 alarms: context canceled"),
+		Failures: []hydrate.RelFailure{
+			{Kind: "event", ID: 1, Relation: "alarms", Cause: context.Canceled},
+		},
+	}
+	if wedgeShaped(cancelled) {
+		t.Error("a cancellation cause must not read as a deterministic wedge")
+	}
+	mixed := &hydrate.HydrationError{
+		Err: errors.Join(errors.New("a"), errors.New("b")),
+		Failures: []hydrate.RelFailure{
+			{Kind: "event", ID: 1, Relation: "alarms", Cause: context.DeadlineExceeded},
+			{Kind: "event", ID: 1, Relation: "alarms", Cause: errors.New("db busy")},
+		},
+	}
+	if wedgeShaped(mixed) {
+		t.Error("a cancelled load taints the whole report; the retry must decide, not the classifier")
+	}
+}
+
+// The user confirms one loss set. A push that would drop a different set
+// must fail closed instead of silently covering more than the user accepted.
+func TestDoctorPushRefusesChangedRelationSet(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	engine, db, q, cal := newDoctorTestEnv(t, srv.URL, "changed-set")
+	ctx := context.Background()
+	seedWedgedEvent(t, engine, db, q, cal.ID, "wedged-set")
+
+	dropped, err := engine.DoctorPush(ctx, cal.ID, "wedged-set", []string{"attendees"})
+	if err == nil {
+		t.Fatalf("DoctorPush succeeded with a mismatched diagnosis, dropped = %v", dropped)
+	}
+	if !strings.Contains(err.Error(), "changed since diagnosis") {
+		t.Errorf("error = %v, want it to name the changed set", err)
+	}
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{CalendarID: cal.ID, Uid: "wedged-set"})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.Dirty != 1 {
+		t.Errorf("resource left the dirty state after a refused push")
+	}
+}
+
+// The regular push skips resources with an open conflict because a PUT under
+// an open conflict desynchronizes the recorded snapshots (issue #104). The
+// doctor must refuse them for the same reason.
+func TestDoctorPushRefusesOpenConflict(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	engine, db, q, cal := newDoctorTestEnv(t, srv.URL, "conflicted")
+	ctx := context.Background()
+	seedWedgedEvent(t, engine, db, q, cal.ID, "wedged-conflict")
+
+	evt, err := q.GetEventByUID(ctx, "wedged-conflict")
+	if err != nil {
+		t.Fatalf("GetEventByUID: %v", err)
+	}
+	if err := q.CreateSyncConflict(ctx, storage.CreateSyncConflictParams{
+		CalendarID: cal.ID,
+		OwnerType:  "event",
+		OwnerID:    evt.ID,
+		Uid:        "wedged-conflict",
+		LocalIcal:  "BEGIN:VCALENDAR",
+		ServerIcal: "BEGIN:VCALENDAR",
+		ServerEtag: `"stale"`,
+	}); err != nil {
+		t.Fatalf("CreateSyncConflict: %v", err)
+	}
+
+	if _, err := engine.DoctorPush(ctx, cal.ID, "wedged-conflict", []string{"alarms"}); err == nil {
+		t.Fatal("DoctorPush succeeded under an open sync conflict")
+	} else if !strings.Contains(err.Error(), "open sync conflict") {
+		t.Errorf("error = %v, want it to name the open conflict", err)
 	}
 }

--- a/internal/sync/engine_export.go
+++ b/internal/sync/engine_export.go
@@ -52,8 +52,9 @@ var ownerOpsByType = map[string]ownerOps{
 			return row.ID, nil
 		},
 		export: func(ctx context.Context, e *Engine, uid string) ([]byte, error) {
-			return exportResourceFor(ctx, e, uid, ownerTypeEvent,
+			data, _, err := exportResourceFor(ctx, e, uid, ownerTypeEvent,
 				e.events.GetByUID, e.events.ListOverridesByUID, hydrateEvent, icalPkg.ExportEvents)
+			return data, err
 		},
 	},
 	ownerTypeTodo: {
@@ -68,8 +69,9 @@ var ownerOpsByType = map[string]ownerOps{
 			return row.ID, nil
 		},
 		export: func(ctx context.Context, e *Engine, uid string) ([]byte, error) {
-			return exportResourceFor(ctx, e, uid, ownerTypeTodo,
+			data, _, err := exportResourceFor(ctx, e, uid, ownerTypeTodo,
 				e.todos.GetByUID, e.todos.ListOverridesByUID, hydrateTodo, icalPkg.ExportTodos)
+			return data, err
 		},
 	},
 	ownerTypeJournal: {
@@ -84,8 +86,9 @@ var ownerOpsByType = map[string]ownerOps{
 			return row.ID, nil
 		},
 		export: func(ctx context.Context, e *Engine, uid string) ([]byte, error) {
-			return exportResourceFor(ctx, e, uid, ownerTypeJournal,
+			data, _, err := exportResourceFor(ctx, e, uid, ownerTypeJournal,
 				e.journals.GetByUID, e.journals.ListOverridesByUID, hydrateJournal, icalPkg.ExportJournals)
+			return data, err
 		},
 	},
 }
@@ -94,6 +97,11 @@ var ownerOpsByType = map[string]ownerOps{
 // iCal payload. CalDAV tracks one resource per UID. Recurring resources are
 // stored as a master row plus override rows that share the UID. We normally
 // bundle master plus overrides so instance edits round-trip to the server.
+//
+// The hydrator decides the failure mode. The strict adapters return an error
+// and nil dropped, so one unreadable relation aborts the export. The
+// best-effort adapters (the sync doctor path) return the relation names they
+// had to drop; the caller owns the decision to send the incomplete payload.
 //
 // Google sometimes serves a single orphan instance under a UID like
 // `<master>_R<recurrence-id>@google.com` with a RECURRENCE-ID property and no
@@ -107,9 +115,9 @@ func exportResourceFor[T any](
 	uid, kind string,
 	get func(context.Context, string) (T, error),
 	listOverrides func(context.Context, string) ([]T, error),
-	hydrate func(context.Context, *Engine, *T) error,
+	hydrate func(context.Context, *Engine, *T) ([]string, error),
 	export func([]T, string) ([]byte, error),
-) ([]byte, error) {
+) ([]byte, []string, error) {
 	var rows []T
 	switch row, err := get(ctx, uid); {
 	case err == nil:
@@ -120,18 +128,21 @@ func exportResourceFor[T any](
 		// I/O error — the same way would export the overrides alone, PUT a
 		// resource with the master VEVENT and its recurrence rule amputated,
 		// then clear the dirty flag so nothing ever retries.
-		return nil, fmt.Errorf("get %s master uid %s: %w", kind, uid, err)
+		return nil, nil, fmt.Errorf("get %s master uid %s: %w", kind, uid, err)
 	}
 	overrides, err := listOverrides(ctx, uid)
 	if err != nil {
-		return nil, fmt.Errorf("list overrides for %s uid %s: %w", kind, uid, err)
+		return nil, nil, fmt.Errorf("list overrides for %s uid %s: %w", kind, uid, err)
 	}
 	rows = append(rows, overrides...)
 	if len(rows) == 0 {
-		return nil, fmt.Errorf("%w: %s uid %s", errResourceMissing, kind, uid)
+		return nil, nil, fmt.Errorf("%w: %s uid %s", errResourceMissing, kind, uid)
 	}
+	var dropped []string
+	seenRel := make(map[string]struct{})
 	for i := range rows {
-		if err := hydrate(ctx, e, &rows[i]); err != nil {
+		rels, err := hydrate(ctx, e, &rows[i])
+		if err != nil {
 			// A hydration failure means the exported iCal would silently omit
 			// alarms/attendees/attachments/... and the PUT would strip them
 			// from the server copy. Abort instead: the dirty flag stays set, so
@@ -148,14 +159,22 @@ func exportResourceFor[T any](
 				for _, f := range hErr.Failures {
 					rels = append(rels, f.Relation)
 				}
-				return nil, fmt.Errorf(
+				return nil, nil, fmt.Errorf(
 					"hydrate %s uid %s: unreadable relation(s) %s; the resource is stuck and no edit reaches the server until it is resolved (see chroncal sync doctor): %w",
 					kind, uid, strings.Join(rels, ", "), err)
 			}
-			return nil, fmt.Errorf("hydrate %s uid %s: %w", kind, uid, err)
+			return nil, nil, fmt.Errorf("hydrate %s uid %s: %w", kind, uid, err)
+		}
+		for _, r := range rels {
+			if _, ok := seenRel[r]; ok {
+				continue
+			}
+			seenRel[r] = struct{}{}
+			dropped = append(dropped, r)
 		}
 	}
-	return export(rows, "")
+	data, err := export(rows, "")
+	return data, dropped, err
 }
 
 // ownerOpsFor resolves the dispatch table for an owner type. It returns
@@ -212,14 +231,14 @@ func (e *Engine) exportResource(ctx context.Context, ownerType string, uid strin
 // methods to the ownerOps export signature. The relation list itself lives in
 // the services (event.Service.Hydrate and friends). Sync, file export, and
 // the CLI then cannot drift apart on what a complete record contains.
-func hydrateEvent(ctx context.Context, e *Engine, evt *event.Event) error {
-	return e.events.Hydrate(ctx, evt)
+func hydrateEvent(ctx context.Context, e *Engine, evt *event.Event) ([]string, error) {
+	return nil, e.events.Hydrate(ctx, evt)
 }
 
-func hydrateTodo(ctx context.Context, e *Engine, t *todo.Todo) error {
-	return e.todos.Hydrate(ctx, t)
+func hydrateTodo(ctx context.Context, e *Engine, t *todo.Todo) ([]string, error) {
+	return nil, e.todos.Hydrate(ctx, t)
 }
 
-func hydrateJournal(ctx context.Context, e *Engine, j *journal.Journal) error {
-	return e.journals.Hydrate(ctx, j)
+func hydrateJournal(ctx context.Context, e *Engine, j *journal.Journal) ([]string, error) {
+	return nil, e.journals.Hydrate(ctx, j)
 }

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5048,8 +5048,8 @@ func TestExportResourceFor_HydrateErrorAbortsExport(t *testing.T) {
 		return nil, nil
 	}
 	marker := errors.New("db busy")
-	hydrate := func(context.Context, *Engine, *event.Event) error {
-		return marker
+	hydrate := func(context.Context, *Engine, *event.Event) ([]string, error) {
+		return nil, marker
 	}
 	exportCalled := false
 	hydrated := func([]event.Event, string) ([]byte, error) {
@@ -5057,7 +5057,7 @@ func TestExportResourceFor_HydrateErrorAbortsExport(t *testing.T) {
 		return []byte("BEGIN:VCALENDAR"), nil
 	}
 
-	_, err := exportResourceFor(context.Background(), nil, "uid-1", "event",
+	_, _, err := exportResourceFor(context.Background(), nil, "uid-1", "event",
 		get, listOverrides, hydrate, hydrated)
 	if err == nil {
 		t.Fatal("expected hydration error to propagate, got nil")
@@ -5085,14 +5085,14 @@ func TestExportResourceFor_MasterReadErrorAbortsExport(t *testing.T) {
 	listOverrides := func(context.Context, string) ([]event.Event, error) {
 		return []event.Event{{UID: "uid-1", ID: 2, RecurrenceID: "20260401T100000Z"}}, nil
 	}
-	hydrate := func(context.Context, *Engine, *event.Event) error { return nil }
+	hydrate := func(context.Context, *Engine, *event.Event) ([]string, error) { return nil, nil }
 	exportCalled := false
 	export := func([]event.Event, string) ([]byte, error) {
 		exportCalled = true
 		return []byte("BEGIN:VCALENDAR"), nil
 	}
 
-	_, err := exportResourceFor(context.Background(), nil, "uid-1", "event",
+	_, _, err := exportResourceFor(context.Background(), nil, "uid-1", "event",
 		get, listOverrides, hydrate, export)
 	if err == nil {
 		t.Fatal("expected the master read error to propagate, got nil")
@@ -5116,14 +5116,14 @@ func TestExportResourceFor_MissingMasterExportsOverrides(t *testing.T) {
 	listOverrides := func(context.Context, string) ([]event.Event, error) {
 		return []event.Event{{UID: "uid-1", ID: 2, RecurrenceID: "20260401T100000Z"}}, nil
 	}
-	hydrate := func(context.Context, *Engine, *event.Event) error { return nil }
+	hydrate := func(context.Context, *Engine, *event.Event) ([]string, error) { return nil, nil }
 	var exported int
 	export := func(rows []event.Event, _ string) ([]byte, error) {
 		exported = len(rows)
 		return []byte("BEGIN:VCALENDAR"), nil
 	}
 
-	if _, err := exportResourceFor(context.Background(), nil, "uid-1", "event",
+	if _, _, err := exportResourceFor(context.Background(), nil, "uid-1", "event",
 		get, listOverrides, hydrate, export); err != nil {
 		t.Fatalf("orphan instance must still export: %v", err)
 	}

--- a/internal/sync/service.go
+++ b/internal/sync/service.go
@@ -67,8 +67,8 @@ func (s *Service) DiagnoseCalendar(ctx context.Context, calendarID int64) ([]Wed
 // omits every relation in dropped. The caller must obtain explicit user
 // confirmation first; this is the one path that knowingly pushes an
 // incomplete record (issue #568).
-func (s *Service) DoctorPush(ctx context.Context, calendarID int64, uid string) ([]string, error) {
-	return s.engine.DoctorPush(ctx, calendarID, uid)
+func (s *Service) DoctorPush(ctx context.Context, calendarID int64, uid string, diagnosed []string) ([]string, error) {
+	return s.engine.DoctorPush(ctx, calendarID, uid, diagnosed)
 }
 
 // SyncStatus returns the current sync status for a calendar.


### PR DESCRIPTION
## Summary

Review follow-ups on #643 (three findings from a two-pass audit of the doctor path):

- **Transient failures no longer read as wedges.** `DiagnoseCalendar` listed any resource whose export produced a `*hydrate.HydrationError` — but `hydrate.Rel` records SQLITE_BUSY (after the 5s busy timeout), I/O errors, and context cancellation the same way it records a corrupt row. A healthy resource could land in the list and trigger the destructive confirmation. A resource is now wedged only when its export names unreadable relations twice in a row, and any context-cancellation cause disqualifies the report outright.
- **Consent fails closed.** Nothing held a lock between diagnosis and confirmation, so a concurrent change could make `DoctorPush` drop a different relation set than the user accepted. `DoctorPush` now takes the diagnosed set, re-runs the best-effort export under the lifecycle lock, and refuses the PUT when the sets differ.
- **Open conflicts block the doctor push.** The regular push skips conflicted UIDs because a PUT under an open conflict desynchronizes the recorded snapshots (#104). `DoctorPush` enforced read-only and dirty checks but would still PUT; it now returns a clear error pointing at `chroncal sync resolve`.

Maintainability: `exportResourceBestEffort` folded into `exportResourceFor` (one row-assembly path, hydrator decides strict vs best-effort); `runDoctorPush` reuses `diagnoseAll`; stale `doctorEntry` comment fixed; `propFromXProperty` single-sources the x-prop params decode in `internal/ical/export.go`.

## Tests

- New: wedge-shape classification (context causes rejected), refusal on changed relation set (resource stays dirty), refusal under open conflict.
- Updated existing `DoctorPush` call sites for the new parameter.

`go test ./...` passes.

Assisted-by: omp:x-preview-f-free