### PR TITLE
fix(ical): strip UTF-8 BOM before import decode

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -109,6 +109,11 @@ func importFile(r io.Reader, remote bool) (ImportResult, error) {
 	if len(data) > maxImportBytes {
 		return result, fmt.Errorf("ical payload exceeds %d bytes", maxImportBytes)
 	}
+
+	// A UTF-8 BOM prefixes the stream in files that Windows editors write.
+	// The decoder reads the BOM bytes as part of the first BEGIN line and
+	// rejects the whole file. Strip the BOM first.
+	data = bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF})
 	data = stripCommentLines(data)
 
 	dec := ical.NewDecoder(bytes.NewReader(data))

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -142,6 +142,24 @@ func TestImport_MinimalEvent(t *testing.T) {
 	}
 }
 
+// TestImport_UTF8BOMPrefix guards a file that starts with a UTF-8 BOM.
+// Some Windows editors write the BOM before the first BEGIN:VCALENDAR
+// line. The decoder then sees the BOM bytes as part of that line and
+// rejects the whole file.
+func TestImport_UTF8BOMPrefix(t *testing.T) {
+	t.Parallel()
+	result, err := ImportFile(strings.NewReader("\ufeff" + minimalEventICS))
+	if err != nil {
+		t.Fatalf("ImportFile error: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	if result.Events[0].UID != "test-uid-1" {
+		t.Errorf("UID = %q, want %q", result.Events[0].UID, "test-uid-1")
+	}
+}
+
 func TestImport_FullEvent(t *testing.T) {
 	t.Parallel()
 	result, err := ImportFile(strings.NewReader(fullEventICS))


### PR DESCRIPTION
## Problem
A UTF-8 BOM at the start of an `.ics` file made `ImportFile` reject the whole stream with `decode ical: ical: malformed component: expected BEGIN property`.

## Evidence
Files saved by Windows editors often carry a UTF-8 BOM before the first line. The go-ical decoder reads the BOM bytes as part of the `BEGIN:VCALENDAR` line and fails, so such a file never imported.

## Fix
`importFile` strips the `\xEF\xBB\xBF` prefix right after the size check, before comment stripping and decode.

## Verification
- New regression test `TestImport_UTF8BOMPrefix` imports a BOM-prefixed minimal VCALENDAR through an inline reader (failed on master with the decode error above, passes with the fix).
- `go test ./internal/ical/ -count=1` — ok.