### PR TITLE
fix(caldav): abort cross-host redirects instead of stripping headers

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -54,17 +54,27 @@ var defaultHTTPClient = &http.Client{
 }
 var errResponseTooLarge = errors.New("caldav response exceeds configured limits")
 
+// checkRedirect governs redirects for defaultHTTPClient. It rejects any
+// redirect that leaves the host of the first request.
+//
+// net/http copies the sensitive headers of the first request (Authorization,
+// Cookie) before it calls this hook. It also forwards those headers to
+// subdomains of the first host. An abort is therefore the only safe answer.
+// The request then fails before it reaches the other host.
 func checkRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= maxRedirects {
 		return fmt.Errorf("stopped after %d redirects", maxRedirects)
 	}
 	if len(via) > 0 && !sameRedirectHost(req.URL, via[0].URL) {
-		req.Header.Del("Authorization")
-		req.Header.Del("Cookie")
+		return fmt.Errorf("refuse redirect from host %q to host %q: a cross-host redirect can leak credentials", via[0].URL.Host, req.URL.Host)
 	}
 	return nil
 }
 
+// sameRedirectHost reports whether two URLs carry the same host name and
+// port. The compare ignores case. A subdomain counts as a different host.
+// This rule is stricter than the net/http default. That default forwards
+// credentials to subdomains of the first host.
 func sameRedirectHost(a, b *url.URL) bool {
 	return strings.EqualFold(a.Host, b.Host)
 }

--- a/internal/caldav/redirect_test.go
+++ b/internal/caldav/redirect_test.go
@@ -5,16 +5,18 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
 
-func TestDefaultHTTPClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+func TestDefaultHTTPClientAbortsCrossHostRedirect(t *testing.T) {
 	t.Parallel()
 
-	var attackerAuth atomic.Value // string
+	var attackerHits atomic.Int64
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attackerAuth.Store(r.Header.Get("Authorization"))
+		attackerHits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	}))
@@ -32,22 +34,24 @@ func TestDefaultHTTPClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	req.SetBasicAuth("alice", "s3cr3t")
 
 	resp, err := defaultHTTPClient.Do(req)
-	if err != nil {
-		t.Fatalf("Do: %v", err)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("Do err = nil, want a cross-host redirect abort")
 	}
-	defer resp.Body.Close()
-
-	if got, _ := attackerAuth.Load().(string); got != "" {
-		t.Fatalf("cross-host redirect leaked Authorization header = %q, want empty", got)
+	if !strings.Contains(err.Error(), "refuse redirect") {
+		t.Fatalf("Do err = %v, want a refuse-redirect error", err)
+	}
+	if n := attackerHits.Load(); n != 0 {
+		t.Fatalf("cross-host redirect sent %d requests to the other host, want 0", n)
 	}
 }
 
-func TestBearerAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+func TestBearerAuthClientAbortsCrossHostRedirect(t *testing.T) {
 	t.Parallel()
 
-	var attackerAuth atomic.Value // string
+	var attackerHits atomic.Int64
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attackerAuth.Store(r.Header.Get("Authorization"))
+		attackerHits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	}))
@@ -68,22 +72,24 @@ func TestBearerAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	}
 
 	resp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		t.Fatalf("Do: %v", err)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("Do err = nil, want a cross-host redirect abort")
 	}
-	defer resp.Body.Close()
-
-	if got, _ := attackerAuth.Load().(string); got != "" {
-		t.Fatalf("cross-host redirect leaked bearer Authorization header = %q, want empty", got)
+	if !strings.Contains(err.Error(), "refuse redirect") {
+		t.Fatalf("Do err = %v, want a refuse-redirect error", err)
+	}
+	if n := attackerHits.Load(); n != 0 {
+		t.Fatalf("cross-host redirect sent %d requests to the other host, want 0", n)
 	}
 }
 
-func TestBasicAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+func TestBasicAuthClientAbortsCrossHostRedirect(t *testing.T) {
 	t.Parallel()
 
-	var attackerAuth atomic.Value // string
+	var attackerHits atomic.Int64
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attackerAuth.Store(r.Header.Get("Authorization"))
+		attackerHits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	}))
@@ -104,13 +110,15 @@ func TestBasicAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	}
 
 	resp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		t.Fatalf("Do: %v", err)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("Do err = nil, want a cross-host redirect abort")
 	}
-	defer resp.Body.Close()
-
-	if got, _ := attackerAuth.Load().(string); got != "" {
-		t.Fatalf("cross-host redirect leaked basic Authorization header = %q, want empty", got)
+	if !strings.Contains(err.Error(), "refuse redirect") {
+		t.Fatalf("Do err = %v, want a refuse-redirect error", err)
+	}
+	if n := attackerHits.Load(); n != 0 {
+		t.Fatalf("cross-host redirect sent %d requests to the other host, want 0", n)
 	}
 }
 
@@ -158,6 +166,7 @@ func TestDefaultHTTPClientCapsRedirects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
+
 	resp, err := defaultHTTPClient.Do(req)
 	if err == nil {
 		resp.Body.Close()
@@ -169,6 +178,41 @@ func TestDefaultHTTPClientHasRedirectPolicy(t *testing.T) {
 	t.Parallel()
 
 	if defaultHTTPClient.CheckRedirect == nil {
-		t.Fatal("defaultHTTPClient.CheckRedirect = nil, want a policy that strips credentials on cross-host redirects")
+		t.Fatal("defaultHTTPClient.CheckRedirect = nil, want a policy that aborts cross-host redirects")
+	}
+}
+
+func TestSameRedirectHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"same host", "https://caldav.example.com/", "https://caldav.example.com/calendar/", true},
+		{"host case differs", "https://CalDAV.example.com/", "https://caldav.example.com/", true},
+		{"subdomain counts as different host", "https://caldav.example.com/", "https://evil.caldav.example.com/", false},
+		{"different registrable domain", "https://caldav.example.com/", "https://caldav.example.org/", false},
+		{"port differs", "https://caldav.example.com:8443/", "https://caldav.example.com/", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a, err := url.Parse(tc.a)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.a, err)
+			}
+			b, err := url.Parse(tc.b)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.b, err)
+			}
+			if got := sameRedirectHost(a, b); got != tc.want {
+				t.Fatalf("sameRedirectHost(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem
`checkRedirect` in `internal/caldav/client.go` tried to strip `Authorization`/`Cookie` with `Header.Del` on cross-host redirects. That code is dead or unsafe: `net/http` copies the first request's sensitive headers **before** it calls `CheckRedirect` (Go 1.26 `client.go`: `copyHeaders(req, stripSensitiveHeaders, ...)` runs ahead of `checkRedirect`), and `shouldCopyHeaderOnRedirect` still **forwards credentials to subdomains** (`isDomainOrSubdomain`).

- True cross-domain hop: the stdlib already stripped the headers, so the `Del` deleted nothing.
- Subdomain hop (e.g. `caldav.example.com` → `evil.caldav.example.com`): the stdlib keeps the credentials. The `Del` removed them, but the unauthenticated request still left the client and reached the other host.

## Evidence
- Go 1.26 `net/http/client.go`: `shouldCopyHeaderOnRedirect` returns `isDomainOrSubdomain(dhost, ihost)`, so subdomain destinations keep `Authorization`/`Cookie`; header copying happens before `CheckRedirect` runs.
- All three auth paths in this package (`NewBasicAuthClient`, `NewBearerAuthClient`, `oauth2HTTPClient`) route through `defaultHTTPClient`, so the hook guards every credential kind.
- Old tests asserted the leaky contract (`Do` returned `nil` on a cross-host redirect).

## Fix
- `checkRedirect` now **returns an error** when `!sameRedirectHost(req.URL, via[0].URL)`. The request fails before it leaves the client. No credential forwarding is possible on any host change.
- `sameRedirectHost` keeps its exact-host rule (name + port, case-insensitive). A subdomain counts as a different host, which is stricter than the stdlib default.

## Verification
- `go test ./internal/caldav/` — ok.
- New/updated tests in `redirect_test.go`:
  - cross-host redirect aborts (`defaultHTTPClient`, bearer, basic auth) and the other host receives **zero** requests;
  - same-host redirect still succeeds with `Authorization` preserved;
  - redirect cap still enforced;
  - `TestSameRedirectHost` pins exact-host semantics (subdomain, registrable-domain, and port changes all count as different hosts).
- Confirmed the abort tests fail against the pre-fix `client.go` (`Do err = nil, want a cross-host redirect abort`) and pass with the fix.

Assisted-by: opencode-zen:x-preview-f-free