### PR TITLE
refactor(caldav): delete unused Client.GetResources

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -257,38 +257,6 @@ func componentNames(set verifySupportedCalendarComponentSet) []string {
 	return names
 }
 
-// GetResources fetches full iCal data for a set of hrefs via calendar-multiget.
-func (c *Client) GetResources(ctx context.Context, calendarPath string, hrefs []string) ([]Resource, error) {
-	calendarPath, err := c.CanonicalCollectionRef(calendarPath)
-	if err != nil {
-		return nil, err
-	}
-
-	multiGet := &caldav.CalendarMultiGet{
-		Paths: hrefs,
-		CompRequest: caldav.CalendarCompRequest{
-			Name:     "VCALENDAR",
-			AllComps: true,
-			AllProps: true,
-		},
-	}
-
-	objects, err := c.inner.MultiGetCalendar(ctx, calendarPath, multiGet)
-	if err != nil {
-		return nil, fmt.Errorf("multiget: %w", err)
-	}
-
-	out := make([]Resource, 0, len(objects))
-	for _, obj := range objects {
-		out = append(out, Resource{
-			Path: obj.Path,
-			ETag: normalizeETag(obj.ETag),
-			Data: obj.Data,
-		})
-	}
-	return out, nil
-}
-
 // QueryAll fetches all resources from a calendar.
 func (c *Client) QueryAll(ctx context.Context, calendarPath string) ([]Resource, error) {
 	calendarPath, err := c.CanonicalCollectionRef(calendarPath)

--- a/internal/caldav/sync_collection.go
+++ b/internal/caldav/sync_collection.go
@@ -23,7 +23,7 @@ var ErrSyncCollectionUnsupported = errors.New("caldav: sync-collection not suppo
 
 // SyncChange describes one changed or removed resource returned by a
 // sync-collection REPORT. Deleted entries carry only Path; updated entries
-// carry Path and ETag (no body — fetch with GetResources).
+// carry Path and ETag (no body — fetch with MultiGetTolerant).
 type SyncChange struct {
 	Path    string
 	ETag    string
@@ -51,8 +51,7 @@ type SyncCollectionResult struct {
 // a full snapshot of hrefs+etags plus a fresh token. Later calls return
 // only resources changed since the supplied token.
 //
-// The body returned only contains hrefs + etags. Use GetResources for the
-// updated paths to download bodies.
+// Use MultiGetTolerant for the updated paths to download bodies.
 func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncToken string) (*SyncCollectionResult, error) {
 	canonicalPath, err := c.CanonicalCollectionRef(calendarPath)
 	if err != nil {


### PR DESCRIPTION
## Problem
`Client.GetResources` in `internal/caldav/client.go` has zero callers (verified with a repo-wide grep: only its definition and two doc-comment references in `sync_collection.go`). It wraps go-webdav's `MultiGetCalendar`, which fails the whole batch when a single href is bad. The sync engine already uses `MultiGetTolerant`, which drops per-resource 404s.

## Evidence
- `grep -r 'GetResources'` across the repo matches only `client.go` (definition) and `sync_collection.go:26,54` (doc comments).
- `internal/sync/engine_apply.go:99` fetches bodies with `client.MultiGetTolerant`.

## Fix
- Delete the dead method.
- Update both doc comments in `sync_collection.go` to point at `MultiGetTolerant`.

## Verification
- `go build ./internal/caldav/` — ok (no callers remain).
- `go test ./internal/caldav/` — ok.
- `gofmt -l internal/caldav/` — clean.

Stacked on #675 (both touch `client.go`).

Assisted-by: opencode-zen:x-preview-f-free
