### PR TITLE
fix(tui): clear pending keep-local ID when ctrl+c supersedes confirm

### DIFF
--- a/internal/tui/app_nav.go
+++ b/internal/tui/app_nav.go
@@ -96,6 +96,7 @@ func (m Model) clearConfirmPending() Model {
 	m.pendingPurgeTitle = ""
 	m.pendingCalendarDelete = 0
 	m.pendingCalendarDeleteName = ""
+	m.pendingCalendarKeepLocal = 0
 	m.pendingCalendarPromote = 0
 	m.pendingCalendarPromoteName = ""
 	m.pendingCalendarPromoteCands = nil

--- a/internal/tui/harness_test.go
+++ b/internal/tui/harness_test.go
@@ -234,3 +234,53 @@ func TestHarness_CreateSave_WritesAlarmRows(t *testing.T) {
 	require.Equal(t, "DISPLAY", stored[0].Action)
 	require.Equal(t, "-PT10M", stored[0].TriggerValue)
 }
+
+// TestHarness_CtrlCSupersede_KeepLocalNotFiredLater drives the full supersede
+// path. The user opens the keep-local confirm, then presses ctrl+c, then
+// cancels the quit confirm. The abandoned keep-local ID must not survive.
+// The next confirmed dialog must then perform its own action. Before the
+// fix, a confirmed delete fired Disconnect on the stale calendar ID and
+// never deleted the event.
+func TestHarness_CtrlCSupersede_KeepLocalNotFiredLater(t *testing.T) {
+	m, a := newDBBackedModel(t)
+	ctx := context.Background()
+
+	seeded, err := a.Events.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Standup",
+		StartTime:  time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+
+	// Open the keep-local confirm the way the calendar manager does.
+	updated, _ := m.Update(CalendarKeepLocalRequestedMsg{ID: 1, Name: "Personal"})
+	m = updated.(Model)
+	require.True(t, m.confirmOpen, "the keep-local confirm did not open")
+	require.EqualValues(t, 1, m.pendingCalendarKeepLocal)
+
+	// ctrl+c replaces the open confirm with the quit confirm.
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+	updated, _ = m.Update(ctrlC)
+	m = updated.(Model)
+	require.True(t, m.pendingQuit, "ctrl+c should open the quit confirm")
+	require.Zero(t, m.pendingCalendarKeepLocal, "ctrl+c must drop the abandoned keep-local ID")
+
+	// Cancel the quit, then confirm an unrelated event delete.
+	updated, _ = m.Update(ConfirmDialogResultMsg{Confirmed: false})
+	m = updated.(Model)
+	require.False(t, m.pendingQuit, "quit cancel did not clear the quit marker")
+	m.pendingDelete = event.Event{ID: seeded.ID, CalendarID: 1, Title: "Standup"}
+	m.confirmOpen = true
+
+	updated, cmd := m.Update(ConfirmDialogResultMsg{Confirmed: true})
+	m = updated.(Model)
+	require.NotNil(t, cmd, "the confirmed delete dispatched no command")
+	result := cmd()
+	done, ok := result.(eventDeletedMsg)
+	require.True(t, ok, "confirmed delete dispatched %T; stale keep-local state hijacked the dialog", result)
+	require.NoError(t, done.err)
+
+	_, err = a.Events.Get(ctx, seeded.ID)
+	require.Error(t, err, "the confirmed delete did not remove the event")
+}

--- a/internal/tui/quit_confirm_test.go
+++ b/internal/tui/quit_confirm_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -108,6 +110,89 @@ func TestCtrlCClearsAccountRemovalPendingState(t *testing.T) {
 	if next.pendingAccountRemoveID != 0 || next.pendingAccountRemoveName != "" {
 		t.Fatalf("abandoned account removal remains armed: id=%d name=%q",
 			next.pendingAccountRemoveID, next.pendingAccountRemoveName)
+	}
+}
+
+// TestCtrlCClearsKeepLocalPendingState guards the keep-local variant of the
+// ctrl+c supersede. The keep-local confirm arms pendingCalendarKeepLocal.
+// ctrl+c must drop that ID with the other wait state. A stale ID survives
+// the canceled quit confirm. The next confirmed dialog then fires Disconnect
+// instead of its own action (handleConfirmDialogResult consumes the field
+// before the delete fallback).
+func TestCtrlCClearsKeepLocalPendingState(t *testing.T) {
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+
+	m := Model{
+		confirmOpen:              true,
+		pendingCalendarKeepLocal: 42,
+	}
+
+	next, _, handled := m.interceptGlobalKeys(ctrlC)
+	if !handled || !next.pendingQuit {
+		t.Fatalf("ctrl+c did not replace the keep-local confirm with quit: handled=%v quit=%v",
+			handled, next.pendingQuit)
+	}
+	if next.pendingCalendarKeepLocal != 0 {
+		t.Fatalf("abandoned keep-local ID remains armed: %d", next.pendingCalendarKeepLocal)
+	}
+}
+
+// pendingFieldsOutsideConfirmClear lists Model fields with a "pending"
+// prefix that clearConfirmPending does not own. Each entry drains through
+// its own lifecycle. Every other "pending" field holds wait state for a
+// confirm or choice dialog, so clearConfirmPending must reset it.
+var pendingFieldsOutsideConfirmClear = map[string]bool{
+	"pendingOrder":               true, // calendar order save; the order-saved message drains it
+	"pendingAccountOrder":        true, // account order save; the order-saved message drains it
+	"pendingAccountOrderIDs":     true, // account order save; the order-saved message drains it
+	"pendingOpenEvent":           true, // event view request; the view loader drains it
+	"pendingEditSave":            true, // recurring edit save; the form drains it
+	"pendingAccountManagementID": true, // account management routing; the manager drains it
+	"pendingDiscoveryAccountID":  true, // OAuth discovery target; the flow drains it
+	"pendingDiscoveryCreated":    true, // OAuth discovery result; the flow drains it
+	"pendingSyncCalendar":        true, // queued sync; syncFinishedMsg drains it
+	"pendingQuit":                true, // quit confirm marker; the quit result drains it
+	"pendingCalendarMove":        true, // move choice state; the choice dialog drains it
+	"pendingScopeKind":           true, // choice scope; the reset writes pendingScopeNone, not zero
+}
+
+// TestClearConfirmPendingResetsAllConfirmWaitFields arms every owned
+// "pending" field, then requires the zero value after the call. Extend the
+// arm literal below when you add a confirm wait field. The reflective check
+// then fails until clearConfirmPending resets the new field too.
+func TestClearConfirmPendingResetsAllConfirmWaitFields(t *testing.T) {
+	m := Model{
+		pendingDelete:                   event.Event{ID: 7, Title: "Standup"},
+		pendingPurgeEntries:             []trash.Entry{{Kind: trash.KindEvent}},
+		pendingPurgeTitle:               "1 item",
+		pendingCalendarDelete:           3,
+		pendingCalendarDeleteName:       "Work",
+		pendingCalendarKeepLocal:        42,
+		pendingCalendarPromote:          9,
+		pendingCalendarPromoteName:      "Home",
+		pendingCalendarPromoteCands:     []int64{3, 9},
+		pendingAccountSelection:         &accountCalendarSelection{},
+		pendingAccountDefaultCandidates: []accountDefaultCandidate{{id: 9, name: "Home"}},
+		pendingAccountRemoveID:          7,
+		pendingAccountRemoveName:        "Personal Google",
+	}
+
+	m = m.clearConfirmPending()
+
+	mv := reflect.ValueOf(m)
+	mt := mv.Type()
+	var stale []string
+	for i := 0; i < mt.NumField(); i++ {
+		f := mt.Field(i)
+		if !strings.HasPrefix(f.Name, "pending") || pendingFieldsOutsideConfirmClear[f.Name] {
+			continue
+		}
+		if !mv.Field(i).IsZero() {
+			stale = append(stale, f.Name)
+		}
+	}
+	if len(stale) > 0 {
+		t.Fatalf("clearConfirmPending left confirm wait state armed: %v", stale)
 	}
 }
 


### PR DESCRIPTION
## Problem
`clearConfirmPending` did not reset `Model.pendingCalendarKeepLocal`. A keep-local confirm superseded by ctrl+c left the calendar ID armed after the quit confirm was canceled. The next unrelated confirmed dialog then fired `Disconnect` on the stale calendar instead of its own action.

## Evidence
Trigger path (verified in code and by a failing test pre-fix):
1. `handleCalendarKeepLocalRequested` (app_update_calendar.go:377) arms `pendingCalendarKeepLocal` and opens the confirm.
2. ctrl+c routes through `interceptGlobalKeys` (app_nav.go:145) → `clearConfirmPending`, which reset every other confirm wait field but kept the keep-local ID.
3. Canceling the quit confirm returns at the `pendingQuit` branch (app_update.go:608-615), so the generic cancel cleanup never runs.
4. `handleConfirmDialogResult` consumes any non-zero `pendingCalendarKeepLocal` (app_update.go:665) before the delete fallback, so a later confirmed delete fired `Disconnect` on the stale ID.

## Fix
Add `m.pendingCalendarKeepLocal = 0` to `clearConfirmPending` next to the other `pendingCalendar*` resets.

## Verification
- `go test ./internal/tui/` — full package green.
- New regression tests, all failing on the pre-fix tree and passing after:
  - `TestCtrlCClearsKeepLocalPendingState` — the ctrl+c intercept drops the armed ID.
  - `TestClearConfirmPendingResetsAllConfirmWaitFields` — reflective invariant: every owned `pending*` field resets; future fields fail until added to the reset.
  - `TestHarness_CtrlCSupersede_KeepLocalNotFiredLater` — database-backed full path: arm keep-local → ctrl+c → cancel quit → confirm an unrelated delete; asserts the event delete runs and the stale state does not hijack the dialog.

Assisted-by: opencode-zen:x-preview-f-free