### PR TITLE
fix(event): abort DeleteSeries on a genuine master-lookup error

### DIFF
--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -859,7 +859,15 @@ func (s *Service) DeleteSeries(ctx context.Context, uid string) error {
 	// tombstone and the soft-delete commit together so a failed tombstone
 	// write can't leave a tombstone for a still-live series whose next sync
 	// would DELETE it from the server (issue #107).
-	if master, err := qtx.GetEventByUID(ctx, uid); err == nil {
+	master, mErr := qtx.GetEventByUID(ctx, uid)
+	// Only ErrNoRows means "no master to track". A genuine lookup error must
+	// abort. Otherwise the series is soft-deleted locally with no tombstone.
+	// The next pull would then resurrect the series. This mirrors the guard
+	// the todo and journal services already carry (issue #290).
+	if mErr != nil && !errors.Is(mErr, sql.ErrNoRows) {
+		return fmt.Errorf("get master: %w", mErr)
+	}
+	if mErr == nil {
 		if _, err := storage.CreateTombstoneIfSynced(ctx, tx, master.CalendarID, uid); err != nil {
 			return fmt.Errorf("create tombstone: %w", err)
 		}

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -814,6 +814,52 @@ func TestSoftDelete_OverrideMasterLookupError(t *testing.T) {
 	}
 }
 
+// TestDeleteSeries_MasterLookupError mirrors the #290/#412 guard for the
+// series path. DeleteSeries must not treat a genuine DB error from the master
+// lookup as "no master". On a non-ErrNoRows error the old code soft-deleted
+// the series locally with no tombstone. The next pull then resurrected the
+// series. The todo and journal services already carry this guard.
+func TestDeleteSeries_MasterLookupError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "series-lookup-err",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	// Force the master lookup (GetEventByUID) to fail with a genuine, non-
+	// ErrNoRows error by writing non-numeric text into the master's integer
+	// sequence column so its row scan fails. The writable check before the
+	// transaction reads only calendar_id. SoftDeleteEventsByUID never scans,
+	// so the buggy path would still soft-delete the series and return nil.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET sequence = 'corrupt' WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("corrupt master sequence: %v", err)
+	}
+
+	if err := svc.DeleteSeries(ctx, master.UID); err == nil {
+		t.Fatal("DeleteSeries should propagate a non-ErrNoRows master-lookup error, got nil")
+	}
+
+	// Repair the master so reads work, then confirm the series is still
+	// live: the transaction must have rolled back.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET sequence = 0 WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("repair master sequence: %v", err)
+	}
+	if _, err := svc.GetByUID(ctx, master.UID); err != nil {
+		t.Fatalf("series should still be live after failed DeleteSeries: %v", err)
+	}
+}
+
 // TestSoftDelete_FromInstanceUndo_ReAddsRDates reproduces issue #490. The TUI
 // truncation-undo path (RestoreUndo of an UndoKindFromInstance) must re-add the
 // post-cutoff RDATEs the truncation trimmed. That matches the trash-restore


### PR DESCRIPTION
## Problem

`DeleteSeries` collapsed any error from the in-transaction `GetEventByUID` master lookup into the "no master" branch (`if master, err := ...; err == nil`). A genuine error such as `SQLITE_BUSY` skipped the tombstone write but still soft-deleted every row for the UID.

## Evidence

internal/event/soft_delete.go `DeleteSeries` (former line 862):

```go
if master, err := qtx.GetEventByUID(ctx, uid); err == nil {
    if _, err := storage.CreateTombstoneIfSynced(...); err != nil { ... }
}
```

Without the tombstone, the next pull re-imported the series: the local delete never reached the server and the series resurrected. The todo and journal services already carry this guard with issue #290 comments (internal/todo/soft_delete.go:394-400, internal/journal/soft_delete.go:399-405); the event `Delete` override path got the same guard via issue #412. `DeleteSeries` was the remaining gap.

## Fix

Mirror the sibling guard: only `ErrNoRows` means "no master to track". Any other lookup error aborts the transaction before the soft-delete.

## Verification

- New regression test `TestDeleteSeries_MasterLookupError` injects a genuine non-`ErrNoRows` lookup error (non-numeric text in the integer `sequence` column makes the row scan fail) and asserts `DeleteSeries` returns an error and the series stays live.
- Confirmed the test fails on the pre-fix code and passes with the fix.
- `go test ./internal/event/` green; `gofmt -l` clean.