### PR TITLE
fix(ical): sanitize free-text values in export parameters

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -293,6 +293,18 @@ func emitXProperties(comp *ical.Component, xprops []model.XProperty) {
 	}
 }
 
+// unsafeParamBytes strips the bytes the iCal parameter grammar cannot
+// carry. The go-ical encoder rejects a parameter value that contains a
+// double-quote. A CR or LF would split the property line.
+var unsafeParamBytes = strings.NewReplacer(`"`, "", "\r", "", "\n", "")
+
+// safeParamValue makes a free-text value safe for an iCal parameter. The
+// export paths use it for CN, FILENAME, and FMTTYPE. One unsafe stored
+// value must not fail the whole export batch.
+func safeParamValue(v string) string {
+	return unsafeParamBytes.Replace(v)
+}
+
 func emitAttachment(props ical.Props, att model.Attachment) {
 	p := &ical.Prop{Name: ical.PropAttach, Params: make(ical.Params)}
 	if att.Data != nil {
@@ -301,13 +313,13 @@ func emitAttachment(props ical.Props, att model.Attachment) {
 		p.Params.Set("ENCODING", "BASE64")
 		p.Params.Set("VALUE", "BINARY")
 		if att.Filename != "" {
-			p.Params.Set("FILENAME", att.Filename)
+			p.Params.Set("FILENAME", safeParamValue(att.Filename))
 		}
 	} else {
 		p.Value = att.URI
 	}
 	if att.FmtType != "" {
-		p.Params.Set("FMTTYPE", att.FmtType)
+		p.Params.Set("FMTTYPE", safeParamValue(att.FmtType))
 	}
 	props.Add(p)
 }

--- a/internal/ical/export_events.go
+++ b/internal/ical/export_events.go
@@ -179,7 +179,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
 				org.Value = "mailto:" + att.Email
 				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, att.Name)
+					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 				}
 				setOrganizerParams(org, att)
 				vevent.Props.Set(org)
@@ -188,7 +188,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
 			attendee.Value = "mailto:" + att.Email
 			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, att.Name)
+				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 			}
 			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
 			attendee.Params.Set(ical.ParamRole, att.Role)

--- a/internal/ical/export_journals.go
+++ b/internal/ical/export_journals.go
@@ -176,7 +176,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
 				org.Value = "mailto:" + att.Email
 				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, att.Name)
+					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 				}
 				setOrganizerParams(org, att)
 				vjournal.Props.Set(org)
@@ -184,7 +184,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
 			attendee.Value = "mailto:" + att.Email
 			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, att.Name)
+				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 			}
 			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
 			attendee.Params.Set(ical.ParamRole, att.Role)

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -976,6 +976,43 @@ func TestExport_EventWithAttendees(t *testing.T) {
 	}
 }
 
+// TestExport_AttendeeNameWithQuoteDoesNotFailExport guards the free-text
+// parameter values (CN, FILENAME, FMTTYPE). The go-ical encoder rejects a
+// parameter value that contains a double-quote. A stored attendee name or
+// an attachment metadata field with a quote then failed the whole export
+// batch. Export must strip the bytes the parameter grammar cannot carry.
+func TestExport_AttendeeNameWithQuoteDoesNotFailExport(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{{
+		UID:       "att-quote",
+		Title:     "Meeting",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Attendees: []model.Attendee{
+			{Name: `He said "ok"`, Email: "user@example.com", RSVPStatus: "NEEDS-ACTION", Role: "REQ-PARTICIPANT"},
+			{Name: "Broken\r\nName", Email: "other@example.com", RSVPStatus: "NEEDS-ACTION", Role: "REQ-PARTICIPANT"},
+		},
+		Attachments: []model.Attachment{
+			{Data: []byte("x"), Filename: `bad"name.txt`, FmtType: "text/plain"},
+		},
+	}}
+
+	data, err := ExportEvents(events, "")
+	if err != nil {
+		t.Fatalf("ExportEvents error: %v", err)
+	}
+	ics := string(data)
+	for _, want := range []string{"CN=He said ok", "CN=BrokenName", "FILENAME=badname.txt", "FMTTYPE=text/plain"} {
+		if !strings.Contains(ics, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, ics)
+		}
+	}
+}
+
 func TestExport_SingleTodo(t *testing.T) {
 	t.Parallel()
 	todos := []todo.Todo{{

--- a/internal/ical/export_todos.go
+++ b/internal/ical/export_todos.go
@@ -243,7 +243,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
 				org.Value = "mailto:" + att.Email
 				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, att.Name)
+					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 				}
 				setOrganizerParams(org, att)
 				vtodo.Props.Set(org)
@@ -251,7 +251,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
 			attendee.Value = "mailto:" + att.Email
 			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, att.Name)
+				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 			}
 			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
 			attendee.Params.Set(ical.ParamRole, att.Role)

--- a/internal/ical/export_valarm.go
+++ b/internal/ical/export_valarm.go
@@ -143,7 +143,7 @@ func buildValarm(alarm model.Alarm, recordTZ string) *ical.Component {
 		p := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
 		p.Value = "mailto:" + att.Email
 		if att.Name != "" {
-			p.Params.Set(ical.ParamCommonName, att.Name)
+			p.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 		}
 		valarm.Props.Add(p)
 	}
@@ -167,7 +167,7 @@ func buildValarm(alarm model.Alarm, recordTZ string) *ical.Component {
 			p.Value = alarm.AttachURI
 		}
 		if alarm.AttachFmtType != "" {
-			p.Params.Set("FMTTYPE", alarm.AttachFmtType)
+			p.Params.Set("FMTTYPE", safeParamValue(alarm.AttachFmtType))
 		}
 		valarm.Props.Add(p)
 	}


### PR DESCRIPTION
## Problem
A stored attendee/organizer `CN`, attachment `FILENAME`, or `FMTTYPE` that contains a double-quote made the whole export batch fail: the go-ical encoder rejects any parameter value containing `"` (`encode ical: ical: failed to encode param value: contains a double-quote`). A CR or LF in such a value would also split the property line.

## Evidence
Reproduced on master: exporting an event with attendee `Name = 'He said "ok"'` fails `ExportEvents` with the encoder error above, so one unsafe stored value drops the entire export/sync push.

## Fix
- Add `safeParamValue` in `internal/ical/export.go`; it strips `"`, CR, and LF.
- Apply it to every free-text parameter `Set`: CN in `export_events.go`, `export_todos.go`, `export_journals.go`, `export_valarm.go`; `FILENAME`/`FMTTYPE` in `emitAttachment` and the VALARM ATTACH path.

## Verification
- New regression test `TestExport_AttendeeNameWithQuoteDoesNotFailExport` (failed on master with the encoder error, passes with the fix) asserts the export succeeds and the sanitized `CN`/`FILENAME`/`FMTTYPE` values reach the output.
- `go test ./internal/ical/ -count=1` — ok. `go build ./...` — ok.