### PR TITLE
fix(retry): cap the Retry-After sleep floor

### DIFF
--- a/internal/retry/backoff.go
+++ b/internal/retry/backoff.go
@@ -6,12 +6,17 @@ import (
 	"time"
 )
 
+// maxBackoffDelay is the maximum sleep between two retries.
+// backoffDuration derives its ceiling from it. retryAfterDelay derives its
+// Retry-After cap from it. One constant keeps both waits in step.
+const maxBackoffDelay = 60 * time.Second
+
 // backoffDuration returns a random duration in [0, 2^attempt) seconds
 // (full jitter). This spreads retries uniformly across the backoff window.
 // It reduces thundering-herd collisions compared to equal or decorrelated jitter.
 func backoffDuration(attempt int) time.Duration {
+	maxBackoff := maxBackoffDelay.Seconds()
 	ceiling := math.Pow(2, float64(attempt)) // seconds
-	const maxBackoff = 60.0
 	if ceiling > maxBackoff {
 		ceiling = maxBackoff
 	}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -75,13 +75,14 @@ func retryDelay(opts RetryOptions, attempt int) time.Duration {
 	return wait
 }
 
-// maxRetryAfterDelay caps a server-requested Retry-After floor. The value
-// matches the 60-second ceiling backoffDuration applies to computed backoff.
-// A hostile or broken server can request an absurd delay (24 hours, for
-// example). The retry caller often holds locks while it waits (the sync
-// push lock is one example), so an uncapped floor would stall the whole
-// account on one bad header.
-const maxRetryAfterDelay = 60 * time.Second
+// maxRetryAfterDelay caps a server-requested Retry-After floor. It equals
+// maxBackoffDelay, the ceiling that backoffDuration applies to computed
+// backoff, so the compiler keeps the two waits in step. A hostile or broken
+// server can request an absurd delay (24 hours, for example). The retry
+// caller often holds locks while it waits (the sync push lock is one
+// example), so an uncapped floor would stall the whole account on one bad
+// header.
+const maxRetryAfterDelay = maxBackoffDelay
 
 // retryAfterDelay returns the server-requested minimum delay for err,
 // capped at maxRetryAfterDelay. Zero means the server gave no usable hint.

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -32,8 +32,9 @@ func Retry[T any](ctx context.Context, opts RetryOptions, fn func(context.Contex
 
 		delay := retryDelay(opts, attempt-1)
 		// Honor a server-requested Retry-After as a floor: never retry
-		// sooner than the server asked, even if it exceeds MaxDelay.
-		if floor := retryAfter(err); floor > delay {
+		// sooner than the server asked, even if it exceeds MaxDelay. The
+		// floor is still capped. See retryAfterDelay for the ceiling.
+		if floor := retryAfterDelay(err); floor > delay {
 			delay = floor
 		}
 		select {
@@ -72,4 +73,22 @@ func retryDelay(opts RetryOptions, attempt int) time.Duration {
 		return opts.MaxDelay
 	}
 	return wait
+}
+
+// maxRetryAfterDelay caps a server-requested Retry-After floor. The value
+// matches the 60-second ceiling backoffDuration applies to computed backoff.
+// A hostile or broken server can request an absurd delay (24 hours, for
+// example). The retry caller often holds locks while it waits (the sync
+// push lock is one example), so an uncapped floor would stall the whole
+// account on one bad header.
+const maxRetryAfterDelay = 60 * time.Second
+
+// retryAfterDelay returns the server-requested minimum delay for err,
+// capped at maxRetryAfterDelay. Zero means the server gave no usable hint.
+func retryAfterDelay(err error) time.Duration {
+	floor := retryAfter(err)
+	if floor > maxRetryAfterDelay {
+		return maxRetryAfterDelay
+	}
+	return floor
 }

--- a/internal/retry/retryafter_test.go
+++ b/internal/retry/retryafter_test.go
@@ -1,0 +1,57 @@
+package retry
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestRetryAfterDelayCapped covers the cap on a server-requested
+// Retry-After floor. A hostile or broken server can request an absurd
+// delay. The retry caller often holds locks (the sync push lock is one
+// example), so the floor must never exceed maxRetryAfterDelay.
+func TestRetryAfterDelayCapped(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{
+			name: "no server hint",
+			err:  errors.New("503 Service Unavailable"),
+			want: 0,
+		},
+		{
+			name: "hint below cap",
+			err:  &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: 30 * time.Second},
+			want: 30 * time.Second,
+		},
+		{
+			name: "hint at cap",
+			err:  &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: 60 * time.Second},
+			want: 60 * time.Second,
+		},
+		{
+			name: "hostile hint above cap",
+			err:  &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: 24 * time.Hour},
+			want: 60 * time.Second,
+		},
+		{
+			name: "negative hint ignored",
+			err:  &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: -time.Second},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := retryAfterDelay(tt.err); got != tt.want {
+				t.Fatalf("retryAfterDelay() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`Retry` honored a server-requested `Retry-After` (`TransientError.RetryAfter`) as the sleep floor with no upper bound. One hostile or broken header (`Retry-After: 86400`) made the caller sleep that long.

## Evidence

`internal/retry/retry.go`: the floor branch applied `retryAfter(err)` directly, and the old comment stated the floor "exceeds MaxDelay" deliberately. The problem: the sync engine calls `caldav.Retry` (which wraps this `Retry`) while it holds the per-calendar push lock and the account sync lock. One bad header therefore stalled every other sync operation on the account, not just the one request.

## Fix

Cap the floor at `maxRetryAfterDelay = 60s` via a new `retryAfterDelay` helper. The chosen ceiling is consistent with existing package semantics: `backoffDuration` already caps computed backoff at 60 seconds (`maxBackoff = 60.0` in `backoff.go`), so no single inter-attempt sleep — computed or server-requested — can exceed 60 seconds. Deliberate design choice kept: a server hint below the cap still overrides `MaxDelay` (the floor semantics that `TestRetryHonorsRetryAfterAsFloor` pins down), because a server the client respects should not be retried sooner than it asked.

## Verification

Table test `TestRetryAfterDelayCapped` (`internal/retry/retryafter_test.go`) covers: no hint, below cap, at cap, hostile 24h hint clamped to 60s, and a negative hint ignored. Full `go test ./internal/retry/` — ok, including the pre-existing floor test.