### PR TITLE
fix(tui): stop empty confirm results from deleting event 0

### DIFF
--- a/internal/tui/app_update.go
+++ b/internal/tui/app_update.go
@@ -691,6 +691,12 @@ func (m Model) handleConfirmDialogResult(msg ConfirmDialogResultMsg) (tea.Model,
 		}
 	}
 	ev := m.pendingDelete
+	if ev.ID == 0 {
+		// No branch above matched: nothing destructive waits behind this
+		// confirm. Do not delete event 0. That call always fails and shows
+		// a spurious error toast.
+		return m, nil
+	}
 	return m, func() tea.Msg {
 		meta, err := m.app.Events.DeleteWithUndo(context.Background(), ev.ID)
 		return eventDeletedMsg{

--- a/internal/tui/harness_test.go
+++ b/internal/tui/harness_test.go
@@ -284,3 +284,19 @@ func TestHarness_CtrlCSupersede_KeepLocalNotFiredLater(t *testing.T) {
 	_, err = a.Events.Get(ctx, seeded.ID)
 	require.Error(t, err, "the confirmed delete did not remove the event")
 }
+
+// TestHarness_EmptyConfirmResult_NoDelete guards the confirm fallback. A
+// confirmed result that no pending branch owns must do nothing. Before the
+// guard, the fallback called DeleteWithUndo with ID 0. That call always
+// failed and set m.err, so the user saw an error toast for an empty
+// confirm.
+func TestHarness_EmptyConfirmResult_NoDelete(t *testing.T) {
+	m, _ := newDBBackedModel(t)
+
+	m.confirmOpen = true
+	updated, cmd := m.Update(ConfirmDialogResultMsg{Confirmed: true})
+	m = updated.(Model)
+	require.False(t, m.confirmOpen, "the confirm dialog must still close")
+	require.Nil(t, cmd, "an empty confirm must not dispatch a delete")
+	require.NoError(t, m.err, "an empty confirm must not raise an error")
+}


### PR DESCRIPTION
## Problem
`handleConfirmDialogResult` ends in an unconditional fallback that calls `DeleteWithUndo(m.pendingDelete.ID)`. When a confirmed result arrived with no pending action armed, `pendingDelete` held the zero `Event`, so the app called `DeleteWithUndo` with ID 0. The lookup always fails and `handleEventDeleted` sets `Model.err`, producing a spurious error toast for an empty confirm.

Stacked on #678 (same file area, kept separate per audit clustering).

## Evidence
- internal/tui/app_update.go:693 — `ev := m.pendingDelete` then unconditional delete, no `ev.ID != 0` guard, while every branch above guards its own pending state.
- internal/event/soft_delete.go:63 — `DeleteWithUndo` starts with `GetEvent(ctx, id)`; ID 0 returns `ErrNoRows`.
- internal/tui/app_update_event.go:486-489 — a non-nil `err` in `eventDeletedMsg` sets `m.err` (user-visible error state).

## Fix
Return `(m, nil)` from the fallback when `pendingDelete.ID == 0`, mirroring the zero-guards of the branches above it.

## Verification
- New `TestHarness_EmptyConfirmResult_NoDelete` (database-backed): a confirmed result with nothing armed must close the dialog, dispatch no command, and raise no error. Fails on the pre-fix tree (`Expected nil, but got: (tea.Cmd)`), passes after.
- `go test ./internal/tui/` — full package green.

Assisted-by: opencode-zen:x-preview-f-free