### PR TITLE
fix(sync): write sync health with a cancellation-free context

### DIFF
--- a/cmd/chroncal/cli_surface_test.go
+++ b/cmd/chroncal/cli_surface_test.go
@@ -70,7 +70,7 @@ func TestCalendarCommandDoesNotRegisterLinkOrUnlink(t *testing.T) {
 func TestSyncStatusEmptyMessageIsCalendarCentric(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "status")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "status")
 	if err != nil {
 		t.Fatalf("sync status: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestSyncStatusEmptyMessageIsCalendarCentric(t *testing.T) {
 func TestSyncStatusHonorsOutputJSON(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "status", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "status", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync status --output json: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestSyncStatusHonorsOutputJSON(t *testing.T) {
 func TestSyncConflictsHonorsOutputJSON(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "conflicts", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "conflicts", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync conflicts --output json: %v", err)
 	}

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -52,6 +52,20 @@ func fprintImportWarnings(w io.Writer, warnings []syncPkg.ImportWarning) {
 	}
 }
 
+// newSyncService builds the sync service for every sync subcommand. The
+// app supplies the database, the domain services, and the credential
+// store scope. A failed store construction returns an error; a command
+// then fails with one clear message instead of a nil store that fails
+// later with a confusing error. Pass a nil logger for silent commands.
+// Pass an explicit logger when the command shows sync logs.
+func newSyncService(a *app.App, logger *slog.Logger) (*syncPkg.Service, error) {
+	credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+	if err != nil {
+		return nil, fmt.Errorf("credential store: %w", err)
+	}
+	return syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, logger), nil
+}
+
 func syncNewCalendars(
 	ctx context.Context,
 	a *app.App,
@@ -184,12 +198,10 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 				}
 			}
 
-			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			svc, err := newSyncService(a, stderrSyncLogger(os.Stderr))
 			if err != nil {
-				return fmt.Errorf("credential store: %w", err)
+				return err
 			}
-
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, stderrSyncLogger(os.Stderr))
 
 			var results []*syncPkg.SyncResult
 			if targetCalendarID != 0 {
@@ -237,8 +249,10 @@ for each connected calendar.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			statuses, err := svc.Status(context.Background())
 			if err != nil {
@@ -302,8 +316,10 @@ A resolved row keeps the recorded local version, so "chroncal sync resolve
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			var conflicts []syncPkg.Conflict
 			if resolved {
@@ -389,8 +405,10 @@ it again with --pick local restores the recorded local version.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			warnings, err := svc.ResolveConflict(context.Background(), id, pick)
 			if err != nil {
@@ -430,8 +448,10 @@ This does not delete your local calendars or entries.`,
 			defer a.Close()
 			ctx := context.Background()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			cals, err := a.Calendars.List(ctx)
 			if err != nil {

--- a/cmd/chroncal/sync_cli_test.go
+++ b/cmd/chroncal/sync_cli_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestSyncResetMatchesCalendarCaseInsensitively(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	createLinkedCalendarForTest(t, dbPath)
 
-	stdout, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "work")
+	stdout, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "reset", "--calendar", "work")
 	if err != nil {
 		t.Fatalf("sync reset --calendar work: %v (stderr: %s)", err, stderr)
 	}
@@ -36,7 +37,7 @@ func TestSyncRunRejectsInvalidConflictStrategy(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	createLinkedCalendarForTest(t, dbPath)
 
-	_, stderr, err := runChroncalCommand(t, "sync", "run", "--conflict", "Prompt")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--conflict", "Prompt")
 	if err == nil {
 		t.Fatalf("sync run --conflict Prompt was accepted; expected an invalid-input error")
 	}
@@ -55,7 +56,7 @@ func TestSyncRunMatchesCalendarCaseInsensitively(t *testing.T) {
 
 	// The run will still fail downstream (no stored credentials), but it must
 	// not fail with the case-sensitive "not found" resolution error.
-	_, stderr, err := runChroncalCommand(t, "sync", "run", "--calendar", "work")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--calendar", "work")
 	if err == nil {
 		return // resolved and ran; resolution is clearly case-insensitive
 	}
@@ -73,7 +74,7 @@ func TestSyncRunRejectsAccountWithCalendar(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	createLinkedCalendarForTest(t, dbPath)
 
-	_, stderr, err := runChroncalCommand(t, "sync", "run",
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run",
 		"--account", "__calendar_test", "--calendar", "Work", "--output", "json")
 	if err == nil {
 		t.Fatalf("sync run --account with --calendar was accepted; expected an invalid_input error")
@@ -117,7 +118,7 @@ func TestSyncRunScopesToRequestedAccount(t *testing.T) {
 	a.Close()
 
 	// An account with no linked calendars: the run is a no-op, not an error.
-	stdout, _, err := runChroncalCommand(t, "sync", "run", "--account", "empty", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--account", "empty", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync run --account empty: %v", err)
 	}
@@ -140,7 +141,7 @@ func TestSyncRunScopesToRequestedAccount(t *testing.T) {
 	// not account-not-found, and any rendered results stay inside the
 	// account: Work is its only calendar, so anything else in results would
 	// mean the run ignored --account.
-	stdout, stderr, err := runChroncalCommand(t, "sync", "run", "--account", "__CALENDAR_TEST", "--output", "json")
+	stdout, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--account", "__CALENDAR_TEST", "--output", "json")
 	if err != nil && strings.Contains(stderr, "not_found") {
 		t.Fatalf("sync run --account __CALENDAR_TEST failed to resolve the account case-insensitively; stderr = %q", stderr)
 	}
@@ -168,7 +169,7 @@ func TestSyncRunScopesToRequestedAccount(t *testing.T) {
 func TestSyncRunUnknownAccountIsNotFound(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	_, stderr, err := runChroncalCommand(t, "sync", "run", "--account", "ghost", "--output", "json")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--account", "ghost", "--output", "json")
 	if err == nil {
 		t.Fatalf("sync run --account ghost was accepted; expected a not_found error")
 	}
@@ -182,5 +183,38 @@ func TestSyncRunUnknownAccountIsNotFound(t *testing.T) {
 	if payload.Code != "not_found" || payload.Error != `account "ghost" not found` {
 		t.Fatalf("sync run --account ghost: code = %q, error = %q; want the account not_found error",
 			payload.Code, payload.Error)
+	}
+}
+
+// TestSyncCommandsFailWhenCredentialStoreUnavailable guards the shared
+// service construction in newSyncService. A dead session bus makes the
+// keyring probe fail on every host. Each sync subcommand must then exit
+// non-zero with the credential store error. A command must not run on
+// with a nil store and fail later with a confusing error.
+func TestSyncCommandsFailWhenCredentialStoreUnavailable(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the session bus probe only applies on Linux")
+	}
+	setupCalendarCLITestEnv(t)
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent/chroncal-test-bus")
+
+	commands := [][]string{
+		{"sync", "run"},
+		{"sync", "status"},
+		{"sync", "conflicts"},
+		{"sync", "doctor"},
+		{"sync", "resolve", "999999", "--pick", "local"},
+		{"sync", "reset", "no-such-calendar"},
+	}
+	for _, args := range commands {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			_, stderr, err := runChroncalCommand(t, args...)
+			if err == nil {
+				t.Fatalf("%v exited 0 with a broken credential store; want non-zero. stderr=%q", args, stderr)
+			}
+			if !strings.Contains(stderr, "credential store") {
+				t.Fatalf("%v stderr = %q, want the credential store error", args, stderr)
+			}
+		})
 	}
 }

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	syncPkg "github.com/douglasdemoura/chroncal/internal/sync"
 )
@@ -40,8 +39,10 @@ before the push and asks for confirmation.`,
 			defer a.Close()
 
 			ctx := context.Background()
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			cals, err := a.Queries.ListCalendars(ctx)
 			if err != nil {

--- a/cmd/chroncal/sync_doctor_cli_test.go
+++ b/cmd/chroncal/sync_doctor_cli_test.go
@@ -69,7 +69,7 @@ func bumpPushFailCount(t *testing.T, dbPath string, count int) {
 func TestSyncDoctorEmptyReportsNone(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "doctor")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor")
 	if err != nil {
 		t.Fatalf("sync doctor: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestSyncDoctorEmptyReportsNone(t *testing.T) {
 func TestSyncDoctorJSONEmptyIsArray(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "doctor", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync doctor --output json: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestSyncDoctorListsWedgedResource(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	seedWedgedCLIResource(t, dbPath)
 
-	stdout, stderr, err := runChroncalCommand(t, "sync", "doctor")
+	stdout, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor")
 	if err != nil {
 		t.Fatalf("sync doctor: %v (stderr: %s)", err, stderr)
 	}
@@ -121,7 +121,7 @@ func TestSyncDoctorListsWedgedResource(t *testing.T) {
 	}
 
 	bumpPushFailCount(t, dbPath, 3)
-	stdout, _, err = runChroncalCommand(t, "sync", "doctor")
+	stdout, _, err = runChroncalCommand(t, "sync", "--allow-plaintext", "doctor")
 	if err != nil {
 		t.Fatalf("sync doctor after bumps: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestSyncDoctorJSONListsWedgedResource(t *testing.T) {
 	seedWedgedCLIResource(t, dbPath)
 	bumpPushFailCount(t, dbPath, 2)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "doctor", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync doctor --output json: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestSyncDoctorPushRefusesNonInteractiveWithoutYes(t *testing.T) {
 
 	// Seed one wedged resource so the push flow reaches its confirmation
 	// gate instead of stopping at the not-found check.
-	_, _, err := runChroncalCommand(t, "sync", "doctor", "--push", "wedge-cli@example.com")
+	_, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor", "--push", "wedge-cli@example.com")
 	if err == nil {
 		t.Fatal("expected refusal without --yes in a non-interactive shell")
 	}
@@ -180,7 +180,7 @@ func TestSyncDoctorPushRefusesNonInteractiveWithoutYes(t *testing.T) {
 func TestSyncDoctorPushUnknownUIDIsNotFound(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	_, stderr, err := runChroncalCommand(t, "sync", "doctor", "--push", "missing@example.com", "--yes", "--output", "json")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor", "--push", "missing@example.com", "--yes", "--output", "json")
 	if err == nil {
 		t.Fatal("push of an unknown uid should fail")
 	}

--- a/cmd/chroncal/sync_json_cli_test.go
+++ b/cmd/chroncal/sync_json_cli_test.go
@@ -65,7 +65,7 @@ func TestSyncResolveOutputJSON(t *testing.T) {
 	id := seedSyncConflictForTest(t, dbPath, calID)
 
 	stdout, stderr, err := runChroncalCommand(t,
-		"sync", "resolve", strconv.FormatInt(id, 10), "--pick", "local", "--output", "json")
+		"--allow-plaintext", "sync", "resolve", strconv.FormatInt(id, 10), "--pick", "local", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync resolve -o json: %v (stderr: %s)", err, stderr)
 	}
@@ -83,7 +83,7 @@ func TestSyncResetOutputJSON(t *testing.T) {
 	createLinkedCalendarForTest(t, dbPath)
 
 	stdout, stderr, err := runChroncalCommand(t,
-		"sync", "reset", "--calendar", "Work", "--output", "json")
+		"--allow-plaintext", "sync", "reset", "--calendar", "Work", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync reset -o json: %v (stderr: %s)", err, stderr)
 	}

--- a/cmd/chroncal/sync_reset_cli_test.go
+++ b/cmd/chroncal/sync_reset_cli_test.go
@@ -14,7 +14,7 @@ func TestSyncResetUnknownCalendarFails(t *testing.T) {
 		t.Fatalf("calendar create: %v", err)
 	}
 
-	_, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "Wrok")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "reset", "--calendar", "Wrok")
 	if err == nil {
 		t.Fatalf("sync reset with unknown calendar exited 0; want non-zero. stderr=%q", stderr)
 	}
@@ -33,7 +33,7 @@ func TestSyncResetLocalOnlyCalendarReportsNotConnected(t *testing.T) {
 		t.Fatalf("calendar create: %v", err)
 	}
 
-	_, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "Work")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "reset", "--calendar", "Work")
 	if err == nil {
 		t.Fatalf("sync reset on local-only calendar exited 0; want non-zero. stderr=%q", stderr)
 	}

--- a/cmd/chroncal/sync_warnings_cli_test.go
+++ b/cmd/chroncal/sync_warnings_cli_test.go
@@ -167,7 +167,7 @@ func TestSyncResolveServerPrintsImportWarnings(t *testing.T) {
 	a.Close()
 
 	stdout, stderr, err := runChroncalCommand(t,
-		"sync", "resolve", strconv.FormatInt(conflictID, 10), "--pick", "server")
+		"--allow-plaintext", "sync", "resolve", strconv.FormatInt(conflictID, 10), "--pick", "server")
 	if err != nil {
 		t.Fatalf("sync resolve: %v (stderr: %s)", err, stderr)
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -399,7 +399,11 @@ func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy Co
 	// permanently failing calendar (issue #416).
 	attemptedAt := time.Now().UTC().Format(time.RFC3339)
 	defer func() {
-		if updateErr := e.updateSyncHealth(ctx, calendarID, attemptedAt, result, err); updateErr != nil {
+		// The sync context can be expired when this defer runs. One example
+		// is the per-calendar deadline that SyncAll enforces. The health
+		// write must still record the failed attempt, so it uses a context
+		// with the cancellation removed.
+		if updateErr := e.updateSyncHealth(context.WithoutCancel(ctx), calendarID, attemptedAt, result, err); updateErr != nil {
 			e.logger.Warn("update sync health failed", "calendar_id", calendarID, "error", updateErr)
 			if result != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("update sync health: %w", updateErr))

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1150,6 +1150,76 @@ func TestEngineSyncCalendarRecordsHealthOnEarlyClientFailure(t *testing.T) {
 	}
 }
 
+// TestEngineSyncCalendarRecordsHealthAfterContextExpiry is the regression
+// test for the stale health bookkeeping on a timed-out sync. SyncAll gives
+// each calendar a deadline. When the context expires mid-sync, the deferred
+// updateSyncHealth ran with the expired context. The write failed, so
+// LastSyncError stayed empty and the ambient ⚠ glyph never lit up for the
+// timed-out calendar. The health write must ignore the expiry.
+func TestEngineSyncCalendarRecordsHealthAfterContextExpiry(t *testing.T) {
+	t.Parallel()
+
+	engine, _, q := newTestEngine(t)
+	ctx := context.Background()
+
+	syncCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// The server cancels the sync context on the first request it sees.
+	// That imitates the per-calendar deadline hitting mid-sync, after
+	// loadCalendarClient already succeeded.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cancel()
+		http.Error(w, "deadline exceeded", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	remoteAccount, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name: "deadline", ServerUrl: server.URL, AuthType: "basic", Username: "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+	remoteURL := server.URL + "/calendar"
+	if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		ID: calendarID, AccountID: &remoteAccount.ID, RemoteUrl: &remoteURL,
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+	engine.credStore.(*mockCredStore).creds[remoteAccount.ID] = auth.Credential{
+		AccountID: remoteAccount.ID, Username: "user", Password: "secret",
+	}
+
+	result, err := engine.SyncCalendar(syncCtx, calendarID, ConflictServerWins)
+	if err != nil {
+		t.Fatalf("SyncCalendar: %v", err)
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("sync errors empty: the canceled sync must report failures")
+	}
+	for _, syncErr := range result.Errors {
+		if strings.Contains(syncErr.Error(), "update sync health") {
+			t.Fatalf("sync errors = %v, want no health-write failure", result.Errors)
+		}
+	}
+
+	calRow, err := q.GetCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if got := storage.NullableToString(calRow.LastSyncError); got == "" {
+		t.Fatal("LastSyncError empty: the timed-out sync still shows healthy")
+	}
+	if got := storage.NullableToString(calRow.LastSyncAttemptedAt); got == "" {
+		t.Fatal("LastSyncAttemptedAt empty: the failed attempt was not recorded")
+	}
+}
+
 // TestEnginePushSerializesConcurrentNewResourceCreate is the regression test
 // for issue #225. Two concurrent push runs for the same calendar (e.g. an
 // opportunistic save-time PushLocalEdits racing a periodic SyncCalendar) must not


### PR DESCRIPTION
## Problem

`SyncCalendar` records the outcome of every attempt in a deferred `updateSyncHealth` call (`LastSyncAttemptedAt`, `LastSyncAt`, `LastSyncError`). The defer reused the sync context, which can already be expired when it runs.

## Evidence

`internal/sync/engine.go` `SyncCalendar`: `SyncAll` wraps each calendar cycle in `context.WithTimeout(ctx, accountCalendarSyncTimeout)` (5 minutes). A sync that times out mid-cycle — or one the user cancels — runs the deferred health write with the expired context. The database write then fails with `context canceled`:

```
sync errors = [push: list dirty: context canceled pull: ... update sync health: context canceled]
```

`LastSyncError` stays empty, so the ambient ⚠ glyph (which keys on a non-empty `LastSyncError`, issue #416) never lights up for a calendar whose syncs keep timing out.

## Fix

The health write alone uses `context.WithoutCancel(ctx)`: context values are kept, deadline and cancellation are dropped. Every sync phase still honors the original context; only the final bookkeeping write survives the expiry.

## Verification

`TestEngineSyncCalendarRecordsHealthAfterContextExpiry` (`internal/sync/engine_test.go`): an httptest server cancels the sync context on the first request it sees, imitating the deadline hitting mid-sync after `loadCalendarClient` succeeded. On the old code the test fails (`update sync health: context canceled` in the result, `LastSyncError` empty). After the fix it passes: no health-write error, `LastSyncError` and `LastSyncAttemptedAt` recorded. Full `go test ./internal/sync/` — ok.