### PR TITLE
fix(storage): fail fast on scan column order mismatch

### DIFF
--- a/internal/storage/query_builder.go
+++ b/internal/storage/query_builder.go
@@ -111,6 +111,10 @@ func (q *Queries) queryEvents(ctx context.Context, where string, args []interfac
 	if err != nil {
 		return nil, err
 	}
+	if err := checkScanColumns(rows, "events", eventColumns); err != nil {
+		rows.Close()
+		return nil, err
+	}
 	return scanEvents(rows)
 }
 
@@ -120,6 +124,10 @@ func (q *Queries) queryTodos(ctx context.Context, where string, args []interface
 	if err != nil {
 		return nil, err
 	}
+	if err := checkScanColumns(rows, "todos", todoColumns); err != nil {
+		rows.Close()
+		return nil, err
+	}
 	return scanTodos(rows)
 }
 
@@ -127,6 +135,10 @@ func (q *Queries) queryJournals(ctx context.Context, where string, args []interf
 	query := "SELECT * FROM journals " + where + " ORDER BY " + orderBy
 	rows, err := q.db.QueryContext(ctx, query, args...)
 	if err != nil {
+		return nil, err
+	}
+	if err := checkScanColumns(rows, "journals", journalColumns); err != nil {
+		rows.Close()
 		return nil, err
 	}
 	return scanJournals(rows)

--- a/internal/storage/scan_alignment_test.go
+++ b/internal/storage/scan_alignment_test.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -68,5 +70,103 @@ func TestScanColumnAlignment(t *testing.T) {
 	}
 	if len(journals) < 1 {
 		t.Error("expected at least one journal")
+	}
+}
+
+// TestExpectedColumnsMatchSchema pins each expected column list to the live
+// schema order. SQLite returns SELECT * columns in migration order. A
+// migration that adds, drops, or moves a column must update the matching
+// list and the scanner together. This test fails until both change.
+func TestExpectedColumnsMatchSchema(t *testing.T) {
+	db, _, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	cases := []struct {
+		table string
+		want  []string
+	}{
+		{"events", eventColumns},
+		{"todos", todoColumns},
+		{"journals", journalColumns},
+	}
+	for _, tc := range cases {
+		rows, err := db.Query("SELECT name FROM pragma_table_info(?)", tc.table)
+		if err != nil {
+			t.Fatalf("table_info %s: %v", tc.table, err)
+		}
+		var got []string
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				t.Fatalf("scan %s column name: %v", tc.table, err)
+			}
+			got = append(got, name)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("iterate %s columns: %v", tc.table, err)
+		}
+		rows.Close()
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("%s schema columns %v do not match the expected list %v; update scan_helpers.go with the migration",
+				tc.table, got, tc.want)
+		}
+	}
+}
+
+// TestQueryRejectsTransposedColumns proves the fail-fast guard. The test
+// swaps two same-type columns through a view, so the row count and the
+// column types stay valid. A plain scan would swap the two values in
+// silence. The guard must return a descriptive error instead.
+func TestQueryRejectsTransposedColumns(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	transposed := func(cols []string) string {
+		swapped := slices.Clone(cols)
+		// Index 3 and 4 hold title/summary and description in every list.
+		// Both columns are TEXT in all three tables.
+		swapped[3], swapped[4] = swapped[4], swapped[3]
+		return strings.Join(swapped, ", ")
+	}
+
+	steps := []struct {
+		table string
+		cols  []string
+		query func() error
+	}{
+		{"events", eventColumns, func() error {
+			_, err := q.queryEvents(ctx, "WHERE 1=0", nil, "id")
+			return err
+		}},
+		{"todos", todoColumns, func() error {
+			_, err := q.queryTodos(ctx, "WHERE 1=0", nil, "id")
+			return err
+		}},
+		{"journals", journalColumns, func() error {
+			_, err := q.queryJournals(ctx, "WHERE 1=0", nil, "id")
+			return err
+		}},
+	}
+	for _, s := range steps {
+		if _, err := db.Exec("ALTER TABLE " + s.table + " RENAME TO " + s.table + "_probe"); err != nil {
+			t.Fatalf("rename %s: %v", s.table, err)
+		}
+		if _, err := db.Exec("CREATE VIEW " + s.table + " AS SELECT " + transposed(s.cols) + " FROM " + s.table + "_probe"); err != nil {
+			t.Fatalf("create %s view: %v", s.table, err)
+		}
+		err := s.query()
+		if err == nil {
+			t.Fatalf("query through the transposed %s view returned no error", s.table)
+		}
+		if !strings.Contains(err.Error(), "scan expects") {
+			t.Errorf("%s transposition error lacks the expected column list: %v", s.table, err)
+		}
 	}
 }

--- a/internal/storage/scan_helpers.go
+++ b/internal/storage/scan_helpers.go
@@ -1,6 +1,62 @@
 package storage
 
-import "database/sql"
+import (
+	"database/sql"
+	"fmt"
+	"slices"
+)
+
+// eventColumns lists the events table columns in migration order. The
+// dynamic queries read the table with SELECT *, and SQLite returns the
+// columns in the order the migrations defined them. scanEvents scans by
+// position, so this list pins that order.
+var eventColumns = []string{
+	"id", "uid", "calendar_id", "title", "description",
+	"location", "start_time", "end_time", "all_day",
+	"recurrence_rule", "timezone", "status", "transp",
+	"sequence", "priority", "class", "url", "exdates",
+	"rdates", "recurrence_id", "geo", "created_at",
+	"updated_at", "duration", "dtstamp", "conference_uri",
+	"deleted_at",
+}
+
+// todoColumns lists the todos table columns in migration order. See
+// eventColumns for why the order matters.
+var todoColumns = []string{
+	"id", "uid", "calendar_id", "summary", "description",
+	"location", "due_date", "start_date", "duration",
+	"completed_at", "percent_complete", "status", "priority",
+	"class", "url", "recurrence_rule", "timezone",
+	"sequence", "exdates", "rdates", "recurrence_id",
+	"geo", "created_at", "updated_at", "dtstamp",
+	"deleted_at",
+}
+
+// journalColumns lists the journals table columns in migration order. See
+// eventColumns for why the order matters.
+var journalColumns = []string{
+	"id", "uid", "calendar_id", "summary", "description",
+	"start_date", "status", "class", "url",
+	"recurrence_rule", "timezone", "sequence",
+	"exdates", "rdates", "recurrence_id", "dtstamp",
+	"created_at", "updated_at",
+	"deleted_at",
+}
+
+// checkScanColumns verifies that rows carry the expected columns in the
+// expected order. A schema change that moves a same-type column then fails
+// the first read with a descriptive error. Without the check, the scan
+// swaps such values in silence.
+func checkScanColumns(rows *sql.Rows, table string, want []string) error {
+	got, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("read %s columns: %w", table, err)
+	}
+	if !slices.Equal(got, want) {
+		return fmt.Errorf("%s query returned columns %v; scan expects %v", table, got, want)
+	}
+	return nil
+}
 
 // scanEvents reads rows into []Event. Column order must match the events table.
 // Columns:


### PR DESCRIPTION
## Problem
The dynamic `queryEvents`/`queryTodos`/`queryJournals` helpers read rows with `SELECT *` and scan by position. The only alignment guard was the implicit column-count check inside `rows.Scan`. A schema change that moved two same-type columns (a table rebuild, a column swap) scanned the transposed values in silence and corrupted every read.

## Evidence
`internal/storage/scan_helpers.go` scanned by position with no order check; `internal/storage/query_builder.go:108-133` passed the raw `SELECT *` rows straight to the scanners.

## Fix
- Add `eventColumns`, `todoColumns`, `journalColumns` package vars (derived from current migration column order) plus `checkScanColumns`.
- Each `queryX` helper compares `rows.Columns()` against the list before scanning; a mismatch returns a descriptive error naming both orders.

## Verification
- `go test ./internal/storage/` — full package green.
- New tests in `scan_alignment_test.go`:
  - `TestExpectedColumnsMatchSchema` pins each list to live `PRAGMA table_info` order.
  - `TestQueryRejectsTransposedColumns` swaps two TEXT columns through a view and proves the read fails instead of transposing values.
- `gofmt -l` clean on changed files.