### PR TITLE
fix(tui): stop LoadTheme fallback from writing to stderr

### DIFF
--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image/color"
 	"io/fs"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 	toml "github.com/pelletier/go-toml/v2"
 
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/tui/oklch"
 )
 
@@ -78,8 +78,10 @@ func LoadBuiltinTheme(name string, hasDarkBG bool) (Theme, error) {
 
 // LoadTheme resolves a theme by name with a safe fallback to the default.
 // An empty name is treated as the default. Unknown or malformed themes log
-// the error and fall back to the default so a typo in config.toml cannot
-// make the TUI unusable.
+// a warning to the state-dir log file and fall back to the default so a
+// typo in config.toml cannot make the TUI unusable. The warning must not
+// go to stderr. LoadTheme runs while the TUI owns the terminal, and a
+// stderr write prints over the display.
 func LoadTheme(name string, hasDarkBG bool) Theme {
 	if name == "" {
 		name = DefaultThemeName
@@ -88,8 +90,8 @@ func LoadTheme(name string, hasDarkBG bool) Theme {
 	if err == nil {
 		return t
 	}
-	fmt.Fprintf(os.Stderr, "theme %q failed to load (%v); falling back to %q\n",
-		name, err, DefaultThemeName)
+	config.SharedStateDirLogger().Warn("theme failed to load; falling back to the default theme",
+		"theme", name, "error", err.Error(), "fallback", DefaultThemeName)
 	def, err := LoadBuiltinTheme(DefaultThemeName, hasDarkBG)
 	if err != nil {
 		panic("built-in default theme failed to load: " + err.Error())

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"io"
+	"os"
 	"testing"
 
 	lipgloss "charm.land/lipgloss/v2"
@@ -215,5 +217,33 @@ func TestAnsi16IndexBoundaries(t *testing.T) {
 		if ok != tc.wantOK || (ok && idx != tc.idx) {
 			t.Errorf("ansi16Index(%q) = (%d, %v); want (%d, %v)", tc.in, idx, ok, tc.idx, tc.wantOK)
 		}
+	}
+}
+
+// LoadTheme runs while the TUI owns the terminal. The fallback for an
+// unknown theme must not write to stderr. A stderr write prints over the
+// alternate screen. The warning goes to the state-dir log file instead
+// (see config.SharedStateDirLogger).
+func TestLoadThemeFallbackDoesNotWriteToStderr(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	th := LoadTheme("does-not-exist", true)
+	os.Stderr = old
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("LoadTheme wrote to stderr: %q", data)
+	}
+	if th.Primary == nil {
+		t.Fatal("fallback theme should still populate tokens")
 	}
 }

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -225,6 +225,12 @@ func TestAnsi16IndexBoundaries(t *testing.T) {
 // alternate screen. The warning goes to the state-dir log file instead
 // (see config.SharedStateDirLogger).
 func TestLoadThemeFallbackDoesNotWriteToStderr(t *testing.T) {
+	// The fallback warning goes through the memoized
+	// config.SharedStateDirLogger. Point XDG_STATE_HOME at a scratch
+	// dir so the test never writes to the developer's real
+	// chroncal.log (see sync_warnings_test.go for the same guard).
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)


### PR DESCRIPTION
## Problem
`LoadTheme` wrote the unknown-theme fallback warning directly to `os.Stderr`. `handleBackgroundColorMsg` re-resolves the theme mid-session (app_update.go) while Bubble Tea owns the terminal, so the write printed over the alternate-screen display. Three thermos-audit reviewers flagged this.

## Evidence
`internal/tui/theme_loader.go` (master): `fmt.Fprintf(os.Stderr, "theme %q failed to load ...")` inside `LoadTheme`, reachable at boot and on every background-color change for a mistyped theme name.

## Fix
Route the warning to `config.SharedStateDirLogger().Warn`, the same log contract as `app.go resolveFullSyncStrategy` and the sync engines. The TUI keeps the alternate screen clean; the fallback message stays durable in $XDG_STATE_HOME/chroncal/chroncal.log.

## Verification
- New regression test `TestLoadThemeFallbackDoesNotWriteToStderr` swaps `os.Stderr` for a pipe, forces the unknown-theme path, and asserts zero bytes are written plus the default theme still resolves.
- `go test ./internal/tui/ -run 'TestLoad*|TestResolve*|TestAnsi16*|TestAutoSentinel' -count=1` — ok.
- `gofmt -l` clean on changed files.

Assisted-by: opencode-zen:x-preview-f-free