### PR TITLE
fix(event): carry the override recurrence_id in DeleteWithUndo

### DIFF
--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -59,7 +59,10 @@ type UndoMeta struct {
 
 // DeleteWithUndo soft-deletes an event by ID and returns the metadata needed
 // to reverse it. For an override, EXDATE mutation on the master is part of
-// the Delete flow. The returned UndoMeta covers the single-row un-hide.
+// the Delete flow. The returned UndoMeta carries the override's
+// recurrence_id. Undo then un-hides exactly that instance. Without it, undo
+// falls back to a UID-wide restore that would also resurrect other
+// soft-deleted overrides of the same series.
 func (s *Service) DeleteWithUndo(ctx context.Context, id int64) (UndoMeta, error) {
 	r, err := s.q.GetEvent(ctx, id)
 	if err != nil {
@@ -70,10 +73,11 @@ func (s *Service) DeleteWithUndo(ctx context.Context, id int64) (UndoMeta, error
 		return UndoMeta{}, err
 	}
 	return UndoMeta{
-		Kind:      UndoKindSingle,
-		UID:       evt.UID,
-		Label:     evt.Title,
-		DeletedAt: time.Now().UTC(),
+		Kind:         UndoKindSingle,
+		UID:          evt.UID,
+		Label:        evt.Title,
+		DeletedAt:    time.Now().UTC(),
+		RecurrenceID: evt.RecurrenceID,
 	}, nil
 }
 
@@ -271,11 +275,11 @@ func (s *Service) PurgeByID(ctx context.Context, id int64) error {
 	return nil
 }
 
-// restoreSingle un-hides one row by (uid, recurrence_id = ""). Use it for
-// DeleteWithUndo and DeleteInstanceWithUndo single-row restore. For an
-// override, callers should fall back to RestoreByUID since we do not know the
-// recurrence_id. UndoKindSingle always targets the master UID, so this
-// finds the master.
+// restoreSingle reverses one single-row delete. The undo paths use it for
+// DeleteWithUndo and DeleteInstanceWithUndo. A non-empty recurrenceID
+// restores exactly that instance: it un-hides the override row and clears
+// the delete-recorded EXDATE for it. An empty recurrenceID targets the
+// master row itself.
 func (s *Service) restoreSingle(ctx context.Context, uid, recurrenceID string) error {
 	r, err := s.q.GetEventByUIDIncludingDeleted(ctx, uid)
 	if err != nil {

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -46,7 +46,9 @@ type UndoMeta struct {
 	Label     string
 	DeletedAt time.Time
 
-	// UndoKindSingle only, when Undo reverses DeleteInstanceWithUndo.
+	// UndoKindSingle only. DeleteWithUndo or DeleteInstanceWithUndo sets
+	// this field when the delete targets an override instance. A standalone
+	// master delete leaves this field empty.
 	RecurrenceID string
 
 	// UndoKindFromInstance only. CutoffTime is the truncation cutoff. It finds

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -927,6 +927,91 @@ func TestDeleteInstance_OverrideLookupError(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_UndoOverrideDeleteRestoresOnlyThatInstance verifies the
+// undo metadata DeleteWithUndo returns for an override. The metadata must
+// carry the override's recurrence_id. Undo then un-hides exactly that
+// instance and clears only its EXDATE. Before the fix, the metadata dropped
+// the recurrence_id. Undo fell back to a UID-wide restore. That resurrected
+// another override of the same series the user had deleted before.
+func TestSoftDelete_UndoOverrideDeleteRestoresOnlyThatInstance(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "undo-override-uid",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	week2 := time.Date(2026, 4, 8, 10, 0, 0, 0, time.UTC)
+	week3 := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+	override2, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Week 2 (moved)",
+		StartTime:    week2.Add(2 * time.Hour),
+		EndTime:      week2.Add(3 * time.Hour),
+		RecurrenceID: week2.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override 2: %v", err)
+	}
+	override3, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Week 3 (moved)",
+		StartTime:    week3.Add(2 * time.Hour),
+		EndTime:      week3.Add(3 * time.Hour),
+		RecurrenceID: week3.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override 3: %v", err)
+	}
+
+	// Delete week 2's override first (an earlier, unrelated delete).
+	if _, err := svc.DeleteWithUndo(ctx, override2.ID); err != nil {
+		t.Fatalf("delete override 2: %v", err)
+	}
+	// Then delete week 3's override and undo just that one.
+	meta, err := svc.DeleteWithUndo(ctx, override3.ID)
+	if err != nil {
+		t.Fatalf("delete override 3: %v", err)
+	}
+	if meta.RecurrenceID != week3.UTC().Format(time.RFC3339) {
+		t.Fatalf("meta.RecurrenceID = %q, want %q", meta.RecurrenceID, week3.UTC().Format(time.RFC3339))
+	}
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+
+	// Week 3 must be live again: override un-hidden, its EXDATE cleared.
+	if _, err := svc.Get(ctx, override3.ID); err != nil {
+		t.Fatalf("override 3 should be live after undo: %v", err)
+	}
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after undo: %v", err)
+	}
+	exdates := got.ParseExDates()
+	if len(exdates) != 1 || !exdates[0].Equal(week2) {
+		t.Fatalf("master EXDATEs after undo = %v, want exactly week 2 (%v)", exdates, week2)
+	}
+
+	// Week 2's earlier delete must stand: its override stays soft-deleted.
+	still, err := svc.GetIncludingDeleted(ctx, override2.ID)
+	if err != nil {
+		t.Fatalf("get override 2 including deleted: %v", err)
+	}
+	if still.DeletedAt == nil {
+		t.Fatal("override 2 was resurrected by the undo of override 3")
+	}
+}
+
 // TestSoftDelete_FromInstanceUndo_ReAddsRDates reproduces issue #490. The TUI
 // truncation-undo path (RestoreUndo of an UndoKindFromInstance) must re-add the
 // post-cutoff RDATEs the truncation trimmed. That matches the trash-restore


### PR DESCRIPTION
## Problem

`DeleteWithUndo` built the `UndoMeta` without a `RecurrenceID` for an override row. `RestoreUndo` dispatches `restoreSingle(meta.UID, meta.RecurrenceID)`; with an empty recurrence_id and a live master it falls back to `restoreEventsByUIDClearingExdates`, which un-hides **every** soft-deleted override of the UID and clears each one's delete-recorded EXDATE.

## Evidence

internal/event/soft_delete.go `DeleteWithUndo` (former line 63) returned:

```go
return UndoMeta{
    Kind:      UndoKindSingle,
    UID:       evt.UID,
    Label:     evt.Title,
    DeletedAt: time.Now().UTC(),
}, nil
```

Concrete failure: delete week-2's override, then delete week-3's override, then undo the week-3 delete. The undo resurrected week 2 (override row un-hidden, its EXDATE stripped) — an unrelated delete the user made earlier. `DeleteInstanceWithUndo` already populates `RecurrenceID`; `DeleteWithUndo` dropped it.

## Fix

Populate `RecurrenceID: evt.RecurrenceID`. Undo of an override delete then routes to `restoreEXDATEOnly(uid, recID)`, which un-hides exactly that instance and clears only its EXDATE. Master and standalone deletes are unaffected (empty recurrence_id keeps the previous behavior). The `restoreSingle` doc comment now states the exact-instance contract.

Stacked on #679 and #683.

## Verification

- New regression test `TestSoftDelete_UndoOverrideDeleteRestoresOnlyThatInstance`: two overrides of one series, first delete stays, undo of the second delete must leave the first deleted (row soft-deleted, its EXDATE still on the master) while restoring the second exactly.
- Confirmed the test fails on the pre-fix code (`meta.RecurrenceID = ""`) and passes with the fix.
- `go test ./internal/event/` green; `go build ./...` clean (the TUI is the only `DeleteWithUndo` caller and consumes the meta opaquely); `gofmt -l` clean.