### PR TITLE
fix(icaltransfer): replace child collections unconditionally on import

### DIFF
--- a/internal/icaltransfer/transfer.go
+++ b/internal/icaltransfer/transfer.go
@@ -291,6 +291,10 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 // returned as a warning rather than only logged. Callers can then show
 // partial child-data loss in the import summary. The function does not
 // report success in silence.
+//
+// Replace every child collection unconditionally. A re-import of a UID
+// must remove a child that the new file omits. This mirrors the CalDAV
+// pull path in internal/sync (engine_persist.go).
 func importEventFields(ctx context.Context, svc *event.Service, id int64, e event.Event) []string {
 	var warns []string
 	add := func(field string, err error) {
@@ -298,30 +302,14 @@ func importEventFields(ctx context.Context, svc *event.Service, id int64, e even
 			warns = append(warns, fmt.Sprintf("import event %d: replace %s: %v", id, field, err))
 		}
 	}
-	if len(e.Alarms) > 0 {
-		add("alarms", svc.ReplaceAlarms(ctx, id, e.Alarms))
-	}
-	if len(e.Attendees) > 0 {
-		add("attendees", svc.ReplaceAttendees(ctx, id, e.Attendees))
-	}
-	if len(e.Attachments) > 0 {
-		add("attachments", svc.ReplaceAttachments(ctx, id, e.Attachments))
-	}
-	if len(e.Comments) > 0 {
-		add("comments", svc.ReplaceComments(ctx, id, e.Comments))
-	}
-	if len(e.Contacts) > 0 {
-		add("contacts", svc.ReplaceContacts(ctx, id, e.Contacts))
-	}
-	if len(e.Resources) > 0 {
-		add("resources", svc.ReplaceResources(ctx, id, e.Resources))
-	}
-	if len(e.Relations) > 0 {
-		add("relations", svc.ReplaceRelations(ctx, id, e.Relations))
-	}
-	if len(e.XProperties) > 0 {
-		add("x-properties", svc.ReplaceXProperties(ctx, id, e.XProperties))
-	}
+	add("alarms", svc.ReplaceAlarms(ctx, id, e.Alarms))
+	add("attendees", svc.ReplaceAttendees(ctx, id, e.Attendees))
+	add("attachments", svc.ReplaceAttachments(ctx, id, e.Attachments))
+	add("comments", svc.ReplaceComments(ctx, id, e.Comments))
+	add("contacts", svc.ReplaceContacts(ctx, id, e.Contacts))
+	add("resources", svc.ReplaceResources(ctx, id, e.Resources))
+	add("relations", svc.ReplaceRelations(ctx, id, e.Relations))
+	add("x-properties", svc.ReplaceXProperties(ctx, id, e.XProperties))
 	return warns
 }
 
@@ -333,30 +321,14 @@ func importTodoFields(ctx context.Context, svc *todo.Service, id int64, t todo.T
 			warns = append(warns, fmt.Sprintf("import todo %d: replace %s: %v", id, field, err))
 		}
 	}
-	if len(t.Alarms) > 0 {
-		add("alarms", svc.ReplaceAlarms(ctx, id, t.Alarms))
-	}
-	if len(t.Attendees) > 0 {
-		add("attendees", svc.ReplaceAttendees(ctx, id, t.Attendees))
-	}
-	if len(t.Attachments) > 0 {
-		add("attachments", svc.ReplaceAttachments(ctx, id, t.Attachments))
-	}
-	if len(t.Comments) > 0 {
-		add("comments", svc.ReplaceComments(ctx, id, t.Comments))
-	}
-	if len(t.Contacts) > 0 {
-		add("contacts", svc.ReplaceContacts(ctx, id, t.Contacts))
-	}
-	if len(t.Resources) > 0 {
-		add("resources", svc.ReplaceResources(ctx, id, t.Resources))
-	}
-	if len(t.Relations) > 0 {
-		add("relations", svc.ReplaceRelations(ctx, id, t.Relations))
-	}
-	if len(t.XProperties) > 0 {
-		add("x-properties", svc.ReplaceXProperties(ctx, id, t.XProperties))
-	}
+	add("alarms", svc.ReplaceAlarms(ctx, id, t.Alarms))
+	add("attendees", svc.ReplaceAttendees(ctx, id, t.Attendees))
+	add("attachments", svc.ReplaceAttachments(ctx, id, t.Attachments))
+	add("comments", svc.ReplaceComments(ctx, id, t.Comments))
+	add("contacts", svc.ReplaceContacts(ctx, id, t.Contacts))
+	add("resources", svc.ReplaceResources(ctx, id, t.Resources))
+	add("relations", svc.ReplaceRelations(ctx, id, t.Relations))
+	add("x-properties", svc.ReplaceXProperties(ctx, id, t.XProperties))
 	return warns
 }
 
@@ -368,24 +340,12 @@ func importJournalFields(ctx context.Context, svc *journal.Service, id int64, j 
 			warns = append(warns, fmt.Sprintf("import journal %d: replace %s: %v", id, field, err))
 		}
 	}
-	if len(j.Attendees) > 0 {
-		add("attendees", svc.ReplaceAttendees(ctx, id, j.Attendees))
-	}
-	if len(j.Attachments) > 0 {
-		add("attachments", svc.ReplaceAttachments(ctx, id, j.Attachments))
-	}
-	if len(j.Comments) > 0 {
-		add("comments", svc.ReplaceComments(ctx, id, j.Comments))
-	}
-	if len(j.Contacts) > 0 {
-		add("contacts", svc.ReplaceContacts(ctx, id, j.Contacts))
-	}
-	if len(j.Relations) > 0 {
-		add("relations", svc.ReplaceRelations(ctx, id, j.Relations))
-	}
-	if len(j.XProperties) > 0 {
-		add("x-properties", svc.ReplaceXProperties(ctx, id, j.XProperties))
-	}
+	add("attendees", svc.ReplaceAttendees(ctx, id, j.Attendees))
+	add("attachments", svc.ReplaceAttachments(ctx, id, j.Attachments))
+	add("comments", svc.ReplaceComments(ctx, id, j.Comments))
+	add("contacts", svc.ReplaceContacts(ctx, id, j.Contacts))
+	add("relations", svc.ReplaceRelations(ctx, id, j.Relations))
+	add("x-properties", svc.ReplaceXProperties(ctx, id, j.XProperties))
 	return warns
 }
 

--- a/internal/icaltransfer/transfer_test.go
+++ b/internal/icaltransfer/transfer_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/ical"
 	"github.com/douglasdemoura/chroncal/internal/icaltransfer"
+	"github.com/douglasdemoura/chroncal/internal/journal"
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
 func newTestApp(t *testing.T) *app.App {
@@ -247,6 +249,79 @@ func TestImport_ChildFieldFailureIsWarningNotFailed(t *testing.T) {
 	}
 	if !containsSubstring(summary.Warnings, "alarms") {
 		t.Errorf("summary.Warnings = %v, want one about dropped alarms", summary.Warnings)
+	}
+}
+
+// TestImport_ReimportRemovesStaleChildren locks in the re-import contract.
+// An import replaces the child collections of a row. It does not merge
+// them. A re-import that omits a child must remove the stored child. The
+// old len>0 guard kept stale alarms and attendees on the row, so a
+// removal on the source never reached the local copy.
+func TestImport_ReimportRemovesStaleChildren(t *testing.T) {
+	ctx := context.Background()
+	a := newTestApp(t)
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC)
+	attendee := model.Attendee{
+		Email: "user@example.com", Name: "User",
+		RSVPStatus: "NEEDS-ACTION", Role: "REQ-PARTICIPANT",
+	}
+	importAll := func(withChildren bool) icaltransfer.Summary {
+		evt := event.Event{
+			UID: "evt-children", Title: "Reimport",
+			StartTime: start, EndTime: start.Add(time.Hour),
+		}
+		td := todo.Todo{UID: "todo-children", Summary: "Reimport todo"}
+		jr := journal.Journal{UID: "jr-children", Summary: "Reimport journal"}
+		if withChildren {
+			evt.Alarms = []model.Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"}}
+			evt.Attendees = []model.Attendee{attendee}
+			td.Alarms = []model.Alarm{{Action: "DISPLAY", TriggerValue: "-PT30M", Related: "START"}}
+			jr.Attendees = []model.Attendee{attendee}
+		}
+		return icaltransfer.Import(ctx, a, cal.ID, &ical.ImportResult{
+			Events:   []event.Event{evt},
+			Todos:    []todo.Todo{td},
+			Journals: []journal.Journal{jr},
+		})
+	}
+
+	if s := importAll(true); s.Failed != 0 {
+		t.Fatalf("first import Failed = %d, want 0 (warnings: %v)", s.Failed, s.Warnings)
+	}
+	if s := importAll(false); s.Failed != 0 {
+		t.Fatalf("re-import Failed = %d, want 0 (warnings: %v)", s.Failed, s.Warnings)
+	}
+
+	evt, err := a.Events.GetByUID(ctx, "evt-children")
+	if err != nil {
+		t.Fatalf("GetByUID event: %v", err)
+	}
+	if alarms, err := a.Events.ListAlarms(ctx, evt.ID); err != nil || len(alarms) != 0 {
+		t.Errorf("event alarms after re-import = %v (err %v), want none", alarms, err)
+	}
+	if atts, err := a.Events.ListAttendees(ctx, evt.ID); err != nil || len(atts) != 0 {
+		t.Errorf("event attendees after re-import = %v (err %v), want none", atts, err)
+	}
+
+	td, err := a.Todos.GetByUID(ctx, "todo-children")
+	if err != nil {
+		t.Fatalf("GetByUID todo: %v", err)
+	}
+	if alarms, err := a.Todos.ListAlarms(ctx, td.ID); err != nil || len(alarms) != 0 {
+		t.Errorf("todo alarms after re-import = %v (err %v), want none", alarms, err)
+	}
+
+	jr, err := a.Journals.GetByUID(ctx, "jr-children")
+	if err != nil {
+		t.Fatalf("GetByUID journal: %v", err)
+	}
+	if atts, err := a.Journals.ListAttendees(ctx, jr.ID); err != nil || len(atts) != 0 {
+		t.Errorf("journal attendees after re-import = %v (err %v), want none", atts, err)
 	}
 }
 


### PR DESCRIPTION
## Problem
`importEventFields`/`importTodoFields`/`importJournalFields` gated every `Replace*` call on `len(...) > 0`. A re-import of an existing UID never removed a child the new file omitted, so alarms/attendees deleted at the source stayed on the local row and were re-exported.

## Evidence
On master: import an event with an alarm and an attendee, re-import the same UID without them — `ListAlarms`/`ListAttendees` still return the stale children (reproduced in the new test before the fix).

## Fix
Drop the length guards so each `Replace*` runs unconditionally; an empty list means "cleared". This mirrors the CalDAV pull path in `internal/sync/engine_persist.go:106-127`.

## Verification
- New regression test `TestImport_ReimportRemovesStaleChildren` covers event alarms+attendees, todo alarms, and journal attendees (failed on master, passes with the fix).
- `go test ./internal/icaltransfer/ -count=1` — ok (existing child-failure warning semantics unchanged).