### PR TITLE
fix(event): commit the instance-delete dirty mark inside the transaction

### DIFF
--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -366,10 +366,15 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, 
 	if err != nil {
 		return Event{}, err
 	}
+	// Mark dirty inside the transaction so a failed sync-tracking write rolls
+	// the edit back rather than committing a change that is never pushed
+	// (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit update event: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 
@@ -408,10 +413,15 @@ func (s *Service) UpdateWithRelations(ctx context.Context, id int64, p UpdatePar
 	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
 		return Event{}, err
 	}
+	// Mark dirty inside the transaction so a failed sync-tracking write rolls
+	// the edit back rather than committing a change that is never pushed
+	// (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit update event: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 
@@ -595,10 +605,15 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 	if err != nil {
 		return Event{}, err
 	}
+	// Mark the override dirty inside the transaction so a failed sync-tracking
+	// write rolls the override back rather than committing a change that is
+	// never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, calendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit override: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
 	return e, nil
 }
 
@@ -632,17 +647,22 @@ func (s *Service) UpdateInstanceWithRelations(ctx context.Context, uid string, i
 	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
 		return Event{}, err
 	}
+	// Mark the override dirty inside the transaction so a failed sync-tracking
+	// write rolls the override and its children back rather than committing a
+	// change that is never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, calendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit override: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
 	return e, nil
 }
 
 // updateInstanceTx creates or updates a per-occurrence override row and its
 // categories using a tx-bound Queries. It returns the event and the master's
-// calendar ID (for a dirty mark after commit). It opens no transaction, so
-// callers can compose it with attendee/alarm writes.
+// calendar ID (for the dirty mark inside the caller's transaction). It opens
+// no transaction, so callers can compose it with attendee/alarm writes.
 func updateInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, instanceTime time.Time, p UpdateParams) (Event, int64, error) {
 	// Every update entry point reaches this function, so the span rule
 	// lives here rather than at each caller.
@@ -824,11 +844,18 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 	if err != nil {
 		return Event{}, err
 	}
+	// Mark both rows dirty inside the transaction so a failed sync-tracking
+	// write rolls the split back rather than committing a change that is
+	// never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, masterCalendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit split: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event")
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 
@@ -862,11 +889,18 @@ func (s *Service) UpdateFromInstanceWithRelations(ctx context.Context, uid strin
 	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
 		return Event{}, err
 	}
+	// Mark both rows dirty inside the transaction so a failed sync-tracking
+	// write rolls the split and its children back rather than committing a
+	// change that is never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, masterCalendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit split: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event")
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -696,11 +696,13 @@ func (s *Service) DeleteInstance(ctx context.Context, uid string, instanceTime t
 		return fmt.Errorf("record exdate delete: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
+	// Mark the master dirty — its EXDATE was modified — inside the same
+	// transaction so a failed mark rolls the EXDATE change back rather than
+	// committing a change that is never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, master.CalendarID, uid, "event"); err != nil {
+		return fmt.Errorf("mark resource dirty: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
-	return nil
+	return tx.Commit()
 }
 
 // DeleteFromInstance truncates a recurring series so that instances at or
@@ -848,10 +850,15 @@ func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTi
 	}
 	postUpdated := truncated.UpdatedAt
 
+	// Mark the master dirty — its RRULE and RDATEs were modified — inside
+	// the same transaction so a failed mark rolls the truncation back rather
+	// than committing a change that is never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, master.CalendarID, uid, "event"); err != nil {
+		return "", fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return "", err
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
 	return postUpdated, nil
 }
 

--- a/internal/event/sync_atomic_test.go
+++ b/internal/event/sync_atomic_test.go
@@ -170,3 +170,88 @@ func TestDeleteSeries_TombstoneIsAtomic(t *testing.T) {
 			"DeleteSeries tombstone is not atomic with the soft-delete", *deletedAt)
 	}
 }
+
+// TestDeleteInstance_SyncMarkIsAtomic is the DeleteInstance analogue of
+// TestCreate_SyncMarkIsAtomic. The master's EXDATE change must commit together
+// with its dirty mark. The old code discarded a failed post-commit
+// MarkResourceDirty. A synced calendar then kept an EXDATE change that no push
+// ever sent (issue #107 contract).
+func TestDeleteInstance_SyncMarkIsAtomic(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "instance-dirty-atomic",
+		CalendarID:     1,
+		Title:          "Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	// Force the dirty-mark INSERT to fail.
+	if _, err := svc.db.ExecContext(ctx, `DROP TABLE sync_resources`); err != nil {
+		t.Fatalf("drop sync_resources: %v", err)
+	}
+
+	instanceAt := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	if err := svc.DeleteInstance(ctx, master.UID, instanceAt); err == nil {
+		t.Fatal("DeleteInstance succeeded but the dirty-mark write failed; the error was discarded")
+	}
+
+	// The mutation must have rolled back: the master carries no EXDATE.
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after failed DeleteInstance: %v", err)
+	}
+	if n := len(got.ParseExDates()); n != 0 {
+		t.Fatalf("master EXDATE count = %d, want 0 (%q); the EXDATE committed despite the "+
+			"dirty-mark write failing", n, got.ExDates)
+	}
+}
+
+// TestDeleteFromInstance_SyncMarkIsAtomic is the DeleteFromInstance analogue
+// of TestCreate_SyncMarkIsAtomic. The truncation must commit together with its
+// dirty mark. The old code discarded a failed post-commit MarkResourceDirty. A
+// synced calendar then kept a truncated RRULE that no push ever sent (issue
+// #107 contract).
+func TestDeleteFromInstance_SyncMarkIsAtomic(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "truncate-dirty-atomic",
+		CalendarID:     1,
+		Title:          "Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	if _, err := svc.db.ExecContext(ctx, `DROP TABLE sync_resources`); err != nil {
+		t.Fatalf("drop sync_resources: %v", err)
+	}
+
+	cutoff := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	if err := svc.DeleteFromInstance(ctx, master.UID, cutoff); err == nil {
+		t.Fatal("DeleteFromInstance succeeded but the dirty-mark write failed; the error was discarded")
+	}
+
+	// The mutation must have rolled back: the RRULE keeps its original COUNT.
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after failed DeleteFromInstance: %v", err)
+	}
+	if got.RecurrenceRule != master.RecurrenceRule {
+		t.Fatalf("master RRULE = %q, want the original %q; the truncation committed despite "+
+			"the dirty-mark write failing", got.RecurrenceRule, master.RecurrenceRule)
+	}
+}

--- a/internal/event/sync_atomic_test.go
+++ b/internal/event/sync_atomic_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
 
@@ -253,5 +254,166 @@ func TestDeleteFromInstance_SyncMarkIsAtomic(t *testing.T) {
 	if got.RecurrenceRule != master.RecurrenceRule {
 		t.Fatalf("master RRULE = %q, want the original %q; the truncation committed despite "+
 			"the dirty-mark write failing", got.RecurrenceRule, master.RecurrenceRule)
+	}
+}
+
+// TestUpdatePaths_SyncMarkIsAtomic extends TestCreate_SyncMarkIsAtomic to
+// the six update entry points in service.go. Each entry point must write its
+// dirty mark inside the mutation transaction. The old code discarded a failed
+// post-commit MarkResourceDirty. A synced calendar then kept an edit that no
+// push ever sent (issue #107 contract).
+func TestUpdatePaths_SyncMarkIsAtomic(t *testing.T) {
+	newStandup := func(t *testing.T, svc *Service) Event {
+		t.Helper()
+		master, err := svc.UpsertByUID(context.Background(), UpsertParams{
+			UID:            "update-dirty-atomic",
+			CalendarID:     1,
+			Title:          "Standup",
+			StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+			EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+			RecurrenceRule: "FREQ=DAILY;COUNT=5",
+		})
+		if err != nil {
+			t.Fatalf("create master: %v", err)
+		}
+		return master
+	}
+	editTitle := func() UpdateParams {
+		return UpdateParams{
+			CalendarID:     1,
+			Title:          "Edited",
+			StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+			EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+			RecurrenceRule: "FREQ=DAILY;COUNT=5",
+		}
+	}
+	attendees := []model.Attendee{{
+		Email: "a@example.com", Role: "REQ-PARTICIPANT", RSVPStatus: "NEEDS-ACTION",
+	}}
+	instanceAt := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+
+	titleUnchanged := func(t *testing.T, svc *Service, master Event) {
+		t.Helper()
+		got, err := svc.Get(context.Background(), master.ID)
+		if err != nil {
+			t.Fatalf("get master after the failed call: %v", err)
+		}
+		if got.Title != "Standup" {
+			t.Fatalf("title = %q, want %q; the edit committed despite the "+
+				"dirty-mark write failing", got.Title, "Standup")
+		}
+	}
+	noOverride := func(t *testing.T, svc *Service, master Event) {
+		t.Helper()
+		var n int
+		if err := svc.db.QueryRowContext(context.Background(),
+			`SELECT COUNT(*) FROM events WHERE uid = ? AND recurrence_id != ''`,
+			master.UID).Scan(&n); err != nil {
+			t.Fatalf("count overrides: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("override rows = %d, want 0; the override committed despite "+
+				"the dirty-mark write failing", n)
+		}
+	}
+	seriesIntact := func(t *testing.T, svc *Service, master Event) {
+		t.Helper()
+		var n int
+		if err := svc.db.QueryRowContext(context.Background(),
+			`SELECT COUNT(*) FROM events`).Scan(&n); err != nil {
+			t.Fatalf("count events: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("event rows = %d, want 1 (the master only); the split series "+
+				"committed despite the dirty-mark write failing", n)
+		}
+		got, err := svc.GetByUID(context.Background(), master.UID)
+		if err != nil {
+			t.Fatalf("get master after the failed call: %v", err)
+		}
+		if got.RecurrenceRule != master.RecurrenceRule {
+			t.Fatalf("master RRULE = %q, want the original %q; the truncation "+
+				"committed despite the dirty-mark write failing",
+				got.RecurrenceRule, master.RecurrenceRule)
+		}
+	}
+
+	cases := []struct {
+		name   string
+		call   func(svc *Service, master Event) error
+		verify func(t *testing.T, svc *Service, master Event)
+	}{
+		{
+			name: "Update",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.Update(context.Background(), master.ID, editTitle())
+				return err
+			},
+			verify: titleUnchanged,
+		},
+		{
+			name: "UpdateWithRelations",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateWithRelations(context.Background(), master.ID,
+					editTitle(), attendees, nil)
+				return err
+			},
+			verify: titleUnchanged,
+		},
+		{
+			name: "UpdateInstance",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateInstance(context.Background(), master.UID,
+					instanceAt, editTitle())
+				return err
+			},
+			verify: noOverride,
+		},
+		{
+			name: "UpdateInstanceWithRelations",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateInstanceWithRelations(context.Background(),
+					master.UID, instanceAt, editTitle(), attendees, nil)
+				return err
+			},
+			verify: noOverride,
+		},
+		{
+			name: "UpdateFromInstance",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateFromInstance(context.Background(), master.UID,
+					instanceAt, editTitle())
+				return err
+			},
+			verify: seriesIntact,
+		},
+		{
+			name: "UpdateFromInstanceWithRelations",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateFromInstanceWithRelations(context.Background(),
+					master.UID, instanceAt, editTitle(), attendees, nil)
+				return err
+			},
+			verify: seriesIntact,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newTestService(t)
+			makeSyncedCalendar(t, svc)
+			master := newStandup(t, svc)
+			ctx := context.Background()
+
+			// Force the dirty-mark INSERT to fail.
+			if _, err := svc.db.ExecContext(ctx, `DROP TABLE sync_resources`); err != nil {
+				t.Fatalf("drop sync_resources: %v", err)
+			}
+
+			if err := tc.call(svc, master); err == nil {
+				t.Fatal("call succeeded but the dirty-mark write failed; the error was discarded")
+			}
+			tc.verify(t, svc, master)
+		})
 	}
 }


### PR DESCRIPTION
## Problem

`DeleteInstance` and `deleteFromInstance` called `storage.MarkResourceDirty` **after** `tx.Commit()` and discarded its error with `_ =`. The issue #107 contract — the sync-record write commits atomically with the mutation and its error is never dropped — is already enforced in this same file by `Create`, `Delete`, and the `Delete` override path (mark inside tx, error propagated).

## Evidence

internal/event/soft_delete.go, both sites:

```go
if err := tx.Commit(); err != nil {
    return err
}
_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
return nil
```

A failed mark (e.g. the `sync_resources` INSERT erroring) left the mutation committed but never pushed. A synced calendar kept an EXDATE change or a truncated RRULE that no push ever sent: the server copy kept the full series while the local view dropped occurrences, and the divergence never surfaced.

## Fix

Move the `MarkResourceDirty` call inside the transaction, before `Commit`, and propagate its error — the exact shape the `Delete` override path already uses.

Stacked on #679, #683, and #687.

## Verification

- New regression tests `TestDeleteInstance_SyncMarkIsAtomic` and `TestDeleteFromInstance_SyncMarkIsAtomic` mirror `TestCreate_SyncMarkIsAtomic`: drop `sync_resources`, run the mutation, assert the error surfaces and the master is untouched (zero EXDATEs / original RRULE).
- Confirmed both tests fail on the pre-fix code ("succeeded but the dirty-mark write failed") and pass with the fix.
- `go test ./internal/event/` green; `gofmt -l` clean.