### PR TITLE
test(storage): guard Go migration registration against silent skips

### DIFF
--- a/internal/storage/migration_registration_test.go
+++ b/internal/storage/migration_registration_test.go
@@ -1,0 +1,81 @@
+package storage
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+// TestProviderRegistersEveryGoMigration guards the manual registration in
+// NewMigrationProvider. goose runs only the migrations that the
+// goose.WithGoMigrations call lists. A new migration_NNN_*.go file that the
+// call omits never runs, and no error reports the skip. The test reads the
+// registered versions from the production provider and compares them with
+// the Go migration files in this package. It also checks that the SQL and
+// Go versions together form one gap-free range.
+func TestProviderRegistersEveryGoMigration(t *testing.T) {
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer conn.Close()
+
+	registered := make(map[int64]bool)
+	all := make(map[int64]struct{})
+	var maxVersion int64
+	for _, s := range migProvider(t, conn).ListSources() {
+		all[s.Version] = struct{}{}
+		if s.Version > maxVersion {
+			maxVersion = s.Version
+		}
+		if s.Type == goose.TypeGo {
+			registered[s.Version] = true
+		}
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate the test source file")
+	}
+	entries, err := os.ReadDir(filepath.Dir(thisFile))
+	if err != nil {
+		t.Fatalf("list the package directory: %v", err)
+	}
+	nameVersion := regexp.MustCompile(`^migration_(\d+)_`)
+	sawGoFile := false
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		m := nameVersion.FindStringSubmatch(name)
+		if m == nil {
+			continue
+		}
+		sawGoFile = true
+		version, err := strconv.ParseInt(m[1], 10, 64)
+		if err != nil {
+			t.Fatalf("parse the version in %s: %v", name, err)
+		}
+		if !registered[version] {
+			t.Errorf("%s carries version %d, but NewMigrationProvider registers no Go migration for it; add the migration to goose.WithGoMigrations so it runs",
+				name, version)
+		}
+	}
+	if !sawGoFile {
+		t.Fatal("find no migration_*.go file in the package; the naming convention changed")
+	}
+
+	for version := int64(1); version <= maxVersion; version++ {
+		if _, ok := all[version]; !ok {
+			t.Errorf("no SQL file and no registered Go migration carries version %d; the migration set has a gap", version)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`NewMigrationProvider` registers each Go migration by hand through `goose.WithGoMigrations`. A new `migration_NNN_*.go` file that the call omits never runs, and goose reports no error. The silent skip stays hidden until a schema mismatch surfaces far from the cause.

## Evidence
`internal/storage/connect.go:377-378` registers only `newSpanColumnMigration()`; nothing compares that list against the Go migration files in the package (`migration_043_span_columns.go` today).

## Fix
Add `TestProviderRegistersEveryGoMigration` in `internal/storage/migration_registration_test.go`:
- Builds the production provider via `NewMigrationProvider` and reads `ListSources`.
- Fails when a `migration_NNN_*.go` file in the package has no matching registered Go migration, with an actionable message.
- Fails when the SQL and Go versions together leave a gap in the version range.

The guard lives in a test on purpose: an installed binary carries no source directory, so a startup check cannot see the file names.

## Verification
- `go test ./internal/storage/ -run TestProviderRegistersEveryGoMigration` — pass.
- Added a temporary unregistered `migration_999_guardprobe.go`; the test fails with the descriptive error. Removed the file; the test passes again.
- Full `go test ./internal/storage/` green; `gofmt -l` clean.

Stacked on #685.