### PR TITLE
fix(event): reconcile sync state when RestoreByUID finds no master row

### DIFF
--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -335,6 +335,20 @@ func (s *Service) restoreSeries(ctx context.Context, uid string) error {
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
 	}
+	// The master row is gone (it was purged on its own). Reconcile on every
+	// calendar the restored rows live on, the same way RestoreByUID does.
+	// Without this, a pending tombstone survives the undo-series. The next
+	// sync would then DELETE the series from the server right after a
+	// successful undo.
+	ids, rErr := s.distinctCalendarIDsByUID(ctx, uid)
+	if rErr != nil {
+		return rErr
+	}
+	for _, id := range ids {
+		if err := s.reconcileSyncAfterRestore(ctx, id, uid); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -198,6 +198,19 @@ func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
 	}
+	// The master row is gone (it was purged on its own). Reconcile on every
+	// calendar the restored rows live on. Without this, a pending tombstone
+	// survives the restore. The next sync would then DELETE the series from
+	// the server right after a successful restore.
+	ids, rErr := s.distinctCalendarIDsByUID(ctx, uid)
+	if rErr != nil {
+		return rErr
+	}
+	for _, id := range ids {
+		if err := s.reconcileSyncAfterRestore(ctx, id, uid); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -838,6 +838,94 @@ func TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_RestoreUndoSeriesOrphanTailClearsTombstone covers the same
+// orphan-tail scenario as TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone,
+// reached through RestoreUndo(UndoKindSeries). The master row was purged on
+// its own after the series delete. Only the soft-deleted override remains.
+// The undo must still reconcile sync state. Before the fix, the undo left a
+// pending tombstone in place. The next sync then DELETEd the series from the
+// server right after a successful local undo.
+func TestSoftDelete_RestoreUndoSeriesOrphanTailClearsTombstone(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "orphan-undo-series-uid",
+		CalendarID:     1,
+		Title:          "Daily Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	instanceAt := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Daily Standup (moved)",
+		StartTime:    instanceAt.Add(time.Hour),
+		EndTime:      instanceAt.Add(90 * time.Minute),
+		RecurrenceID: instanceAt.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Mark the series synced (non-empty remote_url) so the delete queues a
+	// tombstone.
+	if err := svc.q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   master.CalendarID,
+		Uid:          master.UID,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/series.ics",
+		Etag:         "etag-1",
+		Dirty:        0,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("upsert sync resource: %v", err)
+	}
+	meta, err := svc.DeleteSeriesWithUndo(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("DeleteSeriesWithUndo: %v", err)
+	}
+	if meta.Kind != UndoKindSeries {
+		t.Fatalf("undo kind = %d, want UndoKindSeries", meta.Kind)
+	}
+	tombstones, err := svc.q.ListTombstonesByCalendar(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("list tombstones: %v", err)
+	}
+	if len(tombstones) != 1 {
+		t.Fatalf("tombstones after DeleteSeriesWithUndo = %d, want 1", len(tombstones))
+	}
+
+	// Purge the master row on its own. The soft-deleted override stays behind
+	// as an orphan tail with the UID.
+	if err := svc.PurgeByID(ctx, master.ID); err != nil {
+		t.Fatalf("PurgeByID master: %v", err)
+	}
+
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+
+	// The undo must clear the tombstone. A surviving tombstone would
+	// DELETE the series from the server on the next sync.
+	tombstones, err = svc.q.ListTombstonesByCalendar(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("list tombstones after undo: %v", err)
+	}
+	if len(tombstones) != 0 {
+		t.Fatalf("tombstones after RestoreUndo = %d, want 0 (the pending delete outlived the undo)", len(tombstones))
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("orphan override should be live after RestoreUndo: %v", err)
+	}
+}
+
 // TestSoftDelete_OverrideMasterLookupError is the regression test for issue
 // #412. A delete of an override must not collapse a genuine DB error from the
 // master lookup into the "no master" path. On a non-ErrNoRows error the old

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
 
@@ -752,6 +753,88 @@ func TestSoftDelete_RestoreSurfacesTombstoneClearError(t *testing.T) {
 
 	if err := svc.RestoreByID(ctx, e.ID); err == nil {
 		t.Fatal("RestoreByID returned nil, want error when tombstone clear fails")
+	}
+}
+
+// TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone covers the restore of
+// a UID whose master row was purged on its own. Only orphaned overrides
+// remain. The restore must still reconcile sync state. Before the fix, the
+// restore left a pending tombstone in place. The next sync then DELETEd the
+// series from the server right after a successful local restore.
+func TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "orphan-restore-uid",
+		CalendarID:     1,
+		Title:          "Daily Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	instanceAt := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Daily Standup (moved)",
+		StartTime:    instanceAt.Add(time.Hour),
+		EndTime:      instanceAt.Add(90 * time.Minute),
+		RecurrenceID: instanceAt.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Mark the series synced (non-empty remote_url) so the delete queues a
+	// tombstone.
+	if err := svc.q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   master.CalendarID,
+		Uid:          master.UID,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/series.ics",
+		Etag:         "etag-1",
+		Dirty:        0,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("upsert sync resource: %v", err)
+	}
+	if err := svc.DeleteSeries(ctx, master.UID); err != nil {
+		t.Fatalf("DeleteSeries: %v", err)
+	}
+	tombstones, err := svc.q.ListTombstonesByCalendar(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("list tombstones: %v", err)
+	}
+	if len(tombstones) != 1 {
+		t.Fatalf("tombstones after DeleteSeries = %d, want 1", len(tombstones))
+	}
+
+	// Purge the master row on its own. The soft-deleted override stays behind
+	// as an orphan tail with the UID.
+	if err := svc.PurgeByID(ctx, master.ID); err != nil {
+		t.Fatalf("PurgeByID master: %v", err)
+	}
+
+	if err := svc.RestoreByUID(ctx, master.UID); err != nil {
+		t.Fatalf("RestoreByUID: %v", err)
+	}
+
+	// The restore must clear the tombstone. A surviving tombstone would
+	// DELETE the series from the server on the next sync.
+	tombstones, err = svc.q.ListTombstonesByCalendar(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("list tombstones after restore: %v", err)
+	}
+	if len(tombstones) != 0 {
+		t.Fatalf("tombstones after RestoreByUID = %d, want 0 (the pending delete outlived the restore)", len(tombstones))
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("orphan override should be live after RestoreByUID: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`RestoreByUID` skipped the sync reconciliation whenever the master-row lookup returned `ErrNoRows`. That state is reachable: the master was purged on its own (e.g. `PurgeByID`) while soft-deleted overrides of the same UID stayed behind (the "orphan tail" the calendar-access guards already handle). The restore then un-hid the orphaned overrides, reported success, and left the pending tombstone in place.

## Evidence

internal/event/soft_delete.go `RestoreByUID` (former lines 194-197):

```go
if err == nil {  // err is the master lookup error
    return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
}
return nil
```

Consequences of the skip, per the tombstone lifecycle in internal/sync: `processTombstones` pushes the DELETE on the next sync (destroying the server copy right after a successful restore), and until then the pull path's tombstoned-UID filter keeps the UID out, so the restored rows never re-import either. With the master present, the same restore clears the tombstone — the contract was inconsistent.

## Fix

When the master row is gone but rows were restored (`n > 0`), reconcile on every calendar the restored rows live on (`distinctCalendarIDsByUID`), the same clear-tombstone + mark-dirty path the master-present case uses.

Note: `restoreSeries` (the TUI undo path for a series delete) has the same `if err == nil` shape for the master-present check; it only diverges when the master was purged between delete and undo, which is not part of this finding, so it was left untouched.

Stacked on #679, #683, #687, and #689.

## Verification

- New regression test `TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone`: synced calendar, series delete queues a tombstone, master purged on its own, `RestoreByUID` succeeds — then asserts the tombstone is gone and the orphan override is live.
- Confirmed the test fails on the pre-fix code ("tombstones after RestoreByUID = 1, want 0") and passes with the fix.
- `go test ./internal/event/` green; `gofmt -l` clean.