### PR TITLE
fix(tui): keep accent contrast polarity when no OSC 4 answer arrives

### DIFF
--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -150,12 +150,14 @@ func readBuiltinRaw(name string) (*rawTheme, error) {
 // ANSI indices 0..15 are translated to the terminal's actually-rendered
 // RGB via activePalette when an OSC 4 response is available. Themes can
 // then lean on ANSI references (primary = "4"). Exact OKLCh contrast
-// computations still work against real hex values. Indices 16..255 and
-// unrecognized strings fall through to lipgloss.Color.
+// computations still work against real hex values. When the terminal
+// reports no palette entry, a static Base16-style hex for the current
+// background polarity stands in (see assumedPaletteDark). Indices 16..255
+// and unrecognized strings fall through to lipgloss.Color.
 func resolveColor(v any, hasDarkBG bool, field string) (color.Color, error) {
 	switch x := v.(type) {
 	case string:
-		return resolveString(x), nil
+		return resolveString(x, hasDarkBG), nil
 	case map[string]any:
 		key := "light"
 		if hasDarkBG {
@@ -165,7 +167,7 @@ func resolveColor(v any, hasDarkBG bool, field string) (color.Color, error) {
 		if !ok {
 			return nil, fmt.Errorf("field %q variant missing %q string", field, key)
 		}
-		return resolveString(s), nil
+		return resolveString(s, hasDarkBG), nil
 	case nil:
 		return nil, fmt.Errorf("field %q is missing", field)
 	default:
@@ -173,14 +175,58 @@ func resolveColor(v any, hasDarkBG bool, field string) (color.Color, error) {
 	}
 }
 
-// resolveString turns a single TOML color string into a color.Color. If
-// it is an ANSI index 0..15 and the queried terminal palette has a value
-// for that slot, the palette's hex wins. Otherwise lipgloss handles it.
-func resolveString(s string) color.Color {
+// assumedPaletteDark and assumedPaletteLight hold the ANSI 16-color
+// values the loader substitutes when the terminal reported no palette
+// entry for a slot. The values follow the Base16 convention that
+// system.toml documents: slot 0 is the background, slot 7 the foreground,
+// slot 8 the dim line, and slots 9..14 mirror slots 1..6. Slot 1 uses a
+// slightly darker red than the Base16 default. That keeps the
+// computed-foreground ratio above 4.5.
+//
+// The loader returns these hexes instead of ANSI indices. The terminal
+// then renders the exact value the OKLCh contrast math used. A pill and
+// its computed label can no longer disagree about polarity.
+var assumedPaletteDark = Palette{
+	rgbColor("#181818"), rgbColor("#a03e35"), rgbColor("#a1b56c"), rgbColor("#ba823f"),
+	rgbColor("#7cafc2"), rgbColor("#aa759f"), rgbColor("#86c1b9"), rgbColor("#d8d8d8"),
+	rgbColor("#585858"), rgbColor("#a03e35"), rgbColor("#a1b56c"), rgbColor("#ba823f"),
+	rgbColor("#7cafc2"), rgbColor("#aa759f"), rgbColor("#86c1b9"), rgbColor("#f8f8f8"),
+}
+
+var assumedPaletteLight = Palette{
+	rgbColor("#f8f8f8"), rgbColor("#a03e35"), rgbColor("#a1b56c"), rgbColor("#ba823f"),
+	rgbColor("#7cafc2"), rgbColor("#aa759f"), rgbColor("#86c1b9"), rgbColor("#383838"),
+	rgbColor("#b8b8b8"), rgbColor("#a03e35"), rgbColor("#a1b56c"), rgbColor("#ba823f"),
+	rgbColor("#7cafc2"), rgbColor("#aa759f"), rgbColor("#86c1b9"), rgbColor("#181818"),
+}
+
+// rgbColor parses a "#rrggbb" literal into a color. The assumed palettes
+// call it at package init. A malformed literal would silently decode to
+// black, so keep the literals valid. The tests exercise every slot.
+func rgbColor(hex string) color.RGBA {
+	var c color.RGBA
+	_, _ = fmt.Sscanf(hex, "#%02x%02x%02x", &c.R, &c.G, &c.B)
+	c.A = 0xff
+	return c
+}
+
+// resolveString turns a single TOML color string into a color.Color. An
+// ANSI index 0..15 first asks the terminal palette. Without a palette
+// answer, the assumed Base16-style hex for the current background
+// polarity stands in. The terminal then renders the exact value the
+// contrast math used. An index must not fall through to lipgloss here:
+// lipgloss answers with its VGA defaults. Those defaults sit on the wrong
+// lightness side for themed terminals, so every computed foreground
+// flipped polarity against the rendered color.
+func resolveString(s string, hasDarkBG bool) color.Color {
 	if idx, ok := ansi16Index(s); ok {
 		if c := activePalette.Lookup(idx); c != nil {
 			return c
 		}
+		if hasDarkBG {
+			return assumedPaletteDark.Lookup(idx)
+		}
+		return assumedPaletteLight.Lookup(idx)
 	}
 	return lipgloss.Color(s)
 }

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -3,9 +3,12 @@ package tui
 import (
 	"io"
 	"os"
+	"strconv"
 	"testing"
 
 	lipgloss "charm.land/lipgloss/v2"
+
+	"github.com/douglasdemoura/chroncal/internal/tui/oklch"
 )
 
 func TestLoadBuiltinDefault(t *testing.T) {
@@ -133,32 +136,82 @@ func TestResolveStringHonorsActivePalette(t *testing.T) {
 	pal[4] = lipgloss.Color("#123456")
 	SetActivePalette(&pal)
 
-	got := resolveString("4")
+	got := resolveString("4", true)
 	r, g, b, _ := got.RGBA()
 	if r>>8 != 0x12 || g>>8 != 0x34 || b>>8 != 0x56 {
 		t.Errorf("expected palette[4] hex #123456, got rgb(%02x, %02x, %02x)", r>>8, g>>8, b>>8)
 	}
+	// The palette wins in both polarities.
+	got = resolveString("4", false)
+	r, g, b, _ = got.RGBA()
+	if r>>8 != 0x12 || g>>8 != 0x34 || b>>8 != 0x56 {
+		t.Errorf("light mode: expected palette[4] hex #123456, got rgb(%02x, %02x, %02x)", r>>8, g>>8, b>>8)
+	}
 
 	// Out-of-range ANSI indices fall through to lipgloss.
-	if c := resolveString("240"); c == nil {
+	if c := resolveString("240", true); c == nil {
 		t.Errorf("ANSI 240 should fall through to lipgloss, not panic or return nil")
 	}
 	// Hex strings always fall through to lipgloss regardless of palette.
-	hex := resolveString("#abcdef")
+	hex := resolveString("#abcdef", true)
 	hr, hg, hb, _ := hex.RGBA()
 	if hr>>8 != 0xab || hg>>8 != 0xcd || hb>>8 != 0xef {
 		t.Errorf("hex string should not be palette-translated, got rgb(%02x, %02x, %02x)", hr>>8, hg>>8, hb>>8)
 	}
 }
 
-func TestResolveStringWithoutPaletteFallsBack(t *testing.T) {
+// A terminal that does not answer OSC 4 (older terminals, tmux without
+// passthrough) must still get readable accent pairs. Index 8 used to fall
+// through to lipgloss's VGA gray #808080. That gray sits at OKLCh L 0.60,
+// so ContrastingFg picked a dark foreground while themed terminals render
+// slot 8 on the dark side. The button pair then read 1.62:1.
+func TestResolveStringWithoutPaletteKeepsContrastPolarity(t *testing.T) {
 	prev := ActivePalette()
 	t.Cleanup(func() { SetActivePalette(prev) })
 	SetActivePalette(nil)
 
-	if c := resolveString("4"); c == nil {
-		t.Fatal("nil palette must not turn ANSI 4 into a nil color")
+	t.Run("reported bug: dark-mode slot 8", func(t *testing.T) {
+		bg := resolveString("8", true)
+		r, g, b, _ := bg.RGBA()
+		if r>>8 == 0x80 && g>>8 == 0x80 && b>>8 == 0x80 {
+			t.Fatal("slot 8 resolved to the VGA default #808080; want an assumed dark Base16 hex")
+		}
+		bgL, _, _, ok := oklch.FromColor(bg)
+		if !ok || bgL >= 0.55 {
+			t.Fatalf("dark-mode slot 8 L=%.3f, want < 0.550 so the pill reads dark", bgL)
+		}
+		fg := oklch.ContrastingFg(bg)
+		if ratio := oklch.ContrastRatio(bg, fg); ratio < 4.5 {
+			t.Errorf("slot 8 pair reads %.2f:1, want >= 4.50:1", ratio)
+		}
+	})
+
+	// Every ANSI reference a theme may carry, in both polarities. A slot
+	// with a computed foreground must stay readable in degraded mode.
+	for _, tc := range []struct {
+		mode string
+		dark bool
+	}{
+		{"dark", true},
+		{"light", false},
+	} {
+		for idx := range assumedPaletteDark {
+			bg := resolveString(strconv.Itoa(idx), tc.dark)
+			fg := oklch.ContrastingFg(bg)
+			if ratio := oklch.ContrastRatio(bg, fg); ratio < 4.5 {
+				t.Errorf("%s mode: slot %d pair reads %.2f:1, want >= 4.50:1", tc.mode, idx, ratio)
+			}
+		}
 	}
+
+	t.Run("non-ANSI strings still fall through", func(t *testing.T) {
+		if c := resolveString("4", true); c == nil {
+			t.Fatal("nil palette must not turn ANSI 4 into a nil color")
+		}
+		if c := resolveString("240", true); c == nil {
+			t.Error("ANSI 240 should fall through to lipgloss, not panic or return nil")
+		}
+	})
 }
 
 func TestAutoSentinelDerivesFromTextAndSurface(t *testing.T) {

--- a/internal/tui/themes/system.toml
+++ b/internal/tui/themes/system.toml
@@ -13,10 +13,12 @@
 #     rather than guessed from lipgloss's default ANSI table.
 #
 # When the terminal doesn't answer OSC 4 (older terminals, tmux without
-# passthrough), lipgloss renders the ANSI references directly — still
-# correct, just without the OKLCh-on-real-hex precision. Text-on-accent
-# foregrounds are computed at render time via oklch.ContrastingFg, so we
-# no longer ship button_text / badge_text tokens.
+# passthrough), the loader substitutes static Base16-style hexes for the
+# ANSI references. The terminal then renders the exact value the OKLCh
+# contrast math used, so a background and its computed foreground cannot
+# disagree about polarity. Text-on-accent foregrounds are computed at
+# render time via oklch.ContrastingFg, so we no longer ship
+# button_text / badge_text tokens.
 #
 # Base16-aligned palette assumptions (de-facto standard across Omarchy,
 # Catppuccin, Gruvbox, Tokyo Night, Nord, etc.):


### PR DESCRIPTION
## Problem
In degraded mode (terminal never answers OSC 4 — older terminals, tmux without passthrough), `resolveString` let ANSI indices 0..15 fall through to `lipgloss.Color(s)`. lipgloss answers an index with its **VGA defaults**, but the terminal renders the index with its own (Base16-style) palette. `oklch.ContrastingFg` then computed the label against the wrong assumed color and inverted polarity.

## Evidence
Measured on master: system theme `button_bg = "8"` → `lipgloss.Color("8")` → VGA #808080, OKLCh L = 0.60 → light side → **dark** label. Real themed terminals render slot 8 as Base16 base03 (dark, L ≈ 0.46). Dark label on dark pill = **1.62:1** (intended ≈ 9.15:1). Every button, badge, and chip label on the system theme flipped in degraded mode.

## Fix
When the terminal palette lacks a slot, substitute a static **Base16-style hex** keyed by the resolved background polarity (`assumedPaletteDark` / `assumedPaletteLight`, following the convention system.toml already documents). The terminal now renders the exact value the contrast math used, so pill and computed label can never disagree about polarity. Slot 1 uses a slightly darker red than Base16 default (#a03e35) to keep its computed label above 4.5:1. system.toml's degraded-mode comment updated to match.

## Verification
- New `TestResolveStringWithoutPaletteKeepsContrastPolarity`: walks **all 16 slots × dark/light**, asserts every `ContrastingFg` pair ≥ 4.5:1 (worst measured 5.04:1); dedicated guard that dark slot 8 never resolves to the VGA default and lands on the dark side.
- Palette-wins behavior re-verified in both polarities; ANSI-256/hex strings still fall through to lipgloss.
- `go test ./internal/tui/... -count=1` — ok.

Stacked on #690 (uses its `oklch.ContrastRatio` oracle).

Assisted-by: opencode-zen:x-preview-f-free