### PR TITLE
refactor(storage): unify dynamic todo and journal filter params

### DIFF
--- a/cmd/chroncal/todo_search.go
+++ b/cmd/chroncal/todo_search.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
@@ -41,11 +42,11 @@ and categories.`,
 				}
 			}
 
-			completedFilter := 0
+			completedFilter := storage.CompletionAny
 			if completed {
-				completedFilter = 1
+				completedFilter = storage.CompletedOnly
 			} else if incomplete {
-				completedFilter = 2
+				completedFilter = storage.OpenOnly
 			}
 
 			todos, err := a.Todos.Search(ctx, todo.SearchParams{

--- a/internal/journal/search.go
+++ b/internal/journal/search.go
@@ -36,7 +36,7 @@ func (s *Service) Search(ctx context.Context, p SearchParams) ([]Journal, error)
 }
 
 func (s *Service) ExportFiltered(ctx context.Context, p ExportParams) ([]Journal, error) {
-	rows, err := s.q.ListJournalsForExport(ctx, storage.ListJournalsForExportParams{
+	rows, err := s.q.ListJournalsForExport(ctx, storage.JournalFilterParams{
 		CalendarID:   p.CalendarID,
 		FromDate:     p.From,
 		ToDate:       p.To,

--- a/internal/recurrence/list_journals.go
+++ b/internal/recurrence/list_journals.go
@@ -175,11 +175,6 @@ func (s *Service) expandRecurringJournalRows(ctx context.Context, rows []storage
 // date range is provided, recurring journals are expanded. Otherwise master
 // entries are returned as-is.
 func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams) ([]journal.Journal, error) {
-	hideCancelled := int64(0)
-	if p.HideCancelled {
-		hideCancelled = 1
-	}
-
 	fromStr := ""
 	toStr := ""
 	hasRange := !p.From.IsZero() || !p.To.IsZero()
@@ -190,10 +185,10 @@ func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams)
 		toStr = p.To.Format("2006-01-02")
 	}
 
-	rows, err := s.q.ListJournalsFiltered(ctx, storage.ListJournalsFilteredParams{
+	rows, err := s.q.ListJournalsFiltered(ctx, storage.JournalFilterParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
-		HideCancelled:  hideCancelled,
+		HideCancelled:  p.HideCancelled,
 		FromDate:       fromStr,
 		ToDate:         toStr,
 		IncludeDeleted: p.IncludeDeleted,
@@ -207,10 +202,10 @@ func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams)
 		result = append(result, journalFromRow(row))
 	}
 
-	recurringRows, err := s.q.ListRecurringJournalsFiltered(ctx, storage.ListRecurringJournalsFilteredParams{
+	recurringRows, err := s.q.ListRecurringJournalsFiltered(ctx, storage.JournalFilterParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
-		HideCancelled:  hideCancelled,
+		HideCancelled:  p.HideCancelled,
 		IncludeDeleted: p.IncludeDeleted,
 	})
 	if err != nil {

--- a/internal/recurrence/list_todos.go
+++ b/internal/recurrence/list_todos.go
@@ -256,11 +256,6 @@ type TodoListParams struct {
 // range is provided, recurring todos are expanded. Otherwise master entries
 // are returned as-is.
 func (s *Service) ListFilteredTodos(ctx context.Context, p TodoListParams) ([]todo.Todo, error) {
-	hideCompleted := int64(0)
-	if p.HideCompleted {
-		hideCompleted = 1
-	}
-
 	fromStr := ""
 	toStr := ""
 	hasRange := !p.From.IsZero() || !p.To.IsZero()
@@ -271,10 +266,10 @@ func (s *Service) ListFilteredTodos(ctx context.Context, p TodoListParams) ([]to
 		toStr = p.To.Format("2006-01-02")
 	}
 
-	rows, err := s.q.ListTodosFiltered(ctx, storage.ListTodosFilteredParams{
+	rows, err := s.q.ListTodosFiltered(ctx, storage.TodoFilterParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
-		HideCompleted:  hideCompleted,
+		HideCompleted:  p.HideCompleted,
 		FromDate:       fromStr,
 		ToDate:         toStr,
 		IncludeDeleted: p.IncludeDeleted,
@@ -288,10 +283,10 @@ func (s *Service) ListFilteredTodos(ctx context.Context, p TodoListParams) ([]to
 		result = append(result, todoFromRow(row))
 	}
 
-	recurringRows, err := s.q.ListRecurringTodosFiltered(ctx, storage.ListRecurringTodosFilteredParams{
+	recurringRows, err := s.q.ListRecurringTodosFiltered(ctx, storage.TodoFilterParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
-		HideCompleted:  hideCompleted,
+		HideCompleted:  p.HideCompleted,
 		IncludeDeleted: p.IncludeDeleted,
 	})
 	if err != nil {

--- a/internal/storage/fts.go
+++ b/internal/storage/fts.go
@@ -60,7 +60,7 @@ func (q *Queries) SearchEventsFTS(ctx context.Context, query string, calendarID 
 	return q.queryEvents(ctx, where, args, "start_time ASC")
 }
 
-func (q *Queries) SearchTodosFTS(ctx context.Context, query string, calendarID int64, filterStatus string, completedFilter int64) ([]Todo, error) {
+func (q *Queries) SearchTodosFTS(ctx context.Context, query string, calendarID int64, filterStatus string, completedFilter CompletedFilter) ([]Todo, error) {
 	var w whereBuilder
 	w.addSoftDeleteFilter(false, false)
 	w.add("id IN (SELECT rowid FROM todos_fts WHERE todos_fts MATCH ?)", query)
@@ -70,9 +70,10 @@ func (q *Queries) SearchTodosFTS(ctx context.Context, query string, calendarID i
 	if filterStatus != "" {
 		w.add("status = ?", filterStatus)
 	}
-	if completedFilter == 1 {
+	switch completedFilter {
+	case CompletedOnly:
 		w.add("completed_at IS NOT NULL")
-	} else if completedFilter == 2 {
+	case OpenOnly:
 		w.add("completed_at IS NULL")
 	}
 	where, args := w.build()

--- a/internal/storage/journals_dynamic.go
+++ b/internal/storage/journals_dynamic.go
@@ -39,6 +39,10 @@ func (w *whereBuilder) addJournalFilters(arg JournalFilterParams) {
 	if arg.HideCancelled {
 		w.add("status != 'CANCELLED'")
 	}
+	// FromDate and ToDate form the half-open range [FromDate, ToDate).
+	// The filter includes a journal dated on FromDate. The filter
+	// excludes a journal dated on ToDate. A journal with no start date
+	// passes the filter.
 	if arg.FromDate != "" {
 		w.add("(start_date IS NULL OR start_date >= ?)", arg.FromDate)
 	}

--- a/internal/storage/journals_dynamic.go
+++ b/internal/storage/journals_dynamic.go
@@ -4,95 +4,70 @@ import "context"
 
 const journalCategoryExists = "EXISTS (SELECT 1 FROM journal_categories jc WHERE jc.journal_id = journals.id AND jc.category = ?)"
 
-// addJournalListFilters appends the calendar / status / hide-cancelled clauses
-// shared verbatim by ListJournalsFiltered and ListRecurringJournalsFiltered, in
-// the same order so positional args line up.
-func (w *whereBuilder) addJournalListFilters(calendarID int64, filterStatus string, hideCancelled int64) {
-	if calendarID != 0 {
-		w.add("calendar_id = ?", calendarID)
-	}
-	if filterStatus != "" {
-		w.add("status = ?", filterStatus)
-	}
-	if hideCancelled != 0 {
-		w.add("status != 'CANCELLED'")
-	}
-}
-
-type ListJournalsFilteredParams struct {
-	CalendarID     int64
-	FilterStatus   string
-	HideCancelled  int64
-	FromDate       string
-	ToDate         string
+// JournalFilterParams holds optional filters for journal queries.
+// Zero values mean "no filter" for that field.
+type JournalFilterParams struct {
+	CalendarID   int64
+	FilterStatus string
+	Category     string
+	// HideCancelled, when true, hides CANCELLED journals.
+	HideCancelled bool
+	FromDate      string
+	ToDate        string
+	// IncludeDeleted, when true, omits the default `deleted_at IS NULL`
+	// filter. Callers that need to see soft-deleted rows (trash views,
+	// --include-deleted flag) set this to true.
 	IncludeDeleted bool
-	DeletedOnly    bool
+	// DeletedOnly, when true, inverts the default filter to
+	// `deleted_at IS NOT NULL`. Implies IncludeDeleted.
+	DeletedOnly bool
 }
 
-func (q *Queries) ListJournalsFiltered(ctx context.Context, arg ListJournalsFilteredParams) ([]Journal, error) {
-	var w whereBuilder
-	// Non-recurring, non-RDATE-only masters (RDATE-only handled by ListRecurringJournalsFiltered).
-	w.add("recurrence_rule IS NULL AND (rdates IS NULL OR rdates = '') AND recurrence_id = ''")
-	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	w.addJournalListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCancelled)
-	if arg.FromDate != "" {
-		w.add("(start_date IS NULL OR start_date >= ?)", arg.FromDate)
-	}
-	if arg.ToDate != "" {
-		w.add("(start_date IS NULL OR start_date < ?)", arg.ToDate)
-	}
-	where, args := w.build()
-	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
-}
-
-type ListRecurringJournalsFilteredParams struct {
-	CalendarID     int64
-	FilterStatus   string
-	HideCancelled  int64
-	IncludeDeleted bool
-	DeletedOnly    bool
-}
-
-func (q *Queries) ListRecurringJournalsFiltered(ctx context.Context, arg ListRecurringJournalsFilteredParams) ([]Journal, error) {
-	var w whereBuilder
-	// RRULE masters and RDATE-only masters (no RRULE but has RDATEs); both need expansion.
-	w.add("(recurrence_rule IS NOT NULL OR (rdates IS NOT NULL AND rdates != '')) AND recurrence_id = ''")
-	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	w.addJournalListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCancelled)
-	where, args := w.build()
-	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
-}
-
-type ListJournalsForExportParams struct {
-	CalendarID     int64
-	Category       string
-	FilterStatus   string
-	FromDate       string
-	ToDate         string
-	IncludeDeleted bool
-	DeletedOnly    bool
-}
-
-func (q *Queries) ListJournalsForExport(ctx context.Context, arg ListJournalsForExportParams) ([]Journal, error) {
-	var w whereBuilder
+// addJournalFilters appends the soft-delete, calendar, status, category, and
+// date clauses shared by every journal query, in one fixed order.
+func (w *whereBuilder) addJournalFilters(arg JournalFilterParams) {
 	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}
-	if arg.Category != "" {
-		w.add(journalCategoryExists, arg.Category)
-	}
 	if arg.FilterStatus != "" {
 		w.add("status = ?", arg.FilterStatus)
 	}
-	// Match the half-open [from, to) date semantics used by
-	// ListJournalsFiltered; dateless journals pass the filter (NULL stays in).
+	if arg.Category != "" {
+		w.add(journalCategoryExists, arg.Category)
+	}
+	if arg.HideCancelled {
+		w.add("status != 'CANCELLED'")
+	}
 	if arg.FromDate != "" {
 		w.add("(start_date IS NULL OR start_date >= ?)", arg.FromDate)
 	}
 	if arg.ToDate != "" {
 		w.add("(start_date IS NULL OR start_date < ?)", arg.ToDate)
 	}
+}
+
+func (q *Queries) ListJournalsFiltered(ctx context.Context, arg JournalFilterParams) ([]Journal, error) {
+	var w whereBuilder
+	// Non-recurring, non-RDATE-only masters (RDATE-only handled by ListRecurringJournalsFiltered).
+	w.add("recurrence_rule IS NULL AND (rdates IS NULL OR rdates = '') AND recurrence_id = ''")
+	w.addJournalFilters(arg)
+	where, args := w.build()
+	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
+}
+
+func (q *Queries) ListRecurringJournalsFiltered(ctx context.Context, arg JournalFilterParams) ([]Journal, error) {
+	var w whereBuilder
+	// RRULE masters and RDATE-only masters (no RRULE but has RDATEs); both need expansion.
+	w.add("(recurrence_rule IS NOT NULL OR (rdates IS NOT NULL AND rdates != '')) AND recurrence_id = ''")
+	w.addJournalFilters(arg)
+	where, args := w.build()
+	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
+}
+
+func (q *Queries) ListJournalsForExport(ctx context.Context, arg JournalFilterParams) ([]Journal, error) {
+	var w whereBuilder
+	w.addJournalFilters(arg)
 	where, args := w.build()
 	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
 }

--- a/internal/storage/scan_alignment_test.go
+++ b/internal/storage/scan_alignment_test.go
@@ -55,7 +55,7 @@ func TestScanColumnAlignment(t *testing.T) {
 	}
 
 	// Query todos using dynamic function (SELECT * + scanTodos)
-	todos, err := q.ListTodosForExport(ctx, ListTodosForExportParams{CalendarID: calID})
+	todos, err := q.ListTodosForExport(ctx, TodoFilterParams{CalendarID: calID})
 	if err != nil {
 		t.Fatalf("query todos: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestScanColumnAlignment(t *testing.T) {
 	}
 
 	// Query journals using dynamic function (SELECT * + scanJournals)
-	journals, err := q.ListJournalsForExport(ctx, ListJournalsForExportParams{CalendarID: calID})
+	journals, err := q.ListJournalsForExport(ctx, JournalFilterParams{CalendarID: calID})
 	if err != nil {
 		t.Fatalf("query journals: %v", err)
 	}

--- a/internal/storage/todos_dynamic.go
+++ b/internal/storage/todos_dynamic.go
@@ -4,6 +4,19 @@ import "context"
 
 const todoCategoryExists = "EXISTS (SELECT 1 FROM todo_categories tc WHERE tc.todo_id = todos.id AND tc.category = ?)"
 
+// CompletedFilter selects todos by completion state. The zero value
+// (CompletionAny) adds no clause.
+type CompletedFilter int64
+
+const (
+	// CompletionAny keeps completed and open todos.
+	CompletionAny CompletedFilter = iota
+	// CompletedOnly keeps todos with a completion time.
+	CompletedOnly
+	// OpenOnly keeps todos without a completion time.
+	OpenOnly
+)
+
 // TodoFilterParams holds optional filters for todo queries.
 // Zero values mean "no filter" for that field.
 type TodoFilterParams struct {
@@ -12,9 +25,9 @@ type TodoFilterParams struct {
 	Category     string
 	// HideCompleted, when true, hides COMPLETED and CANCELLED todos.
 	HideCompleted bool
-	// CompletedFilter selects rows by completed_at. The value 1 keeps
-	// only completed todos, and the value 2 keeps only open todos.
-	CompletedFilter int64
+	// CompletedFilter selects rows by completed_at. CompletedOnly keeps
+	// only completed todos, and OpenOnly keeps only open todos.
+	CompletedFilter CompletedFilter
 	FromDate        string
 	ToDate          string
 	// IncludeDeleted, when true, omits the default `deleted_at IS NULL`
@@ -42,11 +55,15 @@ func (w *whereBuilder) addTodoFilters(arg TodoFilterParams) {
 	if arg.HideCompleted {
 		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
 	}
-	if arg.CompletedFilter == 1 {
+	switch arg.CompletedFilter {
+	case CompletedOnly:
 		w.add("completed_at IS NOT NULL")
-	} else if arg.CompletedFilter == 2 {
+	case OpenOnly:
 		w.add("completed_at IS NULL")
 	}
+	// FromDate and ToDate form the half-open range [FromDate, ToDate).
+	// The filter includes a todo due on FromDate. The filter excludes a
+	// todo due on ToDate. A todo with no due date passes the filter.
 	if arg.FromDate != "" {
 		w.add("(due_date IS NULL OR due_date >= ?)", arg.FromDate)
 	}

--- a/internal/storage/todos_dynamic.go
+++ b/internal/storage/todos_dynamic.go
@@ -4,101 +4,78 @@ import "context"
 
 const todoCategoryExists = "EXISTS (SELECT 1 FROM todo_categories tc WHERE tc.todo_id = todos.id AND tc.category = ?)"
 
-// addTodoListFilters appends the calendar / status / hide-completed clauses
-// shared verbatim by ListTodosFiltered and ListRecurringTodosFiltered, in the
-// same order so positional args line up.
-func (w *whereBuilder) addTodoListFilters(calendarID int64, filterStatus string, hideCompleted int64) {
-	if calendarID != 0 {
-		w.add("calendar_id = ?", calendarID)
-	}
-	if filterStatus != "" {
-		w.add("status = ?", filterStatus)
-	}
-	if hideCompleted != 0 {
-		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
-	}
-}
-
-type ListTodosFilteredParams struct {
-	CalendarID     int64
-	FilterStatus   string
-	HideCompleted  int64
-	FromDate       string
-	ToDate         string
-	IncludeDeleted bool
-	DeletedOnly    bool
-}
-
-func (q *Queries) ListTodosFiltered(ctx context.Context, arg ListTodosFilteredParams) ([]Todo, error) {
-	var w whereBuilder
-	// Non-recurring, non-RDATE-only masters (RDATE-only handled by ListRecurringTodosFiltered).
-	w.add("recurrence_rule IS NULL AND (rdates IS NULL OR rdates = '') AND recurrence_id = ''")
-	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	w.addTodoListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCompleted)
-	if arg.FromDate != "" {
-		w.add("(due_date IS NULL OR due_date >= ?)", arg.FromDate)
-	}
-	if arg.ToDate != "" {
-		w.add("(due_date IS NULL OR due_date < ?)", arg.ToDate)
-	}
-	where, args := w.build()
-	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
-}
-
-type ListRecurringTodosFilteredParams struct {
-	CalendarID     int64
-	FilterStatus   string
-	HideCompleted  int64
-	IncludeDeleted bool
-	DeletedOnly    bool
-}
-
-func (q *Queries) ListRecurringTodosFiltered(ctx context.Context, arg ListRecurringTodosFilteredParams) ([]Todo, error) {
-	var w whereBuilder
-	// RRULE masters and RDATE-only masters (no RRULE but has RDATEs); both need expansion.
-	w.add("(recurrence_rule IS NOT NULL OR (rdates IS NOT NULL AND rdates != '')) AND recurrence_id = ''")
-	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	w.addTodoListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCompleted)
-	where, args := w.build()
-	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
-}
-
-type ListTodosForExportParams struct {
-	CalendarID      int64
-	Category        string
-	FilterStatus    string
+// TodoFilterParams holds optional filters for todo queries.
+// Zero values mean "no filter" for that field.
+type TodoFilterParams struct {
+	CalendarID   int64
+	FilterStatus string
+	Category     string
+	// HideCompleted, when true, hides COMPLETED and CANCELLED todos.
+	HideCompleted bool
+	// CompletedFilter selects rows by completed_at. The value 1 keeps
+	// only completed todos, and the value 2 keeps only open todos.
 	CompletedFilter int64
 	FromDate        string
 	ToDate          string
-	IncludeDeleted  bool
-	DeletedOnly     bool
+	// IncludeDeleted, when true, omits the default `deleted_at IS NULL`
+	// filter. Callers that need to see soft-deleted rows (trash views,
+	// --include-deleted flag) set this to true.
+	IncludeDeleted bool
+	// DeletedOnly, when true, inverts the default filter to
+	// `deleted_at IS NOT NULL`. Implies IncludeDeleted.
+	DeletedOnly bool
 }
 
-func (q *Queries) ListTodosForExport(ctx context.Context, arg ListTodosForExportParams) ([]Todo, error) {
-	var w whereBuilder
+// addTodoFilters appends the soft-delete, calendar, status, category, and
+// date clauses shared by every todo query, in one fixed order.
+func (w *whereBuilder) addTodoFilters(arg TodoFilterParams) {
 	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}
+	if arg.FilterStatus != "" {
+		w.add("status = ?", arg.FilterStatus)
+	}
 	if arg.Category != "" {
 		w.add(todoCategoryExists, arg.Category)
 	}
-	if arg.FilterStatus != "" {
-		w.add("status = ?", arg.FilterStatus)
+	if arg.HideCompleted {
+		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
 	}
 	if arg.CompletedFilter == 1 {
 		w.add("completed_at IS NOT NULL")
 	} else if arg.CompletedFilter == 2 {
 		w.add("completed_at IS NULL")
 	}
-	// Match the half-open [from, to) date semantics used by
-	// ListTodosFiltered; dateless todos pass the filter (NULL stays in).
 	if arg.FromDate != "" {
 		w.add("(due_date IS NULL OR due_date >= ?)", arg.FromDate)
 	}
 	if arg.ToDate != "" {
 		w.add("(due_date IS NULL OR due_date < ?)", arg.ToDate)
 	}
+}
+
+func (q *Queries) ListTodosFiltered(ctx context.Context, arg TodoFilterParams) ([]Todo, error) {
+	var w whereBuilder
+	// Non-recurring, non-RDATE-only masters (RDATE-only handled by ListRecurringTodosFiltered).
+	w.add("recurrence_rule IS NULL AND (rdates IS NULL OR rdates = '') AND recurrence_id = ''")
+	w.addTodoFilters(arg)
+	where, args := w.build()
+	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
+}
+
+func (q *Queries) ListRecurringTodosFiltered(ctx context.Context, arg TodoFilterParams) ([]Todo, error) {
+	var w whereBuilder
+	// RRULE masters and RDATE-only masters (no RRULE but has RDATEs); both need expansion.
+	w.add("(recurrence_rule IS NOT NULL OR (rdates IS NOT NULL AND rdates != '')) AND recurrence_id = ''")
+	w.addTodoFilters(arg)
+	where, args := w.build()
+	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
+}
+
+func (q *Queries) ListTodosForExport(ctx context.Context, arg TodoFilterParams) ([]Todo, error) {
+	var w whereBuilder
+	w.addTodoFilters(arg)
 	where, args := w.build()
 	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
 }

--- a/internal/todo/search_test.go
+++ b/internal/todo/search_test.go
@@ -61,7 +61,7 @@ func TestService_Search(t *testing.T) {
 		{"summary and description match", SearchParams{Query: "budget"}, 2},
 		{"category match", SearchParams{Query: "personal"}, 2},
 		{"no results", SearchParams{Query: "nonexistent"}, 0},
-		{"filter incomplete only", SearchParams{Query: "budget", Completed: 2}, 2},
+		{"filter incomplete only", SearchParams{Query: "budget", Completed: storage.OpenOnly}, 2},
 	}
 
 	for _, tt := range tests {
@@ -138,7 +138,7 @@ func TestService_ExportFiltered(t *testing.T) {
 	}{
 		{"export all", ExportParams{}, 2},
 		{"export by category", ExportParams{Category: "work"}, 1},
-		{"export incomplete only", ExportParams{Completed: 2}, 2},
+		{"export incomplete only", ExportParams{Completed: storage.OpenOnly}, 2},
 	}
 
 	for _, tt := range tests {

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -252,7 +252,7 @@ func (s *Service) Search(ctx context.Context, p SearchParams) ([]Todo, error) {
 }
 
 func (s *Service) ExportFiltered(ctx context.Context, p ExportParams) ([]Todo, error) {
-	rows, err := s.q.ListTodosForExport(ctx, storage.ListTodosForExportParams{
+	rows, err := s.q.ListTodosForExport(ctx, storage.TodoFilterParams{
 		CalendarID:      p.CalendarID,
 		FromDate:        p.From,
 		ToDate:          p.To,

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -20,7 +20,7 @@ type SearchParams struct {
 	Query      string
 	CalendarID int64  // 0 = all
 	Status     string // empty = all
-	Completed  int    // 0 = all, 1 = completed only, 2 = incomplete only
+	Completed  storage.CompletedFilter
 }
 
 type ExportParams struct {
@@ -29,7 +29,7 @@ type ExportParams struct {
 	To         string // date-only ("YYYY-MM-DD") or empty
 	Category   string // empty = all
 	Status     string // empty = all
-	Completed  int    // 0 = all, 1 = completed, 2 = incomplete
+	Completed  storage.CompletedFilter
 }
 
 type Service struct {
@@ -242,7 +242,7 @@ func (s *Service) Search(ctx context.Context, p SearchParams) ([]Todo, error) {
 	if ftsQuery == "" {
 		return nil, nil
 	}
-	rows, err := s.q.SearchTodosFTS(ctx, ftsQuery, p.CalendarID, p.Status, int64(p.Completed))
+	rows, err := s.q.SearchTodosFTS(ctx, ftsQuery, p.CalendarID, p.Status, p.Completed)
 	if err != nil {
 		return nil, fmt.Errorf("search todos: %w", err)
 	}
@@ -258,7 +258,7 @@ func (s *Service) ExportFiltered(ctx context.Context, p ExportParams) ([]Todo, e
 		ToDate:          p.To,
 		Category:        p.Category,
 		FilterStatus:    p.Status,
-		CompletedFilter: int64(p.Completed),
+		CompletedFilter: p.Completed,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("export todos: %w", err)


### PR DESCRIPTION
## Problem
The todo and journal dynamic queries each carried three per-function params structs and positional filter helpers, while the events queries use one `EventFilterParams` struct and one `addEventFilters` method. The idioms drifted: `ListTodosForExport` and `ListJournalsForExport` built their clauses by hand and skipped the shared helpers.

## Evidence
`internal/storage/todos_dynamic.go` and `journals_dynamic.go` defined `List*FilteredParams`, `ListRecurring*FilteredParams`, and `List*ForExportParams` plus `addTodoListFilters`/`addJournalListFilters(calendarID, filterStatus, hideFlag)` positional helpers; the export functions re-inlined every clause.

## Fix
- One `TodoFilterParams` and one `JournalFilterParams` struct per domain, mirroring `EventFilterParams`.
- All clauses route through `addTodoFilters`/`addJournalFilters`, including the export paths; positional helpers deleted.
- `HideCompleted`/`HideCancelled` become `bool`, so the recurrence services drop their zero-or-one conversions.
- Callers updated: `internal/recurrence/list_todos.go`, `internal/recurrence/list_journals.go`, `internal/todo/service.go`, `internal/journal/search.go`, `internal/storage/scan_alignment_test.go` (struct rename only).

Clause sets and result rows stay identical for every existing caller (zero values add no clause).

## Verification
- `go test ./internal/storage/ ./internal/recurrence/ ./internal/todo/ ./internal/journal/` — all green, storage-layer tests unchanged apart from the intentional struct renames.
- `gofmt -l` clean; `go build ./...` clean.

Stacked on #691.