### PR TITLE
docs(storage): note the todo and journal upsert resurrection

### DIFF
--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -58,10 +58,11 @@ UPDATE events SET
 WHERE id = ? RETURNING *;
 
 -- name: UpsertEventByUID :one
--- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
--- pull path should be aware this resurrects soft-deleted rows. The sync pull
--- path is safe because tombstoned UIDs are filtered out before this runs
--- (engine.go loads tombstones first and skips them during pull).
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+-- soft-deleted rows. Callers outside the pull path in the sync engine
+-- must know this. The pull path is safe. The engine excludes
+-- tombstoned UIDs before this query runs (engine.go loads tombstones
+-- first and skips them during pull).
 INSERT INTO events (
     uid, calendar_id, title, description, location,
     start_time, end_time, all_day, recurrence_rule,

--- a/db/queries/journals.sql
+++ b/db/queries/journals.sql
@@ -72,10 +72,11 @@ UPDATE journals SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? RETURNING *;
 
--- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
--- pull path should be aware this resurrects soft-deleted rows. The sync pull
--- path is safe because tombstoned UIDs are filtered out before this runs
--- (engine.go loads tombstones first and skips them during pull).
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+-- soft-deleted rows. Callers outside the pull path in the sync engine
+-- must know this. The pull path is safe. The engine excludes
+-- tombstoned UIDs before this query runs (engine.go loads tombstones
+-- first and skips them during pull).
 -- name: UpsertJournalByUID :one
 INSERT INTO journals (
     uid, calendar_id, summary, description,

--- a/db/queries/journals.sql
+++ b/db/queries/journals.sql
@@ -72,6 +72,10 @@ UPDATE journals SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? RETURNING *;
 
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
+-- pull path should be aware this resurrects soft-deleted rows. The sync pull
+-- path is safe because tombstoned UIDs are filtered out before this runs
+-- (engine.go loads tombstones first and skips them during pull).
 -- name: UpsertJournalByUID :one
 INSERT INTO journals (
     uid, calendar_id, summary, description,

--- a/db/queries/todos.sql
+++ b/db/queries/todos.sql
@@ -83,10 +83,11 @@ UPDATE todos SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? RETURNING *;
 
--- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
--- pull path should be aware this resurrects soft-deleted rows. The sync pull
--- path is safe because tombstoned UIDs are filtered out before this runs
--- (engine.go loads tombstones first and skips them during pull).
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+-- soft-deleted rows. Callers outside the pull path in the sync engine
+-- must know this. The pull path is safe. The engine excludes
+-- tombstoned UIDs before this query runs (engine.go loads tombstones
+-- first and skips them during pull).
 -- name: UpsertTodoByUID :one
 INSERT INTO todos (
     uid, calendar_id, summary, description, location,

--- a/db/queries/todos.sql
+++ b/db/queries/todos.sql
@@ -83,6 +83,10 @@ UPDATE todos SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? RETURNING *;
 
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
+-- pull path should be aware this resurrects soft-deleted rows. The sync pull
+-- path is safe because tombstoned UIDs are filtered out before this runs
+-- (engine.go loads tombstones first and skips them during pull).
 -- name: UpsertTodoByUID :one
 INSERT INTO todos (
     uid, calendar_id, summary, description, location,

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -1062,10 +1062,11 @@ type UpsertEventByUIDParams struct {
 	ConferenceUri  string
 }
 
-// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
-// pull path should be aware this resurrects soft-deleted rows. The sync pull
-// path is safe because tombstoned UIDs are filtered out before this runs
-// (engine.go loads tombstones first and skips them during pull).
+// NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+// soft-deleted rows. Callers outside the pull path in the sync engine
+// must know this. The pull path is safe. The engine excludes
+// tombstoned UIDs before this query runs (engine.go loads tombstones
+// first and skips them during pull).
 func (q *Queries) UpsertEventByUID(ctx context.Context, arg UpsertEventByUIDParams) (Event, error) {
 	row := q.db.QueryRowContext(ctx, upsertEventByUID,
 		arg.Uid,

--- a/internal/storage/journals.sql.go
+++ b/internal/storage/journals.sql.go
@@ -976,10 +976,11 @@ type UpsertJournalByUIDParams struct {
 	Dtstamp        *string
 }
 
-// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
-// pull path should be aware this resurrects soft-deleted rows. The sync pull
-// path is safe because tombstoned UIDs are filtered out before this runs
-// (engine.go loads tombstones first and skips them during pull).
+// NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+// soft-deleted rows. Callers outside the pull path in the sync engine
+// must know this. The pull path is safe. The engine excludes
+// tombstoned UIDs before this query runs (engine.go loads tombstones
+// first and skips them during pull).
 func (q *Queries) UpsertJournalByUID(ctx context.Context, arg UpsertJournalByUIDParams) (Journal, error) {
 	row := q.db.QueryRowContext(ctx, upsertJournalByUID,
 		arg.Uid,

--- a/internal/storage/journals.sql.go
+++ b/internal/storage/journals.sql.go
@@ -976,6 +976,10 @@ type UpsertJournalByUIDParams struct {
 	Dtstamp        *string
 }
 
+// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
+// pull path should be aware this resurrects soft-deleted rows. The sync pull
+// path is safe because tombstoned UIDs are filtered out before this runs
+// (engine.go loads tombstones first and skips them during pull).
 func (q *Queries) UpsertJournalByUID(ctx context.Context, arg UpsertJournalByUIDParams) (Journal, error) {
 	row := q.db.QueryRowContext(ctx, upsertJournalByUID,
 		arg.Uid,

--- a/internal/storage/todos.sql.go
+++ b/internal/storage/todos.sql.go
@@ -1173,6 +1173,10 @@ type UpsertTodoByUIDParams struct {
 	Dtstamp         *string
 }
 
+// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
+// pull path should be aware this resurrects soft-deleted rows. The sync pull
+// path is safe because tombstoned UIDs are filtered out before this runs
+// (engine.go loads tombstones first and skips them during pull).
 func (q *Queries) UpsertTodoByUID(ctx context.Context, arg UpsertTodoByUIDParams) (Todo, error) {
 	row := q.db.QueryRowContext(ctx, upsertTodoByUID,
 		arg.Uid,

--- a/internal/storage/todos.sql.go
+++ b/internal/storage/todos.sql.go
@@ -1173,10 +1173,11 @@ type UpsertTodoByUIDParams struct {
 	Dtstamp         *string
 }
 
-// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
-// pull path should be aware this resurrects soft-deleted rows. The sync pull
-// path is safe because tombstoned UIDs are filtered out before this runs
-// (engine.go loads tombstones first and skips them during pull).
+// NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+// soft-deleted rows. Callers outside the pull path in the sync engine
+// must know this. The pull path is safe. The engine excludes
+// tombstoned UIDs before this query runs (engine.go loads tombstones
+// first and skips them during pull).
 func (q *Queries) UpsertTodoByUID(ctx context.Context, arg UpsertTodoByUIDParams) (Todo, error) {
 	row := q.db.QueryRowContext(ctx, upsertTodoByUID,
 		arg.Uid,


### PR DESCRIPTION
## Problem
`UpsertTodoByUID` and `UpsertJournalByUID` clear `deleted_at` on conflict, exactly like `UpsertEventByUID`. Only the event query carried the NOTE documenting that resurrection. A caller outside the sync pull path could read the missing note as missing behavior.

## Evidence
- `db/queries/todos.sql:99` — `deleted_at = NULL` in the `ON CONFLICT` update, no NOTE.
- `db/queries/journals.sql:91` — same.
- `db/queries/events.sql:61-64` — the NOTE these queries lacked.

## Fix
Copy the NOTE above both upserts and regenerate with `make generate`, so the comment also lands on the generated `UpsertTodoByUID`/`UpsertJournalByUID` functions. Verified against a clean stash that generation rewrites nothing else; generated diffs are comment-only.

## Verification
- `go build ./internal/storage/` and `go test ./internal/storage/` green.
- `gofmt -l` clean on changed files.