### PR TITLE
fix(tui): make the default dark form label readable

### DIFF
--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -214,6 +214,31 @@ func TestResolveStringWithoutPaletteKeepsContrastPolarity(t *testing.T) {
 	})
 }
 
+// The default theme's form_label must read on its surface in both
+// polarities. A flat "240" (#585858) gave 6.8:1 on the light surface
+// #F9FAFB but only 2.49:1 on the dark surface #111827.
+func TestDefaultThemeFormLabelContrast(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		dark bool
+		min  float64
+	}{
+		{false, 6.8}, // light keeps ANSI 240: 6.81:1 on #F9FAFB
+		{true, 4.5},  // dark takes ANSI 245: 5.14:1 on #111827
+	}
+	for _, tc := range cases {
+		th, err := LoadBuiltinTheme("default", tc.dark)
+		if err != nil {
+			t.Fatalf("LoadBuiltinTheme(default, dark=%v): %v", tc.dark, err)
+		}
+		if ratio := oklch.ContrastRatio(th.Surface, th.FormLabel); ratio < tc.min {
+			t.Errorf("dark=%v: form_label reads %.2f:1 on the surface, want >= %.1f:1",
+				tc.dark, ratio, tc.min)
+		}
+	}
+}
+
 func TestAutoSentinelDerivesFromTextAndSurface(t *testing.T) {
 	// Force palette so "7" and "0" resolve to known hex values.
 	prev := ActivePalette()

--- a/internal/tui/themes/default.toml
+++ b/internal/tui/themes/default.toml
@@ -46,7 +46,10 @@ badge_neutral = "240"
 # Form internals
 # ---------------------------------------------------------------------------
 
-form_label     = "240"
+# Labels must read on the surface below them. Flat "240" (#585858) gives
+# 6.8:1 on the light surface #F9FAFB but only 2.5:1 on the dark surface
+# #111827. Keep 240 for light. Use 245 (#8a8a8a, 5.1:1) for dark.
+form_label     = { light = "240", dark = "245" }
 form_required  = "9"
 form_error     = "9"
 form_highlight = "63"


### PR DESCRIPTION
## Problem
The default theme drew form labels in flat ANSI 240 (#585858) on both polarities. On the dark surface #111827 the label reads **2.49:1** — far under the 4.5:1 WCAG floor for body text (thermos G4).

## Evidence
`themes/default.toml`: `form_label = "240"`; measured with the `oklch.ContrastRatio` oracle from #690: #585858 on #111827 = 2.49:1 (light side was fine: 6.81:1 on #F9FAFB).

## Fix
Split into a light/dark variant table:
- light keeps `"240"` → 6.81:1 on #F9FAFB (unchanged);
- dark takes `"245"` (#8a8a8a) → **5.14:1** on #111827 — the dimmest xterm grayscale ramp entry that clears 4.5:1, so labels stay visually quiet.

## Verification
- New `TestDefaultThemeFormLabelContrast` (token-level): asserts ≥ 6.8:1 light and ≥ 4.5:1 dark against the theme's own resolved `Surface`.
- `go test ./internal/tui/... -count=1` — ok; `gofmt -l` clean.

Stacked on #696.

Assisted-by: opencode-zen:x-preview-f-free