### PR TITLE
refactor(tui): delete the unused Theme.Secondary token

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ Every key is also available as an environment variable (`CHRONCAL_` prefix, dots
 The TUI ships two built-in themes:
 
 - **`system`** (default) — Chrome (text, borders, surfaces, dim text) inherits the terminal ANSI palette (`color0..15`). The TUI then follows themed terminal setups such as [Omarchy](https://learn.omacom.io/2/the-omarchy-manual/52/themes), Catppuccin, Gruvbox, Tokyo Night, or any setup that paints the standard 16 colors. The row-selection highlight adapts to the live terminal background via OSC 11. Accent colors (buttons, badges, "today", errors) sit on a fixed Dracula palette. Text-on-accent contrast then stays guaranteed across themes.
-- **`default`** — Fixed designer palette (violet primary, sky secondary, emerald accent) with light and dark variants. This theme ignores the terminal palette. Pick this if you do not theme your terminal, or if you want the same look on every machine.
+- **`default`** — Fixed designer palette (violet primary, emerald accent) with light and dark variants. This theme ignores the terminal palette. Pick this if you do not theme your terminal, or if you want the same look on every machine.
 
 Override with `ui.theme = "default"` in `config.toml` or
 `CHRONCAL_UI_THEME=default`.

--- a/internal/tui/calendar_manager_view.go
+++ b/internal/tui/calendar_manager_view.go
@@ -159,7 +159,6 @@ func fingerprintTheme(t Theme) string {
 		fmt.Fprintf(&b, "|%d,%d,%d,%d;", r, g, bl, a)
 	}
 	fp("primary", t.Primary)
-	fp("secondary", t.Secondary)
 	fp("accent", t.Accent)
 	fp("muted", t.Muted)
 	fp("text", t.Text)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -23,15 +23,14 @@ const DefaultThemeName = "system"
 // Do not hunt hardcoded values.
 type Theme struct {
 	// Structural chrome
-	Primary   color.Color
-	Secondary color.Color
-	Accent    color.Color
-	Muted     color.Color
-	Text      color.Color
-	TextDim   color.Color
-	Border    color.Color
-	Today     color.Color
-	Selected  color.Color
+	Primary  color.Color
+	Accent   color.Color
+	Muted    color.Color
+	Text     color.Color
+	TextDim  color.Color
+	Border   color.Color
+	Today    color.Color
+	Selected color.Color
 	// SelectedText is the foreground color to use when painting text on
 	// top of Selected. On themes where Selected and Text may converge
 	// (e.g. Base16 system themes where both resolve to dark indices),

--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -28,7 +28,6 @@ type rawTheme struct {
 
 	// Structural chrome.
 	Primary      any `toml:"primary"`
-	Secondary    any `toml:"secondary"`
 	Accent       any `toml:"accent"`
 	Muted        any `toml:"muted"`
 	Text         any `toml:"text"`
@@ -267,7 +266,6 @@ func resolveTheme(r *rawTheme, hasDarkBG bool) (Theme, error) {
 
 	t := Theme{
 		Primary:      pick("primary", r.Primary),
-		Secondary:    pick("secondary", r.Secondary),
 		Accent:       pick("accent", r.Accent),
 		Muted:        pick("muted", r.Muted),
 		Text:         pick("text", r.Text),

--- a/internal/tui/themes/default.toml
+++ b/internal/tui/themes/default.toml
@@ -18,7 +18,6 @@ description = "Default tcal theme — structural chrome adapts to terminal backg
 # ---------------------------------------------------------------------------
 
 primary   = { light = "#7C3AED", dark = "#A78BFA" }
-secondary = { light = "#0284C7", dark = "#38BDF8" }
 accent    = { light = "#059669", dark = "#34D399" }
 muted     = { light = "#9CA3AF", dark = "#6B7280" }
 text      = { light = "#1F2937", dark = "#F9FAFB" }

--- a/internal/tui/themes/system.toml
+++ b/internal/tui/themes/system.toml
@@ -68,7 +68,6 @@ selected_text = "7"   # base05 reads on a neutral gray on both modes
 # ---------------------------------------------------------------------------
 
 primary   = "4"   # base0D blue — brand accent (calendar selected cell border)
-secondary = "6"   # base0C cyan
 accent    = "2"   # base0B green — positive actions
 today     = "1"   # base08 red — "now line", today indicator
 error     = "1"   # base08 red

--- a/internal/tui/themes/system.toml
+++ b/internal/tui/themes/system.toml
@@ -25,7 +25,7 @@
 #
 #   0 base00  background           4 base0D  blue   (primary accent)
 #   1 base08  red    (danger)      5 base0E  magenta (focus highlight)
-#   2 base0B  green  (positive)    6 base0C  cyan   (secondary accent)
+#   2 base0B  green  (positive)    6 base0C  cyan   (cyan accent)
 #   3 base0A  yellow (warning)     7 base05  default foreground
 #   8 base03  comment/dim         15 base07  inverted bg / brightest
 #


### PR DESCRIPTION
## Problem
`Theme.Secondary` was load-required but rendered nowhere (thermos G5). Every theme file carried a `secondary` key, the loader decoded and resolved it, and `fingerprintTheme` hashed it — yet no render path ever read it. Dead config surface: theme authors must set a color the UI ignores.

## Evidence
Repo-wide grep: the only `Secondary` references were the struct field (styles.go), the rawTheme decode + `pick` (theme_loader.go), the fingerprint entry (calendar_manager_view.go), and the two TOML keys. Zero render-path reads. Remaining "secondary" matches are unrelated prose ("secondary actions", "secondary buttons").

## Fix
Deleted all six references: struct field, rawTheme field, resolve pick, fingerprint line, and the `secondary` keys in `default.toml` and `system.toml`. The Base16 header comment in system.toml stays — it documents ANSI slot 6, which `badge_info` still references.

## Verification
- `go build ./...` — clean (no other package referenced the token).
- `go test ./internal/tui/... -count=1` — ok; `gofmt -l` clean.

Stacked on #697.

Assisted-by: opencode-zen:x-preview-f-free