### PR TITLE
fix(event): reject zero and negative --duration

### DIFF
--- a/cmd/chroncal/event_add.go
+++ b/cmd/chroncal/event_add.go
@@ -219,6 +219,9 @@ Alarms default to ACTION=DISPLAY unless prefixed (e.g. EMAIL:-PT1H).`,
 					if err != nil {
 						return err
 					}
+					if dur <= 0 {
+						return errInvalidInputf("--duration must be positive (e.g. 30m, 1h), got %q", durationStr)
+					}
 				}
 				endTime = startTime.Add(dur)
 			}

--- a/cmd/chroncal/event_add.go
+++ b/cmd/chroncal/event_add.go
@@ -219,8 +219,8 @@ Alarms default to ACTION=DISPLAY unless prefixed (e.g. EMAIL:-PT1H).`,
 					if err != nil {
 						return err
 					}
-					if dur <= 0 {
-						return errInvalidInputf("--duration must be positive (e.g. 30m, 1h), got %q", durationStr)
+					if err := mustPositiveDuration("duration", durationStr, dur); err != nil {
+						return err
 					}
 				}
 				endTime = startTime.Add(dur)

--- a/cmd/chroncal/event_cli_test.go
+++ b/cmd/chroncal/event_cli_test.go
@@ -363,6 +363,57 @@ func TestNotFoundErrorJSONHasNoWrapPrefix(t *testing.T) {
 	}
 }
 
+// TestEventDurationMustBePositive guards the --duration end-after-start
+// contract. A zero or negative duration stored end <= start, an event no
+// view or exporter can represent. The end-time path already rejected it;
+// the duration path must reject it too, in add and update.
+func TestEventDurationMustBePositive(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	for _, dur := range []string{"0s", "-30m"} {
+		_, stderr, err := runChroncalCommand(t, "event", "add", "Standup",
+			"--calendar", "Work", "--date", "2026-04-06", "--time", "09:00",
+			"--duration", dur, "--output", "json")
+		if err == nil {
+			t.Fatalf("event add --duration %s was accepted", dur)
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("decode error payload %q: %v", stderr, jerr)
+		}
+		if payload.Code != "invalid_input" {
+			t.Fatalf("--duration %s: code = %q, want invalid_input", dur, payload.Code)
+		}
+	}
+
+	// A positive duration still works, and update rejects the same values.
+	if _, _, err := runChroncalCommand(t, "event", "add", "Standup",
+		"--calendar", "Work", "--date", "2026-04-06", "--time", "09:00",
+		"--duration", "30m"); err != nil {
+		t.Fatalf("event add --duration 30m: %v", err)
+	}
+	_, stderr, err := runChroncalCommand(t, "event", "update", "1", "--duration", "0s", "--output", "json")
+	if err == nil {
+		t.Fatal("event update --duration 0s was accepted")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error payload %q: %v", stderr, jerr)
+	}
+	if payload.Code != "invalid_input" {
+		t.Fatalf("event update --duration 0s: code = %q, want invalid_input", payload.Code)
+	}
+}
+
 // TestEventListJSONIncludesAttendees locks in that `event list --output json`
 // hydrates attendees the same way `event get` does. Chroncal Bar RSVP, the
 // participant filter, and participant search all read the list payload. They

--- a/cmd/chroncal/event_update.go
+++ b/cmd/chroncal/event_update.go
@@ -255,8 +255,8 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				if err != nil {
 					return err
 				}
-				if dur <= 0 {
-					return errInvalidInputf("--duration must be positive (e.g. 30m, 1h), got %q", durationStr)
+				if err := mustPositiveDuration("duration", durationStr, dur); err != nil {
+					return err
 				}
 				p.EndTime = p.StartTime.Add(dur)
 			case cmd.Flags().Changed("date") || cmd.Flags().Changed("time"):

--- a/cmd/chroncal/event_update.go
+++ b/cmd/chroncal/event_update.go
@@ -255,6 +255,9 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				if err != nil {
 					return err
 				}
+				if dur <= 0 {
+					return errInvalidInputf("--duration must be positive (e.g. 30m, 1h), got %q", durationStr)
+				}
 				p.EndTime = p.StartTime.Add(dur)
 			case cmd.Flags().Changed("date") || cmd.Flags().Changed("time"):
 				if existing.AllDay && !p.AllDay {

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -494,3 +494,14 @@ func parseCLIDuration(flag, value string) (time.Duration, error) {
 	}
 	return d, nil
 }
+
+// mustPositiveDuration rejects a zero or negative duration after a
+// successful parseCLIDuration call. Pass the flag name without the leading
+// dashes and the raw flag value. The error names the flag and repeats the
+// value, tagged with code "invalid_input".
+func mustPositiveDuration(flag, raw string, d time.Duration) error {
+	if d <= 0 {
+		return errInvalidInputf("--%s must be positive (e.g. 30m, 1h), got %q", flag, raw)
+	}
+	return nil
+}


### PR DESCRIPTION
## Problem
`--duration -30m` or `0` stored events whose end precedes their start on both add and update paths.

## Fix
Reject durations that fail to produce an end after the start in `event add` and `event update`.

## Verification
Regression tests for zero and negative durations on both commands; package tests pass.

Assisted-by: opencode-zen:x-preview-f-free