### PR TITLE
fix(cli): reject an inverted --from/--to date range

### DIFF
--- a/cmd/chroncal/date_range_test.go
+++ b/cmd/chroncal/date_range_test.go
@@ -131,20 +131,28 @@ func TestParseExportDateBoundsNeither(t *testing.T) {
 // filtered out with no error. The same-day range stays valid because the
 // half-open end bound includes the whole --to day.
 func TestParseDateRangeRejectsInvertedRange(t *testing.T) {
-	_, _, err := parseDateRange("2026-05-10", "2026-05-01")
-	if err == nil {
-		t.Fatal("parseDateRange accepted --to before --from")
-	}
-	var ce *cliError
-	if !errors.As(err, &ce) || ce.Code != "invalid_input" {
-		t.Fatalf("error = %#v, want an invalid_input cliError", err)
-	}
-
-	if _, _, err := parseDateRange("2026-05-10", "2026-05-10"); err != nil {
-		t.Fatalf("same-day range must stay valid, got %v", err)
-	}
-	if _, _, err := parseDateRange("2026-05-10", ""); err != nil {
-		t.Fatalf("default upper bound must stay valid, got %v", err)
+	for _, tc := range []struct {
+		from, to string
+		wantErr  bool
+	}{
+		{"2026-05-10", "2026-05-01", true},  // to strictly before from
+		{"2026-05-10", "2026-05-09", true},  // to one day before from
+		{"2026-05-10", "2026-05-10", false}, // whole --to day included
+		{"2026-05-10", "", false},           // default upper bound
+	} {
+		_, _, err := parseDateRange(tc.from, tc.to)
+		if tc.wantErr && err == nil {
+			t.Fatalf("parseDateRange(%q, %q) accepted an inverted range", tc.from, tc.to)
+		}
+		if !tc.wantErr && err != nil {
+			t.Fatalf("parseDateRange(%q, %q) = %v, want valid", tc.from, tc.to, err)
+		}
+		if err != nil {
+			var ce *cliError
+			if !errors.As(err, &ce) || ce.Code != "invalid_input" {
+				t.Fatalf("error = %#v, want an invalid_input cliError", err)
+			}
+		}
 	}
 }
 

--- a/cmd/chroncal/date_range_test.go
+++ b/cmd/chroncal/date_range_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -122,6 +123,52 @@ func TestParseExportDateBoundsNeither(t *testing.T) {
 	}
 	if !from.IsZero() || !to.IsZero() {
 		t.Fatalf("both bounds must be zero when no flags given, got from=%s to=%s", from, to)
+	}
+}
+
+// TestParseDateRangeRejectsInvertedRange guards against a silent empty
+// window. --to before --from used to be accepted; every row was then
+// filtered out with no error. The same-day range stays valid because the
+// half-open end bound includes the whole --to day.
+func TestParseDateRangeRejectsInvertedRange(t *testing.T) {
+	_, _, err := parseDateRange("2026-05-10", "2026-05-01")
+	if err == nil {
+		t.Fatal("parseDateRange accepted --to before --from")
+	}
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "invalid_input" {
+		t.Fatalf("error = %#v, want an invalid_input cliError", err)
+	}
+
+	if _, _, err := parseDateRange("2026-05-10", "2026-05-10"); err != nil {
+		t.Fatalf("same-day range must stay valid, got %v", err)
+	}
+	if _, _, err := parseDateRange("2026-05-10", ""); err != nil {
+		t.Fatalf("default upper bound must stay valid, got %v", err)
+	}
+}
+
+// TestParseExportDateBoundsRejectsInvertedRange mirrors the guard above
+// for the export bounds parser. Both bounds must be set for the check to
+// run; a single bound keeps its open window (issue #358).
+func TestParseExportDateBoundsRejectsInvertedRange(t *testing.T) {
+	for _, tc := range []struct {
+		from, to string
+		wantErr  bool
+	}{
+		{"2026-05-10", "2026-05-01", true},  // to strictly before from
+		{"2026-05-10", "2026-05-09", true},  // to one day before from
+		{"2026-05-10", "2026-05-10", false}, // whole --to day included
+		{"2026-05-10", "", false},           // open upper bound
+		{"", "2026-05-10", false},           // open lower bound
+	} {
+		_, _, err := parseExportDateBounds(tc.from, tc.to)
+		if tc.wantErr && err == nil {
+			t.Fatalf("parseExportDateBounds(%q, %q) accepted an inverted range", tc.from, tc.to)
+		}
+		if !tc.wantErr && err != nil {
+			t.Fatalf("parseExportDateBounds(%q, %q) = %v, want valid", tc.from, tc.to, err)
+		}
 	}
 }
 

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -418,7 +418,7 @@ func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
 		to = to.AddDate(0, 0, 1) // half-open: include the entire end day
 	}
 	// An inverted window (--to before --from) silently matched nothing.
-	// Reject it so a typo fails loudly instead of hiding every row.
+	// Reject it so a typo gives an error instead of an empty result.
 	if !to.After(from) {
 		return time.Time{}, time.Time{}, errInvalidInputf("--to must be after --from")
 	}

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -417,6 +417,11 @@ func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
 		}
 		to = to.AddDate(0, 0, 1) // half-open: include the entire end day
 	}
+	// An inverted window (--to before --from) silently matched nothing.
+	// Reject it so a typo fails loudly instead of hiding every row.
+	if !to.After(from) {
+		return time.Time{}, time.Time{}, errInvalidInputf("--to must be after --from")
+	}
 	return from, to, nil
 }
 
@@ -444,6 +449,11 @@ func parseExportDateBounds(fromStr, toStr string) (time.Time, time.Time, error) 
 			return time.Time{}, time.Time{}, err
 		}
 		to = to.AddDate(0, 0, 1) // half-open: include the entire end day
+	}
+	// Both bounds set: an inverted window silently matched nothing.
+	// One bound alone stays open, so the check only runs when both exist.
+	if !from.IsZero() && !to.IsZero() && !to.After(from) {
+		return time.Time{}, time.Time{}, errInvalidInputf("--to must be after --from")
 	}
 	return from, to, nil
 }


### PR DESCRIPTION
## Problem
`parseDateRange`/`parseExportDateBounds` accepted to < from silently while freebusy rejects it.

## Fix
Both parsers now return invalid_input when --to is not after --from.

## Verification
Table regression tests for inverted and equal bounds; package tests pass.

Assisted-by: opencode-zen:x-preview-f-free