### PR TITLE
fix(sync): sanitize doctor output strings

### DIFF
--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -112,8 +112,8 @@ func runDoctorList(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Cale
 	}
 	for _, en := range entries {
 		fmt.Fprintf(out, "calendar %q uid %s (%s): unreadable relation(s) %s; %d failed push attempt(s)\n",
-			en.calendarName, en.wedged.UID, en.wedged.OwnerType,
-			strings.Join(en.wedged.Relations, ", "), en.wedged.PushFailCount)
+			safeText(en.calendarName), safeText(en.wedged.UID), safeText(en.wedged.OwnerType),
+			safeText(strings.Join(en.wedged.Relations, ", ")), en.wedged.PushFailCount)
 	}
 	// The whole hint block goes to stdout. A consumer that captures stdout
 	// then also captures the recovery command.
@@ -138,7 +138,7 @@ func runDoctorPush(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Cale
 		}
 		question := fmt.Sprintf(
 			"Push %s from calendar %q without relation(s) %s? The server copy loses those fields",
-			uid, en.calendarName, strings.Join(w.Relations, ", "))
+			safeText(uid), safeText(en.calendarName), safeText(strings.Join(w.Relations, ", ")))
 		if err := confirmDestructive(cmd, question); err != nil {
 			return err
 		}

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -169,7 +169,7 @@ func renderDoctorPush(cmd *cobra.Command, uid string, dropped []string) error {
 	}
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "Pushed %s. Dropped relation(s): %s.\n",
-		uid, strings.Join(dropped, ", "))
+		safeText(uid), safeText(strings.Join(dropped, ", ")))
 	fmt.Fprintln(out, "The resource is no longer dirty. Other edits flow again.")
 	return nil
 }

--- a/cmd/chroncal/sync_doctor_cli_test.go
+++ b/cmd/chroncal/sync_doctor_cli_test.go
@@ -16,6 +16,14 @@ import (
 // helper process still opens the database afterwards.
 func seedWedgedCLIResource(t *testing.T, dbPath string) {
 	t.Helper()
+	seedWedgedCLIResourceWithUID(t, dbPath, "wedge-cli@example.com")
+}
+
+// seedWedgedCLIResourceWithUID seeds one wedged resource whose sync UID is
+// the given string. The doctor then lists exactly that UID. The helper
+// renames event_relations back at cleanup like the fixed-UID variant.
+func seedWedgedCLIResourceWithUID(t *testing.T, dbPath string, uid string) {
+	t.Helper()
 	a, err := app.New(dbPath)
 	if err != nil {
 		t.Fatalf("app.New: %v", err)
@@ -29,14 +37,14 @@ func seedWedgedCLIResource(t *testing.T, dbPath string) {
 	if _, err := a.DB.ExecContext(ctx,
 		`INSERT INTO events (uid, calendar_id, title, start_time, end_time, status, transp, class)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		"wedge-cli@example.com", cals[0].ID, "Wedged",
+		uid, cals[0].ID, "Wedged",
 		"2026-04-03T10:00:00Z", "2026-04-03T11:00:00Z", "CONFIRMED", "OPAQUE", "PUBLIC",
 	); err != nil {
 		t.Fatalf("insert event: %v", err)
 	}
 	if err := a.Queries.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
 		CalendarID:   cals[0].ID,
-		Uid:          "wedge-cli@example.com",
+		Uid:          uid,
 		OwnerType:    "event",
 		Etag:         "",
 		Dirty:        1,
@@ -127,6 +135,26 @@ func TestSyncDoctorListsWedgedResource(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "3 failed push attempt(s)") {
 		t.Errorf("output %q misses the recorded push-failure count", stdout)
+	}
+}
+
+// TestSyncDoctorSanitizesRemoteDerivedStrings guards the doctor output.
+// The UID and owner type come from remote iCal data. A UID with terminal
+// escape bytes must not reach the terminal raw. Every other wedged line
+// passes through safeText like the sync status and conflict lines.
+func TestSyncDoctorSanitizesRemoteDerivedStrings(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	seedWedgedCLIResourceWithUID(t, dbPath, "\x1b[31mwedge\x1b[0m@example.com")
+
+	stdout, _, err := runChroncalCommand(t, "sync", "doctor")
+	if err != nil {
+		t.Fatalf("sync doctor: %v", err)
+	}
+	if strings.Contains(stdout, "\x1b") {
+		t.Fatalf("doctor line leaked a raw escape byte:\n%q", stdout)
+	}
+	if !strings.Contains(stdout, "uid wedge@example.com (event):") {
+		t.Fatalf("output %q misses the sanitized wedged line", stdout)
 	}
 }
 


### PR DESCRIPTION
## Problem
`sync doctor` printed remote-derived calendar names, UIDs, owner types, and relations without textsafe sanitization. A hostile server response could inject control sequences into terminal output.

## Fix
Wrap every remote-derived string with safeText, matching writeSyncConflictLine in safe_output.go.

## Verification
Regression test seeds a wedged resource with hostile characters and asserts sanitized output.

Assisted-by: opencode-zen:x-preview-f-free