### PR TITLE
fix(sync): propagate the credential store error in sync read commands

### DIFF
--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -237,7 +237,10 @@ for each connected calendar.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			statuses, err := svc.Status(context.Background())
@@ -302,9 +305,11 @@ A resolved row keeps the recorded local version, so "chroncal sync resolve
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
-
 			var conflicts []syncPkg.Conflict
 			if resolved {
 				conflicts, err = svc.ListResolvedConflicts(context.Background())
@@ -389,7 +394,10 @@ it again with --pick local restores the recorded local version.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			warnings, err := svc.ResolveConflict(context.Background(), id, pick)
@@ -430,7 +438,10 @@ This does not delete your local calendars or entries.`,
 			defer a.Close()
 			ctx := context.Background()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			cals, err := a.Calendars.List(ctx)

--- a/cmd/chroncal/sync_cli_test.go
+++ b/cmd/chroncal/sync_cli_test.go
@@ -28,6 +28,33 @@ func TestSyncResetMatchesCalendarCaseInsensitively(t *testing.T) {
 	}
 }
 
+// TestSyncCommandsFailWhenCredentialStoreUnavailable guards the sync read
+// commands. They used to discard the auth.NewCredentialStore error, built
+// the service on a nil store, and exited 0. The first command that needed
+// a credential would then fail far from the cause, or misbehave. A store
+// that cannot open must fail the command up front, like `sync run` does.
+// The test points DBUS_SESSION_BUS_ADDRESS at a dead socket, so the OS
+// keyring probe fails deterministically, and the plaintext fallback stays
+// off (the default in a fresh config).
+func TestSyncCommandsFailWhenCredentialStoreUnavailable(t *testing.T) {
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent-chroncal-test")
+	setupCalendarCLITestEnv(t)
+
+	for _, args := range [][]string{
+		{"sync", "status", "--output", "json"},
+		{"sync", "conflicts", "--output", "json"},
+		{"sync", "doctor", "--output", "json"},
+	} {
+		_, stderr, err := runChroncalCommand(t, args...)
+		if err == nil {
+			t.Fatalf("%s exited 0 with a dead credential store; want a failure", strings.Join(args, " "))
+		}
+		if !strings.Contains(stderr, "credential store") {
+			t.Fatalf("%s stderr = %q, want the credential store failure", strings.Join(args, " "), stderr)
+		}
+	}
+}
+
 // TestSyncRunRejectsInvalidConflictStrategy guards against issue #215.
 // `sync run --conflict <bad>` must be rejected up front. It must not
 // fall back to server-wins in silence. That would discard local edits

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -40,7 +40,10 @@ before the push and asks for confirmation.`,
 			defer a.Close()
 
 			ctx := context.Background()
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			cals, err := a.Queries.ListCalendars(ctx)


### PR DESCRIPTION
## Problem
Five sync subcommands discarded the `auth.NewCredentialStore` error (`credStore, _ := ...\`). A config typo produced a nil store passed into the engine instead of a labeled startup failure.

## Fix
Propagate the constructor error like account.go and freebusy.go already do.

## Verification
Regression test forces keyring failure (unset DBUS session) and asserts the clean startup error; targeted tests pass.

Assisted-by: opencode-zen:x-preview-f-free