### PR TITLE
fix(cli): unify the calendar not-found error code

### DIFF
--- a/cmd/chroncal/calendar.go
+++ b/cmd/chroncal/calendar.go
@@ -164,7 +164,7 @@ hidden calendars as opted out of the sidebar.`
 			}
 			target, err := findCalendarByRef(cals, args[0])
 			if err != nil {
-				return errInvalidInputf("%v", err)
+				return err
 			}
 			if err := setCalendarHidden(target.ID, hide); err != nil {
 				return err
@@ -616,7 +616,7 @@ func resolveNewDefault(cmd *cobra.Command, a *app.App, ctx context.Context, cal 
 	if promote != "" {
 		chosen, err := findCalendarByRef(candidates, promote)
 		if err != nil {
-			return calendarpkg.Calendar{}, errInvalidInputf("promote: %v", err)
+			return calendarpkg.Calendar{}, fmt.Errorf("promote: %w", err)
 		}
 		return chosen, nil
 	}
@@ -661,7 +661,7 @@ func promptForNewDefault(cmd *cobra.Command, cal calendarpkg.Calendar, candidate
 	}
 	chosen, err := findCalendarByRef(candidates, answer)
 	if err != nil {
-		return calendarpkg.Calendar{}, errInvalidInputf("promote: %v", err)
+		return calendarpkg.Calendar{}, fmt.Errorf("promote: %w", err)
 	}
 	return chosen, nil
 }
@@ -680,7 +680,7 @@ func findCalendarByRef(cals []calendarpkg.Calendar, ref string) (calendarpkg.Cal
 				return cal, nil
 			}
 		}
-		return calendarpkg.Calendar{}, fmt.Errorf("calendar %q not found", ref)
+		return calendarpkg.Calendar{}, &cliError{Code: "not_found", Msg: fmt.Sprintf("calendar %q not found", ref)}
 	}
 
 	var matches []calendarpkg.Calendar
@@ -691,11 +691,11 @@ func findCalendarByRef(cals []calendarpkg.Calendar, ref string) (calendarpkg.Cal
 	}
 	switch len(matches) {
 	case 0:
-		return calendarpkg.Calendar{}, fmt.Errorf("calendar %q not found", ref)
+		return calendarpkg.Calendar{}, &cliError{Code: "not_found", Msg: fmt.Sprintf("calendar %q not found", ref)}
 	case 1:
 		return matches[0], nil
 	default:
-		return calendarpkg.Calendar{}, fmt.Errorf("calendar name %q is ambiguous; use its numeric ID instead", ref)
+		return calendarpkg.Calendar{}, errInvalidInputf("calendar name %q is ambiguous; use its numeric ID instead", ref)
 	}
 }
 

--- a/cmd/chroncal/calendar_cli_test.go
+++ b/cmd/chroncal/calendar_cli_test.go
@@ -374,7 +374,7 @@ func TestCalendarHideShowJSON(t *testing.T) {
 	}
 }
 
-func TestCalendarHideUnknownIDIsInvalidInput(t *testing.T) {
+func TestCalendarHideUnknownIDIsNotFound(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
 	_, stderr, err := runChroncalCommand(t, "calendar", "hide", "99999", "--output", "json")
@@ -388,11 +388,51 @@ func TestCalendarHideUnknownIDIsInvalidInput(t *testing.T) {
 	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
 		t.Fatalf("decode error payload %q: %v", stderr, jerr)
 	}
-	if payload.Code != "invalid_input" {
-		t.Fatalf("code = %q, want invalid_input", payload.Code)
+	// findCalendarByRef tags an unknown reference not_found itself, so
+	// calendar hide/show, set-default, sync run/reset, and the --calendar
+	// flag of every write command report the same code.
+	if payload.Code != "not_found" {
+		t.Fatalf("code = %q, want not_found", payload.Code)
 	}
 	if !strings.Contains(payload.Error, "99999") {
 		t.Fatalf("error = %q, want it to mention the unknown id", payload.Error)
+	}
+}
+
+// TestCalendarRefNotFoundCodeUniform guards the unified taxonomy: the same
+// unknown calendar reference must report one code on every surface that
+// resolves a reference. Before the fix, calendar hide/show re-tagged it
+// invalid_input, sync re-tagged it not_found, and calendar set-default and
+// the --calendar flag of write commands left it the generic error code.
+func TestCalendarRefNotFoundCodeUniform(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	for _, args := range [][]string{
+		{"calendar", "hide", "Ghost"},
+		{"calendar", "set-default", "Ghost"},
+		{"sync", "reset", "--calendar", "Ghost"},
+		{"event", "add", "Title", "--calendar", "Ghost"},
+	} {
+		_, stderr, err := runChroncalCommand(t, append(args, "--output", "json")...)
+		if err == nil {
+			t.Fatalf("%s accepted an unknown calendar", strings.Join(args, " "))
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("%s: decode error payload %q: %v", strings.Join(args, " "), stderr, jerr)
+		}
+		if payload.Code != "not_found" {
+			t.Fatalf("%s: code = %q, want not_found", strings.Join(args, " "), payload.Code)
+		}
+		if !strings.Contains(payload.Error, "Ghost") {
+			t.Fatalf("%s: error = %q, want it to name the unknown reference", strings.Join(args, " "), payload.Error)
+		}
 	}
 }
 

--- a/cmd/chroncal/calendar_link_test.go
+++ b/cmd/chroncal/calendar_link_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/calendar"
@@ -33,6 +34,32 @@ func TestFindCalendarByRef(t *testing.T) {
 		if got.ID != tt.wantID {
 			t.Fatalf("findCalendarByRef(%q) ID = %d, want %d", tt.ref, got.ID, tt.wantID)
 		}
+	}
+}
+
+// TestFindCalendarByRefErrorTaxonomy locks the error codes: an unknown
+// reference (numeric or by name) is not_found, and an ambiguous name is
+// invalid_input. Every caller then reports the same code without
+// re-wrapping, so --output json consumers can dispatch on it.
+func TestFindCalendarByRefErrorTaxonomy(t *testing.T) {
+	cals := []calendar.Calendar{
+		{ID: 1, Name: "Work"},
+		{ID: 2, Name: "Work"},
+		{ID: 3, Name: "Personal"},
+	}
+
+	for _, ref := range []string{"999", "Ghost"} {
+		_, err := findCalendarByRef(cals, ref)
+		var ce *cliError
+		if !errors.As(err, &ce) || ce.Code != "not_found" {
+			t.Fatalf("findCalendarByRef(%q) = %#v, want a not_found cliError", ref, err)
+		}
+	}
+
+	_, err := findCalendarByRef(cals, "work")
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "invalid_input" {
+		t.Fatalf("findCalendarByRef(%q) = %#v, want an invalid_input cliError for an ambiguous name", "work", err)
 	}
 }
 

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -163,7 +163,7 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 			if calendarName != "" {
 				target, err := findCalendarByRef(cals, calendarName)
 				if err != nil {
-					return &cliError{Code: "not_found", Msg: err.Error()}
+					return err
 				}
 				targetCalendarID = target.ID
 			} else if accountName != "" {
@@ -451,14 +451,14 @@ This does not delete your local calendars or entries.`,
 
 			var connected, failed int
 			// Resolve --calendar by ID or case-insensitive name via the shared
-			// findCalendarByRef helper. It already reports not_found for an
-			// unknown reference, so a non-zero targetID is guaranteed to match a
+			// findCalendarByRef helper. It reports not_found for an unknown
+			// reference, so a non-zero targetID is guaranteed to match a
 			// calendar below.
 			var targetID int64
 			if calendarName != "" {
 				target, err := findCalendarByRef(cals, calendarName)
 				if err != nil {
-					return &cliError{Code: "not_found", Msg: err.Error()}
+					return err
 				}
 				targetID = target.ID
 			}


### PR DESCRIPTION
## Problem
The same 'calendar reference not found' failure surfaced as three different cliError codes depending on entry point (calendar hide/set-default/sync reset/event add).

## Fix
findCalendarByRef now returns the not_found cliError itself; per-caller re-wrapping removed at all call sites.

## Verification
Regression test asserts one machine code across the previously divergent surfaces.

Assisted-by: opencode-zen:x-preview-f-free