### PR TITLE
fix(cli): tag exdate and restore failures with the proper error code

### DIFF
--- a/cmd/chroncal/event_add.go
+++ b/cmd/chroncal/event_add.go
@@ -230,13 +230,13 @@ Alarms default to ACTION=DISPLAY unless prefixed (e.g. EMAIL:-PT1H).`,
 			if !allDay {
 				exrdateRef = startTime
 			}
-			parsedExDates, err := parseDateFlags(exdates, timezone, exrdateRef)
+			parsedExDates, err := parseExdateRdateFlags("exception-date-times", exdates, timezone, exrdateRef)
 			if err != nil {
-				return errInvalidInputf("--exception-date-times: %v", err)
+				return err
 			}
-			parsedRDates, err := parseDateFlags(rdates, timezone, exrdateRef)
+			parsedRDates, err := parseExdateRdateFlags("recurrence-date-times", rdates, timezone, exrdateRef)
 			if err != nil {
-				return errInvalidInputf("--recurrence-date-times: %v", err)
+				return err
 			}
 
 			// Validate all parseable flags before creating the event so a

--- a/cmd/chroncal/event_cli_test.go
+++ b/cmd/chroncal/event_cli_test.go
@@ -695,3 +695,31 @@ func TestEventUpdate_RecurrenceIDRejectsNonOccurrence(t *testing.T) {
 		t.Fatalf("non-occurrence update created an override:\n%s", listed)
 	}
 }
+
+// TestEventRestoreNotFoundIsTagged guards the error taxonomy of the restore
+// command. A live or missing event surfaced as a generic error code. The
+// not-found case must report not_found like event get, so --output json
+// consumers can dispatch on the code.
+func TestEventRestoreNotFoundIsTagged(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	for _, ref := range []string{"999", "ghost-uid@example.com"} {
+		_, stderr, err := runChroncalCommand(t, "event", "restore", ref, "--output", "json")
+		if err == nil {
+			t.Fatalf("event restore %s should fail", ref)
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("event restore %s: decode error payload %q: %v", ref, stderr, jerr)
+		}
+		if payload.Code != "not_found" {
+			t.Fatalf("event restore %s: code = %q, want not_found", ref, payload.Code)
+		}
+		if !strings.Contains(payload.Error, "not found") {
+			t.Fatalf("event restore %s: error = %q, want a not-found message", ref, payload.Error)
+		}
+	}
+}

--- a/cmd/chroncal/event_parse.go
+++ b/cmd/chroncal/event_parse.go
@@ -492,6 +492,19 @@ func validateRRule(rrule string) error {
 	return errInvalidInputf("invalid --rrule %q: must contain FREQ= (e.g. FREQ=WEEKLY;BYDAY=MO)", rrule)
 }
 
+// parseExdateRdateFlags parses the values of one recurrence-date flag. The
+// flag argument is the long name without the leading dashes, for example
+// "exception-date-times". The function tags a parse failure with code
+// "invalid_input" and names the flag in the message. Pass the start time in
+// startTime so date-only values inherit it, as parseDateFlags describes.
+func parseExdateRdateFlags(flag string, values []string, tz string, startTime time.Time) (string, error) {
+	parsed, err := parseDateFlags(values, tz, startTime)
+	if err != nil {
+		return "", errInvalidInputf("--%s: %v", flag, err)
+	}
+	return parsed, nil
+}
+
 // validateGeo checks that a GEO value is "lat;lon" with valid ranges per
 // RFC 5545 Section 3.8.1.6. Empty string is allowed (optional field).
 func validateGeo(geo string) error {

--- a/cmd/chroncal/event_purge.go
+++ b/cmd/chroncal/event_purge.go
@@ -52,7 +52,7 @@ attendees, attachments, overrides) cascade.`,
 
 			if err := a.Events.PurgeByID(ctx, id); err != nil {
 				if errors.Is(err, event.ErrNotDeleted) {
-					return fmt.Errorf("event %d not found or not soft-deleted", id)
+					return errNotFoundf("event %d not found or not soft-deleted", id)
 				}
 				return fmt.Errorf("purge: %w", err)
 			}

--- a/cmd/chroncal/event_restore.go
+++ b/cmd/chroncal/event_restore.go
@@ -40,7 +40,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
 				if err := a.Events.RestoreByID(ctx, id); err != nil {
 					if errors.Is(err, event.ErrNotDeleted) {
-						return &cliError{Code: "not_found", Msg: fmt.Sprintf("event %d not found (may have been purged)", id)}
+						return errNotFoundf("event %d not found (may have been purged)", id)
 					}
 					return fmt.Errorf("restore event: %w", err)
 				}
@@ -54,7 +54,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			// UID path: restore every row sharing the UID.
 			if err := a.Events.RestoreByUID(ctx, ref); err != nil {
 				if errors.Is(err, event.ErrNotDeleted) {
-					return &cliError{Code: "not_found", Msg: fmt.Sprintf("event %q not found (may have been purged)", ref)}
+					return errNotFoundf("event %q not found (may have been purged)", ref)
 				}
 				return fmt.Errorf("restore event: %w", err)
 			}

--- a/cmd/chroncal/event_restore.go
+++ b/cmd/chroncal/event_restore.go
@@ -40,7 +40,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
 				if err := a.Events.RestoreByID(ctx, id); err != nil {
 					if errors.Is(err, event.ErrNotDeleted) {
-						return fmt.Errorf("event %d not found (may have been purged)", id)
+						return &cliError{Code: "not_found", Msg: fmt.Sprintf("event %d not found (may have been purged)", id)}
 					}
 					return fmt.Errorf("restore event: %w", err)
 				}
@@ -54,7 +54,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			// UID path: restore every row sharing the UID.
 			if err := a.Events.RestoreByUID(ctx, ref); err != nil {
 				if errors.Is(err, event.ErrNotDeleted) {
-					return fmt.Errorf("event %q not found (may have been purged)", ref)
+					return &cliError{Code: "not_found", Msg: fmt.Sprintf("event %q not found (may have been purged)", ref)}
 				}
 				return fmt.Errorf("restore event: %w", err)
 			}

--- a/cmd/chroncal/event_update.go
+++ b/cmd/chroncal/event_update.go
@@ -274,9 +274,9 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				if !p.AllDay {
 					exrdateRef = p.StartTime
 				}
-				parsed, err := parseDateFlags(exdates, tz, exrdateRef)
+				parsed, err := parseExdateRdateFlags("exception-date-times", exdates, tz, exrdateRef)
 				if err != nil {
-					return errInvalidInputf("--exception-date-times: %v", err)
+					return err
 				}
 				p.ExDates = parsed
 			}
@@ -285,9 +285,9 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				if !p.AllDay {
 					exrdateRef = p.StartTime
 				}
-				parsed, err := parseDateFlags(rdates, tz, exrdateRef)
+				parsed, err := parseExdateRdateFlags("recurrence-date-times", rdates, tz, exrdateRef)
 				if err != nil {
-					return errInvalidInputf("--recurrence-date-times: %v", err)
+					return err
 				}
 				p.RDates = parsed
 			}

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -262,11 +262,11 @@ Defaults: status=FINAL, class=PUBLIC, calendar=Personal.`,
 
 			parsedExDates, err := parseDateFlags(exdates, "", time.Time{})
 			if err != nil {
-				return fmt.Errorf("--exdate: %w", err)
+				return errInvalidInputf("--exception-date-times: %v", err)
 			}
 			parsedRDates, err := parseDateFlags(rdates, "", time.Time{})
 			if err != nil {
-				return fmt.Errorf("--rdate: %w", err)
+				return errInvalidInputf("--recurrence-date-times: %v", err)
 			}
 
 			// Validate all parseable flags before creating the journal so a
@@ -503,14 +503,14 @@ Repeatable flags (--attendee, --comment, --contact, --attach,
 			if cmd.Flags().Changed("exception-date-times") || cmd.Flags().Changed("exdate") {
 				parsed, err := parseDateFlags(exdates, "", time.Time{})
 				if err != nil {
-					return fmt.Errorf("--exdate: %w", err)
+					return errInvalidInputf("--exception-date-times: %v", err)
 				}
 				p.ExDates = parsed
 			}
 			if cmd.Flags().Changed("recurrence-date-times") || cmd.Flags().Changed("rdate") {
 				parsed, err := parseDateFlags(rdates, "", time.Time{})
 				if err != nil {
-					return fmt.Errorf("--rdate: %w", err)
+					return errInvalidInputf("--recurrence-date-times: %v", err)
 				}
 				p.RDates = parsed
 			}

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -260,13 +260,13 @@ Defaults: status=FINAL, class=PUBLIC, calendar=Personal.`,
 				startDate = dateStr
 			}
 
-			parsedExDates, err := parseDateFlags(exdates, "", time.Time{})
+			parsedExDates, err := parseExdateRdateFlags("exception-date-times", exdates, "", time.Time{})
 			if err != nil {
-				return errInvalidInputf("--exception-date-times: %v", err)
+				return err
 			}
-			parsedRDates, err := parseDateFlags(rdates, "", time.Time{})
+			parsedRDates, err := parseExdateRdateFlags("recurrence-date-times", rdates, "", time.Time{})
 			if err != nil {
-				return errInvalidInputf("--recurrence-date-times: %v", err)
+				return err
 			}
 
 			// Validate all parseable flags before creating the journal so a
@@ -501,16 +501,16 @@ Repeatable flags (--attendee, --comment, --contact, --attach,
 				p.RecurrenceRule = rrule
 			}
 			if cmd.Flags().Changed("exception-date-times") || cmd.Flags().Changed("exdate") {
-				parsed, err := parseDateFlags(exdates, "", time.Time{})
+				parsed, err := parseExdateRdateFlags("exception-date-times", exdates, "", time.Time{})
 				if err != nil {
-					return errInvalidInputf("--exception-date-times: %v", err)
+					return err
 				}
 				p.ExDates = parsed
 			}
 			if cmd.Flags().Changed("recurrence-date-times") || cmd.Flags().Changed("rdate") {
-				parsed, err := parseDateFlags(rdates, "", time.Time{})
+				parsed, err := parseExdateRdateFlags("recurrence-date-times", rdates, "", time.Time{})
 				if err != nil {
-					return errInvalidInputf("--recurrence-date-times: %v", err)
+					return err
 				}
 				p.RDates = parsed
 			}
@@ -720,7 +720,7 @@ the next sync cycle recreates it remotely.`,
 			if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
 				if err := a.Journals.RestoreByID(ctx, id); err != nil {
 					if errors.Is(err, journal.ErrNotDeleted) {
-						return fmt.Errorf("journal %d not found (may have been purged)", id)
+						return errNotFoundf("journal %d not found (may have been purged)", id)
 					}
 					return fmt.Errorf("restore journal: %w", err)
 				}
@@ -733,7 +733,7 @@ the next sync cycle recreates it remotely.`,
 
 			if err := a.Journals.RestoreByUID(ctx, ref); err != nil {
 				if errors.Is(err, journal.ErrNotDeleted) {
-					return fmt.Errorf("journal %q not found (may have been purged)", ref)
+					return errNotFoundf("journal %q not found (may have been purged)", ref)
 				}
 				return fmt.Errorf("restore journal: %w", err)
 			}
@@ -787,7 +787,7 @@ use 'journal delete' first. Purging is not reversible — child rows cascade.`,
 
 			if err := a.Journals.PurgeByID(ctx, id); err != nil {
 				if errors.Is(err, journal.ErrNotDeleted) {
-					return fmt.Errorf("journal %d not found or not soft-deleted", id)
+					return errNotFoundf("journal %d not found or not soft-deleted", id)
 				}
 				return fmt.Errorf("purge: %w", err)
 			}

--- a/cmd/chroncal/journal_cli_test.go
+++ b/cmd/chroncal/journal_cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -77,5 +78,46 @@ func TestJournalListHidesCancelledByDefault(t *testing.T) {
 	}
 	if strings.Contains(stdoutStatus, "Active note") {
 		t.Fatalf("--status CANCELLED list = %q, should not contain FINAL entry %q", stdoutStatus, "Active note")
+	}
+}
+
+// TestJournalExdateParseFailureIsInvalidInput guards the error taxonomy. A
+// bad --exdate value in journal add/update used to surface as a generic
+// error. It must report invalid_input like the event and todo commands.
+func TestJournalExdateParseFailureIsInvalidInput(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	_, stderr, err := runChroncalCommand(t, "journal", "add", "Note",
+		"--calendar", "Work", "--exdate", "not-a-date", "--output", "json")
+	if err == nil {
+		t.Fatal("journal add accepted a bad --exdate value")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error payload %q: %v", stderr, jerr)
+	}
+	if payload.Code != "invalid_input" {
+		t.Fatalf("code = %q, want invalid_input", payload.Code)
+	}
+
+	if _, _, err := runChroncalCommand(t, "journal", "add", "Note", "--calendar", "Work"); err != nil {
+		t.Fatalf("journal add: %v", err)
+	}
+	_, stderr, err = runChroncalCommand(t, "journal", "update", "1",
+		"--exdate", "not-a-date", "--output", "json")
+	if err == nil {
+		t.Fatal("journal update accepted a bad --exdate value")
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error payload %q: %v", stderr, jerr)
+	}
+	if payload.Code != "invalid_input" {
+		t.Fatalf("journal update: code = %q, want invalid_input", payload.Code)
 	}
 }

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -54,6 +54,13 @@ func errInvalidInputf(format string, args ...any) error {
 	return &cliError{Code: "invalid_input", Msg: fmt.Sprintf(format, args...)}
 }
 
+// errNotFoundf is the printf counterpart to notFoundErr. It produces a
+// *cliError tagged with code "not_found". Use it when a command cannot
+// find the row that the user named, for example on a restore or a purge.
+func errNotFoundf(format string, args ...any) error {
+	return &cliError{Code: "not_found", Msg: fmt.Sprintf(format, args...)}
+}
+
 // printCLIError writes err to stderr in the format that matches --output.
 // Text mode keeps "Error: <msg>". JSON emits a structured payload.
 // Aborted errors drop the "Error: " prefix in text mode. They come from

--- a/cmd/chroncal/todo_add.go
+++ b/cmd/chroncal/todo_add.go
@@ -176,11 +176,11 @@ and percent-complete to 100.`,
 
 			parsedExDates, err := parseDateFlags(exdates, "", time.Time{})
 			if err != nil {
-				return fmt.Errorf("--exdate: %w", err)
+				return errInvalidInputf("--exception-date-times: %v", err)
 			}
 			parsedRDates, err := parseDateFlags(rdates, "", time.Time{})
 			if err != nil {
-				return fmt.Errorf("--rdate: %w", err)
+				return errInvalidInputf("--recurrence-date-times: %v", err)
 			}
 
 			// Validate all parseable flags before creating the todo so a

--- a/cmd/chroncal/todo_add.go
+++ b/cmd/chroncal/todo_add.go
@@ -174,13 +174,13 @@ and percent-complete to 100.`,
 				return fmt.Errorf("--status COMPLETED requires 100%% progress, got %d (omit --progress or set it to 100)", progress)
 			}
 
-			parsedExDates, err := parseDateFlags(exdates, "", time.Time{})
+			parsedExDates, err := parseExdateRdateFlags("exception-date-times", exdates, "", time.Time{})
 			if err != nil {
-				return errInvalidInputf("--exception-date-times: %v", err)
+				return err
 			}
-			parsedRDates, err := parseDateFlags(rdates, "", time.Time{})
+			parsedRDates, err := parseExdateRdateFlags("recurrence-date-times", rdates, "", time.Time{})
 			if err != nil {
-				return errInvalidInputf("--recurrence-date-times: %v", err)
+				return err
 			}
 
 			// Validate all parseable flags before creating the todo so a

--- a/cmd/chroncal/todo_cli_test.go
+++ b/cmd/chroncal/todo_cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -23,4 +24,42 @@ func TestTodoSearchCompletedAndIncompleteAreMutuallyExclusive(t *testing.T) {
 		t.Fatalf("todo search --completed --incomplete: error = %q, want it to mention %q",
 			err.Error(), "mutually exclusive")
 	}
+}
+
+// TestTodoExdateParseFailureIsInvalidInput guards the error taxonomy. A bad
+// --exdate value in todo add/update used to surface as a generic error.
+// The event commands already tagged it invalid_input; the todo commands
+// must report the same code so --output json consumers can dispatch on it.
+func TestTodoExdateParseFailureIsInvalidInput(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	assertInvalidInput := func(args ...string) {
+		t.Helper()
+		_, stderr, err := runChroncalCommand(t, args...)
+		if err == nil {
+			t.Fatalf("%s accepted a bad --exdate value", strings.Join(args, " "))
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("%s: decode error payload %q: %v", strings.Join(args, " "), stderr, jerr)
+		}
+		if payload.Code != "invalid_input" {
+			t.Fatalf("%s: code = %q, want invalid_input", strings.Join(args, " "), payload.Code)
+		}
+	}
+
+	assertInvalidInput("todo", "add", "Task", "--calendar", "Work",
+		"--exdate", "not-a-date", "--output", "json")
+
+	if _, _, err := runChroncalCommand(t, "todo", "add", "Task", "--calendar", "Work"); err != nil {
+		t.Fatalf("todo add: %v", err)
+	}
+	assertInvalidInput("todo", "update", "1",
+		"--recurrence-date-times", "not-a-date", "--output", "json")
 }

--- a/cmd/chroncal/todo_purge.go
+++ b/cmd/chroncal/todo_purge.go
@@ -51,7 +51,7 @@ use 'todo delete' first. Purging is not reversible — child rows cascade.`,
 
 			if err := a.Todos.PurgeByID(ctx, id); err != nil {
 				if errors.Is(err, todo.ErrNotDeleted) {
-					return fmt.Errorf("todo %d not found or not soft-deleted", id)
+					return errNotFoundf("todo %d not found or not soft-deleted", id)
 				}
 				return fmt.Errorf("purge: %w", err)
 			}

--- a/cmd/chroncal/todo_restore.go
+++ b/cmd/chroncal/todo_restore.go
@@ -39,7 +39,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
 				if err := a.Todos.RestoreByID(ctx, id); err != nil {
 					if errors.Is(err, todo.ErrNotDeleted) {
-						return fmt.Errorf("todo %d not found (may have been purged)", id)
+						return errNotFoundf("todo %d not found (may have been purged)", id)
 					}
 					return fmt.Errorf("restore todo: %w", err)
 				}
@@ -52,7 +52,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 
 			if err := a.Todos.RestoreByUID(ctx, ref); err != nil {
 				if errors.Is(err, todo.ErrNotDeleted) {
-					return fmt.Errorf("todo %q not found (may have been purged)", ref)
+					return errNotFoundf("todo %q not found (may have been purged)", ref)
 				}
 				return fmt.Errorf("restore todo: %w", err)
 			}

--- a/cmd/chroncal/todo_update.go
+++ b/cmd/chroncal/todo_update.go
@@ -218,16 +218,16 @@ a --progress value other than 100.`,
 				p.RecurrenceRule = rrule
 			}
 			if cmd.Flags().Changed("exception-date-times") || cmd.Flags().Changed("exdate") {
-				parsed, err := parseDateFlags(exdates, "", time.Time{})
+				parsed, err := parseExdateRdateFlags("exception-date-times", exdates, "", time.Time{})
 				if err != nil {
-					return errInvalidInputf("--exception-date-times: %v", err)
+					return err
 				}
 				p.ExDates = parsed
 			}
 			if cmd.Flags().Changed("recurrence-date-times") || cmd.Flags().Changed("rdate") {
-				parsed, err := parseDateFlags(rdates, "", time.Time{})
+				parsed, err := parseExdateRdateFlags("recurrence-date-times", rdates, "", time.Time{})
 				if err != nil {
-					return errInvalidInputf("--recurrence-date-times: %v", err)
+					return err
 				}
 				p.RDates = parsed
 			}

--- a/cmd/chroncal/todo_update.go
+++ b/cmd/chroncal/todo_update.go
@@ -220,14 +220,14 @@ a --progress value other than 100.`,
 			if cmd.Flags().Changed("exception-date-times") || cmd.Flags().Changed("exdate") {
 				parsed, err := parseDateFlags(exdates, "", time.Time{})
 				if err != nil {
-					return fmt.Errorf("--exdate: %w", err)
+					return errInvalidInputf("--exception-date-times: %v", err)
 				}
 				p.ExDates = parsed
 			}
 			if cmd.Flags().Changed("recurrence-date-times") || cmd.Flags().Changed("rdate") {
 				parsed, err := parseDateFlags(rdates, "", time.Time{})
 				if err != nil {
-					return fmt.Errorf("--rdate: %w", err)
+					return errInvalidInputf("--recurrence-date-times: %v", err)
 				}
 				p.RDates = parsed
 			}


### PR DESCRIPTION
## Problem
Todo/journal --exdate failures returned generic errors while event add used invalid_input; event restore returned a plain not-found error outside the cliError taxonomy, breaking -o json consumers.

## Fix
Route exdate failures through errInvalidInputf and not-found paths through the notFoundErr taxonomy.

## Verification
Regression tests for todo/journal exdate and event restore; package tests pass.

Assisted-by: opencode-zen:x-preview-f-free