### PR TITLE
fix(sync): propagate organizer lookup failures instead of failing open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ The TUI background purge loop writes logs to the state-dir file `$XDG_STATE_HOME
 
 There are exactly two variants: `Button` (neutral default) and `ButtonDanger` (destructive). There is no Primary, no Secondary, and no Ghost.
 
-`ButtonDanger` at rest shares the same pill and background as `Button`. Only the label is bold red (`Theme.Error`). On focus, Danger inverts (red background, contrast foreground). It does not use `FormHighlight`. Some themes have a warm or red focus highlight. Red text on that highlight is not readable.
+`ButtonDanger` at rest shares the same pill and background as `Button`. Only the label is bold red, derived from `Theme.Error`. A lightness clamp keeps the label at least 0.25 OKLCh L from the pill and at or above 3:1 contrast (bold text). On focus, Danger inverts (red background, contrast foreground). It does not use `FormHighlight`. Some themes have a warm or red focus highlight. Red text on that highlight is not readable.
 
 Put the red on the background. Compute a contrast label with `oklch.ContrastingFg`. That pair stays readable on every theme. It also shows the destructive signal when the user is about to commit.
 

--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ Every key is also available as an environment variable (`CHRONCAL_` prefix, dots
 The TUI ships two built-in themes:
 
 - **`system`** (default) — Chrome (text, borders, surfaces, dim text) inherits the terminal ANSI palette (`color0..15`). The TUI then follows themed terminal setups such as [Omarchy](https://learn.omacom.io/2/the-omarchy-manual/52/themes), Catppuccin, Gruvbox, Tokyo Night, or any setup that paints the standard 16 colors. The row-selection highlight adapts to the live terminal background via OSC 11. Accent colors (buttons, badges, "today", errors) sit on a fixed Dracula palette. Text-on-accent contrast then stays guaranteed across themes.
-- **`default`** — Fixed designer palette (violet primary, sky secondary, emerald accent) with light and dark variants. This theme ignores the terminal palette. Pick this if you do not theme your terminal, or if you want the same look on every machine.
+- **`default`** — Fixed designer palette (violet primary, emerald accent) with light and dark variants. This theme ignores the terminal palette. Pick this if you do not theme your terminal, or if you want the same look on every machine.
 
 Override with `ui.theme = "default"` in `config.toml` or
 `CHRONCAL_UI_THEME=default`.

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -759,8 +759,8 @@ See "chroncal alarm check --help" for notification types and SMTP configuration.
   # Check every 10 seconds
   chroncal alarm daemon --interval 10s`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Validate before initApp so a bad interval fails without
-			// touching the database, like the --days check in alarm missed.
+			// Validate before initApp so a bad interval fails before the
+			// database opens, like the --days check in alarm missed.
 			dur, err := parseCLIDuration("interval", interval)
 			if err != nil {
 				return err

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -97,32 +97,53 @@ type fireResult struct {
 	FireErr error
 }
 
-// markAndFireEventAlarm claims a due event alarm. Only on a successful
-// claim does it dispatch its notification. For a fresh fire (StateID == 0)
-// the claim is the INSERT performed by MarkFired. The (alarm_id, trigger_at)
-// UNIQUE index guards it. When two checkers overlap, both observe "no state"
-// and both try to insert. Only one wins. The loser's UNIQUE-constraint error
-// is reported as a non-fired, non-error result. Callers then suppress output
-// for it.
+// dueClaim carries the per-domain pieces of a mark-and-fire attempt. The
+// event and todo paths differ only in their mark calls, display name, and
+// unified view; the claim protocol is identical.
+type dueClaim struct {
+	// stateID is 0 for a fresh fire, or the snoozed state to re-fire.
+	stateID int64
+	// markRefire claims an expired-snoozed refire. claimed == false means
+	// another checker won.
+	markRefire func(ctx context.Context, stateID int64) (bool, error)
+	// markFired claims a fresh fire. It returns the new state row id.
+	markFired func(ctx context.Context) (int64, error)
+	// summary is the display name for error lines. It arrives sanitized.
+	summary string
+	// action is the alarm action for error lines.
+	action string
+	// label is the domain tag for error lines: "event" or "todo".
+	label string
+	// due is the unified view handed to the notifier.
+	due alarm.DueAlarm
+}
+
+// claimAndFireAlarm runs the shared mark-and-fire protocol. Only on a
+// successful claim does it dispatch the notification. For a fresh fire
+// (stateID == 0) the claim is the INSERT performed by MarkFired. The
+// (alarm_id, trigger_at) UNIQUE index guards it. When two checkers overlap,
+// both observe "no state" and both try to insert. Only one wins. The loser's
+// UNIQUE-constraint error is reported as a non-fired, non-error result.
+// Callers then suppress output for it.
 //
-// The refire path (StateID != 0, an expired-snoozed alarm) uses MarkRefired.
-// Its UPDATE is gated on snoozed_to IS NOT NULL. When two checkers overlap,
-// both observe the expired-snoozed row. Only the UPDATE that clears
-// snoozed_to first affects a row and wins the claim. The loser sees claimed
-// == false. That is likewise a non-fired, non-error result.
-func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) fireResult {
-	stateID := da.StateID
+// The refire path (stateID != 0, an expired-snoozed alarm) uses the refire
+// mark. Its UPDATE is gated on snoozed_to IS NOT NULL. When two checkers
+// overlap, both observe the expired-snoozed row. Only the UPDATE that clears
+// snoozed_to first affects a row and wins the claim. The loser sees
+// claimed == false. That is likewise a non-fired, non-error result.
+func claimAndFireAlarm(ctx context.Context, a *app.App, c dueClaim, policy alarmExecutionPolicy) fireResult {
+	stateID := c.stateID
 	var markErr error
 	op := "mark-fired"
 	if stateID != 0 {
 		op = "mark-refired"
 		var claimed bool
-		if claimed, markErr = a.Alarms.MarkRefired(ctx, stateID); markErr == nil && !claimed {
+		if claimed, markErr = c.markRefire(ctx, stateID); markErr == nil && !claimed {
 			return fireResult{} // another checker already re-fired this alarm
 		}
 	} else {
 		var newID int64
-		if newID, markErr = a.Alarms.MarkFired(ctx, da); markErr == nil {
+		if newID, markErr = c.markFired(ctx); markErr == nil {
 			stateID = newID
 		}
 	}
@@ -133,52 +154,48 @@ func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, p
 		if errors.Is(markErr, alarm.ErrNotFireable) {
 			return fireResult{} // a sync pull disabled this alarm (issue #579)
 		}
-		fmt.Fprintf(os.Stderr, "chroncal: %s error: event=%q: %v\n", op, safeText(da.Event.Title), markErr)
+		fmt.Fprintf(os.Stderr, "chroncal: %s error: %s=%q: %v\n", op, c.label, c.summary, markErr)
 		return fireResult{StateID: stateID, MarkErr: markErr}
 	}
 
-	fireErr := fireAlarmFn(da, policy)
+	fireErr := fireAlarmFn(c.due, policy)
 	if fireErr != nil {
-		fmt.Fprintf(os.Stderr, "chroncal: alarm error: %s (event=%q action=%s): %v\n",
-			da.TriggerAt.Local().Format("15:04"), safeText(da.Event.Title), da.Alarm.Action, fireErr)
+		fmt.Fprintf(os.Stderr, "chroncal: alarm error: %s (%s=%q action=%s): %v\n",
+			c.due.TriggerAt.Local().Format("15:04"), c.label, c.summary, c.action, fireErr)
 	}
 	return fireResult{StateID: stateID, Fired: true, FireErr: fireErr}
 }
 
-// markAndFireTodoAlarm is the todo counterpart of markAndFireEventAlarm.
-func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlarm, policy alarmExecutionPolicy) fireResult {
-	stateID := tda.StateID
-	var markErr error
-	op := "mark-fired"
-	if stateID != 0 {
-		op = "mark-refired"
-		var claimed bool
-		if claimed, markErr = a.Alarms.MarkTodoRefired(ctx, stateID); markErr == nil && !claimed {
-			return fireResult{} // another checker already re-fired this alarm
-		}
-	} else {
-		var newID int64
-		if newID, markErr = a.Alarms.MarkTodoFired(ctx, tda); markErr == nil {
-			stateID = newID
-		}
-	}
-	if markErr != nil {
-		if isAlarmAlreadyClaimed(markErr) {
-			return fireResult{} // another checker already fired this alarm
-		}
-		if errors.Is(markErr, alarm.ErrNotFireable) {
-			return fireResult{} // a sync pull disabled this alarm (issue #579)
-		}
-		fmt.Fprintf(os.Stderr, "chroncal: %s error: todo=%q: %v\n", op, safeText(tda.Todo.Summary), markErr)
-		return fireResult{StateID: stateID, MarkErr: markErr}
-	}
+// markAndFireEventAlarm claims and fires one event alarm through the shared
+// protocol.
+func markAndFireEventAlarm(ctx context.Context, a *app.App, da alarm.DueAlarm, policy alarmExecutionPolicy) fireResult {
+	return claimAndFireAlarm(ctx, a, dueClaim{
+		stateID:    da.StateID,
+		markRefire: a.Alarms.MarkRefired,
+		markFired: func(ctx context.Context) (int64, error) {
+			return a.Alarms.MarkFired(ctx, da)
+		},
+		summary: safeText(da.Event.Title),
+		action:  da.Alarm.Action,
+		label:   "event",
+		due:     da,
+	}, policy)
+}
 
-	fireErr := fireAlarmFn(todoDueAlarmToDueAlarm(tda), policy)
-	if fireErr != nil {
-		fmt.Fprintf(os.Stderr, "chroncal: todo alarm error: %s (todo=%q action=%s): %v\n",
-			tda.TriggerAt.Local().Format("15:04"), safeText(tda.Todo.Summary), tda.Alarm.Action, fireErr)
-	}
-	return fireResult{StateID: stateID, Fired: true, FireErr: fireErr}
+// markAndFireTodoAlarm claims and fires one todo alarm through the shared
+// protocol.
+func markAndFireTodoAlarm(ctx context.Context, a *app.App, tda alarm.TodoDueAlarm, policy alarmExecutionPolicy) fireResult {
+	return claimAndFireAlarm(ctx, a, dueClaim{
+		stateID:    tda.StateID,
+		markRefire: a.Alarms.MarkTodoRefired,
+		markFired: func(ctx context.Context) (int64, error) {
+			return a.Alarms.MarkTodoFired(ctx, tda)
+		},
+		summary: safeText(tda.Todo.Summary),
+		action:  tda.Alarm.Action,
+		label:   "todo",
+		due:     todoDueAlarmToDueAlarm(tda),
+	}, policy)
 }
 
 func alarmCmd() *cobra.Command {
@@ -785,33 +802,7 @@ See "chroncal alarm check --help" for notification types and SMTP configuration.
 			// a fired alarm could not be marked (an unmarked alarm re-fires
 			// every tick, so persistent mark failures mean notification spam).
 			runCheck := func() error {
-				due, todoDue, err := a.Alarms.Check(ctx, time.Now())
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "chroncal: check error: %v\n", err)
-					return err
-				}
-				var dbErr error
-				for _, da := range due {
-					res := markAndFireEventAlarm(ctx, a, da, policy)
-					if res.MarkErr != nil {
-						dbErr = res.MarkErr
-					}
-					if !res.Fired || res.FireErr != nil {
-						continue
-					}
-					writeAlarmCheckLine(w, da.TriggerAt, da.Alarm.Action, da.Event.Title, false)
-				}
-				for _, tda := range todoDue {
-					res := markAndFireTodoAlarm(ctx, a, tda, policy)
-					if res.MarkErr != nil {
-						dbErr = res.MarkErr
-					}
-					if !res.Fired || res.FireErr != nil {
-						continue
-					}
-					writeAlarmCheckLine(w, tda.TriggerAt, tda.Alarm.Action, tda.Todo.Summary, true)
-				}
-				return dbErr
+				return runDaemonTick(ctx, a, w, policy)
 			}
 
 			// A failed tick is usually transient (the TUI holding the write
@@ -970,4 +961,37 @@ system was not running when they became due.`,
 	}
 	cmd.Flags().IntVar(&days, "days", 7, "lookback window in days")
 	return cmd
+}
+
+// runDaemonTick runs one daemon pass. It differs from runAlarmCheck on
+// purpose: the daemon always writes text lines, emits no JSON records, and
+// reports the first mark failure so the tick breaker can count it.
+func runDaemonTick(ctx context.Context, a *app.App, w io.Writer, policy alarmExecutionPolicy) error {
+	due, todoDue, err := a.Alarms.Check(ctx, time.Now())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "chroncal: check error: %v\n", err)
+		return err
+	}
+	var dbErr error
+	for _, da := range due {
+		res := markAndFireEventAlarm(ctx, a, da, policy)
+		if res.MarkErr != nil {
+			dbErr = res.MarkErr
+		}
+		if !res.Fired || res.FireErr != nil {
+			continue
+		}
+		writeAlarmCheckLine(w, da.TriggerAt, da.Alarm.Action, da.Event.Title, false)
+	}
+	for _, tda := range todoDue {
+		res := markAndFireTodoAlarm(ctx, a, tda, policy)
+		if res.MarkErr != nil {
+			dbErr = res.MarkErr
+		}
+		if !res.Fired || res.FireErr != nil {
+			continue
+		}
+		writeAlarmCheckLine(w, tda.TriggerAt, tda.Alarm.Action, tda.Todo.Summary, true)
+	}
+	return dbErr
 }

--- a/cmd/chroncal/alarm.go
+++ b/cmd/chroncal/alarm.go
@@ -759,16 +759,21 @@ See "chroncal alarm check --help" for notification types and SMTP configuration.
   # Check every 10 seconds
   chroncal alarm daemon --interval 10s`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Validate before initApp so a bad interval fails without
+			// touching the database, like the --days check in alarm missed.
+			dur, err := parseCLIDuration("interval", interval)
+			if err != nil {
+				return err
+			}
+			if dur <= 0 {
+				return errInvalidInputf("--interval must be a positive duration (e.g. 30s, 1m), got %q", interval)
+			}
+
 			a, err := initApp()
 			if err != nil {
 				return err
 			}
 			defer a.Close()
-
-			dur, err := parseCLIDuration("interval", interval)
-			if err != nil {
-				return err
-			}
 
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()

--- a/cmd/chroncal/alarm_missed_test.go
+++ b/cmd/chroncal/alarm_missed_test.go
@@ -140,7 +140,7 @@ func TestAlarmMissed_JSONIsFlatArray(t *testing.T) {
 // TestAlarmDaemon_RejectsNonPositiveInterval guards against a panic:
 // time.NewTicker panics on a zero or negative interval. A bad --interval
 // must fail as invalid_input instead. Validation runs before initApp, so
-// the command fails with no touch of the database.
+// the command fails before the database opens.
 func TestAlarmDaemon_RejectsNonPositiveInterval(t *testing.T) {
 	for _, interval := range []string{"0s", "-1m", "-30s"} {
 		t.Run("interval="+interval, func(t *testing.T) {

--- a/cmd/chroncal/alarm_missed_test.go
+++ b/cmd/chroncal/alarm_missed_test.go
@@ -136,3 +136,30 @@ func TestAlarmMissed_JSONIsFlatArray(t *testing.T) {
 		t.Fatalf("output still uses map shape with events/todos keys:\n%s", out.String())
 	}
 }
+
+// TestAlarmDaemon_RejectsNonPositiveInterval guards against a panic:
+// time.NewTicker panics on a zero or negative interval. A bad --interval
+// must fail as invalid_input instead. Validation runs before initApp, so
+// the command fails with no touch of the database.
+func TestAlarmDaemon_RejectsNonPositiveInterval(t *testing.T) {
+	for _, interval := range []string{"0s", "-1m", "-30s"} {
+		t.Run("interval="+interval, func(t *testing.T) {
+			cmd := alarmDaemonCmd()
+			if err := cmd.ParseFlags([]string{"--interval", interval}); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+
+			err := cmd.RunE(cmd, nil)
+			if err == nil {
+				t.Fatalf("--interval %s: want error, got nil", interval)
+			}
+			var ce *cliError
+			if !errors.As(err, &ce) {
+				t.Fatalf("--interval %s: want *cliError, got %T: %v", interval, err, err)
+			}
+			if ce.Code != "invalid_input" {
+				t.Fatalf("--interval %s: code = %q, want invalid_input", interval, ce.Code)
+			}
+		})
+	}
+}

--- a/cmd/chroncal/calendar.go
+++ b/cmd/chroncal/calendar.go
@@ -164,7 +164,7 @@ hidden calendars as opted out of the sidebar.`
 			}
 			target, err := findCalendarByRef(cals, args[0])
 			if err != nil {
-				return errInvalidInputf("%v", err)
+				return err
 			}
 			if err := setCalendarHidden(target.ID, hide); err != nil {
 				return err
@@ -616,7 +616,7 @@ func resolveNewDefault(cmd *cobra.Command, a *app.App, ctx context.Context, cal 
 	if promote != "" {
 		chosen, err := findCalendarByRef(candidates, promote)
 		if err != nil {
-			return calendarpkg.Calendar{}, errInvalidInputf("promote: %v", err)
+			return calendarpkg.Calendar{}, fmt.Errorf("promote: %w", err)
 		}
 		return chosen, nil
 	}
@@ -661,7 +661,7 @@ func promptForNewDefault(cmd *cobra.Command, cal calendarpkg.Calendar, candidate
 	}
 	chosen, err := findCalendarByRef(candidates, answer)
 	if err != nil {
-		return calendarpkg.Calendar{}, errInvalidInputf("promote: %v", err)
+		return calendarpkg.Calendar{}, fmt.Errorf("promote: %w", err)
 	}
 	return chosen, nil
 }
@@ -680,7 +680,7 @@ func findCalendarByRef(cals []calendarpkg.Calendar, ref string) (calendarpkg.Cal
 				return cal, nil
 			}
 		}
-		return calendarpkg.Calendar{}, fmt.Errorf("calendar %q not found", ref)
+		return calendarpkg.Calendar{}, &cliError{Code: "not_found", Msg: fmt.Sprintf("calendar %q not found", ref)}
 	}
 
 	var matches []calendarpkg.Calendar
@@ -691,11 +691,11 @@ func findCalendarByRef(cals []calendarpkg.Calendar, ref string) (calendarpkg.Cal
 	}
 	switch len(matches) {
 	case 0:
-		return calendarpkg.Calendar{}, fmt.Errorf("calendar %q not found", ref)
+		return calendarpkg.Calendar{}, &cliError{Code: "not_found", Msg: fmt.Sprintf("calendar %q not found", ref)}
 	case 1:
 		return matches[0], nil
 	default:
-		return calendarpkg.Calendar{}, fmt.Errorf("calendar name %q is ambiguous; use its numeric ID instead", ref)
+		return calendarpkg.Calendar{}, errInvalidInputf("calendar name %q is ambiguous; use its numeric ID instead", ref)
 	}
 }
 

--- a/cmd/chroncal/calendar.go
+++ b/cmd/chroncal/calendar.go
@@ -544,7 +544,13 @@ to stderr.`,
 			if getErr != nil {
 				return notFoundErr(getErr, "calendar", id)
 			}
-			eventCount, _ := a.Queries.CountEventsByCalendar(ctx, id)
+			eventCount, err := a.Queries.CountEventsByCalendar(ctx, id)
+			if err != nil {
+				// The confirm prompt quotes this count. Abort when it is
+				// unknown: a prompt that says "0 event(s)" in error would
+				// understate a destructive action.
+				return fmt.Errorf("count events: %w", err)
+			}
 
 			var (
 				newDefaultID   int64

--- a/cmd/chroncal/calendar_cli_test.go
+++ b/cmd/chroncal/calendar_cli_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -433,6 +434,81 @@ func TestCalendarRefNotFoundCodeUniform(t *testing.T) {
 		if !strings.Contains(payload.Error, "Ghost") {
 			t.Fatalf("%s: error = %q, want it to name the unknown reference", strings.Join(args, " "), payload.Error)
 		}
+	}
+}
+
+// TestCalendarDeleteAbortsWhenEventCountUnknown guards the destructive
+// prompt. calendar delete swallowed the CountEventsByCalendar error, so
+// the confirm quoted a zero count and the delete proceeded. The command
+// must abort while the risk summary is unknown, and keep the calendar.
+func TestCalendarDeleteAbortsWhenEventCountUnknown(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	// Break the events table so the count query fails, like an I/O error
+	// would. Only the count reads it at this stage of the command.
+	func() {
+		a, err := app.New(dbPath)
+		if err != nil {
+			t.Fatalf("app.New: %v", err)
+		}
+		defer a.Close()
+		if _, err := a.DB.ExecContext(context.Background(),
+			"ALTER TABLE events RENAME TO events_hidden"); err != nil {
+			t.Fatalf("hide events: %v", err)
+		}
+		t.Cleanup(func() {
+			b, berr := app.New(dbPath)
+			if berr != nil {
+				t.Fatalf("app.New for restore: %v", berr)
+			}
+			defer b.Close()
+			if _, err := b.DB.ExecContext(context.Background(),
+				"ALTER TABLE events_hidden RENAME TO events"); err != nil {
+				t.Fatalf("restore events: %v", err)
+			}
+		})
+	}()
+
+	var calID int64
+	{
+		a, err := app.New(dbPath)
+		if err != nil {
+			t.Fatalf("app.New: %v", err)
+		}
+		defer a.Close()
+		cals, err := a.Calendars.List(context.Background())
+		if err != nil {
+			t.Fatalf("calendar list: %v", err)
+		}
+		for _, c := range cals {
+			if c.Name == "Work" {
+				calID = c.ID
+			}
+		}
+		if calID == 0 {
+			t.Fatalf("calendar Work missing before delete")
+		}
+	}
+
+	_, stderr, err := runChroncalCommand(t, "calendar", "delete",
+		strconv.FormatInt(calID, 10), "--yes", "--output", "json")
+	if err == nil {
+		t.Fatal("calendar delete must abort when the event count is unknown")
+	}
+	if !strings.Contains(stderr, "count events") {
+		t.Fatalf("stderr = %q, want the count-events failure", stderr)
+	}
+
+	a, err := app.New(dbPath)
+	if err != nil {
+		t.Fatalf("app.New: %v", err)
+	}
+	defer a.Close()
+	if _, err := a.Calendars.Get(context.Background(), calID); err != nil {
+		t.Fatalf("calendar %d was deleted despite the abort: %v", calID, err)
 	}
 }
 

--- a/cmd/chroncal/calendar_cli_test.go
+++ b/cmd/chroncal/calendar_cli_test.go
@@ -374,7 +374,7 @@ func TestCalendarHideShowJSON(t *testing.T) {
 	}
 }
 
-func TestCalendarHideUnknownIDIsInvalidInput(t *testing.T) {
+func TestCalendarHideUnknownIDIsNotFound(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
 	_, stderr, err := runChroncalCommand(t, "calendar", "hide", "99999", "--output", "json")
@@ -388,11 +388,51 @@ func TestCalendarHideUnknownIDIsInvalidInput(t *testing.T) {
 	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
 		t.Fatalf("decode error payload %q: %v", stderr, jerr)
 	}
-	if payload.Code != "invalid_input" {
-		t.Fatalf("code = %q, want invalid_input", payload.Code)
+	// findCalendarByRef tags an unknown reference not_found itself, so
+	// calendar hide/show, set-default, sync run/reset, and the --calendar
+	// flag of every write command report the same code.
+	if payload.Code != "not_found" {
+		t.Fatalf("code = %q, want not_found", payload.Code)
 	}
 	if !strings.Contains(payload.Error, "99999") {
 		t.Fatalf("error = %q, want it to mention the unknown id", payload.Error)
+	}
+}
+
+// TestCalendarRefNotFoundCodeUniform guards the unified taxonomy: the same
+// unknown calendar reference must report one code on every surface that
+// resolves a reference. Before the fix, calendar hide/show re-tagged it
+// invalid_input, sync re-tagged it not_found, and calendar set-default and
+// the --calendar flag of write commands left it the generic error code.
+func TestCalendarRefNotFoundCodeUniform(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	for _, args := range [][]string{
+		{"calendar", "hide", "Ghost"},
+		{"calendar", "set-default", "Ghost"},
+		{"sync", "reset", "--calendar", "Ghost"},
+		{"event", "add", "Title", "--calendar", "Ghost"},
+	} {
+		_, stderr, err := runChroncalCommand(t, append(args, "--output", "json")...)
+		if err == nil {
+			t.Fatalf("%s accepted an unknown calendar", strings.Join(args, " "))
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("%s: decode error payload %q: %v", strings.Join(args, " "), stderr, jerr)
+		}
+		if payload.Code != "not_found" {
+			t.Fatalf("%s: code = %q, want not_found", strings.Join(args, " "), payload.Code)
+		}
+		if !strings.Contains(payload.Error, "Ghost") {
+			t.Fatalf("%s: error = %q, want it to name the unknown reference", strings.Join(args, " "), payload.Error)
+		}
 	}
 }
 

--- a/cmd/chroncal/calendar_link_test.go
+++ b/cmd/chroncal/calendar_link_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/calendar"
@@ -33,6 +34,32 @@ func TestFindCalendarByRef(t *testing.T) {
 		if got.ID != tt.wantID {
 			t.Fatalf("findCalendarByRef(%q) ID = %d, want %d", tt.ref, got.ID, tt.wantID)
 		}
+	}
+}
+
+// TestFindCalendarByRefErrorTaxonomy locks the error codes: an unknown
+// reference (numeric or by name) is not_found, and an ambiguous name is
+// invalid_input. Every caller then reports the same code without
+// re-wrapping, so --output json consumers can dispatch on it.
+func TestFindCalendarByRefErrorTaxonomy(t *testing.T) {
+	cals := []calendar.Calendar{
+		{ID: 1, Name: "Work"},
+		{ID: 2, Name: "Work"},
+		{ID: 3, Name: "Personal"},
+	}
+
+	for _, ref := range []string{"999", "Ghost"} {
+		_, err := findCalendarByRef(cals, ref)
+		var ce *cliError
+		if !errors.As(err, &ce) || ce.Code != "not_found" {
+			t.Fatalf("findCalendarByRef(%q) = %#v, want a not_found cliError", ref, err)
+		}
+	}
+
+	_, err := findCalendarByRef(cals, "work")
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "invalid_input" {
+		t.Fatalf("findCalendarByRef(%q) = %#v, want an invalid_input cliError for an ambiguous name", "work", err)
 	}
 }
 

--- a/cmd/chroncal/cli_surface_test.go
+++ b/cmd/chroncal/cli_surface_test.go
@@ -70,7 +70,7 @@ func TestCalendarCommandDoesNotRegisterLinkOrUnlink(t *testing.T) {
 func TestSyncStatusEmptyMessageIsCalendarCentric(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "status")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "status")
 	if err != nil {
 		t.Fatalf("sync status: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestSyncStatusEmptyMessageIsCalendarCentric(t *testing.T) {
 func TestSyncStatusHonorsOutputJSON(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "status", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "status", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync status --output json: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestSyncStatusHonorsOutputJSON(t *testing.T) {
 func TestSyncConflictsHonorsOutputJSON(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "conflicts", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "conflicts", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync conflicts --output json: %v", err)
 	}

--- a/cmd/chroncal/date_range_test.go
+++ b/cmd/chroncal/date_range_test.go
@@ -131,20 +131,28 @@ func TestParseExportDateBoundsNeither(t *testing.T) {
 // filtered out with no error. The same-day range stays valid because the
 // half-open end bound includes the whole --to day.
 func TestParseDateRangeRejectsInvertedRange(t *testing.T) {
-	_, _, err := parseDateRange("2026-05-10", "2026-05-01")
-	if err == nil {
-		t.Fatal("parseDateRange accepted --to before --from")
-	}
-	var ce *cliError
-	if !errors.As(err, &ce) || ce.Code != "invalid_input" {
-		t.Fatalf("error = %#v, want an invalid_input cliError", err)
-	}
-
-	if _, _, err := parseDateRange("2026-05-10", "2026-05-10"); err != nil {
-		t.Fatalf("same-day range must stay valid, got %v", err)
-	}
-	if _, _, err := parseDateRange("2026-05-10", ""); err != nil {
-		t.Fatalf("default upper bound must stay valid, got %v", err)
+	for _, tc := range []struct {
+		from, to string
+		wantErr  bool
+	}{
+		{"2026-05-10", "2026-05-01", true},  // to strictly before from
+		{"2026-05-10", "2026-05-09", true},  // to one day before from
+		{"2026-05-10", "2026-05-10", false}, // whole --to day included
+		{"2026-05-10", "", false},           // default upper bound
+	} {
+		_, _, err := parseDateRange(tc.from, tc.to)
+		if tc.wantErr && err == nil {
+			t.Fatalf("parseDateRange(%q, %q) accepted an inverted range", tc.from, tc.to)
+		}
+		if !tc.wantErr && err != nil {
+			t.Fatalf("parseDateRange(%q, %q) = %v, want valid", tc.from, tc.to, err)
+		}
+		if err != nil {
+			var ce *cliError
+			if !errors.As(err, &ce) || ce.Code != "invalid_input" {
+				t.Fatalf("error = %#v, want an invalid_input cliError", err)
+			}
+		}
 	}
 }
 

--- a/cmd/chroncal/date_range_test.go
+++ b/cmd/chroncal/date_range_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -122,6 +123,52 @@ func TestParseExportDateBoundsNeither(t *testing.T) {
 	}
 	if !from.IsZero() || !to.IsZero() {
 		t.Fatalf("both bounds must be zero when no flags given, got from=%s to=%s", from, to)
+	}
+}
+
+// TestParseDateRangeRejectsInvertedRange guards against a silent empty
+// window. --to before --from used to be accepted; every row was then
+// filtered out with no error. The same-day range stays valid because the
+// half-open end bound includes the whole --to day.
+func TestParseDateRangeRejectsInvertedRange(t *testing.T) {
+	_, _, err := parseDateRange("2026-05-10", "2026-05-01")
+	if err == nil {
+		t.Fatal("parseDateRange accepted --to before --from")
+	}
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "invalid_input" {
+		t.Fatalf("error = %#v, want an invalid_input cliError", err)
+	}
+
+	if _, _, err := parseDateRange("2026-05-10", "2026-05-10"); err != nil {
+		t.Fatalf("same-day range must stay valid, got %v", err)
+	}
+	if _, _, err := parseDateRange("2026-05-10", ""); err != nil {
+		t.Fatalf("default upper bound must stay valid, got %v", err)
+	}
+}
+
+// TestParseExportDateBoundsRejectsInvertedRange mirrors the guard above
+// for the export bounds parser. Both bounds must be set for the check to
+// run; a single bound keeps its open window (issue #358).
+func TestParseExportDateBoundsRejectsInvertedRange(t *testing.T) {
+	for _, tc := range []struct {
+		from, to string
+		wantErr  bool
+	}{
+		{"2026-05-10", "2026-05-01", true},  // to strictly before from
+		{"2026-05-10", "2026-05-09", true},  // to one day before from
+		{"2026-05-10", "2026-05-10", false}, // whole --to day included
+		{"2026-05-10", "", false},           // open upper bound
+		{"", "2026-05-10", false},           // open lower bound
+	} {
+		_, _, err := parseExportDateBounds(tc.from, tc.to)
+		if tc.wantErr && err == nil {
+			t.Fatalf("parseExportDateBounds(%q, %q) accepted an inverted range", tc.from, tc.to)
+		}
+		if !tc.wantErr && err != nil {
+			t.Fatalf("parseExportDateBounds(%q, %q) = %v, want valid", tc.from, tc.to, err)
+		}
 	}
 }
 

--- a/cmd/chroncal/event_add.go
+++ b/cmd/chroncal/event_add.go
@@ -230,13 +230,13 @@ Alarms default to ACTION=DISPLAY unless prefixed (e.g. EMAIL:-PT1H).`,
 			if !allDay {
 				exrdateRef = startTime
 			}
-			parsedExDates, err := parseDateFlags(exdates, timezone, exrdateRef)
+			parsedExDates, err := parseExdateRdateFlags("exception-date-times", exdates, timezone, exrdateRef)
 			if err != nil {
-				return errInvalidInputf("--exception-date-times: %v", err)
+				return err
 			}
-			parsedRDates, err := parseDateFlags(rdates, timezone, exrdateRef)
+			parsedRDates, err := parseExdateRdateFlags("recurrence-date-times", rdates, timezone, exrdateRef)
 			if err != nil {
-				return errInvalidInputf("--recurrence-date-times: %v", err)
+				return err
 			}
 
 			// Validate all parseable flags before creating the event so a

--- a/cmd/chroncal/event_add.go
+++ b/cmd/chroncal/event_add.go
@@ -219,6 +219,9 @@ Alarms default to ACTION=DISPLAY unless prefixed (e.g. EMAIL:-PT1H).`,
 					if err != nil {
 						return err
 					}
+					if dur <= 0 {
+						return errInvalidInputf("--duration must be positive (e.g. 30m, 1h), got %q", durationStr)
+					}
 				}
 				endTime = startTime.Add(dur)
 			}

--- a/cmd/chroncal/event_add.go
+++ b/cmd/chroncal/event_add.go
@@ -219,8 +219,8 @@ Alarms default to ACTION=DISPLAY unless prefixed (e.g. EMAIL:-PT1H).`,
 					if err != nil {
 						return err
 					}
-					if dur <= 0 {
-						return errInvalidInputf("--duration must be positive (e.g. 30m, 1h), got %q", durationStr)
+					if err := mustPositiveDuration("duration", durationStr, dur); err != nil {
+						return err
 					}
 				}
 				endTime = startTime.Add(dur)

--- a/cmd/chroncal/event_cli_test.go
+++ b/cmd/chroncal/event_cli_test.go
@@ -363,6 +363,57 @@ func TestNotFoundErrorJSONHasNoWrapPrefix(t *testing.T) {
 	}
 }
 
+// TestEventDurationMustBePositive guards the --duration end-after-start
+// contract. A zero or negative duration stored end <= start, an event no
+// view or exporter can represent. The end-time path already rejected it;
+// the duration path must reject it too, in add and update.
+func TestEventDurationMustBePositive(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	for _, dur := range []string{"0s", "-30m"} {
+		_, stderr, err := runChroncalCommand(t, "event", "add", "Standup",
+			"--calendar", "Work", "--date", "2026-04-06", "--time", "09:00",
+			"--duration", dur, "--output", "json")
+		if err == nil {
+			t.Fatalf("event add --duration %s was accepted", dur)
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("decode error payload %q: %v", stderr, jerr)
+		}
+		if payload.Code != "invalid_input" {
+			t.Fatalf("--duration %s: code = %q, want invalid_input", dur, payload.Code)
+		}
+	}
+
+	// A positive duration still works, and update rejects the same values.
+	if _, _, err := runChroncalCommand(t, "event", "add", "Standup",
+		"--calendar", "Work", "--date", "2026-04-06", "--time", "09:00",
+		"--duration", "30m"); err != nil {
+		t.Fatalf("event add --duration 30m: %v", err)
+	}
+	_, stderr, err := runChroncalCommand(t, "event", "update", "1", "--duration", "0s", "--output", "json")
+	if err == nil {
+		t.Fatal("event update --duration 0s was accepted")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error payload %q: %v", stderr, jerr)
+	}
+	if payload.Code != "invalid_input" {
+		t.Fatalf("event update --duration 0s: code = %q, want invalid_input", payload.Code)
+	}
+}
+
 // TestEventListJSONIncludesAttendees locks in that `event list --output json`
 // hydrates attendees the same way `event get` does. Chroncal Bar RSVP, the
 // participant filter, and participant search all read the list payload. They

--- a/cmd/chroncal/event_cli_test.go
+++ b/cmd/chroncal/event_cli_test.go
@@ -695,3 +695,31 @@ func TestEventUpdate_RecurrenceIDRejectsNonOccurrence(t *testing.T) {
 		t.Fatalf("non-occurrence update created an override:\n%s", listed)
 	}
 }
+
+// TestEventRestoreNotFoundIsTagged guards the error taxonomy of the restore
+// command. A live or missing event surfaced as a generic error code. The
+// not-found case must report not_found like event get, so --output json
+// consumers can dispatch on the code.
+func TestEventRestoreNotFoundIsTagged(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+
+	for _, ref := range []string{"999", "ghost-uid@example.com"} {
+		_, stderr, err := runChroncalCommand(t, "event", "restore", ref, "--output", "json")
+		if err == nil {
+			t.Fatalf("event restore %s should fail", ref)
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("event restore %s: decode error payload %q: %v", ref, stderr, jerr)
+		}
+		if payload.Code != "not_found" {
+			t.Fatalf("event restore %s: code = %q, want not_found", ref, payload.Code)
+		}
+		if !strings.Contains(payload.Error, "not found") {
+			t.Fatalf("event restore %s: error = %q, want a not-found message", ref, payload.Error)
+		}
+	}
+}

--- a/cmd/chroncal/event_parse.go
+++ b/cmd/chroncal/event_parse.go
@@ -492,6 +492,19 @@ func validateRRule(rrule string) error {
 	return errInvalidInputf("invalid --rrule %q: must contain FREQ= (e.g. FREQ=WEEKLY;BYDAY=MO)", rrule)
 }
 
+// parseExdateRdateFlags parses the values of one recurrence-date flag. The
+// flag argument is the long name without the leading dashes, for example
+// "exception-date-times". The function tags a parse failure with code
+// "invalid_input" and names the flag in the message. Pass the start time in
+// startTime so date-only values inherit it, as parseDateFlags describes.
+func parseExdateRdateFlags(flag string, values []string, tz string, startTime time.Time) (string, error) {
+	parsed, err := parseDateFlags(values, tz, startTime)
+	if err != nil {
+		return "", errInvalidInputf("--%s: %v", flag, err)
+	}
+	return parsed, nil
+}
+
 // validateGeo checks that a GEO value is "lat;lon" with valid ranges per
 // RFC 5545 Section 3.8.1.6. Empty string is allowed (optional field).
 func validateGeo(geo string) error {

--- a/cmd/chroncal/event_purge.go
+++ b/cmd/chroncal/event_purge.go
@@ -52,7 +52,7 @@ attendees, attachments, overrides) cascade.`,
 
 			if err := a.Events.PurgeByID(ctx, id); err != nil {
 				if errors.Is(err, event.ErrNotDeleted) {
-					return fmt.Errorf("event %d not found or not soft-deleted", id)
+					return errNotFoundf("event %d not found or not soft-deleted", id)
 				}
 				return fmt.Errorf("purge: %w", err)
 			}

--- a/cmd/chroncal/event_restore.go
+++ b/cmd/chroncal/event_restore.go
@@ -40,7 +40,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
 				if err := a.Events.RestoreByID(ctx, id); err != nil {
 					if errors.Is(err, event.ErrNotDeleted) {
-						return &cliError{Code: "not_found", Msg: fmt.Sprintf("event %d not found (may have been purged)", id)}
+						return errNotFoundf("event %d not found (may have been purged)", id)
 					}
 					return fmt.Errorf("restore event: %w", err)
 				}
@@ -54,7 +54,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			// UID path: restore every row sharing the UID.
 			if err := a.Events.RestoreByUID(ctx, ref); err != nil {
 				if errors.Is(err, event.ErrNotDeleted) {
-					return &cliError{Code: "not_found", Msg: fmt.Sprintf("event %q not found (may have been purged)", ref)}
+					return errNotFoundf("event %q not found (may have been purged)", ref)
 				}
 				return fmt.Errorf("restore event: %w", err)
 			}

--- a/cmd/chroncal/event_restore.go
+++ b/cmd/chroncal/event_restore.go
@@ -40,7 +40,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
 				if err := a.Events.RestoreByID(ctx, id); err != nil {
 					if errors.Is(err, event.ErrNotDeleted) {
-						return fmt.Errorf("event %d not found (may have been purged)", id)
+						return &cliError{Code: "not_found", Msg: fmt.Sprintf("event %d not found (may have been purged)", id)}
 					}
 					return fmt.Errorf("restore event: %w", err)
 				}
@@ -54,7 +54,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			// UID path: restore every row sharing the UID.
 			if err := a.Events.RestoreByUID(ctx, ref); err != nil {
 				if errors.Is(err, event.ErrNotDeleted) {
-					return fmt.Errorf("event %q not found (may have been purged)", ref)
+					return &cliError{Code: "not_found", Msg: fmt.Sprintf("event %q not found (may have been purged)", ref)}
 				}
 				return fmt.Errorf("restore event: %w", err)
 			}

--- a/cmd/chroncal/event_update.go
+++ b/cmd/chroncal/event_update.go
@@ -255,8 +255,8 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				if err != nil {
 					return err
 				}
-				if dur <= 0 {
-					return errInvalidInputf("--duration must be positive (e.g. 30m, 1h), got %q", durationStr)
+				if err := mustPositiveDuration("duration", durationStr, dur); err != nil {
+					return err
 				}
 				p.EndTime = p.StartTime.Add(dur)
 			case cmd.Flags().Changed("date") || cmd.Flags().Changed("time"):

--- a/cmd/chroncal/event_update.go
+++ b/cmd/chroncal/event_update.go
@@ -255,6 +255,9 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				if err != nil {
 					return err
 				}
+				if dur <= 0 {
+					return errInvalidInputf("--duration must be positive (e.g. 30m, 1h), got %q", durationStr)
+				}
 				p.EndTime = p.StartTime.Add(dur)
 			case cmd.Flags().Changed("date") || cmd.Flags().Changed("time"):
 				if existing.AllDay && !p.AllDay {

--- a/cmd/chroncal/event_update.go
+++ b/cmd/chroncal/event_update.go
@@ -274,9 +274,9 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				if !p.AllDay {
 					exrdateRef = p.StartTime
 				}
-				parsed, err := parseDateFlags(exdates, tz, exrdateRef)
+				parsed, err := parseExdateRdateFlags("exception-date-times", exdates, tz, exrdateRef)
 				if err != nil {
-					return errInvalidInputf("--exception-date-times: %v", err)
+					return err
 				}
 				p.ExDates = parsed
 			}
@@ -285,9 +285,9 @@ values. Repeatable flags such as --alarm, --attendee, --resource, and
 				if !p.AllDay {
 					exrdateRef = p.StartTime
 				}
-				parsed, err := parseDateFlags(rdates, tz, exrdateRef)
+				parsed, err := parseExdateRdateFlags("recurrence-date-times", rdates, tz, exrdateRef)
 				if err != nil {
-					return errInvalidInputf("--recurrence-date-times: %v", err)
+					return err
 				}
 				p.RDates = parsed
 			}

--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -256,16 +256,9 @@ them.`,
 						From:       fromT,
 						To:         toT,
 					})
-					if eerr == nil {
-						seen := make(map[int64]bool, len(events))
-						for _, e := range events {
-							seen[e.ID] = true
-						}
-						for _, e := range extra {
-							if !seen[e.ID] {
-								events = append(events, e)
-							}
-						}
+					events, err = appendRecurringExtras(events, extra, eerr)
+					if err != nil {
+						return err
 					}
 				}
 
@@ -405,6 +398,26 @@ them.`,
 	cmd.Flags().BoolVar(&skipUnreadable, "skip-unreadable", false,
 		"export past unreadable relations and mark incomplete records (default: abort)")
 	return cmd
+}
+
+// appendRecurringExtras merges recurring masters from the expansion query
+// into the export set. expandErr is the error from that query. A failed
+// expansion must abort the export: a backup file that silently drops
+// series masters is incomplete, so no file may be written.
+func appendRecurringExtras(events, extra []event.Event, expandErr error) ([]event.Event, error) {
+	if expandErr != nil {
+		return nil, fmt.Errorf("export aborted, no file written: expand recurring events: %w", expandErr)
+	}
+	seen := make(map[int64]bool, len(events))
+	for _, e := range events {
+		seen[e.ID] = true
+	}
+	for _, e := range extra {
+		if !seen[e.ID] {
+			events = append(events, e)
+		}
+	}
+	return events, nil
 }
 
 // unreadableRecord names one record that exported without all its relations.

--- a/cmd/chroncal/ical_export_skip_unreadable_test.go
+++ b/cmd/chroncal/ical_export_skip_unreadable_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/ical"
 )
 
@@ -165,5 +167,35 @@ func TestICalExportSkipUnreadable(t *testing.T) {
 	}
 	if !brokenOK || !healthyOK {
 		t.Fatalf("missing records after round-trip: broken=%v healthy=%v", brokenOK, healthyOK)
+	}
+}
+
+// TestAppendRecurringExtrasPropagatesExpansionError guards the export
+// abort contract for the recurring-master expansion. The export command
+// used to swallow the ExportExpandedByDateRange error, so a failed
+// expansion still wrote an incomplete backup and exited 0.
+func TestAppendRecurringExtrasPropagatesExpansionError(t *testing.T) {
+	boom := fmt.Errorf("disk I/O error")
+	_, err := appendRecurringExtras(nil, nil, boom)
+	if err == nil {
+		t.Fatal("appendRecurringExtras must return the expansion error")
+	}
+	if !strings.Contains(err.Error(), "no file written") || !strings.Contains(err.Error(), "disk I/O error") {
+		t.Fatalf("error = %q, want the abort message to carry the cause", err)
+	}
+}
+
+// TestAppendRecurringExtrasMergesAndDedupes verifies the merge half of the
+// helper: masters already in the export set stay single, new masters append.
+func TestAppendRecurringExtrasMergesAndDedupes(t *testing.T) {
+	events := []event.Event{{ID: 1}, {ID: 2}}
+	extra := []event.Event{{ID: 2}, {ID: 3}}
+
+	got, err := appendRecurringExtras(events, extra, nil)
+	if err != nil {
+		t.Fatalf("appendRecurringExtras: %v", err)
+	}
+	if len(got) != 3 || got[0].ID != 1 || got[1].ID != 2 || got[2].ID != 3 {
+		t.Fatalf("merged = %+v, want ids [1 2 3]", got)
 	}
 }

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -262,11 +262,11 @@ Defaults: status=FINAL, class=PUBLIC, calendar=Personal.`,
 
 			parsedExDates, err := parseDateFlags(exdates, "", time.Time{})
 			if err != nil {
-				return fmt.Errorf("--exdate: %w", err)
+				return errInvalidInputf("--exception-date-times: %v", err)
 			}
 			parsedRDates, err := parseDateFlags(rdates, "", time.Time{})
 			if err != nil {
-				return fmt.Errorf("--rdate: %w", err)
+				return errInvalidInputf("--recurrence-date-times: %v", err)
 			}
 
 			// Validate all parseable flags before creating the journal so a
@@ -503,14 +503,14 @@ Repeatable flags (--attendee, --comment, --contact, --attach,
 			if cmd.Flags().Changed("exception-date-times") || cmd.Flags().Changed("exdate") {
 				parsed, err := parseDateFlags(exdates, "", time.Time{})
 				if err != nil {
-					return fmt.Errorf("--exdate: %w", err)
+					return errInvalidInputf("--exception-date-times: %v", err)
 				}
 				p.ExDates = parsed
 			}
 			if cmd.Flags().Changed("recurrence-date-times") || cmd.Flags().Changed("rdate") {
 				parsed, err := parseDateFlags(rdates, "", time.Time{})
 				if err != nil {
-					return fmt.Errorf("--rdate: %w", err)
+					return errInvalidInputf("--recurrence-date-times: %v", err)
 				}
 				p.RDates = parsed
 			}

--- a/cmd/chroncal/journal.go
+++ b/cmd/chroncal/journal.go
@@ -260,13 +260,13 @@ Defaults: status=FINAL, class=PUBLIC, calendar=Personal.`,
 				startDate = dateStr
 			}
 
-			parsedExDates, err := parseDateFlags(exdates, "", time.Time{})
+			parsedExDates, err := parseExdateRdateFlags("exception-date-times", exdates, "", time.Time{})
 			if err != nil {
-				return errInvalidInputf("--exception-date-times: %v", err)
+				return err
 			}
-			parsedRDates, err := parseDateFlags(rdates, "", time.Time{})
+			parsedRDates, err := parseExdateRdateFlags("recurrence-date-times", rdates, "", time.Time{})
 			if err != nil {
-				return errInvalidInputf("--recurrence-date-times: %v", err)
+				return err
 			}
 
 			// Validate all parseable flags before creating the journal so a
@@ -501,16 +501,16 @@ Repeatable flags (--attendee, --comment, --contact, --attach,
 				p.RecurrenceRule = rrule
 			}
 			if cmd.Flags().Changed("exception-date-times") || cmd.Flags().Changed("exdate") {
-				parsed, err := parseDateFlags(exdates, "", time.Time{})
+				parsed, err := parseExdateRdateFlags("exception-date-times", exdates, "", time.Time{})
 				if err != nil {
-					return errInvalidInputf("--exception-date-times: %v", err)
+					return err
 				}
 				p.ExDates = parsed
 			}
 			if cmd.Flags().Changed("recurrence-date-times") || cmd.Flags().Changed("rdate") {
-				parsed, err := parseDateFlags(rdates, "", time.Time{})
+				parsed, err := parseExdateRdateFlags("recurrence-date-times", rdates, "", time.Time{})
 				if err != nil {
-					return errInvalidInputf("--recurrence-date-times: %v", err)
+					return err
 				}
 				p.RDates = parsed
 			}
@@ -720,7 +720,7 @@ the next sync cycle recreates it remotely.`,
 			if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
 				if err := a.Journals.RestoreByID(ctx, id); err != nil {
 					if errors.Is(err, journal.ErrNotDeleted) {
-						return fmt.Errorf("journal %d not found (may have been purged)", id)
+						return errNotFoundf("journal %d not found (may have been purged)", id)
 					}
 					return fmt.Errorf("restore journal: %w", err)
 				}
@@ -733,7 +733,7 @@ the next sync cycle recreates it remotely.`,
 
 			if err := a.Journals.RestoreByUID(ctx, ref); err != nil {
 				if errors.Is(err, journal.ErrNotDeleted) {
-					return fmt.Errorf("journal %q not found (may have been purged)", ref)
+					return errNotFoundf("journal %q not found (may have been purged)", ref)
 				}
 				return fmt.Errorf("restore journal: %w", err)
 			}
@@ -787,7 +787,7 @@ use 'journal delete' first. Purging is not reversible — child rows cascade.`,
 
 			if err := a.Journals.PurgeByID(ctx, id); err != nil {
 				if errors.Is(err, journal.ErrNotDeleted) {
-					return fmt.Errorf("journal %d not found or not soft-deleted", id)
+					return errNotFoundf("journal %d not found or not soft-deleted", id)
 				}
 				return fmt.Errorf("purge: %w", err)
 			}

--- a/cmd/chroncal/journal_cli_test.go
+++ b/cmd/chroncal/journal_cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -77,5 +78,46 @@ func TestJournalListHidesCancelledByDefault(t *testing.T) {
 	}
 	if strings.Contains(stdoutStatus, "Active note") {
 		t.Fatalf("--status CANCELLED list = %q, should not contain FINAL entry %q", stdoutStatus, "Active note")
+	}
+}
+
+// TestJournalExdateParseFailureIsInvalidInput guards the error taxonomy. A
+// bad --exdate value in journal add/update used to surface as a generic
+// error. It must report invalid_input like the event and todo commands.
+func TestJournalExdateParseFailureIsInvalidInput(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	_, stderr, err := runChroncalCommand(t, "journal", "add", "Note",
+		"--calendar", "Work", "--exdate", "not-a-date", "--output", "json")
+	if err == nil {
+		t.Fatal("journal add accepted a bad --exdate value")
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error payload %q: %v", stderr, jerr)
+	}
+	if payload.Code != "invalid_input" {
+		t.Fatalf("code = %q, want invalid_input", payload.Code)
+	}
+
+	if _, _, err := runChroncalCommand(t, "journal", "add", "Note", "--calendar", "Work"); err != nil {
+		t.Fatalf("journal add: %v", err)
+	}
+	_, stderr, err = runChroncalCommand(t, "journal", "update", "1",
+		"--exdate", "not-a-date", "--output", "json")
+	if err == nil {
+		t.Fatal("journal update accepted a bad --exdate value")
+	}
+	if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+		t.Fatalf("decode error payload %q: %v", stderr, jerr)
+	}
+	if payload.Code != "invalid_input" {
+		t.Fatalf("journal update: code = %q, want invalid_input", payload.Code)
 	}
 }

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -494,3 +494,14 @@ func parseCLIDuration(flag, value string) (time.Duration, error) {
 	}
 	return d, nil
 }
+
+// mustPositiveDuration rejects a zero or negative duration after a
+// successful parseCLIDuration call. Pass the flag name without the leading
+// dashes and the raw flag value. The error names the flag and repeats the
+// value, tagged with code "invalid_input".
+func mustPositiveDuration(flag, raw string, d time.Duration) error {
+	if d <= 0 {
+		return errInvalidInputf("--%s must be positive (e.g. 30m, 1h), got %q", flag, raw)
+	}
+	return nil
+}

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -418,7 +418,7 @@ func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
 		to = to.AddDate(0, 0, 1) // half-open: include the entire end day
 	}
 	// An inverted window (--to before --from) silently matched nothing.
-	// Reject it so a typo fails loudly instead of hiding every row.
+	// Reject it so a typo gives an error instead of an empty result.
 	if !to.After(from) {
 		return time.Time{}, time.Time{}, errInvalidInputf("--to must be after --from")
 	}

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -417,6 +417,11 @@ func parseDateRange(fromStr, toStr string) (time.Time, time.Time, error) {
 		}
 		to = to.AddDate(0, 0, 1) // half-open: include the entire end day
 	}
+	// An inverted window (--to before --from) silently matched nothing.
+	// Reject it so a typo fails loudly instead of hiding every row.
+	if !to.After(from) {
+		return time.Time{}, time.Time{}, errInvalidInputf("--to must be after --from")
+	}
 	return from, to, nil
 }
 
@@ -444,6 +449,11 @@ func parseExportDateBounds(fromStr, toStr string) (time.Time, time.Time, error) 
 			return time.Time{}, time.Time{}, err
 		}
 		to = to.AddDate(0, 0, 1) // half-open: include the entire end day
+	}
+	// Both bounds set: an inverted window silently matched nothing.
+	// One bound alone stays open, so the check only runs when both exist.
+	if !from.IsZero() && !to.IsZero() && !to.After(from) {
+		return time.Time{}, time.Time{}, errInvalidInputf("--to must be after --from")
 	}
 	return from, to, nil
 }

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -54,6 +54,13 @@ func errInvalidInputf(format string, args ...any) error {
 	return &cliError{Code: "invalid_input", Msg: fmt.Sprintf(format, args...)}
 }
 
+// errNotFoundf is the printf counterpart to notFoundErr. It produces a
+// *cliError tagged with code "not_found". Use it when a command cannot
+// find the row that the user named, for example on a restore or a purge.
+func errNotFoundf(format string, args ...any) error {
+	return &cliError{Code: "not_found", Msg: fmt.Sprintf(format, args...)}
+}
+
 // printCLIError writes err to stderr in the format that matches --output.
 // Text mode keeps "Error: <msg>". JSON emits a structured payload.
 // Aborted errors drop the "Error: " prefix in text mode. They come from

--- a/cmd/chroncal/service.go
+++ b/cmd/chroncal/service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -239,7 +240,7 @@ func systemdUserDir() (string, error) {
 	return filepath.Join(home, ".config", "systemd", "user"), nil
 }
 
-func installLinuxService(ctx context.Context, w interface{ Write([]byte) (int, error) }, data map[string]string) error {
+func installLinuxService(ctx context.Context, w io.Writer, data map[string]string) error {
 	dir, err := systemdUserDir()
 	if err != nil {
 		return fmt.Errorf("resolve systemd user dir: %w", err)
@@ -283,7 +284,7 @@ func installLinuxService(ctx context.Context, w interface{ Write([]byte) (int, e
 	return nil
 }
 
-func installDarwinService(ctx context.Context, w interface{ Write([]byte) (int, error) }, data map[string]string) error {
+func installDarwinService(ctx context.Context, w io.Writer, data map[string]string) error {
 	home := data["HomeDir"]
 	dir := filepath.Join(home, "Library", "LaunchAgents")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -334,7 +335,7 @@ func serviceUninstallCmd() *cobra.Command {
 	return cmd
 }
 
-func uninstallLinuxService(ctx context.Context, w interface{ Write([]byte) (int, error) }) error {
+func uninstallLinuxService(ctx context.Context, w io.Writer) error {
 	dir, err := systemdUserDir()
 	if err != nil {
 		return fmt.Errorf("resolve systemd user dir: %w", err)
@@ -386,7 +387,7 @@ const windowsWrapperTmpl = `@echo off
 {{end}}"{{.BinaryPath}}" service run
 `
 
-func installWindowsService(ctx context.Context, w interface{ Write([]byte) (int, error) }, data map[string]string) error {
+func installWindowsService(ctx context.Context, w io.Writer, data map[string]string) error {
 	wrapperPath, err := windowsWrapperPath()
 	if err != nil {
 		return fmt.Errorf("resolve wrapper path: %w", err)
@@ -423,7 +424,7 @@ func installWindowsService(ctx context.Context, w interface{ Write([]byte) (int,
 	return nil
 }
 
-func uninstallWindowsService(ctx context.Context, w interface{ Write([]byte) (int, error) }) error {
+func uninstallWindowsService(ctx context.Context, w io.Writer) error {
 	out, err := exec.CommandContext(ctx, "schtasks", "/Delete", "/F", "/TN", windowsTaskName).CombinedOutput()
 	if len(out) > 0 {
 		fmt.Fprint(w, string(out))
@@ -446,7 +447,7 @@ func uninstallWindowsService(ctx context.Context, w interface{ Write([]byte) (in
 	return nil
 }
 
-func uninstallDarwinService(ctx context.Context, w interface{ Write([]byte) (int, error) }) error {
+func uninstallDarwinService(ctx context.Context, w io.Writer) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("get home dir: %w", err)

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -163,7 +163,7 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 			if calendarName != "" {
 				target, err := findCalendarByRef(cals, calendarName)
 				if err != nil {
-					return &cliError{Code: "not_found", Msg: err.Error()}
+					return err
 				}
 				targetCalendarID = target.ID
 			} else if accountName != "" {
@@ -451,14 +451,14 @@ This does not delete your local calendars or entries.`,
 
 			var connected, failed int
 			// Resolve --calendar by ID or case-insensitive name via the shared
-			// findCalendarByRef helper. It already reports not_found for an
-			// unknown reference, so a non-zero targetID is guaranteed to match a
+			// findCalendarByRef helper. It reports not_found for an unknown
+			// reference, so a non-zero targetID is guaranteed to match a
 			// calendar below.
 			var targetID int64
 			if calendarName != "" {
 				target, err := findCalendarByRef(cals, calendarName)
 				if err != nil {
-					return &cliError{Code: "not_found", Msg: err.Error()}
+					return err
 				}
 				targetID = target.ID
 			}

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -237,7 +237,10 @@ for each connected calendar.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			statuses, err := svc.Status(context.Background())
@@ -302,9 +305,11 @@ A resolved row keeps the recorded local version, so "chroncal sync resolve
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
-
 			var conflicts []syncPkg.Conflict
 			if resolved {
 				conflicts, err = svc.ListResolvedConflicts(context.Background())
@@ -389,7 +394,10 @@ it again with --pick local restores the recorded local version.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			warnings, err := svc.ResolveConflict(context.Background(), id, pick)
@@ -430,7 +438,10 @@ This does not delete your local calendars or entries.`,
 			defer a.Close()
 			ctx := context.Background()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			cals, err := a.Calendars.List(ctx)

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -52,6 +52,20 @@ func fprintImportWarnings(w io.Writer, warnings []syncPkg.ImportWarning) {
 	}
 }
 
+// newSyncService builds the sync service for every sync subcommand. The
+// app supplies the database, the domain services, and the credential
+// store scope. A failed store construction returns an error; a command
+// then fails with one clear message instead of a nil store that fails
+// later with a confusing error. Pass a nil logger for silent commands.
+// Pass an explicit logger when the command shows sync logs.
+func newSyncService(a *app.App, logger *slog.Logger) (*syncPkg.Service, error) {
+	credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+	if err != nil {
+		return nil, fmt.Errorf("credential store: %w", err)
+	}
+	return syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, logger), nil
+}
+
 func syncNewCalendars(
 	ctx context.Context,
 	a *app.App,
@@ -184,12 +198,10 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 				}
 			}
 
-			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			svc, err := newSyncService(a, stderrSyncLogger(os.Stderr))
 			if err != nil {
-				return fmt.Errorf("credential store: %w", err)
+				return err
 			}
-
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, stderrSyncLogger(os.Stderr))
 
 			var results []*syncPkg.SyncResult
 			if targetCalendarID != 0 {
@@ -237,8 +249,10 @@ for each connected calendar.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			statuses, err := svc.Status(context.Background())
 			if err != nil {
@@ -302,8 +316,10 @@ A resolved row keeps the recorded local version, so "chroncal sync resolve
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			var conflicts []syncPkg.Conflict
 			if resolved {
@@ -389,8 +405,10 @@ it again with --pick local restores the recorded local version.`,
 			}
 			defer a.Close()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			warnings, err := svc.ResolveConflict(context.Background(), id, pick)
 			if err != nil {
@@ -430,8 +448,10 @@ This does not delete your local calendars or entries.`,
 			defer a.Close()
 			ctx := context.Background()
 
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			cals, err := a.Calendars.List(ctx)
 			if err != nil {

--- a/cmd/chroncal/sync_cli_test.go
+++ b/cmd/chroncal/sync_cli_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestSyncResetMatchesCalendarCaseInsensitively(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	createLinkedCalendarForTest(t, dbPath)
 
-	stdout, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "work")
+	stdout, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "reset", "--calendar", "work")
 	if err != nil {
 		t.Fatalf("sync reset --calendar work: %v (stderr: %s)", err, stderr)
 	}
@@ -36,7 +37,7 @@ func TestSyncRunRejectsInvalidConflictStrategy(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	createLinkedCalendarForTest(t, dbPath)
 
-	_, stderr, err := runChroncalCommand(t, "sync", "run", "--conflict", "Prompt")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--conflict", "Prompt")
 	if err == nil {
 		t.Fatalf("sync run --conflict Prompt was accepted; expected an invalid-input error")
 	}
@@ -55,7 +56,7 @@ func TestSyncRunMatchesCalendarCaseInsensitively(t *testing.T) {
 
 	// The run will still fail downstream (no stored credentials), but it must
 	// not fail with the case-sensitive "not found" resolution error.
-	_, stderr, err := runChroncalCommand(t, "sync", "run", "--calendar", "work")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--calendar", "work")
 	if err == nil {
 		return // resolved and ran; resolution is clearly case-insensitive
 	}
@@ -73,7 +74,7 @@ func TestSyncRunRejectsAccountWithCalendar(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	createLinkedCalendarForTest(t, dbPath)
 
-	_, stderr, err := runChroncalCommand(t, "sync", "run",
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run",
 		"--account", "__calendar_test", "--calendar", "Work", "--output", "json")
 	if err == nil {
 		t.Fatalf("sync run --account with --calendar was accepted; expected an invalid_input error")
@@ -117,7 +118,7 @@ func TestSyncRunScopesToRequestedAccount(t *testing.T) {
 	a.Close()
 
 	// An account with no linked calendars: the run is a no-op, not an error.
-	stdout, _, err := runChroncalCommand(t, "sync", "run", "--account", "empty", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--account", "empty", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync run --account empty: %v", err)
 	}
@@ -140,7 +141,7 @@ func TestSyncRunScopesToRequestedAccount(t *testing.T) {
 	// not account-not-found, and any rendered results stay inside the
 	// account: Work is its only calendar, so anything else in results would
 	// mean the run ignored --account.
-	stdout, stderr, err := runChroncalCommand(t, "sync", "run", "--account", "__CALENDAR_TEST", "--output", "json")
+	stdout, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--account", "__CALENDAR_TEST", "--output", "json")
 	if err != nil && strings.Contains(stderr, "not_found") {
 		t.Fatalf("sync run --account __CALENDAR_TEST failed to resolve the account case-insensitively; stderr = %q", stderr)
 	}
@@ -168,7 +169,7 @@ func TestSyncRunScopesToRequestedAccount(t *testing.T) {
 func TestSyncRunUnknownAccountIsNotFound(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	_, stderr, err := runChroncalCommand(t, "sync", "run", "--account", "ghost", "--output", "json")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "run", "--account", "ghost", "--output", "json")
 	if err == nil {
 		t.Fatalf("sync run --account ghost was accepted; expected a not_found error")
 	}
@@ -182,5 +183,38 @@ func TestSyncRunUnknownAccountIsNotFound(t *testing.T) {
 	if payload.Code != "not_found" || payload.Error != `account "ghost" not found` {
 		t.Fatalf("sync run --account ghost: code = %q, error = %q; want the account not_found error",
 			payload.Code, payload.Error)
+	}
+}
+
+// TestSyncCommandsFailWhenCredentialStoreUnavailable guards the shared
+// service construction in newSyncService. A dead session bus makes the
+// keyring probe fail on every host. Each sync subcommand must then exit
+// non-zero with the credential store error. A command must not run on
+// with a nil store and fail later with a confusing error.
+func TestSyncCommandsFailWhenCredentialStoreUnavailable(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the session bus probe only applies on Linux")
+	}
+	setupCalendarCLITestEnv(t)
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent/chroncal-test-bus")
+
+	commands := [][]string{
+		{"sync", "run"},
+		{"sync", "status"},
+		{"sync", "conflicts"},
+		{"sync", "doctor"},
+		{"sync", "resolve", "999999", "--pick", "local"},
+		{"sync", "reset", "no-such-calendar"},
+	}
+	for _, args := range commands {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			_, stderr, err := runChroncalCommand(t, args...)
+			if err == nil {
+				t.Fatalf("%v exited 0 with a broken credential store; want non-zero. stderr=%q", args, stderr)
+			}
+			if !strings.Contains(stderr, "credential store") {
+				t.Fatalf("%v stderr = %q, want the credential store error", args, stderr)
+			}
+		})
 	}
 }

--- a/cmd/chroncal/sync_cli_test.go
+++ b/cmd/chroncal/sync_cli_test.go
@@ -29,33 +29,6 @@ func TestSyncResetMatchesCalendarCaseInsensitively(t *testing.T) {
 	}
 }
 
-// TestSyncCommandsFailWhenCredentialStoreUnavailable guards the sync read
-// commands. They used to discard the auth.NewCredentialStore error, built
-// the service on a nil store, and exited 0. The first command that needed
-// a credential would then fail far from the cause, or misbehave. A store
-// that cannot open must fail the command up front, like `sync run` does.
-// The test points DBUS_SESSION_BUS_ADDRESS at a dead socket, so the OS
-// keyring probe fails deterministically, and the plaintext fallback stays
-// off (the default in a fresh config).
-func TestSyncCommandsFailWhenCredentialStoreUnavailable(t *testing.T) {
-	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent-chroncal-test")
-	setupCalendarCLITestEnv(t)
-
-	for _, args := range [][]string{
-		{"sync", "status", "--output", "json"},
-		{"sync", "conflicts", "--output", "json"},
-		{"sync", "doctor", "--output", "json"},
-	} {
-		_, stderr, err := runChroncalCommand(t, args...)
-		if err == nil {
-			t.Fatalf("%s exited 0 with a dead credential store; want a failure", strings.Join(args, " "))
-		}
-		if !strings.Contains(stderr, "credential store") {
-			t.Fatalf("%s stderr = %q, want the credential store failure", strings.Join(args, " "), stderr)
-		}
-	}
-}
-
 // TestSyncRunRejectsInvalidConflictStrategy guards against issue #215.
 // `sync run --conflict <bad>` must be rejected up front. It must not
 // fall back to server-wins in silence. That would discard local edits

--- a/cmd/chroncal/sync_cli_test.go
+++ b/cmd/chroncal/sync_cli_test.go
@@ -28,6 +28,33 @@ func TestSyncResetMatchesCalendarCaseInsensitively(t *testing.T) {
 	}
 }
 
+// TestSyncCommandsFailWhenCredentialStoreUnavailable guards the sync read
+// commands. They used to discard the auth.NewCredentialStore error, built
+// the service on a nil store, and exited 0. The first command that needed
+// a credential would then fail far from the cause, or misbehave. A store
+// that cannot open must fail the command up front, like `sync run` does.
+// The test points DBUS_SESSION_BUS_ADDRESS at a dead socket, so the OS
+// keyring probe fails deterministically, and the plaintext fallback stays
+// off (the default in a fresh config).
+func TestSyncCommandsFailWhenCredentialStoreUnavailable(t *testing.T) {
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent-chroncal-test")
+	setupCalendarCLITestEnv(t)
+
+	for _, args := range [][]string{
+		{"sync", "status", "--output", "json"},
+		{"sync", "conflicts", "--output", "json"},
+		{"sync", "doctor", "--output", "json"},
+	} {
+		_, stderr, err := runChroncalCommand(t, args...)
+		if err == nil {
+			t.Fatalf("%s exited 0 with a dead credential store; want a failure", strings.Join(args, " "))
+		}
+		if !strings.Contains(stderr, "credential store") {
+			t.Fatalf("%s stderr = %q, want the credential store failure", strings.Join(args, " "), stderr)
+		}
+	}
+}
+
 // TestSyncRunRejectsInvalidConflictStrategy guards against issue #215.
 // `sync run --conflict <bad>` must be rejected up front. It must not
 // fall back to server-wins in silence. That would discard local edits

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -40,7 +40,10 @@ before the push and asks for confirmation.`,
 			defer a.Close()
 
 			ctx := context.Background()
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			credStore, err := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
+			if err != nil {
+				return fmt.Errorf("credential store: %w", err)
+			}
 			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
 
 			cals, err := a.Queries.ListCalendars(ctx)

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -112,8 +112,8 @@ func runDoctorList(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Cale
 	}
 	for _, en := range entries {
 		fmt.Fprintf(out, "calendar %q uid %s (%s): unreadable relation(s) %s; %d failed push attempt(s)\n",
-			en.calendarName, en.wedged.UID, en.wedged.OwnerType,
-			strings.Join(en.wedged.Relations, ", "), en.wedged.PushFailCount)
+			safeText(en.calendarName), safeText(en.wedged.UID), safeText(en.wedged.OwnerType),
+			safeText(strings.Join(en.wedged.Relations, ", ")), en.wedged.PushFailCount)
 	}
 	// The whole hint block goes to stdout. A consumer that captures stdout
 	// then also captures the recovery command.
@@ -138,7 +138,7 @@ func runDoctorPush(cmd *cobra.Command, svc *syncPkg.Service, cals []storage.Cale
 		}
 		question := fmt.Sprintf(
 			"Push %s from calendar %q without relation(s) %s? The server copy loses those fields",
-			uid, en.calendarName, strings.Join(w.Relations, ", "))
+			safeText(uid), safeText(en.calendarName), safeText(strings.Join(w.Relations, ", ")))
 		if err := confirmDestructive(cmd, question); err != nil {
 			return err
 		}

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -169,7 +169,7 @@ func renderDoctorPush(cmd *cobra.Command, uid string, dropped []string) error {
 	}
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "Pushed %s. Dropped relation(s): %s.\n",
-		uid, strings.Join(dropped, ", "))
+		safeText(uid), safeText(strings.Join(dropped, ", ")))
 	fmt.Fprintln(out, "The resource is no longer dirty. Other edits flow again.")
 	return nil
 }

--- a/cmd/chroncal/sync_doctor.go
+++ b/cmd/chroncal/sync_doctor.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 	syncPkg "github.com/douglasdemoura/chroncal/internal/sync"
 )
@@ -40,8 +39,10 @@ before the push and asks for confirmation.`,
 			defer a.Close()
 
 			ctx := context.Background()
-			credStore, _ := auth.NewCredentialStore(a.CredentialNamespace, a.PreviousCredentialNamespaces, a.MigrateLegacyCredentials, a.AllowPlaintext)
-			svc := syncPkg.NewService(a.DB, a.Queries, credStore, a.Calendars, a.Events, a.Todos, a.Journals, nil)
+			svc, err := newSyncService(a, nil)
+			if err != nil {
+				return err
+			}
 
 			cals, err := a.Queries.ListCalendars(ctx)
 			if err != nil {

--- a/cmd/chroncal/sync_doctor_cli_test.go
+++ b/cmd/chroncal/sync_doctor_cli_test.go
@@ -69,7 +69,7 @@ func bumpPushFailCount(t *testing.T, dbPath string, count int) {
 func TestSyncDoctorEmptyReportsNone(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "doctor")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor")
 	if err != nil {
 		t.Fatalf("sync doctor: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestSyncDoctorEmptyReportsNone(t *testing.T) {
 func TestSyncDoctorJSONEmptyIsArray(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "doctor", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync doctor --output json: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestSyncDoctorListsWedgedResource(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	seedWedgedCLIResource(t, dbPath)
 
-	stdout, stderr, err := runChroncalCommand(t, "sync", "doctor")
+	stdout, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor")
 	if err != nil {
 		t.Fatalf("sync doctor: %v (stderr: %s)", err, stderr)
 	}
@@ -121,7 +121,7 @@ func TestSyncDoctorListsWedgedResource(t *testing.T) {
 	}
 
 	bumpPushFailCount(t, dbPath, 3)
-	stdout, _, err = runChroncalCommand(t, "sync", "doctor")
+	stdout, _, err = runChroncalCommand(t, "sync", "--allow-plaintext", "doctor")
 	if err != nil {
 		t.Fatalf("sync doctor after bumps: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestSyncDoctorJSONListsWedgedResource(t *testing.T) {
 	seedWedgedCLIResource(t, dbPath)
 	bumpPushFailCount(t, dbPath, 2)
 
-	stdout, _, err := runChroncalCommand(t, "sync", "doctor", "--output", "json")
+	stdout, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync doctor --output json: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestSyncDoctorPushRefusesNonInteractiveWithoutYes(t *testing.T) {
 
 	// Seed one wedged resource so the push flow reaches its confirmation
 	// gate instead of stopping at the not-found check.
-	_, _, err := runChroncalCommand(t, "sync", "doctor", "--push", "wedge-cli@example.com")
+	_, _, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor", "--push", "wedge-cli@example.com")
 	if err == nil {
 		t.Fatal("expected refusal without --yes in a non-interactive shell")
 	}
@@ -180,7 +180,7 @@ func TestSyncDoctorPushRefusesNonInteractiveWithoutYes(t *testing.T) {
 func TestSyncDoctorPushUnknownUIDIsNotFound(t *testing.T) {
 	setupCalendarCLITestEnv(t)
 
-	_, stderr, err := runChroncalCommand(t, "sync", "doctor", "--push", "missing@example.com", "--yes", "--output", "json")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "doctor", "--push", "missing@example.com", "--yes", "--output", "json")
 	if err == nil {
 		t.Fatal("push of an unknown uid should fail")
 	}

--- a/cmd/chroncal/sync_doctor_cli_test.go
+++ b/cmd/chroncal/sync_doctor_cli_test.go
@@ -16,6 +16,14 @@ import (
 // helper process still opens the database afterwards.
 func seedWedgedCLIResource(t *testing.T, dbPath string) {
 	t.Helper()
+	seedWedgedCLIResourceWithUID(t, dbPath, "wedge-cli@example.com")
+}
+
+// seedWedgedCLIResourceWithUID seeds one wedged resource whose sync UID is
+// the given string. The doctor then lists exactly that UID. The helper
+// renames event_relations back at cleanup like the fixed-UID variant.
+func seedWedgedCLIResourceWithUID(t *testing.T, dbPath string, uid string) {
+	t.Helper()
 	a, err := app.New(dbPath)
 	if err != nil {
 		t.Fatalf("app.New: %v", err)
@@ -29,14 +37,14 @@ func seedWedgedCLIResource(t *testing.T, dbPath string) {
 	if _, err := a.DB.ExecContext(ctx,
 		`INSERT INTO events (uid, calendar_id, title, start_time, end_time, status, transp, class)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		"wedge-cli@example.com", cals[0].ID, "Wedged",
+		uid, cals[0].ID, "Wedged",
 		"2026-04-03T10:00:00Z", "2026-04-03T11:00:00Z", "CONFIRMED", "OPAQUE", "PUBLIC",
 	); err != nil {
 		t.Fatalf("insert event: %v", err)
 	}
 	if err := a.Queries.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
 		CalendarID:   cals[0].ID,
-		Uid:          "wedge-cli@example.com",
+		Uid:          uid,
 		OwnerType:    "event",
 		Etag:         "",
 		Dirty:        1,
@@ -127,6 +135,26 @@ func TestSyncDoctorListsWedgedResource(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "3 failed push attempt(s)") {
 		t.Errorf("output %q misses the recorded push-failure count", stdout)
+	}
+}
+
+// TestSyncDoctorSanitizesRemoteDerivedStrings guards the doctor output.
+// The UID and owner type come from remote iCal data. A UID with terminal
+// escape bytes must not reach the terminal raw. Every other wedged line
+// passes through safeText like the sync status and conflict lines.
+func TestSyncDoctorSanitizesRemoteDerivedStrings(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	seedWedgedCLIResourceWithUID(t, dbPath, "\x1b[31mwedge\x1b[0m@example.com")
+
+	stdout, _, err := runChroncalCommand(t, "sync", "doctor")
+	if err != nil {
+		t.Fatalf("sync doctor: %v", err)
+	}
+	if strings.Contains(stdout, "\x1b") {
+		t.Fatalf("doctor line leaked a raw escape byte:\n%q", stdout)
+	}
+	if !strings.Contains(stdout, "uid wedge@example.com (event):") {
+		t.Fatalf("output %q misses the sanitized wedged line", stdout)
 	}
 }
 

--- a/cmd/chroncal/sync_json_cli_test.go
+++ b/cmd/chroncal/sync_json_cli_test.go
@@ -65,7 +65,7 @@ func TestSyncResolveOutputJSON(t *testing.T) {
 	id := seedSyncConflictForTest(t, dbPath, calID)
 
 	stdout, stderr, err := runChroncalCommand(t,
-		"sync", "resolve", strconv.FormatInt(id, 10), "--pick", "local", "--output", "json")
+		"--allow-plaintext", "sync", "resolve", strconv.FormatInt(id, 10), "--pick", "local", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync resolve -o json: %v (stderr: %s)", err, stderr)
 	}
@@ -83,7 +83,7 @@ func TestSyncResetOutputJSON(t *testing.T) {
 	createLinkedCalendarForTest(t, dbPath)
 
 	stdout, stderr, err := runChroncalCommand(t,
-		"sync", "reset", "--calendar", "Work", "--output", "json")
+		"--allow-plaintext", "sync", "reset", "--calendar", "Work", "--output", "json")
 	if err != nil {
 		t.Fatalf("sync reset -o json: %v (stderr: %s)", err, stderr)
 	}

--- a/cmd/chroncal/sync_reset_cli_test.go
+++ b/cmd/chroncal/sync_reset_cli_test.go
@@ -14,7 +14,7 @@ func TestSyncResetUnknownCalendarFails(t *testing.T) {
 		t.Fatalf("calendar create: %v", err)
 	}
 
-	_, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "Wrok")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "reset", "--calendar", "Wrok")
 	if err == nil {
 		t.Fatalf("sync reset with unknown calendar exited 0; want non-zero. stderr=%q", stderr)
 	}
@@ -33,7 +33,7 @@ func TestSyncResetLocalOnlyCalendarReportsNotConnected(t *testing.T) {
 		t.Fatalf("calendar create: %v", err)
 	}
 
-	_, stderr, err := runChroncalCommand(t, "sync", "reset", "--calendar", "Work")
+	_, stderr, err := runChroncalCommand(t, "sync", "--allow-plaintext", "reset", "--calendar", "Work")
 	if err == nil {
 		t.Fatalf("sync reset on local-only calendar exited 0; want non-zero. stderr=%q", stderr)
 	}

--- a/cmd/chroncal/sync_warnings_cli_test.go
+++ b/cmd/chroncal/sync_warnings_cli_test.go
@@ -167,7 +167,7 @@ func TestSyncResolveServerPrintsImportWarnings(t *testing.T) {
 	a.Close()
 
 	stdout, stderr, err := runChroncalCommand(t,
-		"sync", "resolve", strconv.FormatInt(conflictID, 10), "--pick", "server")
+		"--allow-plaintext", "sync", "resolve", strconv.FormatInt(conflictID, 10), "--pick", "server")
 	if err != nil {
 		t.Fatalf("sync resolve: %v (stderr: %s)", err, stderr)
 	}

--- a/cmd/chroncal/todo_add.go
+++ b/cmd/chroncal/todo_add.go
@@ -176,11 +176,11 @@ and percent-complete to 100.`,
 
 			parsedExDates, err := parseDateFlags(exdates, "", time.Time{})
 			if err != nil {
-				return fmt.Errorf("--exdate: %w", err)
+				return errInvalidInputf("--exception-date-times: %v", err)
 			}
 			parsedRDates, err := parseDateFlags(rdates, "", time.Time{})
 			if err != nil {
-				return fmt.Errorf("--rdate: %w", err)
+				return errInvalidInputf("--recurrence-date-times: %v", err)
 			}
 
 			// Validate all parseable flags before creating the todo so a

--- a/cmd/chroncal/todo_add.go
+++ b/cmd/chroncal/todo_add.go
@@ -174,13 +174,13 @@ and percent-complete to 100.`,
 				return fmt.Errorf("--status COMPLETED requires 100%% progress, got %d (omit --progress or set it to 100)", progress)
 			}
 
-			parsedExDates, err := parseDateFlags(exdates, "", time.Time{})
+			parsedExDates, err := parseExdateRdateFlags("exception-date-times", exdates, "", time.Time{})
 			if err != nil {
-				return errInvalidInputf("--exception-date-times: %v", err)
+				return err
 			}
-			parsedRDates, err := parseDateFlags(rdates, "", time.Time{})
+			parsedRDates, err := parseExdateRdateFlags("recurrence-date-times", rdates, "", time.Time{})
 			if err != nil {
-				return errInvalidInputf("--recurrence-date-times: %v", err)
+				return err
 			}
 
 			// Validate all parseable flags before creating the todo so a

--- a/cmd/chroncal/todo_cli_test.go
+++ b/cmd/chroncal/todo_cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -23,4 +24,42 @@ func TestTodoSearchCompletedAndIncompleteAreMutuallyExclusive(t *testing.T) {
 		t.Fatalf("todo search --completed --incomplete: error = %q, want it to mention %q",
 			err.Error(), "mutually exclusive")
 	}
+}
+
+// TestTodoExdateParseFailureIsInvalidInput guards the error taxonomy. A bad
+// --exdate value in todo add/update used to surface as a generic error.
+// The event commands already tagged it invalid_input; the todo commands
+// must report the same code so --output json consumers can dispatch on it.
+func TestTodoExdateParseFailureIsInvalidInput(t *testing.T) {
+	setupCalendarCLITestEnv(t)
+	if _, _, err := runChroncalCommand(t, "calendar", "create", "Work"); err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+
+	assertInvalidInput := func(args ...string) {
+		t.Helper()
+		_, stderr, err := runChroncalCommand(t, args...)
+		if err == nil {
+			t.Fatalf("%s accepted a bad --exdate value", strings.Join(args, " "))
+		}
+		var payload struct {
+			Code  string `json:"code"`
+			Error string `json:"error"`
+		}
+		if jerr := json.Unmarshal([]byte(stderr), &payload); jerr != nil {
+			t.Fatalf("%s: decode error payload %q: %v", strings.Join(args, " "), stderr, jerr)
+		}
+		if payload.Code != "invalid_input" {
+			t.Fatalf("%s: code = %q, want invalid_input", strings.Join(args, " "), payload.Code)
+		}
+	}
+
+	assertInvalidInput("todo", "add", "Task", "--calendar", "Work",
+		"--exdate", "not-a-date", "--output", "json")
+
+	if _, _, err := runChroncalCommand(t, "todo", "add", "Task", "--calendar", "Work"); err != nil {
+		t.Fatalf("todo add: %v", err)
+	}
+	assertInvalidInput("todo", "update", "1",
+		"--recurrence-date-times", "not-a-date", "--output", "json")
 }

--- a/cmd/chroncal/todo_purge.go
+++ b/cmd/chroncal/todo_purge.go
@@ -51,7 +51,7 @@ use 'todo delete' first. Purging is not reversible — child rows cascade.`,
 
 			if err := a.Todos.PurgeByID(ctx, id); err != nil {
 				if errors.Is(err, todo.ErrNotDeleted) {
-					return fmt.Errorf("todo %d not found or not soft-deleted", id)
+					return errNotFoundf("todo %d not found or not soft-deleted", id)
 				}
 				return fmt.Errorf("purge: %w", err)
 			}

--- a/cmd/chroncal/todo_restore.go
+++ b/cmd/chroncal/todo_restore.go
@@ -39,7 +39,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 			if id, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
 				if err := a.Todos.RestoreByID(ctx, id); err != nil {
 					if errors.Is(err, todo.ErrNotDeleted) {
-						return fmt.Errorf("todo %d not found (may have been purged)", id)
+						return errNotFoundf("todo %d not found (may have been purged)", id)
 					}
 					return fmt.Errorf("restore todo: %w", err)
 				}
@@ -52,7 +52,7 @@ the next sync cycle recreates it remotely (with a fresh resource URL).`,
 
 			if err := a.Todos.RestoreByUID(ctx, ref); err != nil {
 				if errors.Is(err, todo.ErrNotDeleted) {
-					return fmt.Errorf("todo %q not found (may have been purged)", ref)
+					return errNotFoundf("todo %q not found (may have been purged)", ref)
 				}
 				return fmt.Errorf("restore todo: %w", err)
 			}

--- a/cmd/chroncal/todo_search.go
+++ b/cmd/chroncal/todo_search.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
@@ -41,11 +42,11 @@ and categories.`,
 				}
 			}
 
-			completedFilter := 0
+			completedFilter := storage.CompletionAny
 			if completed {
-				completedFilter = 1
+				completedFilter = storage.CompletedOnly
 			} else if incomplete {
-				completedFilter = 2
+				completedFilter = storage.OpenOnly
 			}
 
 			todos, err := a.Todos.Search(ctx, todo.SearchParams{

--- a/cmd/chroncal/todo_update.go
+++ b/cmd/chroncal/todo_update.go
@@ -218,16 +218,16 @@ a --progress value other than 100.`,
 				p.RecurrenceRule = rrule
 			}
 			if cmd.Flags().Changed("exception-date-times") || cmd.Flags().Changed("exdate") {
-				parsed, err := parseDateFlags(exdates, "", time.Time{})
+				parsed, err := parseExdateRdateFlags("exception-date-times", exdates, "", time.Time{})
 				if err != nil {
-					return errInvalidInputf("--exception-date-times: %v", err)
+					return err
 				}
 				p.ExDates = parsed
 			}
 			if cmd.Flags().Changed("recurrence-date-times") || cmd.Flags().Changed("rdate") {
-				parsed, err := parseDateFlags(rdates, "", time.Time{})
+				parsed, err := parseExdateRdateFlags("recurrence-date-times", rdates, "", time.Time{})
 				if err != nil {
-					return errInvalidInputf("--recurrence-date-times: %v", err)
+					return err
 				}
 				p.RDates = parsed
 			}

--- a/cmd/chroncal/todo_update.go
+++ b/cmd/chroncal/todo_update.go
@@ -220,14 +220,14 @@ a --progress value other than 100.`,
 			if cmd.Flags().Changed("exception-date-times") || cmd.Flags().Changed("exdate") {
 				parsed, err := parseDateFlags(exdates, "", time.Time{})
 				if err != nil {
-					return fmt.Errorf("--exdate: %w", err)
+					return errInvalidInputf("--exception-date-times: %v", err)
 				}
 				p.ExDates = parsed
 			}
 			if cmd.Flags().Changed("recurrence-date-times") || cmd.Flags().Changed("rdate") {
 				parsed, err := parseDateFlags(rdates, "", time.Time{})
 				if err != nil {
-					return fmt.Errorf("--rdate: %w", err)
+					return errInvalidInputf("--recurrence-date-times: %v", err)
 				}
 				p.RDates = parsed
 			}

--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -58,10 +58,11 @@ UPDATE events SET
 WHERE id = ? RETURNING *;
 
 -- name: UpsertEventByUID :one
--- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
--- pull path should be aware this resurrects soft-deleted rows. The sync pull
--- path is safe because tombstoned UIDs are filtered out before this runs
--- (engine.go loads tombstones first and skips them during pull).
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+-- soft-deleted rows. Callers outside the pull path in the sync engine
+-- must know this. The pull path is safe. The engine excludes
+-- tombstoned UIDs before this query runs (engine.go loads tombstones
+-- first and skips them during pull).
 INSERT INTO events (
     uid, calendar_id, title, description, location,
     start_time, end_time, all_day, recurrence_rule,

--- a/db/queries/journals.sql
+++ b/db/queries/journals.sql
@@ -72,10 +72,11 @@ UPDATE journals SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? RETURNING *;
 
--- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
--- pull path should be aware this resurrects soft-deleted rows. The sync pull
--- path is safe because tombstoned UIDs are filtered out before this runs
--- (engine.go loads tombstones first and skips them during pull).
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+-- soft-deleted rows. Callers outside the pull path in the sync engine
+-- must know this. The pull path is safe. The engine excludes
+-- tombstoned UIDs before this query runs (engine.go loads tombstones
+-- first and skips them during pull).
 -- name: UpsertJournalByUID :one
 INSERT INTO journals (
     uid, calendar_id, summary, description,

--- a/db/queries/journals.sql
+++ b/db/queries/journals.sql
@@ -72,6 +72,10 @@ UPDATE journals SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? RETURNING *;
 
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
+-- pull path should be aware this resurrects soft-deleted rows. The sync pull
+-- path is safe because tombstoned UIDs are filtered out before this runs
+-- (engine.go loads tombstones first and skips them during pull).
 -- name: UpsertJournalByUID :one
 INSERT INTO journals (
     uid, calendar_id, summary, description,

--- a/db/queries/todos.sql
+++ b/db/queries/todos.sql
@@ -83,10 +83,11 @@ UPDATE todos SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? RETURNING *;
 
--- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
--- pull path should be aware this resurrects soft-deleted rows. The sync pull
--- path is safe because tombstoned UIDs are filtered out before this runs
--- (engine.go loads tombstones first and skips them during pull).
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+-- soft-deleted rows. Callers outside the pull path in the sync engine
+-- must know this. The pull path is safe. The engine excludes
+-- tombstoned UIDs before this query runs (engine.go loads tombstones
+-- first and skips them during pull).
 -- name: UpsertTodoByUID :one
 INSERT INTO todos (
     uid, calendar_id, summary, description, location,

--- a/db/queries/todos.sql
+++ b/db/queries/todos.sql
@@ -83,6 +83,10 @@ UPDATE todos SET
     updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
 WHERE id = ? RETURNING *;
 
+-- NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
+-- pull path should be aware this resurrects soft-deleted rows. The sync pull
+-- path is safe because tombstoned UIDs are filtered out before this runs
+-- (engine.go loads tombstones first and skips them during pull).
 -- name: UpsertTodoByUID :one
 INSERT INTO todos (
     uid, calendar_id, summary, description, location,

--- a/internal/alarm/service.go
+++ b/internal/alarm/service.go
@@ -200,7 +200,7 @@ func (s *Service) CheckMissed(ctx context.Context, now time.Time, lookback time.
 			}
 
 			instances := recurrence.ExpandTodo(td, windowStart, windowEnd)
-			if td.RecurrenceRule != "" && td.RecurrenceID == "" {
+			if isRecurringTodoMaster(td) {
 				if suppressed := overrideKeys[td.UID]; len(suppressed) > 0 {
 					kept := instances[:0]
 					for _, inst := range instances {

--- a/internal/alarm/todo_service.go
+++ b/internal/alarm/todo_service.go
@@ -108,7 +108,7 @@ func (s *TodoService) CheckTodos(ctx context.Context, now time.Time) ([]TodoDueA
 		// For recurring masters, suppress occurrences that have been overridden.
 		// Without this, the master fires its alarm for the overridden slot while
 		// the override row also fires its own alarm — causing a duplicate.
-		if t.RecurrenceRule != "" && t.RecurrenceID == "" {
+		if isRecurringTodoMaster(t) {
 			if suppressed := overrideKeys[t.UID]; len(suppressed) > 0 {
 				kept := instances[:0]
 				for _, inst := range instances {
@@ -217,6 +217,14 @@ func buildOverrideSuppressionKeys(rows []storage.Todo) map[string]map[string]str
 		m[row.Uid][key] = struct{}{}
 	}
 	return m
+}
+
+// isRecurringTodoMaster reports whether a todo row is a recurring master. A
+// master carries no recurrence_id. The series recurs through an RRULE, through
+// RDATEs, or through both. An RDATE-only master expands several instances, so
+// it needs override suppression like an RRULE master.
+func isRecurringTodoMaster(td todo.Todo) bool {
+	return td.RecurrenceID == "" && (td.RecurrenceRule != "" || td.RDates != "")
 }
 
 // todoIsOpen reports whether a todo can still fire an alarm. A completed

--- a/internal/alarm/todo_service_test.go
+++ b/internal/alarm/todo_service_test.go
@@ -2,6 +2,7 @@ package alarm
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -665,6 +666,70 @@ func TestCheckTodos_OverrideAwareness(t *testing.T) {
 
 	if len(due) != 1 {
 		t.Errorf("CheckTodos = %d due alarms, want 1; master must not fire for overridden slot (issue #366)", len(due))
+		for i, d := range due {
+			t.Logf("  [%d] todo_id=%d summary=%q trigger=%v", i, d.Todo.ID, d.Todo.Summary, d.TriggerAt)
+		}
+		return
+	}
+	if due[0].Todo.ID != override.ID {
+		t.Errorf("due alarm is for todo ID %d (master=%d), want override ID %d", due[0].Todo.ID, master.ID, override.ID)
+	}
+}
+
+// TestCheckTodos_RDateOnlyMaster_OverrideAwareness extends the issue #366 fix
+// to RDATE-only masters. A master with an empty RRULE and two RDATEs expands
+// both slots. Without the isRecurringTodoMaster check the master fired its
+// alarm for the overridden slot while the override row also fired — a
+// duplicate.
+func TestCheckTodos_RDateOnlyMaster_OverrideAwareness(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	ctx := context.Background()
+	todoSvc := todo.NewService(db, q)
+
+	// Master: no RRULE. Two RDATE occurrences on Apr 1 and Apr 2 at 17:00 UTC.
+	apr1 := time.Date(2026, 4, 1, 17, 0, 0, 0, time.UTC)
+	apr2 := time.Date(2026, 4, 2, 17, 0, 0, 0, time.UTC)
+	master, err := todoSvc.UpsertByUID(ctx, todo.UpsertParams{
+		UID:        "rdate-override-alarm-test",
+		CalendarID: 1,
+		Summary:    "Twice-only task",
+		DueDate:    apr1.Format(time.RFC3339),
+		RDates:     strings.Join([]string{apr1.Format(time.RFC3339), apr2.Format(time.RFC3339)}, ","),
+	})
+	if err != nil {
+		t.Fatalf("upsert master todo: %v", err)
+	}
+	if err := todoSvc.ReplaceAlarms(ctx, master.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT1H"},
+	}); err != nil {
+		t.Fatalf("replace master alarms: %v", err)
+	}
+
+	override, err := todoSvc.UpsertByUID(ctx, todo.UpsertParams{
+		UID:          "rdate-override-alarm-test",
+		CalendarID:   1,
+		Summary:      "Twice-only task (rescheduled)",
+		DueDate:      apr2.Format(time.RFC3339),
+		RecurrenceID: apr2.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("upsert override todo: %v", err)
+	}
+	if err := todoSvc.ReplaceAlarms(ctx, override.ID, []model.Alarm{
+		{Action: "DISPLAY", TriggerValue: "-PT1H"},
+	}); err != nil {
+		t.Fatalf("replace override alarms: %v", err)
+	}
+
+	checkTime := time.Date(2026, 4, 2, 17, 30, 0, 0, time.UTC)
+	todoAlarmSvc := NewTodoService(db, q, todoSvc)
+	due, err := todoAlarmSvc.CheckTodos(ctx, checkTime)
+	if err != nil {
+		t.Fatalf("check todos: %v", err)
+	}
+
+	if len(due) != 1 {
+		t.Errorf("CheckTodos = %d due alarms, want 1; RDATE-only master must not fire for overridden slot", len(due))
 		for i, d := range due {
 			t.Logf("  [%d] todo_id=%d summary=%q trigger=%v", i, d.Todo.ID, d.Todo.Summary, d.TriggerAt)
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/alarm"
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/calendar"
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/fileid"
 	"github.com/douglasdemoura/chroncal/internal/journal"
@@ -127,15 +128,7 @@ func DefaultDBPath() (string, error) {
 // On Linux this follows XDG: $XDG_DATA_HOME or ~/.local/share.
 // On macOS and Windows, config and data share the same path.
 func userDataDir() (string, error) {
-	if runtime.GOOS == "linux" {
-		if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
-			return dir, nil
-		}
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".local", "share"), nil
-	}
-	return os.UserConfigDir()
+	// The env variable now wins on every OS, matching the config and state
+	// resolvers. Previously only Linux read XDG_DATA_HOME.
+	return config.BaseDir("XDG_DATA_HOME", runtime.GOOS, ".local", "share")
 }

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -275,12 +275,28 @@ func (s *PlaintextFileStore) Set(cred Credential) error {
 		tmp.Close()
 		return fmt.Errorf("write credential: %w", err)
 	}
+	// Sync the data before the rename. Without the sync, a power loss can
+	// persist the rename and lose the data blocks. The write then destroys
+	// the previous secret.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync credential temp file: %w", err)
+	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close credential file: %w", err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
 		return fmt.Errorf("replace credential file: %w", err)
 	}
+	// Sync the directory so the rename survives a power loss. Some
+	// platforms do not support a sync on a directory handle. Ignore that
+	// failure.
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return fmt.Errorf("open credential dir: %w", err)
+	}
+	dir.Sync()
+	dir.Close()
 	w := s.warnWriter()
 	fmt.Fprintf(w, "Warning: credentials stored in plaintext at %s\n", path)
 	if cred.OAuthClientSecret != "" {

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -457,6 +457,11 @@ func keyringAccountName(namespace string, accountID int64) string {
 	return fmt.Sprintf("db_%s_account_%d", namespace, accountID)
 }
 
+// newKeyringAvailabilityProbe builds a one-shot probe for the OS keyring.
+// The probe only reads a nonexistent item. A backend that answers proves it
+// is reachable. A write-based probe leaves a probe item in the production
+// keyring when the process dies between the set and the delete, so this
+// probe never writes.
 func newKeyringAvailabilityProbe() func() error {
 	var (
 		once     sync.Once
@@ -464,13 +469,19 @@ func newKeyringAvailabilityProbe() func() error {
 	)
 	return func() error {
 		once.Do(func() {
-			probeUser := "__chroncal_probe__"
-			probeValue := "ok"
-			if err := keyringSetFn(keyringService, probeUser, probeValue); err != nil {
-				probeErr = err
+			_, err := keyringGetFn(keyringService, "__chroncal_probe__")
+			if err == nil {
 				return
 			}
-			_ = keyringDeleteFn(keyringService, probeUser)
+			// Backends disagree on the shape of an "item absent" answer:
+			// go-keyring maps it to ErrNotFound, but some Secret Service
+			// paths surface a raw "object does not exist" error instead.
+			// Any absence-shaped answer proves the backend is reachable.
+			if errors.Is(err, keyring.ErrNotFound) || strings.Contains(strings.ToLower(err.Error()), "does not exist") ||
+				strings.Contains(strings.ToLower(err.Error()), "not found") {
+				return
+			}
+			probeErr = err
 		})
 		return probeErr
 	}

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -256,8 +256,30 @@ func (s *PlaintextFileStore) Set(cred Credential) error {
 		return fmt.Errorf("marshal credential: %w", err)
 	}
 	path := s.path(cred.AccountID)
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	// Write through a temp file in the same directory and rename. A crash
+	// or a full disk then leaves the old file intact instead of a truncated
+	// secret. The rename is atomic within one filesystem.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".credential-*")
+	if err != nil {
+		return fmt.Errorf("create credential temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	// os.WriteFile keeps the mode of an existing file. Enforce 0600 on every
+	// write so a pre-existing loose file cannot survive forever.
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("restrict credential file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
 		return fmt.Errorf("write credential: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close credential file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("replace credential file: %w", err)
 	}
 	w := s.warnWriter()
 	fmt.Fprintf(w, "Warning: credentials stored in plaintext at %s\n", path)

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/zalando/go-keyring"
 )
 
@@ -282,26 +283,13 @@ func (s *PlaintextFileStore) path(accountID int64) string {
 	return filepath.Join(s.dir, "db_"+s.namespace, fmt.Sprintf("account_%d.json", accountID))
 }
 
-// appConfigBaseDir returns the OS base config directory. It honours
-// XDG_CONFIG_HOME on every platform. That matches the behaviour of the config
-// loader's configDir. goos is a runtime.GOOS value. It is a parameter so
-// tests can call it with a non-current GOOS to verify cross-platform behaviour.
+// appConfigBaseDir returns the OS base config directory for the credential
+// store. It delegates to config.BaseDir so the config loader and the
+// credential store share one resolver. goos is a runtime.GOOS value. It is
+// a parameter so tests can call it with a non-current GOOS to verify
+// cross-platform behaviour.
 func appConfigBaseDir(goos string) (string, error) {
-	// XDG_CONFIG_HOME takes precedence on every OS, not just Linux.
-	// Many CLI tools adopt this so users on macOS/Windows can relocate
-	// config with a single env var. Checking it first here matches the
-	// behaviour of the config loader (internal/config.configDir).
-	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-		return dir, nil
-	}
-	if goos == "linux" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".config"), nil
-	}
-	return os.UserConfigDir()
+	return config.BaseDir("XDG_CONFIG_HOME", goos, ".config")
 }
 
 func credentialDir() (string, error) {

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -461,7 +461,8 @@ func keyringAccountName(namespace string, accountID int64) string {
 // The probe only reads a nonexistent item. A backend that answers proves it
 // is reachable. A write-based probe leaves a probe item in the production
 // keyring when the process dies between the set and the delete, so this
-// probe never writes.
+// probe never writes. When the backend answers, the probe removes the probe
+// item that an older, write-based probe left behind.
 func newKeyringAvailabilityProbe() func() error {
 	var (
 		once     sync.Once
@@ -470,19 +471,26 @@ func newKeyringAvailabilityProbe() func() error {
 	return func() error {
 		once.Do(func() {
 			_, err := keyringGetFn(keyringService, "__chroncal_probe__")
-			if err == nil {
-				return
-			}
-			// Backends disagree on the shape of an "item absent" answer:
-			// go-keyring maps it to ErrNotFound, but some Secret Service
-			// paths surface a raw "object does not exist" error instead.
-			// Any absence-shaped answer proves the backend is reachable.
-			if errors.Is(err, keyring.ErrNotFound) || strings.Contains(strings.ToLower(err.Error()), "does not exist") ||
-				strings.Contains(strings.ToLower(err.Error()), "not found") {
+			if err == nil || errors.Is(err, keyring.ErrNotFound) || secretServiceReportsAbsentItem(err) {
+				// Remove the residue of the older write-based probe.
+				// The cleanup is best effort: no error from it changes
+				// the availability answer. An absent item answers with
+				// ErrNotFound, which the cleanup ignores.
+				_ = keyringDeleteFn(keyringService, "__chroncal_probe__")
 				return
 			}
 			probeErr = err
 		})
 		return probeErr
 	}
+}
+
+// secretServiceReportsAbsentItem reports whether err carries a Secret Service
+// or DBus error identity. Some Secret Service paths answer a missing item
+// with such a raw error instead of ErrNotFound. The match stays narrow: a
+// broad text match reads a broken backend as an absent item.
+func secretServiceReportsAbsentItem(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "org.freedesktop.secret") ||
+		strings.Contains(msg, "org.freedesktop.dbus.error")
 }

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -235,22 +235,17 @@ func TestNewCredentialStore_NoKeyring_NoPlaintext(t *testing.T) {
 
 func TestNewCredentialStore_IncludesKeyringProbeError(t *testing.T) {
 	prevUnavailableReason := keyringUnavailableReasonFn
-	prevSet := keyringSetFn
-	prevDelete := keyringDeleteFn
+	prevGet := keyringGetFn
 
 	probeErr := errors.New("dbus: org.freedesktop.secrets unavailable")
-	keyringSetFn = func(service, user, value string) error {
-		return probeErr
-	}
-	keyringDeleteFn = func(service, user string) error {
-		return nil
+	keyringGetFn = func(service, user string) (string, error) {
+		return "", probeErr
 	}
 	keyringUnavailableReasonFn = newKeyringAvailabilityProbe()
 
 	t.Cleanup(func() {
 		keyringUnavailableReasonFn = prevUnavailableReason
-		keyringSetFn = prevSet
-		keyringDeleteFn = prevDelete
+		keyringGetFn = prevGet
 	})
 
 	_, err := NewCredentialStore("test", nil, true, false)
@@ -746,6 +741,80 @@ func TestPlaintextFileStore_SetTightensLoosePermissions(t *testing.T) {
 	for _, e := range entries {
 		if strings.HasPrefix(e.Name(), ".credential-") {
 			t.Errorf("temp file %s survived Set", e.Name())
+		}
+	}
+}
+
+// TestKeyringProbeNeverWrites guards the no-write contract of the
+// availability probe. The probe reads a nonexistent item; a backend that
+// answers with ErrNotFound proves it is reachable. A write-based probe left
+// residue in the production keyring when the process died between the set
+// and the delete.
+func TestKeyringProbeNeverWrites(t *testing.T) {
+	prevGet := keyringGetFn
+	prevSet := keyringSetFn
+	prevDelete := keyringDeleteFn
+	t.Cleanup(func() {
+		keyringGetFn = prevGet
+		keyringSetFn = prevSet
+		keyringDeleteFn = prevDelete
+	})
+
+	writes, deletes := 0, 0
+	keyringSetFn = func(service, user string, value string) error {
+		writes++
+		return nil
+	}
+	keyringDeleteFn = func(service, user string) error {
+		deletes++
+		return nil
+	}
+
+	t.Run("not found means available", func(t *testing.T) {
+		keyringUnavailableReasonFn = newKeyringAvailabilityProbe()
+		keyringGetFn = func(service, user string) (string, error) {
+			return "", errCredentialNotFound
+		}
+		if err := keyringUnavailableReason(); err != nil {
+			t.Errorf("probe = %v, want nil on ErrNotFound", err)
+		}
+	})
+	t.Run("backend failure surfaces", func(t *testing.T) {
+		keyringUnavailableReasonFn = newKeyringAvailabilityProbe()
+		keyringGetFn = func(service, user string) (string, error) {
+			return "", errors.New("dbus broken")
+		}
+		if err := keyringUnavailableReason(); err == nil {
+			t.Error("probe = nil, want the backend error")
+		}
+	})
+	if writes != 0 || deletes != 0 {
+		t.Errorf("probe wrote %d items and deleted %d; it must not write at all", writes, deletes)
+	}
+}
+
+// TestKeyringProbeAcceptsAbsenceVariants pins the tolerant matcher. Some
+// Secret Service paths answer a missing item with a raw "object does not
+// exist" error instead of ErrNotFound. The probe must treat every absence
+// shape as a reachable backend.
+func TestKeyringProbeAcceptsAbsenceVariants(t *testing.T) {
+	prevGet := keyringGetFn
+	prevUnavailableReason := keyringUnavailableReasonFn
+	t.Cleanup(func() {
+		keyringGetFn = prevGet
+		keyringUnavailableReasonFn = prevUnavailableReason
+	})
+
+	for _, msg := range []string{
+		"secret not found in keyring",
+		"Object does not exist at path /org/freedesktop/secrets/collection/Default_keyring/49405",
+	} {
+		keyringGetFn = func(service, user string) (string, error) {
+			return "", errors.New(msg)
+		}
+		keyringUnavailableReasonFn = newKeyringAvailabilityProbe()
+		if err := keyringUnavailableReason(); err != nil {
+			t.Errorf("probe rejected absence answer %q: %v", msg, err)
 		}
 	}
 }

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -713,3 +713,39 @@ func TestPlaintextFileStore_WarningsRouteToInjectedWriter(t *testing.T) {
 		t.Errorf("missing OAuth-secret warning; got %q", out)
 	}
 }
+
+// TestPlaintextFileStore_SetTightensLoosePermissions guards the contract
+// that every Set enforces 0600. os.WriteFile keeps the mode of an existing
+// file, so a file created loose once stayed loose forever before the
+// temp-file rename.
+func TestPlaintextFileStore_SetTightensLoosePermissions(t *testing.T) {
+	dir := t.TempDir()
+	store := &PlaintextFileStore{dir: dir, warn: io.Discard}
+
+	path := filepath.Join(dir, "account_7.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("seed loose file: %v", err)
+	}
+
+	if err := store.Set(Credential{AccountID: 7, Username: "bob", Password: "pw"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credential file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file permissions after Set = %o, want 0600", perm)
+	}
+
+	// The atomic rename must leave no temp files behind.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".credential-") {
+			t.Errorf("temp file %s survived Set", e.Name())
+		}
+	}
+}

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -237,7 +238,9 @@ func TestNewCredentialStore_IncludesKeyringProbeError(t *testing.T) {
 	prevUnavailableReason := keyringUnavailableReasonFn
 	prevGet := keyringGetFn
 
-	probeErr := errors.New("dbus: org.freedesktop.secrets unavailable")
+	// A plain "not found" text reports a broken backend, not an absent
+	// item. The probe must surface it instead of scraping the text.
+	probeErr := errors.New("dbus: secret service not found")
 	keyringGetFn = func(service, user string) (string, error) {
 		return "", probeErr
 	}
@@ -749,7 +752,8 @@ func TestPlaintextFileStore_SetTightensLoosePermissions(t *testing.T) {
 // availability probe. The probe reads a nonexistent item; a backend that
 // answers with ErrNotFound proves it is reachable. A write-based probe left
 // residue in the production keyring when the process died between the set
-// and the delete.
+// and the delete. The probe still deletes the residue item that the older
+// write-based probe left behind. It writes nothing.
 func TestKeyringProbeNeverWrites(t *testing.T) {
 	prevGet := keyringGetFn
 	prevSet := keyringSetFn
@@ -760,13 +764,14 @@ func TestKeyringProbeNeverWrites(t *testing.T) {
 		keyringDeleteFn = prevDelete
 	})
 
-	writes, deletes := 0, 0
+	writes := 0
+	var deleted []string
 	keyringSetFn = func(service, user string, value string) error {
 		writes++
 		return nil
 	}
 	keyringDeleteFn = func(service, user string) error {
-		deletes++
+		deleted = append(deleted, service+"/"+user)
 		return nil
 	}
 
@@ -788,26 +793,35 @@ func TestKeyringProbeNeverWrites(t *testing.T) {
 			t.Error("probe = nil, want the backend error")
 		}
 	})
-	if writes != 0 || deletes != 0 {
-		t.Errorf("probe wrote %d items and deleted %d; it must not write at all", writes, deletes)
+	if writes != 0 {
+		t.Errorf("probe wrote %d items; it must not write at all", writes)
+	}
+	wantCleanup := []string{"chroncal/__chroncal_probe__"}
+	if !slices.Equal(deleted, wantCleanup) {
+		t.Errorf("probe deleted %v; want only the legacy residue %v", deleted, wantCleanup)
 	}
 }
 
-// TestKeyringProbeAcceptsAbsenceVariants pins the tolerant matcher. Some
-// Secret Service paths answer a missing item with a raw "object does not
-// exist" error instead of ErrNotFound. The probe must treat every absence
-// shape as a reachable backend.
+// TestKeyringProbeAcceptsAbsenceVariants pins the narrow matcher. Some
+// Secret Service paths answer a missing item with a raw DBus error instead
+// of ErrNotFound. The probe must treat a DBus error identity as an absent
+// item. The probe must reject a plain "not found" text: such a text can also
+// report a broken backend, and a broad match reads that backend as reachable.
 func TestKeyringProbeAcceptsAbsenceVariants(t *testing.T) {
 	prevGet := keyringGetFn
+	prevDelete := keyringDeleteFn
 	prevUnavailableReason := keyringUnavailableReasonFn
 	t.Cleanup(func() {
 		keyringGetFn = prevGet
+		keyringDeleteFn = prevDelete
 		keyringUnavailableReasonFn = prevUnavailableReason
 	})
 
+	keyringDeleteFn = func(service, user string) error { return nil }
+
 	for _, msg := range []string{
-		"secret not found in keyring",
-		"Object does not exist at path /org/freedesktop/secrets/collection/Default_keyring/49405",
+		"org.freedesktop.Secret.Error.NoSuchObject: object does not exist at path /org/freedesktop/secrets/collection/Default_keyring/49405",
+		"org.freedesktop.DBus.Error.UnknownObject: no such item",
 	} {
 		keyringGetFn = func(service, user string) (string, error) {
 			return "", errors.New(msg)
@@ -815,6 +829,19 @@ func TestKeyringProbeAcceptsAbsenceVariants(t *testing.T) {
 		keyringUnavailableReasonFn = newKeyringAvailabilityProbe()
 		if err := keyringUnavailableReason(); err != nil {
 			t.Errorf("probe rejected absence answer %q: %v", msg, err)
+		}
+	}
+
+	for _, msg := range []string{
+		"secret not found in keyring",
+		"the name was not provided by any .service files",
+	} {
+		keyringGetFn = func(service, user string) (string, error) {
+			return "", errors.New(msg)
+		}
+		keyringUnavailableReasonFn = newKeyringAvailabilityProbe()
+		if err := keyringUnavailableReason(); err == nil {
+			t.Errorf("probe accepted broad answer %q; it must surface it", msg)
 		}
 	}
 }

--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -283,7 +283,10 @@ func exchangeGoogleCode(ctx context.Context, clientID, clientSecret, code, redir
 
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode != 200 {
-			return nil, fmt.Errorf("token exchange failed (%d): %s", resp.StatusCode, body)
+			// The typed status lets retry.IsTransient classify a transient
+			// exchange failure without scraping the message text.
+			return nil, retry.NewHTTPError(resp.StatusCode,
+				fmt.Errorf("token exchange failed (%d): %s", resp.StatusCode, body))
 		}
 
 		var result struct {
@@ -333,7 +336,10 @@ func RefreshGoogleToken(ctx context.Context, clientID, clientSecret, refreshToke
 
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode != 200 {
-			return nil, fmt.Errorf("token refresh failed (%d): %s", resp.StatusCode, body)
+			// The typed status lets retry.IsTransient classify a transient
+			// refresh failure without scraping the message text.
+			return nil, retry.NewHTTPError(resp.StatusCode,
+				fmt.Errorf("token refresh failed (%d): %s", resp.StatusCode, body))
 		}
 
 		var result struct {

--- a/internal/caldav/auth_test.go
+++ b/internal/caldav/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/douglasdemoura/chroncal/internal/retry"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -151,7 +152,9 @@ func TestOAuth2HTTPClient_FailsFastOnNonTransientRefreshError(t *testing.T) {
 func TestOAuth2HTTPClient_ProceedsWithStaleTokenOnTransientRefreshError(t *testing.T) {
 	prevRefresh := refreshGoogleTokenFn
 	refreshGoogleTokenFn = func(ctx context.Context, clientID, clientSecret, refreshToken string) (*auth.GoogleOAuthResult, error) {
-		return nil, errors.New("token refresh failed (503): Service Unavailable")
+		// Match the production contract: google.go returns a typed status
+		// so IsTransient classifies without scraping the message.
+		return nil, retry.NewHTTPError(503, errors.New("token refresh failed (503): Service Unavailable"))
 	}
 	t.Cleanup(func() { refreshGoogleTokenFn = prevRefresh })
 

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -196,34 +196,33 @@ func propfindCalendarCollections(ctx context.Context, httpClient webdav.HTTPClie
 
 	out := make([]RemoteCalendar, 0, len(ms.Responses))
 	for _, r := range ms.Responses {
-		if len(r.PropStats) == 0 {
-			continue
-		}
 		isCalendar := false
 		remote := RemoteCalendar{}
-		ps, ok := firstOKPropstat(r)
-		if !ok {
-			continue
-		}
-		if remote.Name == "" {
-			remote.Name = strings.TrimSpace(ps.DisplayName)
-		}
-		if remote.Description == "" {
-			remote.Description = strings.TrimSpace(ps.CalendarDescription)
-		}
-		if remote.Color == "" {
-			remote.Color = NormalizeCalendarColor(ps.CalendarColor)
-		}
-		if len(remote.SupportedComponentSet) == 0 {
-			remote.SupportedComponentSet = componentNames(ps.SupportedComponents)
-		}
-		// calendarAccessFromPrivileges never returns "", so the first
-		// successful propstat wins — matching the verify path.
-		if remote.Access == "" {
-			remote.Access = calendarAccessFromPrivileges(ps.CurrentPrivileges)
-		}
-		if ps.ResourceType.Calendar != nil {
-			isCalendar = true
+		// RFC 4918 §9.1.2 lets a server split the properties of one
+		// response across several 2xx propstats. Merge every 2xx
+		// propstat per field; the first propstat that fills a field
+		// wins.
+		for _, ps := range allOKPropstats(r) {
+			if remote.Name == "" {
+				remote.Name = strings.TrimSpace(ps.DisplayName)
+			}
+			if remote.Description == "" {
+				remote.Description = strings.TrimSpace(ps.CalendarDescription)
+			}
+			if remote.Color == "" {
+				remote.Color = NormalizeCalendarColor(ps.CalendarColor)
+			}
+			if len(remote.SupportedComponentSet) == 0 {
+				remote.SupportedComponentSet = componentNames(ps.SupportedComponents)
+			}
+			// calendarAccessFromPrivileges never returns "", so the first
+			// successful propstat wins — matching the verify path.
+			if remote.Access == "" {
+				remote.Access = calendarAccessFromPrivileges(ps.CurrentPrivileges)
+			}
+			if ps.ResourceType.Calendar != nil {
+				isCalendar = true
+			}
 		}
 		if !isCalendar {
 			continue

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -257,38 +257,6 @@ func componentNames(set verifySupportedCalendarComponentSet) []string {
 	return names
 }
 
-// GetResources fetches full iCal data for a set of hrefs via calendar-multiget.
-func (c *Client) GetResources(ctx context.Context, calendarPath string, hrefs []string) ([]Resource, error) {
-	calendarPath, err := c.CanonicalCollectionRef(calendarPath)
-	if err != nil {
-		return nil, err
-	}
-
-	multiGet := &caldav.CalendarMultiGet{
-		Paths: hrefs,
-		CompRequest: caldav.CalendarCompRequest{
-			Name:     "VCALENDAR",
-			AllComps: true,
-			AllProps: true,
-		},
-	}
-
-	objects, err := c.inner.MultiGetCalendar(ctx, calendarPath, multiGet)
-	if err != nil {
-		return nil, fmt.Errorf("multiget: %w", err)
-	}
-
-	out := make([]Resource, 0, len(objects))
-	for _, obj := range objects {
-		out = append(out, Resource{
-			Path: obj.Path,
-			ETag: normalizeETag(obj.ETag),
-			Data: obj.Data,
-		})
-	}
-	return out, nil
-}
-
 // QueryAll fetches all resources from a calendar.
 func (c *Client) QueryAll(ctx context.Context, calendarPath string) ([]Resource, error) {
 	calendarPath, err := c.CanonicalCollectionRef(calendarPath)

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -189,7 +189,7 @@ func propfindCalendarCollections(ctx context.Context, httpClient webdav.HTTPClie
 		return nil, httpError(resp)
 	}
 
-	var ms verifyMultiStatus
+	var ms davMultiStatus[verifyProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return nil, fmt.Errorf("decode discovery PROPFIND response: %w", err)
 	}
@@ -201,30 +201,29 @@ func propfindCalendarCollections(ctx context.Context, httpClient webdav.HTTPClie
 		}
 		isCalendar := false
 		remote := RemoteCalendar{}
-		for _, ps := range r.PropStats {
-			if code := parseStatusCode(ps.Status); code < 200 || code >= 300 {
-				continue
-			}
-			if remote.Name == "" {
-				remote.Name = strings.TrimSpace(ps.Prop.DisplayName)
-			}
-			if remote.Description == "" {
-				remote.Description = strings.TrimSpace(ps.Prop.CalendarDescription)
-			}
-			if remote.Color == "" {
-				remote.Color = NormalizeCalendarColor(ps.Prop.CalendarColor)
-			}
-			if len(remote.SupportedComponentSet) == 0 {
-				remote.SupportedComponentSet = componentNames(ps.Prop.SupportedComponents)
-			}
-			// calendarAccessFromPrivileges never returns "", so the first
-			// successful propstat wins — matching the verify path.
-			if remote.Access == "" {
-				remote.Access = calendarAccessFromPrivileges(ps.Prop.CurrentPrivileges)
-			}
-			if ps.Prop.ResourceType.Calendar != nil {
-				isCalendar = true
-			}
+		ps, ok := firstOKPropstat(r)
+		if !ok {
+			continue
+		}
+		if remote.Name == "" {
+			remote.Name = strings.TrimSpace(ps.DisplayName)
+		}
+		if remote.Description == "" {
+			remote.Description = strings.TrimSpace(ps.CalendarDescription)
+		}
+		if remote.Color == "" {
+			remote.Color = NormalizeCalendarColor(ps.CalendarColor)
+		}
+		if len(remote.SupportedComponentSet) == 0 {
+			remote.SupportedComponentSet = componentNames(ps.SupportedComponents)
+		}
+		// calendarAccessFromPrivileges never returns "", so the first
+		// successful propstat wins — matching the verify path.
+		if remote.Access == "" {
+			remote.Access = calendarAccessFromPrivileges(ps.CurrentPrivileges)
+		}
+		if ps.ResourceType.Calendar != nil {
+			isCalendar = true
 		}
 		if !isCalendar {
 			continue

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -54,17 +54,27 @@ var defaultHTTPClient = &http.Client{
 }
 var errResponseTooLarge = errors.New("caldav response exceeds configured limits")
 
+// checkRedirect governs redirects for defaultHTTPClient. It rejects any
+// redirect that leaves the host of the first request.
+//
+// net/http copies the sensitive headers of the first request (Authorization,
+// Cookie) before it calls this hook. It also forwards those headers to
+// subdomains of the first host. An abort is therefore the only safe answer.
+// The request then fails before it reaches the other host.
 func checkRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= maxRedirects {
 		return fmt.Errorf("stopped after %d redirects", maxRedirects)
 	}
 	if len(via) > 0 && !sameRedirectHost(req.URL, via[0].URL) {
-		req.Header.Del("Authorization")
-		req.Header.Del("Cookie")
+		return fmt.Errorf("refuse redirect from host %q to host %q: a cross-host redirect can leak credentials", via[0].URL.Host, req.URL.Host)
 	}
 	return nil
 }
 
+// sameRedirectHost reports whether two URLs carry the same host name and
+// port. The compare ignores case. A subdomain counts as a different host.
+// This rule is stricter than the net/http default. That default forwards
+// credentials to subdomains of the first host.
 func sameRedirectHost(a, b *url.URL) bool {
 	return strings.EqualFold(a.Host, b.Host)
 }

--- a/internal/caldav/discovery_test.go
+++ b/internal/caldav/discovery_test.go
@@ -117,6 +117,76 @@ func TestDiscoverCalendarsReturnsCollectionMetadata(t *testing.T) {
 	}
 }
 
+// TestPropfindCalendarCollections_MergesSplitPropstats covers RFC 4918
+// §9.1.2: a server may split the properties of one response across several
+// 2xx propstats. The work calendar carries resourcetype only in the second
+// 200 propstat. Discovery must still see the calendar and must merge its
+// fields across both propstats. The first propstat that fills a field wins
+// (the shadowed displayname in the second propstat must not overwrite Work).
+// calendarAccessFromPrivileges never returns an empty value, so the first
+// 200 propstat decides the access field.
+func TestPropfindCalendarCollections_MergesSplitPropstats(t *testing.T) {
+	const fixture = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:ic="http://apple.com/ns/ical/">
+  <d:response>
+    <d:href>/cal/work/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>Work</d:displayname>
+        <ic:calendar-color>#123456FF</ic:calendar-color>
+        <d:current-user-privilege-set><d:privilege><d:read/></d:privilege></d:current-user-privilege-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop><d:getetag/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>Shadowed</d:displayname>
+        <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+        <c:supported-calendar-component-set><c:comp name="VTODO"/></c:supported-calendar-component-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PROPFIND" {
+			t.Errorf("method = %s, want PROPFIND", r.Method)
+		}
+		w.WriteHeader(http.StatusMultiStatus)
+		_, _ = w.Write([]byte(fixture))
+	}))
+	t.Cleanup(srv.Close)
+
+	found, err := propfindCalendarCollections(context.Background(), srv.Client(), srv.URL+"/cal/")
+	if err != nil {
+		t.Fatalf("propfindCalendarCollections: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("calendar count = %d, want 1 (resourcetype sits in the second 200 propstat and must not hide the calendar)", len(found))
+	}
+	work := found[0]
+	if work.Path != "/cal/work/" {
+		t.Errorf("path = %q, want /cal/work/", work.Path)
+	}
+	if work.Name != "Work" {
+		t.Errorf("name = %q, want Work (the first propstat that fills the field wins)", work.Name)
+	}
+	if work.Color != "#123456" {
+		t.Errorf("color = %q, want #123456 from the first propstat", work.Color)
+	}
+	if work.Access != CalendarAccessRead {
+		t.Errorf("access = %q, want read from the first propstat", work.Access)
+	}
+	if len(work.SupportedComponentSet) != 1 || work.SupportedComponentSet[0] != "VTODO" {
+		t.Errorf("components = %v, want [VTODO] from the second 200 propstat", work.SupportedComponentSet)
+	}
+}
+
 func multistatus(href, prop string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
 <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">

--- a/internal/caldav/multiget.go
+++ b/internal/caldav/multiget.go
@@ -57,7 +57,7 @@ func (c *Client) MultiGetTolerant(ctx context.Context, calendarPath string, href
 		return nil, fmt.Errorf("REPORT calendar-multiget: %w", httpError(resp))
 	}
 
-	var ms multiGetMultiStatus
+	var ms davMultiStatus[multiGetProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return nil, fmt.Errorf("decode multiget response: %w", err)
 	}
@@ -73,20 +73,9 @@ func (c *Client) MultiGetTolerant(ctx context.Context, calendarPath string, href
 			result.Missing = append(result.Missing, href)
 			continue
 		}
-		var etag, data string
-		var ok bool
-		for _, ps := range r.PropStats {
-			code := parseStatusCode(ps.Status)
-			if code == http.StatusNotFound {
-				continue
-			}
-			if code >= 200 && code < 300 {
-				etag = normalizeETag(ps.Prop.ETag)
-				data = ps.Prop.CalendarData
-				ok = true
-				break
-			}
-		}
+		ps, ok := firstOKPropstat(r)
+		etag := normalizeETag(ps.ETag)
+		data := ps.CalendarData
 		if !ok || data == "" {
 			result.Missing = append(result.Missing, href)
 			continue
@@ -123,21 +112,8 @@ func buildMultiGetBody(hrefs []string) string {
 %s</c:calendar-multiget>`, hrefXML.String())
 }
 
-type multiGetMultiStatus struct {
-	XMLName   xml.Name           `xml:"DAV: multistatus"`
-	Responses []multiGetResponse `xml:"DAV: response"`
-}
-
-type multiGetResponse struct {
-	Href      string             `xml:"DAV: href"`
-	Status    string             `xml:"DAV: status"`
-	PropStats []multiGetPropStat `xml:"DAV: propstat"`
-}
-
-type multiGetPropStat struct {
-	Status string `xml:"DAV: status"`
-	Prop   struct {
-		ETag         string `xml:"DAV: getetag"`
-		CalendarData string `xml:"urn:ietf:params:xml:ns:caldav calendar-data"`
-	} `xml:"DAV: prop"`
+// multiGetProps is the DAV: prop payload of a calendar-multiget REPORT.
+type multiGetProps struct {
+	ETag         string `xml:"DAV: getetag"`
+	CalendarData string `xml:"urn:ietf:params:xml:ns:caldav calendar-data"`
 }

--- a/internal/caldav/multistatus.go
+++ b/internal/caldav/multistatus.go
@@ -1,0 +1,47 @@
+package caldav
+
+import "encoding/xml"
+
+// This file carries the one shared WebDAV multistatus envelope. Every
+// REPORT/PROPFIND response decodes through it. Before the consolidation, four
+// packages-private struct hierarchies restated the same
+// multistatus → response → propstat shape with per-call-site Prop payloads,
+// and drifted independently.
+//
+// A call site defines only its Prop payload type and instantiates the generic
+// envelope with it.
+
+// davMultiStatus decodes a DAV: multistatus document. P is the call site's
+// expected DAV: prop payload.
+type davMultiStatus[P any] struct {
+	XMLName   xml.Name         `xml:"DAV: multistatus"`
+	Responses []davResponse[P] `xml:"DAV: response"`
+	// SyncToken is present only in sync-collection responses; other reports
+	// leave it empty.
+	SyncToken string `xml:"DAV: sync-token"`
+}
+
+// davResponse is one DAV: response element.
+type davResponse[P any] struct {
+	Href      string           `xml:"DAV: href"`
+	Status    string           `xml:"DAV: status"`
+	PropStats []davPropStat[P] `xml:"DAV: propstat"`
+}
+
+// davPropStat pairs a status line with its property payload.
+type davPropStat[P any] struct {
+	Status string `xml:"DAV: status"`
+	Prop   P      `xml:"DAV: prop"`
+}
+
+// firstOKPropstat returns the first 2xx propstat of a response. ok is false
+// when the response carries no 2xx propstat.
+func firstOKPropstat[P any](r davResponse[P]) (P, bool) {
+	for _, ps := range r.PropStats {
+		if code := parseStatusCode(ps.Status); code >= 200 && code < 300 {
+			return ps.Prop, true
+		}
+	}
+	var zero P
+	return zero, false
+}

--- a/internal/caldav/multistatus.go
+++ b/internal/caldav/multistatus.go
@@ -2,14 +2,11 @@ package caldav
 
 import "encoding/xml"
 
-// This file carries the one shared WebDAV multistatus envelope. Every
-// REPORT/PROPFIND response decodes through it. Before the consolidation, four
-// packages-private struct hierarchies restated the same
-// multistatus → response → propstat shape with per-call-site Prop payloads,
-// and drifted independently.
-//
-// A call site defines only its Prop payload type and instantiates the generic
-// envelope with it.
+// This file carries the single shared WebDAV multistatus envelope. The
+// package decodes every REPORT and PROPFIND response through this envelope.
+// A call site defines only its Prop payload type and instantiates the
+// generic envelope with it. The envelope owns the multistatus, response,
+// and propstat shape, so all call sites decode that shape in the same way.
 
 // davMultiStatus decodes a DAV: multistatus document. P is the call site's
 // expected DAV: prop payload.
@@ -44,4 +41,20 @@ func firstOKPropstat[P any](r davResponse[P]) (P, bool) {
 	}
 	var zero P
 	return zero, false
+}
+
+// allOKPropstats returns the prop payload of every 2xx propstat, in
+// document order. RFC 4918 §9.1.2 lets a server split the properties of one
+// response across several 2xx propstats, so a caller that merges fields
+// iterates all of them. The slice is empty when the response carries no 2xx
+// propstat. A caller that needs only the first 2xx propstat uses
+// firstOKPropstat instead.
+func allOKPropstats[P any](r davResponse[P]) []P {
+	var props []P
+	for _, ps := range r.PropStats {
+		if code := parseStatusCode(ps.Status); code >= 200 && code < 300 {
+			props = append(props, ps.Prop)
+		}
+	}
+	return props
 }

--- a/internal/caldav/multistatus_test.go
+++ b/internal/caldav/multistatus_test.go
@@ -1,0 +1,64 @@
+package caldav
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+// TestDavMultiStatusDecodesCanonicalSample pins the shared envelope against a
+// canonical multistatus body: one 404 propstat, then a 200 propstat. The
+// decoder must keep both and firstOKPropstat must select the 200 one.
+func TestDavMultiStatusDecodesCanonicalSample(t *testing.T) {
+	body := `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:ic="http://apple.com/ns/ical/">
+  <d:response>
+    <d:href>/cal/one/</d:href>
+    <d:propstat>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+      <d:prop><d:getetag/></d:prop>
+    </d:propstat>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop>
+        <d:getetag>"abc"</d:getetag>
+        <ic:calendar-color>#FF0000AA</ic:calendar-color>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	var ms davMultiStatus[multiGetProps]
+	if err := xml.NewDecoder(strings.NewReader(body)).Decode(&ms); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(ms.Responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(ms.Responses))
+	}
+	r := ms.Responses[0]
+	if r.Href != "/cal/one/" {
+		t.Errorf("href = %q, want /cal/one/", r.Href)
+	}
+	if len(r.PropStats) != 2 {
+		t.Fatalf("propstats = %d, want 2 (the envelope must keep non-2xx propstats)", len(r.PropStats))
+	}
+
+	ps, ok := firstOKPropstat(r)
+	if !ok {
+		t.Fatal("firstOKPropstat found no 2xx propstat")
+	}
+	if ps.ETag != `"abc"` {
+		t.Errorf("etag = %q, want %q", ps.ETag, `"abc"`)
+	}
+
+	// A response with only error propstats yields ok == false, not an error.
+	var ms2 davMultiStatus[multiGetProps]
+	bad := strings.Replace(body, "200 OK", "500 Server Error", 1)
+	bad = strings.Replace(bad, "404 Not Found", "500 Server Error", 1)
+	if err := xml.NewDecoder(strings.NewReader(bad)).Decode(&ms2); err != nil {
+		t.Fatalf("decode bad: %v", err)
+	}
+	if _, ok := firstOKPropstat(ms2.Responses[0]); ok {
+		t.Error("firstOKPropstat accepted a 500 propstat")
+	}
+}

--- a/internal/caldav/multistatus_test.go
+++ b/internal/caldav/multistatus_test.go
@@ -62,3 +62,54 @@ func TestDavMultiStatusDecodesCanonicalSample(t *testing.T) {
 		t.Error("firstOKPropstat accepted a 500 propstat")
 	}
 }
+
+// TestAllOKPropstatsReturnsEvery2xxPayload pins the helper that the discovery
+// and verify paths use. RFC 4918 §9.1.2 lets a server split the properties of
+// one response across several 2xx propstats. The helper must return every 2xx
+// payload in document order and skip every non-2xx propstat.
+func TestAllOKPropstatsReturnsEvery2xxPayload(t *testing.T) {
+	const body = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/cal/one/</d:href>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop><d:getetag>"first"</d:getetag></d:prop>
+    </d:propstat>
+    <d:propstat>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+      <d:prop><d:getetag>"dropped"</d:getetag></d:prop>
+    </d:propstat>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop><c:calendar-data>BEGIN:VCALENDAR
+END:VCALENDAR</c:calendar-data></d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	var ms davMultiStatus[multiGetProps]
+	if err := xml.NewDecoder(strings.NewReader(body)).Decode(&ms); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	props := allOKPropstats(ms.Responses[0])
+	if len(props) != 2 {
+		t.Fatalf("2xx payloads = %d, want 2 (the 404 propstat must be skipped)", len(props))
+	}
+	if props[0].ETag != `"first"` || props[1].ETag != "" {
+		t.Errorf("payload order = [%q, %q], want the 200 propstats in document order", props[0].ETag, props[1].ETag)
+	}
+	if !strings.Contains(props[1].CalendarData, "BEGIN:VCALENDAR") {
+		t.Errorf("second payload calendar-data = %q, want the VCALENDAR text from the third propstat", props[1].CalendarData)
+	}
+
+	// A response with only error propstats yields an empty slice, not an error.
+	bad := strings.ReplaceAll(body, "200 OK", "500 Server Error")
+	var ms2 davMultiStatus[multiGetProps]
+	if err := xml.NewDecoder(strings.NewReader(bad)).Decode(&ms2); err != nil {
+		t.Fatalf("decode bad: %v", err)
+	}
+	if props := allOKPropstats(ms2.Responses[0]); len(props) != 0 {
+		t.Errorf("allOKPropstats accepted a 500 propstat: %+v", props)
+	}
+}

--- a/internal/caldav/properties.go
+++ b/internal/caldav/properties.go
@@ -11,19 +11,9 @@ import (
 	"github.com/emersion/go-webdav"
 )
 
-type calendarColorMultiStatus struct {
-	Responses []calendarColorResponse `xml:"DAV: response"`
-}
-
-type calendarColorResponse struct {
-	PropStats []calendarColorPropStat `xml:"DAV: propstat"`
-}
-
-type calendarColorPropStat struct {
-	Status string `xml:"DAV: status"`
-	Prop   struct {
-		CalendarColor string `xml:"http://apple.com/ns/ical/ calendar-color"`
-	} `xml:"DAV: prop"`
+// calendarColorProps is the DAV: prop payload of the calendar-color PROPFIND.
+type calendarColorProps struct {
+	CalendarColor string `xml:"http://apple.com/ns/ical/ calendar-color"`
 }
 
 // GetCalendarColor fetches the current calendar-color property for a calendar.
@@ -55,7 +45,7 @@ func GetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 		return "", fmt.Errorf("PROPFIND calendar-color: %w", httpError(resp))
 	}
 
-	var ms calendarColorMultiStatus
+	var ms davMultiStatus[calendarColorProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return "", fmt.Errorf("decode PROPFIND response: %w", err)
 	}
@@ -146,7 +136,7 @@ func SetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 	case http.StatusOK, http.StatusNoContent:
 		return nil
 	case http.StatusMultiStatus:
-		var ms calendarColorMultiStatus
+		var ms davMultiStatus[calendarColorProps]
 		if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 			return fmt.Errorf("decode PROPPATCH response: %w", err)
 		}

--- a/internal/caldav/redirect_test.go
+++ b/internal/caldav/redirect_test.go
@@ -5,16 +5,18 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
 
-func TestDefaultHTTPClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+func TestDefaultHTTPClientAbortsCrossHostRedirect(t *testing.T) {
 	t.Parallel()
 
-	var attackerAuth atomic.Value // string
+	var attackerHits atomic.Int64
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attackerAuth.Store(r.Header.Get("Authorization"))
+		attackerHits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	}))
@@ -32,22 +34,24 @@ func TestDefaultHTTPClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	req.SetBasicAuth("alice", "s3cr3t")
 
 	resp, err := defaultHTTPClient.Do(req)
-	if err != nil {
-		t.Fatalf("Do: %v", err)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("Do err = nil, want a cross-host redirect abort")
 	}
-	defer resp.Body.Close()
-
-	if got, _ := attackerAuth.Load().(string); got != "" {
-		t.Fatalf("cross-host redirect leaked Authorization header = %q, want empty", got)
+	if !strings.Contains(err.Error(), "refuse redirect") {
+		t.Fatalf("Do err = %v, want a refuse-redirect error", err)
+	}
+	if n := attackerHits.Load(); n != 0 {
+		t.Fatalf("cross-host redirect sent %d requests to the other host, want 0", n)
 	}
 }
 
-func TestBearerAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+func TestBearerAuthClientAbortsCrossHostRedirect(t *testing.T) {
 	t.Parallel()
 
-	var attackerAuth atomic.Value // string
+	var attackerHits atomic.Int64
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attackerAuth.Store(r.Header.Get("Authorization"))
+		attackerHits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	}))
@@ -68,22 +72,24 @@ func TestBearerAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	}
 
 	resp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		t.Fatalf("Do: %v", err)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("Do err = nil, want a cross-host redirect abort")
 	}
-	defer resp.Body.Close()
-
-	if got, _ := attackerAuth.Load().(string); got != "" {
-		t.Fatalf("cross-host redirect leaked bearer Authorization header = %q, want empty", got)
+	if !strings.Contains(err.Error(), "refuse redirect") {
+		t.Fatalf("Do err = %v, want a refuse-redirect error", err)
+	}
+	if n := attackerHits.Load(); n != 0 {
+		t.Fatalf("cross-host redirect sent %d requests to the other host, want 0", n)
 	}
 }
 
-func TestBasicAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
+func TestBasicAuthClientAbortsCrossHostRedirect(t *testing.T) {
 	t.Parallel()
 
-	var attackerAuth atomic.Value // string
+	var attackerHits atomic.Int64
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attackerAuth.Store(r.Header.Get("Authorization"))
+		attackerHits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	}))
@@ -104,13 +110,15 @@ func TestBasicAuthClientStripsAuthOnCrossHostRedirect(t *testing.T) {
 	}
 
 	resp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		t.Fatalf("Do: %v", err)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("Do err = nil, want a cross-host redirect abort")
 	}
-	defer resp.Body.Close()
-
-	if got, _ := attackerAuth.Load().(string); got != "" {
-		t.Fatalf("cross-host redirect leaked basic Authorization header = %q, want empty", got)
+	if !strings.Contains(err.Error(), "refuse redirect") {
+		t.Fatalf("Do err = %v, want a refuse-redirect error", err)
+	}
+	if n := attackerHits.Load(); n != 0 {
+		t.Fatalf("cross-host redirect sent %d requests to the other host, want 0", n)
 	}
 }
 
@@ -158,6 +166,7 @@ func TestDefaultHTTPClientCapsRedirects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
+
 	resp, err := defaultHTTPClient.Do(req)
 	if err == nil {
 		resp.Body.Close()
@@ -169,6 +178,41 @@ func TestDefaultHTTPClientHasRedirectPolicy(t *testing.T) {
 	t.Parallel()
 
 	if defaultHTTPClient.CheckRedirect == nil {
-		t.Fatal("defaultHTTPClient.CheckRedirect = nil, want a policy that strips credentials on cross-host redirects")
+		t.Fatal("defaultHTTPClient.CheckRedirect = nil, want a policy that aborts cross-host redirects")
+	}
+}
+
+func TestSameRedirectHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"same host", "https://caldav.example.com/", "https://caldav.example.com/calendar/", true},
+		{"host case differs", "https://CalDAV.example.com/", "https://caldav.example.com/", true},
+		{"subdomain counts as different host", "https://caldav.example.com/", "https://evil.caldav.example.com/", false},
+		{"different registrable domain", "https://caldav.example.com/", "https://caldav.example.org/", false},
+		{"port differs", "https://caldav.example.com:8443/", "https://caldav.example.com/", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a, err := url.Parse(tc.a)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.a, err)
+			}
+			b, err := url.Parse(tc.b)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.b, err)
+			}
+			if got := sameRedirectHost(a, b); got != tc.want {
+				t.Fatalf("sameRedirectHost(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/caldav/sync_collection.go
+++ b/internal/caldav/sync_collection.go
@@ -23,7 +23,7 @@ var ErrSyncCollectionUnsupported = errors.New("caldav: sync-collection not suppo
 
 // SyncChange describes one changed or removed resource returned by a
 // sync-collection REPORT. Deleted entries carry only Path; updated entries
-// carry Path and ETag (no body — fetch with GetResources).
+// carry Path and ETag (no body — fetch with MultiGetTolerant).
 type SyncChange struct {
 	Path    string
 	ETag    string
@@ -51,8 +51,7 @@ type SyncCollectionResult struct {
 // a full snapshot of hrefs+etags plus a fresh token. Later calls return
 // only resources changed since the supplied token.
 //
-// The body returned only contains hrefs + etags. Use GetResources for the
-// updated paths to download bodies.
+// Use MultiGetTolerant for the updated paths to download bodies.
 func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncToken string) (*SyncCollectionResult, error) {
 	canonicalPath, err := c.CanonicalCollectionRef(calendarPath)
 	if err != nil {

--- a/internal/caldav/sync_collection.go
+++ b/internal/caldav/sync_collection.go
@@ -96,7 +96,7 @@ func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncTo
 		return nil, fmt.Errorf("REPORT sync-collection: %w", httpError(resp))
 	}
 
-	var ms syncCollectionMultiStatus
+	var ms davMultiStatus[syncCollectionProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return nil, fmt.Errorf("decode sync-collection response: %w", err)
 	}
@@ -124,12 +124,8 @@ func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncTo
 			continue
 		}
 		var etag string
-		for _, ps := range r.PropStats {
-			code := parseStatusCode(ps.Status)
-			if code >= 200 && code < 300 {
-				etag = normalizeETag(ps.Prop.ETag)
-				break
-			}
+		if ps, ok := firstOKPropstat(r); ok {
+			etag = normalizeETag(ps.ETag)
 		}
 		result.Changes = append(result.Changes, SyncChange{Path: href, ETag: etag})
 	}
@@ -147,21 +143,7 @@ func buildSyncCollectionBody(syncToken string) string {
 </d:sync-collection>`, xmlEscape(syncToken))
 }
 
-type syncCollectionMultiStatus struct {
-	XMLName   xml.Name                 `xml:"DAV: multistatus"`
-	Responses []syncCollectionResponse `xml:"DAV: response"`
-	SyncToken string                   `xml:"DAV: sync-token"`
-}
-
-type syncCollectionResponse struct {
-	Href      string                   `xml:"DAV: href"`
-	Status    string                   `xml:"DAV: status"`
-	PropStats []syncCollectionPropStat `xml:"DAV: propstat"`
-}
-
-type syncCollectionPropStat struct {
-	Status string `xml:"DAV: status"`
-	Prop   struct {
-		ETag string `xml:"DAV: getetag"`
-	} `xml:"DAV: prop"`
+// syncCollectionProps is the DAV: prop payload of a sync-collection REPORT.
+type syncCollectionProps struct {
+	ETag string `xml:"DAV: getetag"`
 }

--- a/internal/caldav/verify.go
+++ b/internal/caldav/verify.go
@@ -164,24 +164,26 @@ func fetchCalendarMetadata(ctx context.Context, calendarURL string, httpClient w
 	meta := CalendarMetadata{}
 	isCalendar := false
 	for _, r := range ms.Responses {
-		prop, ok := firstOKPropstat(r)
-		if !ok {
-			continue
-		}
-		if meta.DisplayName == "" {
-			meta.DisplayName = strings.TrimSpace(prop.DisplayName)
-		}
-		if meta.Color == "" {
-			meta.Color = NormalizeCalendarColor(prop.CalendarColor)
-		}
-		if meta.Access == "" {
-			meta.Access = calendarAccessFromPrivileges(prop.CurrentPrivileges)
-		}
-		if meta.SupportedComponents == nil && len(prop.SupportedComponents.Components) > 0 {
-			meta.SupportedComponents = componentNames(prop.SupportedComponents)
-		}
-		if prop.ResourceType.Calendar != nil {
-			isCalendar = true
+		// RFC 4918 §9.1.2 lets a server split the properties of one
+		// response across several 2xx propstats. Merge every 2xx
+		// propstat per field; the first propstat that fills a field
+		// wins.
+		for _, prop := range allOKPropstats(r) {
+			if meta.DisplayName == "" {
+				meta.DisplayName = strings.TrimSpace(prop.DisplayName)
+			}
+			if meta.Color == "" {
+				meta.Color = NormalizeCalendarColor(prop.CalendarColor)
+			}
+			if meta.Access == "" {
+				meta.Access = calendarAccessFromPrivileges(prop.CurrentPrivileges)
+			}
+			if meta.SupportedComponents == nil && len(prop.SupportedComponents.Components) > 0 {
+				meta.SupportedComponents = componentNames(prop.SupportedComponents)
+			}
+			if prop.ResourceType.Calendar != nil {
+				isCalendar = true
+			}
 		}
 	}
 	if meta.Access == "" {

--- a/internal/caldav/verify.go
+++ b/internal/caldav/verify.go
@@ -11,21 +11,8 @@ import (
 	"github.com/emersion/go-webdav"
 )
 
-type verifyMultiStatus struct {
-	Responses []verifyResponse `xml:"DAV: response"`
-}
-
-type verifyResponse struct {
-	Href      string           `xml:"DAV: href"`
-	PropStats []verifyPropStat `xml:"DAV: propstat"`
-}
-
-type verifyPropStat struct {
-	Status string        `xml:"DAV: status"`
-	Prop   verifyPropSet `xml:"DAV: prop"`
-}
-
-type verifyPropSet struct {
+// verifyProps is the DAV: prop payload of the calendar-home-set PROPFIND.
+type verifyProps struct {
 	DisplayName         string                              `xml:"DAV: displayname"`
 	ResourceType        verifyResourceTypeEl                `xml:"DAV: resourcetype"`
 	CalendarDescription string                              `xml:"urn:ietf:params:xml:ns:caldav calendar-description"`
@@ -169,7 +156,7 @@ func fetchCalendarMetadata(ctx context.Context, calendarURL string, httpClient w
 		return CalendarMetadata{}, httpError(resp)
 	}
 
-	var ms verifyMultiStatus
+	var ms davMultiStatus[verifyProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return CalendarMetadata{}, fmt.Errorf("decode PROPFIND response: %w", err)
 	}
@@ -177,26 +164,24 @@ func fetchCalendarMetadata(ctx context.Context, calendarURL string, httpClient w
 	meta := CalendarMetadata{}
 	isCalendar := false
 	for _, r := range ms.Responses {
-		for _, ps := range r.PropStats {
-			code := parseStatusCode(ps.Status)
-			if code < 200 || code >= 300 {
-				continue
-			}
-			if meta.DisplayName == "" {
-				meta.DisplayName = strings.TrimSpace(ps.Prop.DisplayName)
-			}
-			if meta.Color == "" {
-				meta.Color = NormalizeCalendarColor(ps.Prop.CalendarColor)
-			}
-			if meta.Access == "" {
-				meta.Access = calendarAccessFromPrivileges(ps.Prop.CurrentPrivileges)
-			}
-			if meta.SupportedComponents == nil && len(ps.Prop.SupportedComponents.Components) > 0 {
-				meta.SupportedComponents = componentNames(ps.Prop.SupportedComponents)
-			}
-			if ps.Prop.ResourceType.Calendar != nil {
-				isCalendar = true
-			}
+		prop, ok := firstOKPropstat(r)
+		if !ok {
+			continue
+		}
+		if meta.DisplayName == "" {
+			meta.DisplayName = strings.TrimSpace(prop.DisplayName)
+		}
+		if meta.Color == "" {
+			meta.Color = NormalizeCalendarColor(prop.CalendarColor)
+		}
+		if meta.Access == "" {
+			meta.Access = calendarAccessFromPrivileges(prop.CurrentPrivileges)
+		}
+		if meta.SupportedComponents == nil && len(prop.SupportedComponents.Components) > 0 {
+			meta.SupportedComponents = componentNames(prop.SupportedComponents)
+		}
+		if prop.ResourceType.Calendar != nil {
+			isCalendar = true
 		}
 	}
 	if meta.Access == "" {

--- a/internal/caldav/verify_test.go
+++ b/internal/caldav/verify_test.go
@@ -114,6 +114,63 @@ func TestFetchCalendarMetadata_DoesNotRequireCalendarResourceType(t *testing.T) 
 	}
 }
 
+// TestFetchCalendarMetadata_MergesSplitPropstats covers RFC 4918 §9.1.2: a
+// server may split the properties of one response across several 2xx
+// propstats. Here the first 200 propstat carries displayname, color, and the
+// ACL, and the second carries resourcetype and the component set. The
+// metadata must merge all of them, and the first propstat that fills a field
+// wins (the shadowed displayname in the second propstat must not overwrite
+// Work).
+func TestFetchCalendarMetadata_MergesSplitPropstats(t *testing.T) {
+	t.Parallel()
+
+	const fixture = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:ic="http://apple.com/ns/ical/">
+  <d:response>
+    <d:href>/cal/work/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>Work</d:displayname>
+        <ic:calendar-color>#9FE1E7FF</ic:calendar-color>
+        <d:current-user-privilege-set><d:privilege><d:write/></d:privilege></d:current-user-privilege-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>Shadowed</d:displayname>
+        <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+        <c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMultiStatus)
+		_, _ = w.Write([]byte(fixture))
+	}))
+	t.Cleanup(srv.Close)
+
+	meta, err := VerifyCalendarURL(context.Background(), srv.URL+"/cal/work/", "user", "pass", "basic", true)
+	if err != nil {
+		t.Fatalf("VerifyCalendarURL: %v", err)
+	}
+	if meta.DisplayName != "Work" {
+		t.Errorf("DisplayName = %q, want Work (the first propstat that fills the field wins)", meta.DisplayName)
+	}
+	if meta.Color != "#9FE1E7" {
+		t.Errorf("Color = %q, want #9FE1E7 from the first propstat", meta.Color)
+	}
+	if meta.Access != CalendarAccessWrite {
+		t.Errorf("Access = %q, want %q from the first propstat", meta.Access, CalendarAccessWrite)
+	}
+	if got := strings.Join(meta.SupportedComponents, ","); got != "VEVENT" {
+		t.Errorf("SupportedComponents = %q, want VEVENT from the second propstat", got)
+	}
+}
+
 func priv(names ...string) verifyCurrentUserPrivilegeSet {
 	set := verifyCurrentUserPrivilegeSet{}
 	for _, n := range names {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -154,17 +153,5 @@ func newViper() *viper.Viper {
 }
 
 func configDir() (string, error) {
-	// Honour XDG_CONFIG_HOME on every OS. Many CLI tools do this so users
-	// on macOS/Windows can override the default config location.
-	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-		return dir, nil
-	}
-	if runtime.GOOS == "linux" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".config"), nil
-	}
-	return os.UserConfigDir()
+	return BaseDir("XDG_CONFIG_HOME", runtime.GOOS, ".config")
 }

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -85,15 +85,5 @@ func stateFile() (string, error) {
 // stateDir resolves XDG_STATE_HOME. It falls back to ~/.local/state on
 // Linux and os.UserConfigDir() on platforms without a state convention.
 func stateDir() (string, error) {
-	if dir := os.Getenv("XDG_STATE_HOME"); dir != "" {
-		return dir, nil
-	}
-	if runtime.GOOS == "linux" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".local", "state"), nil
-	}
-	return os.UserConfigDir()
+	return BaseDir("XDG_STATE_HOME", runtime.GOOS, ".local", "state")
 }

--- a/internal/config/xdg.go
+++ b/internal/config/xdg.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// BaseDir resolves an XDG-style base directory. env is the XDG variable (for
+// example XDG_STATE_HOME). linuxFallback is the spec path under $HOME for
+// Linux, as relative path segments (for example ".local/state").
+//
+// The env variable wins on every OS, not just Linux. Many CLI tools adopt
+// this so users on macOS and Windows relocate a directory with one setting.
+// On Linux the fallback is the XDG spec path. Other platforms have no
+// convention for that category, so they fall back to os.UserConfigDir.
+func BaseDir(env string, goos string, linuxFallback ...string) (string, error) {
+	if dir := os.Getenv(env); dir != "" {
+		return dir, nil
+	}
+	if goos == "linux" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(append([]string{home}, linuxFallback...)...), nil
+	}
+	return os.UserConfigDir()
+}

--- a/internal/event/alarms.go
+++ b/internal/event/alarms.go
@@ -390,8 +390,7 @@ func (s *Service) ReplaceAlarmsForSync(ctx context.Context, eventID int64, alarm
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return s.markDirtyByID(ctx, eventID)
 }
 
 // replaceAlarmsTx reconciles an event's alarms (content/UID match, in-place

--- a/internal/event/attendees.go
+++ b/internal/event/attendees.go
@@ -56,8 +56,7 @@ func (s *Service) ReplaceAttendeesForSync(ctx context.Context, eventID int64, at
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return s.markDirtyByID(ctx, eventID)
 }
 
 // replaceAttendeesTx replaces an event's attendees using a tx-bound Queries. It

--- a/internal/event/relations.go
+++ b/internal/event/relations.go
@@ -95,8 +95,7 @@ func (s *Service) ReplaceAttachments(ctx context.Context, eventID int64, attachm
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return s.markDirtyByID(ctx, eventID)
 }
 
 // Comment CRUD
@@ -133,8 +132,7 @@ func (s *Service) ReplaceComments(ctx context.Context, eventID int64, comments [
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return s.markDirtyByID(ctx, eventID)
 }
 
 // Contact CRUD
@@ -171,8 +169,7 @@ func (s *Service) ReplaceContacts(ctx context.Context, eventID int64, contacts [
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return s.markDirtyByID(ctx, eventID)
 }
 
 // Resource CRUD
@@ -209,8 +206,7 @@ func (s *Service) ReplaceResources(ctx context.Context, eventID int64, resources
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return s.markDirtyByID(ctx, eventID)
 }
 
 // Relation CRUD
@@ -247,8 +243,7 @@ func (s *Service) ReplaceRelations(ctx context.Context, eventID int64, relations
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return s.markDirtyByID(ctx, eventID)
 }
 
 // X-Property CRUD
@@ -292,6 +287,5 @@ func (s *Service) ReplaceXProperties(ctx context.Context, eventID int64, xprops 
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, eventID)
-	return nil
+	return s.markDirtyByID(ctx, eventID)
 }

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -366,10 +366,15 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, 
 	if err != nil {
 		return Event{}, err
 	}
+	// Mark dirty inside the transaction so a failed sync-tracking write rolls
+	// the edit back rather than committing a change that is never pushed
+	// (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit update event: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 
@@ -408,10 +413,15 @@ func (s *Service) UpdateWithRelations(ctx context.Context, id int64, p UpdatePar
 	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
 		return Event{}, err
 	}
+	// Mark dirty inside the transaction so a failed sync-tracking write rolls
+	// the edit back rather than committing a change that is never pushed
+	// (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit update event: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 
@@ -595,10 +605,15 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 	if err != nil {
 		return Event{}, err
 	}
+	// Mark the override dirty inside the transaction so a failed sync-tracking
+	// write rolls the override back rather than committing a change that is
+	// never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, calendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit override: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
 	return e, nil
 }
 
@@ -632,17 +647,22 @@ func (s *Service) UpdateInstanceWithRelations(ctx context.Context, uid string, i
 	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
 		return Event{}, err
 	}
+	// Mark the override dirty inside the transaction so a failed sync-tracking
+	// write rolls the override and its children back rather than committing a
+	// change that is never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, calendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit override: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
 	return e, nil
 }
 
 // updateInstanceTx creates or updates a per-occurrence override row and its
 // categories using a tx-bound Queries. It returns the event and the master's
-// calendar ID (for a dirty mark after commit). It opens no transaction, so
-// callers can compose it with attendee/alarm writes.
+// calendar ID (for the dirty mark inside the caller's transaction). It opens
+// no transaction, so callers can compose it with attendee/alarm writes.
 func updateInstanceTx(ctx context.Context, qtx *storage.Queries, uid string, instanceTime time.Time, p UpdateParams) (Event, int64, error) {
 	// Every update entry point reaches this function, so the span rule
 	// lives here rather than at each caller.
@@ -824,11 +844,18 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 	if err != nil {
 		return Event{}, err
 	}
+	// Mark both rows dirty inside the transaction so a failed sync-tracking
+	// write rolls the split back rather than committing a change that is
+	// never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, masterCalendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit split: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event")
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 
@@ -862,11 +889,18 @@ func (s *Service) UpdateFromInstanceWithRelations(ctx context.Context, uid strin
 	if err := replaceRelationsTx(ctx, qtx, e.ID, attendees, alarms); err != nil {
 		return Event{}, err
 	}
+	// Mark both rows dirty inside the transaction so a failed sync-tracking
+	// write rolls the split and its children back rather than committing a
+	// change that is never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, masterCalendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, tx, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit split: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event")
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
 	return e, nil
 }
 

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -195,13 +195,18 @@ func (p *UpdateParams) applyDefaults() {
 	normalizeEventTimes(&p.StartTime, &p.EndTime, p.AllDay)
 }
 
-// markDirtyByID looks up an event by ID and marks its sync resource as dirty.
-func (s *Service) markDirtyByID(ctx context.Context, eventID int64) {
+// markDirtyTx marks the sync resource of the event with the given ID dirty
+// inside the caller's transaction. A failed mark aborts the mutation per the
+// issue #107 contract: a change that is never pushed must not commit.
+func (s *Service) markDirtyByID(ctx context.Context, eventID int64) error {
 	r, err := s.q.GetEvent(ctx, eventID)
 	if err != nil {
-		return
+		return fmt.Errorf("get event for dirty mark: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "event")
+	if err := storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "event"); err != nil {
+		return fmt.Errorf("mark resource dirty: %w", err)
+	}
+	return nil
 }
 
 // ensureEventWritable resolves an event by ID and enforces remote
@@ -369,7 +374,9 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Event, 
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit update event: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
+	if err := storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	return e, nil
 }
 
@@ -411,7 +418,9 @@ func (s *Service) UpdateWithRelations(ctx context.Context, id int64, p UpdatePar
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit update event: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
+	if err := storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	return e, nil
 }
 
@@ -598,7 +607,9 @@ func (s *Service) UpdateInstance(ctx context.Context, uid string, instanceTime t
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit override: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
+	if err := storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	return e, nil
 }
 
@@ -635,7 +646,9 @@ func (s *Service) UpdateInstanceWithRelations(ctx context.Context, uid string, i
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit override: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event")
+	if err := storage.MarkResourceDirty(ctx, s.db, calendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	return e, nil
 }
 
@@ -827,8 +840,12 @@ func (s *Service) UpdateFromInstance(ctx context.Context, uid string, instanceTi
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit split: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event")
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
+	if err := storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark master resource dirty: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	return e, nil
 }
 
@@ -865,8 +882,12 @@ func (s *Service) UpdateFromInstanceWithRelations(ctx context.Context, uid strin
 	if err := tx.Commit(); err != nil {
 		return Event{}, fmt.Errorf("commit split: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event")
-	_ = storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event")
+	if err := storage.MarkResourceDirty(ctx, s.db, masterCalendarID, uid, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark master resource dirty: %w", err)
+	}
+	if err := storage.MarkResourceDirty(ctx, s.db, e.CalendarID, e.UID, "event"); err != nil {
+		return Event{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	return e, nil
 }
 

--- a/internal/event/service.go
+++ b/internal/event/service.go
@@ -195,13 +195,19 @@ func (p *UpdateParams) applyDefaults() {
 	normalizeEventTimes(&p.StartTime, &p.EndTime, p.AllDay)
 }
 
-// markDirtyByID looks up an event by ID and marks its sync resource as dirty.
-func (s *Service) markDirtyByID(ctx context.Context, eventID int64) {
+// markDirtyByID marks the sync resource of the event with the given ID dirty
+// through the service's current dirty executor. A failed mark returns an
+// error so every caller can propagate it per the issue #107 contract: a
+// change that is never pushed must not stay silent.
+func (s *Service) markDirtyByID(ctx context.Context, eventID int64) error {
 	r, err := s.q.GetEvent(ctx, eventID)
 	if err != nil {
-		return
+		return fmt.Errorf("get event for dirty mark: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "event")
+	if err := storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "event"); err != nil {
+		return fmt.Errorf("mark resource dirty: %w", err)
+	}
+	return nil
 }
 
 // ensureEventWritable resolves an event by ID and enforces remote

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -59,7 +59,10 @@ type UndoMeta struct {
 
 // DeleteWithUndo soft-deletes an event by ID and returns the metadata needed
 // to reverse it. For an override, EXDATE mutation on the master is part of
-// the Delete flow. The returned UndoMeta covers the single-row un-hide.
+// the Delete flow. The returned UndoMeta carries the override's
+// recurrence_id. Undo then un-hides exactly that instance. Without it, undo
+// falls back to a UID-wide restore that would also resurrect other
+// soft-deleted overrides of the same series.
 func (s *Service) DeleteWithUndo(ctx context.Context, id int64) (UndoMeta, error) {
 	r, err := s.q.GetEvent(ctx, id)
 	if err != nil {
@@ -70,10 +73,11 @@ func (s *Service) DeleteWithUndo(ctx context.Context, id int64) (UndoMeta, error
 		return UndoMeta{}, err
 	}
 	return UndoMeta{
-		Kind:      UndoKindSingle,
-		UID:       evt.UID,
-		Label:     evt.Title,
-		DeletedAt: time.Now().UTC(),
+		Kind:         UndoKindSingle,
+		UID:          evt.UID,
+		Label:        evt.Title,
+		DeletedAt:    time.Now().UTC(),
+		RecurrenceID: evt.RecurrenceID,
 	}, nil
 }
 
@@ -271,11 +275,11 @@ func (s *Service) PurgeByID(ctx context.Context, id int64) error {
 	return nil
 }
 
-// restoreSingle un-hides one row by (uid, recurrence_id = ""). Use it for
-// DeleteWithUndo and DeleteInstanceWithUndo single-row restore. For an
-// override, callers should fall back to RestoreByUID since we do not know the
-// recurrence_id. UndoKindSingle always targets the master UID, so this
-// finds the master.
+// restoreSingle reverses one single-row delete. The undo paths use it for
+// DeleteWithUndo and DeleteInstanceWithUndo. A non-empty recurrenceID
+// restores exactly that instance: it un-hides the override row and clears
+// the delete-recorded EXDATE for it. An empty recurrenceID targets the
+// master row itself.
 func (s *Service) restoreSingle(ctx context.Context, uid, recurrenceID string) error {
 	r, err := s.q.GetEventByUIDIncludingDeleted(ctx, uid)
 	if err != nil {

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -46,7 +46,9 @@ type UndoMeta struct {
 	Label     string
 	DeletedAt time.Time
 
-	// UndoKindSingle only, when Undo reverses DeleteInstanceWithUndo.
+	// UndoKindSingle only. DeleteWithUndo or DeleteInstanceWithUndo sets
+	// this field when the delete targets an override instance. A standalone
+	// master delete leaves this field empty.
 	RecurrenceID string
 
 	// UndoKindFromInstance only. CutoffTime is the truncation cutoff. It finds

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -667,6 +667,14 @@ func (s *Service) DeleteInstance(ctx context.Context, uid string, instanceTime t
 		Uid:          uid,
 		RecurrenceID: recID,
 	})
+	// Only ErrNoRows means "this occurrence has no override row". A genuine
+	// lookup error must abort. Otherwise the EXDATE and its provenance commit
+	// while the live override row stays. The deleted occurrence then stays
+	// visible through the override. This mirrors the master-lookup guard the
+	// Delete override path carries (issue #412).
+	if oErr != nil && !errors.Is(oErr, sql.ErrNoRows) {
+		return fmt.Errorf("get override: %w", oErr)
+	}
 	if oErr == nil {
 		if err := qtx.SoftDeleteEvent(ctx, override.ID); err != nil {
 			return fmt.Errorf("soft-delete override: %w", err)

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -335,6 +335,20 @@ func (s *Service) restoreSeries(ctx context.Context, uid string) error {
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
 	}
+	// The master row is gone (it was purged on its own). Reconcile on every
+	// calendar the restored rows live on, the same way RestoreByUID does.
+	// Without this, a pending tombstone survives the undo-series. The next
+	// sync would then DELETE the series from the server right after a
+	// successful undo.
+	ids, rErr := s.distinctCalendarIDsByUID(ctx, uid)
+	if rErr != nil {
+		return rErr
+	}
+	for _, id := range ids {
+		if err := s.reconcileSyncAfterRestore(ctx, id, uid); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -696,11 +696,13 @@ func (s *Service) DeleteInstance(ctx context.Context, uid string, instanceTime t
 		return fmt.Errorf("record exdate delete: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
+	// Mark the master dirty — its EXDATE was modified — inside the same
+	// transaction so a failed mark rolls the EXDATE change back rather than
+	// committing a change that is never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, master.CalendarID, uid, "event"); err != nil {
+		return fmt.Errorf("mark resource dirty: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
-	return nil
+	return tx.Commit()
 }
 
 // DeleteFromInstance truncates a recurring series so that instances at or
@@ -848,10 +850,15 @@ func (s *Service) deleteFromInstance(ctx context.Context, uid string, instanceTi
 	}
 	postUpdated := truncated.UpdatedAt
 
+	// Mark the master dirty — its RRULE and RDATEs were modified — inside
+	// the same transaction so a failed mark rolls the truncation back rather
+	// than committing a change that is never pushed (issue #107).
+	if err := storage.MarkResourceDirty(ctx, tx, master.CalendarID, uid, "event"); err != nil {
+		return "", fmt.Errorf("mark resource dirty: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return "", err
 	}
-	_ = storage.MarkResourceDirty(ctx, s.db, master.CalendarID, uid, "event")
 	return postUpdated, nil
 }
 

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -859,7 +859,15 @@ func (s *Service) DeleteSeries(ctx context.Context, uid string) error {
 	// tombstone and the soft-delete commit together so a failed tombstone
 	// write can't leave a tombstone for a still-live series whose next sync
 	// would DELETE it from the server (issue #107).
-	if master, err := qtx.GetEventByUID(ctx, uid); err == nil {
+	master, mErr := qtx.GetEventByUID(ctx, uid)
+	// Only ErrNoRows means "no master to track". A genuine lookup error must
+	// abort. Otherwise the series is soft-deleted locally with no tombstone.
+	// The next pull would then resurrect the series. This mirrors the guard
+	// the todo and journal services already carry (issue #290).
+	if mErr != nil && !errors.Is(mErr, sql.ErrNoRows) {
+		return fmt.Errorf("get master: %w", mErr)
+	}
+	if mErr == nil {
 		if _, err := storage.CreateTombstoneIfSynced(ctx, tx, master.CalendarID, uid); err != nil {
 			return fmt.Errorf("create tombstone: %w", err)
 		}

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -198,6 +198,19 @@ func (s *Service) RestoreByUID(ctx context.Context, uid string) error {
 	if err == nil {
 		return s.reconcileSyncAfterRestore(ctx, master.CalendarID, uid)
 	}
+	// The master row is gone (it was purged on its own). Reconcile on every
+	// calendar the restored rows live on. Without this, a pending tombstone
+	// survives the restore. The next sync would then DELETE the series from
+	// the server right after a successful restore.
+	ids, rErr := s.distinctCalendarIDsByUID(ctx, uid)
+	if rErr != nil {
+		return rErr
+	}
+	for _, id := range ids {
+		if err := s.reconcileSyncAfterRestore(ctx, id, uid); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -838,6 +838,94 @@ func TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_RestoreUndoSeriesOrphanTailClearsTombstone covers the same
+// orphan-tail scenario as TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone,
+// reached through RestoreUndo(UndoKindSeries). The master row was purged on
+// its own after the series delete. Only the soft-deleted override remains.
+// The undo must still reconcile sync state. Before the fix, the undo left a
+// pending tombstone in place. The next sync then DELETEd the series from the
+// server right after a successful local undo.
+func TestSoftDelete_RestoreUndoSeriesOrphanTailClearsTombstone(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "orphan-undo-series-uid",
+		CalendarID:     1,
+		Title:          "Daily Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	instanceAt := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Daily Standup (moved)",
+		StartTime:    instanceAt.Add(time.Hour),
+		EndTime:      instanceAt.Add(90 * time.Minute),
+		RecurrenceID: instanceAt.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Mark the series synced (non-empty remote_url) so the delete queues a
+	// tombstone.
+	if err := svc.q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   master.CalendarID,
+		Uid:          master.UID,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/series.ics",
+		Etag:         "etag-1",
+		Dirty:        0,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("upsert sync resource: %v", err)
+	}
+	meta, err := svc.DeleteSeriesWithUndo(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("DeleteSeriesWithUndo: %v", err)
+	}
+	if meta.Kind != UndoKindSeries {
+		t.Fatalf("undo kind = %d, want UndoKindSeries", meta.Kind)
+	}
+	tombstones, err := svc.q.ListTombstonesByCalendar(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("list tombstones: %v", err)
+	}
+	if len(tombstones) != 1 {
+		t.Fatalf("tombstones after DeleteSeriesWithUndo = %d, want 1", len(tombstones))
+	}
+
+	// Purge the master row on its own. The soft-deleted override stays behind
+	// as an orphan tail with the UID.
+	if err := svc.PurgeByID(ctx, master.ID); err != nil {
+		t.Fatalf("PurgeByID master: %v", err)
+	}
+
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+
+	// The undo must clear the tombstone. A surviving tombstone would
+	// DELETE the series from the server on the next sync.
+	tombstones, err = svc.q.ListTombstonesByCalendar(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("list tombstones after undo: %v", err)
+	}
+	if len(tombstones) != 0 {
+		t.Fatalf("tombstones after RestoreUndo = %d, want 0 (the pending delete outlived the undo)", len(tombstones))
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("orphan override should be live after RestoreUndo: %v", err)
+	}
+}
+
 // TestSoftDelete_OverrideMasterLookupError is the regression test for issue
 // #412. A delete of an override must not collapse a genuine DB error from the
 // master lookup into the "no master" path. On a non-ErrNoRows error the old

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -860,6 +860,73 @@ func TestDeleteSeries_MasterLookupError(t *testing.T) {
 	}
 }
 
+// TestDeleteInstance_OverrideLookupError mirrors the #290/#412 guard for the
+// instance path. DeleteInstance must not treat a genuine DB error from the
+// override lookup as "no override". On a non-ErrNoRows error the old code
+// committed the EXDATE and its provenance log while the live override row
+// stayed. The deleted occurrence then stayed visible through the override,
+// and the trash entry could not un-hide it.
+func TestDeleteInstance_OverrideLookupError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "instance-lookup-err",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	instanceAt := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Weekly Review (moved)",
+		StartTime:    time.Date(2026, 4, 15, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 15, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: instanceAt.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Force the override lookup (GetEventByUIDAndRecurrenceID) to fail with
+	// a genuine, non-ErrNoRows error by writing non-numeric text into the
+	// override's integer sequence column so its row scan fails. The master
+	// read and UpdateEventExdates never scan the override row, so the buggy
+	// path still committed the EXDATE and returned nil.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET sequence = 'corrupt' WHERE id = ?", override.ID); err != nil {
+		t.Fatalf("corrupt override sequence: %v", err)
+	}
+
+	err = svc.DeleteInstance(ctx, master.UID, instanceAt)
+	if err == nil {
+		t.Fatal("DeleteInstance should propagate a non-ErrNoRows override-lookup error, got nil")
+	}
+
+	// Repair the override so reads work, then confirm nothing committed: the
+	// master carries no EXDATE and the override is still live.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET sequence = 0 WHERE id = ?", override.ID); err != nil {
+		t.Fatalf("repair override sequence: %v", err)
+	}
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after failed DeleteInstance: %v", err)
+	}
+	if n := len(got.ParseExDates()); n != 0 {
+		t.Fatalf("master EXDATE count = %d, want 0 (%q)", n, got.ExDates)
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("override should still be live after failed DeleteInstance: %v", err)
+	}
+}
+
 // TestSoftDelete_FromInstanceUndo_ReAddsRDates reproduces issue #490. The TUI
 // truncation-undo path (RestoreUndo of an UndoKindFromInstance) must re-add the
 // post-cutoff RDATEs the truncation trimmed. That matches the trash-restore

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -927,6 +927,91 @@ func TestDeleteInstance_OverrideLookupError(t *testing.T) {
 	}
 }
 
+// TestSoftDelete_UndoOverrideDeleteRestoresOnlyThatInstance verifies the
+// undo metadata DeleteWithUndo returns for an override. The metadata must
+// carry the override's recurrence_id. Undo then un-hides exactly that
+// instance and clears only its EXDATE. Before the fix, the metadata dropped
+// the recurrence_id. Undo fell back to a UID-wide restore. That resurrected
+// another override of the same series the user had deleted before.
+func TestSoftDelete_UndoOverrideDeleteRestoresOnlyThatInstance(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "undo-override-uid",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	week2 := time.Date(2026, 4, 8, 10, 0, 0, 0, time.UTC)
+	week3 := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+	override2, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Week 2 (moved)",
+		StartTime:    week2.Add(2 * time.Hour),
+		EndTime:      week2.Add(3 * time.Hour),
+		RecurrenceID: week2.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override 2: %v", err)
+	}
+	override3, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Week 3 (moved)",
+		StartTime:    week3.Add(2 * time.Hour),
+		EndTime:      week3.Add(3 * time.Hour),
+		RecurrenceID: week3.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override 3: %v", err)
+	}
+
+	// Delete week 2's override first (an earlier, unrelated delete).
+	if _, err := svc.DeleteWithUndo(ctx, override2.ID); err != nil {
+		t.Fatalf("delete override 2: %v", err)
+	}
+	// Then delete week 3's override and undo just that one.
+	meta, err := svc.DeleteWithUndo(ctx, override3.ID)
+	if err != nil {
+		t.Fatalf("delete override 3: %v", err)
+	}
+	if meta.RecurrenceID != week3.UTC().Format(time.RFC3339) {
+		t.Fatalf("meta.RecurrenceID = %q, want %q", meta.RecurrenceID, week3.UTC().Format(time.RFC3339))
+	}
+	if err := svc.RestoreUndo(ctx, meta); err != nil {
+		t.Fatalf("RestoreUndo: %v", err)
+	}
+
+	// Week 3 must be live again: override un-hidden, its EXDATE cleared.
+	if _, err := svc.Get(ctx, override3.ID); err != nil {
+		t.Fatalf("override 3 should be live after undo: %v", err)
+	}
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after undo: %v", err)
+	}
+	exdates := got.ParseExDates()
+	if len(exdates) != 1 || !exdates[0].Equal(week2) {
+		t.Fatalf("master EXDATEs after undo = %v, want exactly week 2 (%v)", exdates, week2)
+	}
+
+	// Week 2's earlier delete must stand: its override stays soft-deleted.
+	still, err := svc.GetIncludingDeleted(ctx, override2.ID)
+	if err != nil {
+		t.Fatalf("get override 2 including deleted: %v", err)
+	}
+	if still.DeletedAt == nil {
+		t.Fatal("override 2 was resurrected by the undo of override 3")
+	}
+}
+
 // TestSoftDelete_FromInstanceUndo_ReAddsRDates reproduces issue #490. The TUI
 // truncation-undo path (RestoreUndo of an UndoKindFromInstance) must re-add the
 // post-cutoff RDATEs the truncation trimmed. That matches the trash-restore

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/timeutil"
 )
 
@@ -752,6 +753,88 @@ func TestSoftDelete_RestoreSurfacesTombstoneClearError(t *testing.T) {
 
 	if err := svc.RestoreByID(ctx, e.ID); err == nil {
 		t.Fatal("RestoreByID returned nil, want error when tombstone clear fails")
+	}
+}
+
+// TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone covers the restore of
+// a UID whose master row was purged on its own. Only orphaned overrides
+// remain. The restore must still reconcile sync state. Before the fix, the
+// restore left a pending tombstone in place. The next sync then DELETEd the
+// series from the server right after a successful local restore.
+func TestSoftDelete_RestoreByUIDOrphanTailClearsTombstone(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "orphan-restore-uid",
+		CalendarID:     1,
+		Title:          "Daily Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+	instanceAt := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	override, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Daily Standup (moved)",
+		StartTime:    instanceAt.Add(time.Hour),
+		EndTime:      instanceAt.Add(90 * time.Minute),
+		RecurrenceID: instanceAt.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// Mark the series synced (non-empty remote_url) so the delete queues a
+	// tombstone.
+	if err := svc.q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   master.CalendarID,
+		Uid:          master.UID,
+		OwnerType:    "event",
+		RemoteUrl:    "https://example.com/cal/series.ics",
+		Etag:         "etag-1",
+		Dirty:        0,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("upsert sync resource: %v", err)
+	}
+	if err := svc.DeleteSeries(ctx, master.UID); err != nil {
+		t.Fatalf("DeleteSeries: %v", err)
+	}
+	tombstones, err := svc.q.ListTombstonesByCalendar(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("list tombstones: %v", err)
+	}
+	if len(tombstones) != 1 {
+		t.Fatalf("tombstones after DeleteSeries = %d, want 1", len(tombstones))
+	}
+
+	// Purge the master row on its own. The soft-deleted override stays behind
+	// as an orphan tail with the UID.
+	if err := svc.PurgeByID(ctx, master.ID); err != nil {
+		t.Fatalf("PurgeByID master: %v", err)
+	}
+
+	if err := svc.RestoreByUID(ctx, master.UID); err != nil {
+		t.Fatalf("RestoreByUID: %v", err)
+	}
+
+	// The restore must clear the tombstone. A surviving tombstone would
+	// DELETE the series from the server on the next sync.
+	tombstones, err = svc.q.ListTombstonesByCalendar(ctx, master.CalendarID)
+	if err != nil {
+		t.Fatalf("list tombstones after restore: %v", err)
+	}
+	if len(tombstones) != 0 {
+		t.Fatalf("tombstones after RestoreByUID = %d, want 0 (the pending delete outlived the restore)", len(tombstones))
+	}
+	if _, err := svc.Get(ctx, override.ID); err != nil {
+		t.Fatalf("orphan override should be live after RestoreByUID: %v", err)
 	}
 }
 

--- a/internal/event/soft_delete_test.go
+++ b/internal/event/soft_delete_test.go
@@ -814,6 +814,52 @@ func TestSoftDelete_OverrideMasterLookupError(t *testing.T) {
 	}
 }
 
+// TestDeleteSeries_MasterLookupError mirrors the #290/#412 guard for the
+// series path. DeleteSeries must not treat a genuine DB error from the master
+// lookup as "no master". On a non-ErrNoRows error the old code soft-deleted
+// the series locally with no tombstone. The next pull then resurrected the
+// series. The todo and journal services already carry this guard.
+func TestDeleteSeries_MasterLookupError(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "series-lookup-err",
+		CalendarID:     1,
+		Title:          "Weekly Review",
+		StartTime:      time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=WEEKLY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	// Force the master lookup (GetEventByUID) to fail with a genuine, non-
+	// ErrNoRows error by writing non-numeric text into the master's integer
+	// sequence column so its row scan fails. The writable check before the
+	// transaction reads only calendar_id. SoftDeleteEventsByUID never scans,
+	// so the buggy path would still soft-delete the series and return nil.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET sequence = 'corrupt' WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("corrupt master sequence: %v", err)
+	}
+
+	if err := svc.DeleteSeries(ctx, master.UID); err == nil {
+		t.Fatal("DeleteSeries should propagate a non-ErrNoRows master-lookup error, got nil")
+	}
+
+	// Repair the master so reads work, then confirm the series is still
+	// live: the transaction must have rolled back.
+	if _, err := svc.db.ExecContext(ctx,
+		"UPDATE events SET sequence = 0 WHERE id = ?", master.ID); err != nil {
+		t.Fatalf("repair master sequence: %v", err)
+	}
+	if _, err := svc.GetByUID(ctx, master.UID); err != nil {
+		t.Fatalf("series should still be live after failed DeleteSeries: %v", err)
+	}
+}
+
 // TestSoftDelete_FromInstanceUndo_ReAddsRDates reproduces issue #490. The TUI
 // truncation-undo path (RestoreUndo of an UndoKindFromInstance) must re-add the
 // post-cutoff RDATEs the truncation trimmed. That matches the trash-restore

--- a/internal/event/sync_atomic_test.go
+++ b/internal/event/sync_atomic_test.go
@@ -170,3 +170,88 @@ func TestDeleteSeries_TombstoneIsAtomic(t *testing.T) {
 			"DeleteSeries tombstone is not atomic with the soft-delete", *deletedAt)
 	}
 }
+
+// TestDeleteInstance_SyncMarkIsAtomic is the DeleteInstance analogue of
+// TestCreate_SyncMarkIsAtomic. The master's EXDATE change must commit together
+// with its dirty mark. The old code discarded a failed post-commit
+// MarkResourceDirty. A synced calendar then kept an EXDATE change that no push
+// ever sent (issue #107 contract).
+func TestDeleteInstance_SyncMarkIsAtomic(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "instance-dirty-atomic",
+		CalendarID:     1,
+		Title:          "Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	// Force the dirty-mark INSERT to fail.
+	if _, err := svc.db.ExecContext(ctx, `DROP TABLE sync_resources`); err != nil {
+		t.Fatalf("drop sync_resources: %v", err)
+	}
+
+	instanceAt := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	if err := svc.DeleteInstance(ctx, master.UID, instanceAt); err == nil {
+		t.Fatal("DeleteInstance succeeded but the dirty-mark write failed; the error was discarded")
+	}
+
+	// The mutation must have rolled back: the master carries no EXDATE.
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after failed DeleteInstance: %v", err)
+	}
+	if n := len(got.ParseExDates()); n != 0 {
+		t.Fatalf("master EXDATE count = %d, want 0 (%q); the EXDATE committed despite the "+
+			"dirty-mark write failing", n, got.ExDates)
+	}
+}
+
+// TestDeleteFromInstance_SyncMarkIsAtomic is the DeleteFromInstance analogue
+// of TestCreate_SyncMarkIsAtomic. The truncation must commit together with its
+// dirty mark. The old code discarded a failed post-commit MarkResourceDirty. A
+// synced calendar then kept a truncated RRULE that no push ever sent (issue
+// #107 contract).
+func TestDeleteFromInstance_SyncMarkIsAtomic(t *testing.T) {
+	svc := newTestService(t)
+	makeSyncedCalendar(t, svc)
+	ctx := context.Background()
+
+	master, err := svc.UpsertByUID(ctx, UpsertParams{
+		UID:            "truncate-dirty-atomic",
+		CalendarID:     1,
+		Title:          "Standup",
+		StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+		RecurrenceRule: "FREQ=DAILY;COUNT=5",
+	})
+	if err != nil {
+		t.Fatalf("create master: %v", err)
+	}
+
+	if _, err := svc.db.ExecContext(ctx, `DROP TABLE sync_resources`); err != nil {
+		t.Fatalf("drop sync_resources: %v", err)
+	}
+
+	cutoff := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	if err := svc.DeleteFromInstance(ctx, master.UID, cutoff); err == nil {
+		t.Fatal("DeleteFromInstance succeeded but the dirty-mark write failed; the error was discarded")
+	}
+
+	// The mutation must have rolled back: the RRULE keeps its original COUNT.
+	got, err := svc.GetByUID(ctx, master.UID)
+	if err != nil {
+		t.Fatalf("get master after failed DeleteFromInstance: %v", err)
+	}
+	if got.RecurrenceRule != master.RecurrenceRule {
+		t.Fatalf("master RRULE = %q, want the original %q; the truncation committed despite "+
+			"the dirty-mark write failing", got.RecurrenceRule, master.RecurrenceRule)
+	}
+}

--- a/internal/event/sync_atomic_test.go
+++ b/internal/event/sync_atomic_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/douglasdemoura/chroncal/internal/model"
 	"github.com/douglasdemoura/chroncal/internal/storage"
 )
 
@@ -253,5 +254,166 @@ func TestDeleteFromInstance_SyncMarkIsAtomic(t *testing.T) {
 	if got.RecurrenceRule != master.RecurrenceRule {
 		t.Fatalf("master RRULE = %q, want the original %q; the truncation committed despite "+
 			"the dirty-mark write failing", got.RecurrenceRule, master.RecurrenceRule)
+	}
+}
+
+// TestUpdatePaths_SyncMarkIsAtomic extends TestCreate_SyncMarkIsAtomic to
+// the six update entry points in service.go. Each entry point must write its
+// dirty mark inside the mutation transaction. The old code discarded a failed
+// post-commit MarkResourceDirty. A synced calendar then kept an edit that no
+// push ever sent (issue #107 contract).
+func TestUpdatePaths_SyncMarkIsAtomic(t *testing.T) {
+	newStandup := func(t *testing.T, svc *Service) Event {
+		t.Helper()
+		master, err := svc.UpsertByUID(context.Background(), UpsertParams{
+			UID:            "update-dirty-atomic",
+			CalendarID:     1,
+			Title:          "Standup",
+			StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+			EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+			RecurrenceRule: "FREQ=DAILY;COUNT=5",
+		})
+		if err != nil {
+			t.Fatalf("create master: %v", err)
+		}
+		return master
+	}
+	editTitle := func() UpdateParams {
+		return UpdateParams{
+			CalendarID:     1,
+			Title:          "Edited",
+			StartTime:      time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+			EndTime:        time.Date(2026, 4, 1, 9, 15, 0, 0, time.UTC),
+			RecurrenceRule: "FREQ=DAILY;COUNT=5",
+		}
+	}
+	attendees := []model.Attendee{{
+		Email: "a@example.com", Role: "REQ-PARTICIPANT", RSVPStatus: "NEEDS-ACTION",
+	}}
+	instanceAt := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+
+	titleUnchanged := func(t *testing.T, svc *Service, master Event) {
+		t.Helper()
+		got, err := svc.Get(context.Background(), master.ID)
+		if err != nil {
+			t.Fatalf("get master after the failed call: %v", err)
+		}
+		if got.Title != "Standup" {
+			t.Fatalf("title = %q, want %q; the edit committed despite the "+
+				"dirty-mark write failing", got.Title, "Standup")
+		}
+	}
+	noOverride := func(t *testing.T, svc *Service, master Event) {
+		t.Helper()
+		var n int
+		if err := svc.db.QueryRowContext(context.Background(),
+			`SELECT COUNT(*) FROM events WHERE uid = ? AND recurrence_id != ''`,
+			master.UID).Scan(&n); err != nil {
+			t.Fatalf("count overrides: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("override rows = %d, want 0; the override committed despite "+
+				"the dirty-mark write failing", n)
+		}
+	}
+	seriesIntact := func(t *testing.T, svc *Service, master Event) {
+		t.Helper()
+		var n int
+		if err := svc.db.QueryRowContext(context.Background(),
+			`SELECT COUNT(*) FROM events`).Scan(&n); err != nil {
+			t.Fatalf("count events: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("event rows = %d, want 1 (the master only); the split series "+
+				"committed despite the dirty-mark write failing", n)
+		}
+		got, err := svc.GetByUID(context.Background(), master.UID)
+		if err != nil {
+			t.Fatalf("get master after the failed call: %v", err)
+		}
+		if got.RecurrenceRule != master.RecurrenceRule {
+			t.Fatalf("master RRULE = %q, want the original %q; the truncation "+
+				"committed despite the dirty-mark write failing",
+				got.RecurrenceRule, master.RecurrenceRule)
+		}
+	}
+
+	cases := []struct {
+		name   string
+		call   func(svc *Service, master Event) error
+		verify func(t *testing.T, svc *Service, master Event)
+	}{
+		{
+			name: "Update",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.Update(context.Background(), master.ID, editTitle())
+				return err
+			},
+			verify: titleUnchanged,
+		},
+		{
+			name: "UpdateWithRelations",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateWithRelations(context.Background(), master.ID,
+					editTitle(), attendees, nil)
+				return err
+			},
+			verify: titleUnchanged,
+		},
+		{
+			name: "UpdateInstance",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateInstance(context.Background(), master.UID,
+					instanceAt, editTitle())
+				return err
+			},
+			verify: noOverride,
+		},
+		{
+			name: "UpdateInstanceWithRelations",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateInstanceWithRelations(context.Background(),
+					master.UID, instanceAt, editTitle(), attendees, nil)
+				return err
+			},
+			verify: noOverride,
+		},
+		{
+			name: "UpdateFromInstance",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateFromInstance(context.Background(), master.UID,
+					instanceAt, editTitle())
+				return err
+			},
+			verify: seriesIntact,
+		},
+		{
+			name: "UpdateFromInstanceWithRelations",
+			call: func(svc *Service, master Event) error {
+				_, err := svc.UpdateFromInstanceWithRelations(context.Background(),
+					master.UID, instanceAt, editTitle(), attendees, nil)
+				return err
+			},
+			verify: seriesIntact,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newTestService(t)
+			makeSyncedCalendar(t, svc)
+			master := newStandup(t, svc)
+			ctx := context.Background()
+
+			// Force the dirty-mark INSERT to fail.
+			if _, err := svc.db.ExecContext(ctx, `DROP TABLE sync_resources`); err != nil {
+				t.Fatalf("drop sync_resources: %v", err)
+			}
+
+			if err := tc.call(svc, master); err == nil {
+				t.Fatal("call succeeded but the dirty-mark write failed; the error was discarded")
+			}
+			tc.verify(t, svc, master)
+		})
 	}
 }

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -323,3 +323,31 @@ func emitAttachment(props ical.Props, att model.Attachment) {
 	}
 	props.Add(p)
 }
+
+// emitAttendees writes the ORGANIZER and ATTENDEE properties for one
+// component. The organizer uses Set (one per component); attendees append.
+// Text in the CN parameter passes through safeParamValue, because the
+// encoder rejects parameter values that carry a double quote.
+func emitAttendees(props ical.Props, attendees []model.Attendee) {
+	for _, att := range attendees {
+		if att.Organizer {
+			org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
+			org.Value = "mailto:" + att.Email
+			if att.Name != "" {
+				org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
+			}
+			setOrganizerParams(org, att)
+			props.Set(org)
+		}
+
+		attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
+		attendee.Value = "mailto:" + att.Email
+		if att.Name != "" {
+			attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
+		}
+		attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
+		attendee.Params.Set(ical.ParamRole, att.Role)
+		setAttendeeParams(attendee, att)
+		props.Add(attendee)
+	}
+}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -293,6 +293,18 @@ func emitXProperties(comp *ical.Component, xprops []model.XProperty) {
 	}
 }
 
+// unsafeParamBytes strips the bytes the iCal parameter grammar cannot
+// carry. The go-ical encoder rejects a parameter value that contains a
+// double-quote. A CR or LF would split the property line.
+var unsafeParamBytes = strings.NewReplacer(`"`, "", "\r", "", "\n", "")
+
+// safeParamValue makes a free-text value safe for an iCal parameter. The
+// export paths use it for CN, FILENAME, and FMTTYPE. One unsafe stored
+// value must not fail the whole export batch.
+func safeParamValue(v string) string {
+	return unsafeParamBytes.Replace(v)
+}
+
 func emitAttachment(props ical.Props, att model.Attachment) {
 	p := &ical.Prop{Name: ical.PropAttach, Params: make(ical.Params)}
 	if att.Data != nil {
@@ -301,13 +313,13 @@ func emitAttachment(props ical.Props, att model.Attachment) {
 		p.Params.Set("ENCODING", "BASE64")
 		p.Params.Set("VALUE", "BINARY")
 		if att.Filename != "" {
-			p.Params.Set("FILENAME", att.Filename)
+			p.Params.Set("FILENAME", safeParamValue(att.Filename))
 		}
 	} else {
 		p.Value = att.URI
 	}
 	if att.FmtType != "" {
-		p.Params.Set("FMTTYPE", att.FmtType)
+		p.Params.Set("FMTTYPE", safeParamValue(att.FmtType))
 	}
 	props.Add(p)
 }

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -395,3 +395,25 @@ func emitRelations(props ical.Props, relations []model.Relation) {
 		props.Add(p)
 	}
 }
+
+// setZonedDateTime writes one datetime property under the shared timezone
+// rules. A "FLOATING" timezone emits bare wall-clock numbers (no Z, no TZID),
+// matching the stored floating semantics. A resolvable IANA timezone emits
+// the zone-local wall clock plus the TZID parameter. An empty or
+// unresolvable timezone falls back to UTC.
+func setZonedDateTime(props ical.Props, name string, t time.Time, timezone string) {
+	if timezone == "FLOATING" {
+		p := &ical.Prop{Name: name}
+		p.Value = t.UTC().Format("20060102T150405")
+		props.Set(p)
+		return
+	}
+	if loc, err := time.LoadLocation(timezone); timezone != "" && err == nil {
+		props.SetDateTime(name, t.In(loc))
+		if p := props.Get(name); p != nil {
+			p.Params.Set(ical.ParamTimezoneID, timezone)
+		}
+		return
+	}
+	props.SetDateTime(name, t.UTC())
+}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -351,3 +351,47 @@ func emitAttendees(props ical.Props, attendees []model.Attendee) {
 		props.Add(attendee)
 	}
 }
+
+// emitTimestamps writes DTSTAMP, CREATED, and LAST-MODIFIED. A parseable
+// dtstamp wins; otherwise the updated timestamp stands in for DTSTAMP.
+func emitTimestamps(props ical.Props, dtstamp string, createdAt, updatedAt time.Time) {
+	if ts, err := time.Parse(time.RFC3339, dtstamp); err == nil {
+		props.SetDateTime(ical.PropDateTimeStamp, ts.UTC())
+	} else {
+		props.SetDateTime(ical.PropDateTimeStamp, updatedAt.UTC())
+	}
+	props.SetDateTime(ical.PropCreated, createdAt.UTC())
+	props.SetDateTime(ical.PropLastModified, updatedAt.UTC())
+}
+
+// emitTextProps appends one TEXT property per value (COMMENT, CONTACT).
+func emitTextProps(props ical.Props, name string, values []string) {
+	for _, c := range values {
+		p := &ical.Prop{Name: name}
+		p.SetText(c)
+		props.Add(p)
+	}
+}
+
+// emitResources writes the comma-separated RESOURCES list property. It skips
+// an empty list, because a bare RESOURCES carries no information.
+func emitResources(props ical.Props, resources []string) {
+	if len(resources) > 0 {
+		resProp := &ical.Prop{Name: ical.PropResources}
+		resProp.SetTextList(resources)
+		props.Set(resProp)
+	}
+}
+
+// emitRelations appends one RELATED-TO property per relation. The RELTYPE
+// parameter is omitted for the default PARENT type.
+func emitRelations(props ical.Props, relations []model.Relation) {
+	for _, r := range relations {
+		p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}
+		p.Value = r.RelUID
+		if r.RelType != "" && r.RelType != "PARENT" {
+			p.Params.Set("RELTYPE", r.RelType)
+		}
+		props.Add(p)
+	}
+}

--- a/internal/ical/export_events.go
+++ b/internal/ical/export_events.go
@@ -112,53 +112,22 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 			vevent.Props.Set(p)
 		}
 
-		if e.DtStamp != "" {
-			if ts, err := time.Parse(time.RFC3339, e.DtStamp); err == nil {
-				vevent.Props.SetDateTime(ical.PropDateTimeStamp, ts.UTC())
-			} else {
-				vevent.Props.SetDateTime(ical.PropDateTimeStamp, e.UpdatedAt.UTC())
-			}
-		} else {
-			vevent.Props.SetDateTime(ical.PropDateTimeStamp, e.UpdatedAt.UTC())
-		}
-		vevent.Props.SetDateTime(ical.PropCreated, e.CreatedAt.UTC())
-		vevent.Props.SetDateTime(ical.PropLastModified, e.UpdatedAt.UTC())
+		emitTimestamps(vevent.Props, e.DtStamp, e.CreatedAt, e.UpdatedAt)
 
 		// ATTACH
 		for _, att := range e.Attachments {
 			emitAttachment(vevent.Props, att)
 		}
 
-		// COMMENT
-		for _, c := range e.Comments {
-			p := &ical.Prop{Name: ical.PropComment}
-			p.SetText(c)
-			vevent.Props.Add(p)
-		}
+		emitTextProps(vevent.Props, ical.PropComment, e.Comments)
 
-		// CONTACT
-		for _, c := range e.Contacts {
-			p := &ical.Prop{Name: ical.PropContact}
-			p.SetText(c)
-			vevent.Props.Add(p)
-		}
+		emitTextProps(vevent.Props, ical.PropContact, e.Contacts)
 
 		// RESOURCES (comma-separated list, like CATEGORIES)
-		if len(e.Resources) > 0 {
-			resProp := &ical.Prop{Name: ical.PropResources}
-			resProp.SetTextList(e.Resources)
-			vevent.Props.Set(resProp)
-		}
+		emitResources(vevent.Props, e.Resources)
 
 		// RELATED-TO
-		for _, r := range e.Relations {
-			p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}
-			p.Value = r.RelUID
-			if r.RelType != "" && r.RelType != "PARENT" {
-				p.Params.Set("RELTYPE", r.RelType)
-			}
-			vevent.Props.Add(p)
-		}
+		emitRelations(vevent.Props, e.Relations)
 
 		// X-Properties (round-trip preservation)
 		emitXProperties(vevent.Component, e.XProperties)

--- a/internal/ical/export_events.go
+++ b/internal/ical/export_events.go
@@ -173,28 +173,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 			}
 		}
 
-		// ATTENDEE / ORGANIZER
-		for _, att := range e.Attendees {
-			if att.Organizer {
-				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
-				org.Value = "mailto:" + att.Email
-				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-				}
-				setOrganizerParams(org, att)
-				vevent.Props.Set(org)
-			}
-
-			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
-			attendee.Value = "mailto:" + att.Email
-			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-			}
-			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
-			attendee.Params.Set(ical.ParamRole, att.Role)
-			setAttendeeParams(attendee, att)
-			vevent.Props.Add(attendee)
-		}
+		emitAttendees(vevent.Props, e.Attendees)
 
 		cal.Children = append(cal.Children, vevent.Component)
 	}

--- a/internal/ical/export_events.go
+++ b/internal/ical/export_events.go
@@ -179,7 +179,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
 				org.Value = "mailto:" + att.Email
 				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, att.Name)
+					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 				}
 				setOrganizerParams(org, att)
 				vevent.Props.Set(org)
@@ -188,7 +188,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
 			attendee.Value = "mailto:" + att.Email
 			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, att.Name)
+				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 			}
 			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
 			attendee.Params.Set(ical.ParamRole, att.Role)

--- a/internal/ical/export_journals.go
+++ b/internal/ical/export_journals.go
@@ -126,17 +126,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 			emitRecurrenceID(vjournal.Props, j.RecurrenceID, timeutil.IsDateOnly(j.StartDate), j.Timezone == "FLOATING")
 		}
 
-		if j.DtStamp != "" {
-			if ts, err := time.Parse(time.RFC3339, j.DtStamp); err == nil {
-				vjournal.Props.SetDateTime(ical.PropDateTimeStamp, ts.UTC())
-			} else {
-				vjournal.Props.SetDateTime(ical.PropDateTimeStamp, j.UpdatedAt.UTC())
-			}
-		} else {
-			vjournal.Props.SetDateTime(ical.PropDateTimeStamp, j.UpdatedAt.UTC())
-		}
-		vjournal.Props.SetDateTime(ical.PropCreated, j.CreatedAt.UTC())
-		vjournal.Props.SetDateTime(ical.PropLastModified, j.UpdatedAt.UTC())
+		emitTimestamps(vjournal.Props, j.DtStamp, j.CreatedAt, j.UpdatedAt)
 
 		// ATTACH
 		for _, att := range j.Attachments {
@@ -144,28 +134,13 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 		}
 
 		// COMMENT
-		for _, c := range j.Comments {
-			p := &ical.Prop{Name: ical.PropComment}
-			p.SetText(c)
-			vjournal.Props.Add(p)
-		}
+		emitTextProps(vjournal.Props, ical.PropComment, j.Comments)
 
 		// CONTACT
-		for _, c := range j.Contacts {
-			p := &ical.Prop{Name: ical.PropContact}
-			p.SetText(c)
-			vjournal.Props.Add(p)
-		}
+		emitTextProps(vjournal.Props, ical.PropContact, j.Contacts)
 
 		// RELATED-TO
-		for _, r := range j.Relations {
-			p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}
-			p.Value = r.RelUID
-			if r.RelType != "" && r.RelType != "PARENT" {
-				p.Params.Set("RELTYPE", r.RelType)
-			}
-			vjournal.Props.Add(p)
-		}
+		emitRelations(vjournal.Props, j.Relations)
 
 		// X-Properties (round-trip preservation)
 		emitXProperties(vjournal, j.XProperties)

--- a/internal/ical/export_journals.go
+++ b/internal/ical/export_journals.go
@@ -170,27 +170,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 		// X-Properties (round-trip preservation)
 		emitXProperties(vjournal, j.XProperties)
 
-		// ATTENDEE / ORGANIZER
-		for _, att := range j.Attendees {
-			if att.Organizer {
-				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
-				org.Value = "mailto:" + att.Email
-				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-				}
-				setOrganizerParams(org, att)
-				vjournal.Props.Set(org)
-			}
-			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
-			attendee.Value = "mailto:" + att.Email
-			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-			}
-			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
-			attendee.Params.Set(ical.ParamRole, att.Role)
-			setAttendeeParams(attendee, att)
-			vjournal.Props.Add(attendee)
-		}
+		emitAttendees(vjournal.Props, j.Attendees)
 
 		cal.Children = append(cal.Children, vjournal)
 	}

--- a/internal/ical/export_journals.go
+++ b/internal/ical/export_journals.go
@@ -69,22 +69,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 			if d, err := time.Parse("2006-01-02", j.StartDate); err == nil {
 				vjournal.Props.SetDate(ical.PropDateTimeStart, d)
 			} else if start, err := time.Parse(time.RFC3339, j.StartDate); err == nil {
-				if j.Timezone == "FLOATING" {
-					p := &ical.Prop{Name: ical.PropDateTimeStart}
-					p.Value = start.UTC().Format("20060102T150405")
-					vjournal.Props.Set(p)
-				} else if j.Timezone != "" {
-					if loc, lerr := time.LoadLocation(j.Timezone); lerr == nil {
-						vjournal.Props.SetDateTime(ical.PropDateTimeStart, start.In(loc))
-						if p := vjournal.Props.Get(ical.PropDateTimeStart); p != nil {
-							p.Params.Set(ical.ParamTimezoneID, j.Timezone)
-						}
-					} else {
-						vjournal.Props.SetDateTime(ical.PropDateTimeStart, start.UTC())
-					}
-				} else {
-					vjournal.Props.SetDateTime(ical.PropDateTimeStart, start.UTC())
-				}
+				setZonedDateTime(vjournal.Props, ical.PropDateTimeStart, start, j.Timezone)
 			}
 		}
 

--- a/internal/ical/export_journals.go
+++ b/internal/ical/export_journals.go
@@ -176,7 +176,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
 				org.Value = "mailto:" + att.Email
 				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, att.Name)
+					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 				}
 				setOrganizerParams(org, att)
 				vjournal.Props.Set(org)
@@ -184,7 +184,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
 			attendee.Value = "mailto:" + att.Email
 			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, att.Name)
+				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 			}
 			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
 			attendee.Params.Set(ical.ParamRole, att.Role)

--- a/internal/ical/export_test.go
+++ b/internal/ical/export_test.go
@@ -976,6 +976,43 @@ func TestExport_EventWithAttendees(t *testing.T) {
 	}
 }
 
+// TestExport_AttendeeNameWithQuoteDoesNotFailExport guards the free-text
+// parameter values (CN, FILENAME, FMTTYPE). The go-ical encoder rejects a
+// parameter value that contains a double-quote. A stored attendee name or
+// an attachment metadata field with a quote then failed the whole export
+// batch. Export must strip the bytes the parameter grammar cannot carry.
+func TestExport_AttendeeNameWithQuoteDoesNotFailExport(t *testing.T) {
+	t.Parallel()
+	events := []event.Event{{
+		UID:       "att-quote",
+		Title:     "Meeting",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Attendees: []model.Attendee{
+			{Name: `He said "ok"`, Email: "user@example.com", RSVPStatus: "NEEDS-ACTION", Role: "REQ-PARTICIPANT"},
+			{Name: "Broken\r\nName", Email: "other@example.com", RSVPStatus: "NEEDS-ACTION", Role: "REQ-PARTICIPANT"},
+		},
+		Attachments: []model.Attachment{
+			{Data: []byte("x"), Filename: `bad"name.txt`, FmtType: "text/plain"},
+		},
+	}}
+
+	data, err := ExportEvents(events, "")
+	if err != nil {
+		t.Fatalf("ExportEvents error: %v", err)
+	}
+	ics := string(data)
+	for _, want := range []string{"CN=He said ok", "CN=BrokenName", "FILENAME=badname.txt", "FMTTYPE=text/plain"} {
+		if !strings.Contains(ics, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, ics)
+		}
+	}
+}
+
 func TestExport_SingleTodo(t *testing.T) {
 	t.Parallel()
 	todos := []todo.Todo{{

--- a/internal/ical/export_todos.go
+++ b/internal/ical/export_todos.go
@@ -54,44 +54,14 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			if d, err := time.Parse("2006-01-02", t.DueDate); err == nil {
 				vtodo.Props.SetDate(ical.PropDue, d)
 			} else if due, err := time.Parse(time.RFC3339, t.DueDate); err == nil {
-				if t.Timezone == "FLOATING" {
-					p := &ical.Prop{Name: ical.PropDue}
-					p.Value = due.UTC().Format("20060102T150405")
-					vtodo.Props.Set(p)
-				} else if t.Timezone != "" {
-					if loc, lerr := time.LoadLocation(t.Timezone); lerr == nil {
-						vtodo.Props.SetDateTime(ical.PropDue, due.In(loc))
-						if p := vtodo.Props.Get(ical.PropDue); p != nil {
-							p.Params.Set(ical.ParamTimezoneID, t.Timezone)
-						}
-					} else {
-						vtodo.Props.SetDateTime(ical.PropDue, due.UTC())
-					}
-				} else {
-					vtodo.Props.SetDateTime(ical.PropDue, due.UTC())
-				}
+				setZonedDateTime(vtodo.Props, ical.PropDue, due, t.Timezone)
 			}
 		}
 		if t.StartDate != "" {
 			if d, err := time.Parse("2006-01-02", t.StartDate); err == nil {
 				vtodo.Props.SetDate(ical.PropDateTimeStart, d)
 			} else if start, err := time.Parse(time.RFC3339, t.StartDate); err == nil {
-				if t.Timezone == "FLOATING" {
-					p := &ical.Prop{Name: ical.PropDateTimeStart}
-					p.Value = start.UTC().Format("20060102T150405")
-					vtodo.Props.Set(p)
-				} else if t.Timezone != "" {
-					if loc, lerr := time.LoadLocation(t.Timezone); lerr == nil {
-						vtodo.Props.SetDateTime(ical.PropDateTimeStart, start.In(loc))
-						if p := vtodo.Props.Get(ical.PropDateTimeStart); p != nil {
-							p.Params.Set(ical.ParamTimezoneID, t.Timezone)
-						}
-					} else {
-						vtodo.Props.SetDateTime(ical.PropDateTimeStart, start.UTC())
-					}
-				} else {
-					vtodo.Props.SetDateTime(ical.PropDateTimeStart, start.UTC())
-				}
+				setZonedDateTime(vtodo.Props, ical.PropDateTimeStart, start, t.Timezone)
 			}
 		}
 		// RFC 5545 (and go-ical's encoder) only accept DURATION on a VTODO when

--- a/internal/ical/export_todos.go
+++ b/internal/ical/export_todos.go
@@ -176,53 +176,22 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			vtodo.Props.Set(p)
 		}
 
-		if t.DtStamp != "" {
-			if ts, err := time.Parse(time.RFC3339, t.DtStamp); err == nil {
-				vtodo.Props.SetDateTime(ical.PropDateTimeStamp, ts.UTC())
-			} else {
-				vtodo.Props.SetDateTime(ical.PropDateTimeStamp, t.UpdatedAt.UTC())
-			}
-		} else {
-			vtodo.Props.SetDateTime(ical.PropDateTimeStamp, t.UpdatedAt.UTC())
-		}
-		vtodo.Props.SetDateTime(ical.PropCreated, t.CreatedAt.UTC())
-		vtodo.Props.SetDateTime(ical.PropLastModified, t.UpdatedAt.UTC())
+		emitTimestamps(vtodo.Props, t.DtStamp, t.CreatedAt, t.UpdatedAt)
 
 		// ATTACH
 		for _, att := range t.Attachments {
 			emitAttachment(vtodo.Props, att)
 		}
 
-		// COMMENT
-		for _, c := range t.Comments {
-			p := &ical.Prop{Name: ical.PropComment}
-			p.SetText(c)
-			vtodo.Props.Add(p)
-		}
+		emitTextProps(vtodo.Props, ical.PropComment, t.Comments)
 
-		// CONTACT
-		for _, c := range t.Contacts {
-			p := &ical.Prop{Name: ical.PropContact}
-			p.SetText(c)
-			vtodo.Props.Add(p)
-		}
+		emitTextProps(vtodo.Props, ical.PropContact, t.Contacts)
 
 		// RESOURCES (comma-separated list, like CATEGORIES)
-		if len(t.Resources) > 0 {
-			resProp := &ical.Prop{Name: ical.PropResources}
-			resProp.SetTextList(t.Resources)
-			vtodo.Props.Set(resProp)
-		}
+		emitResources(vtodo.Props, t.Resources)
 
 		// RELATED-TO
-		for _, r := range t.Relations {
-			p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}
-			p.Value = r.RelUID
-			if r.RelType != "" && r.RelType != "PARENT" {
-				p.Params.Set("RELTYPE", r.RelType)
-			}
-			vtodo.Props.Add(p)
-		}
+		emitRelations(vtodo.Props, t.Relations)
 
 		// X-Properties (round-trip preservation)
 		emitXProperties(vtodo, t.XProperties)

--- a/internal/ical/export_todos.go
+++ b/internal/ical/export_todos.go
@@ -243,7 +243,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
 				org.Value = "mailto:" + att.Email
 				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, att.Name)
+					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 				}
 				setOrganizerParams(org, att)
 				vtodo.Props.Set(org)
@@ -251,7 +251,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
 			attendee.Value = "mailto:" + att.Email
 			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, att.Name)
+				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 			}
 			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
 			attendee.Params.Set(ical.ParamRole, att.Role)

--- a/internal/ical/export_todos.go
+++ b/internal/ical/export_todos.go
@@ -237,27 +237,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			}
 		}
 
-		// ATTENDEE / ORGANIZER
-		for _, att := range t.Attendees {
-			if att.Organizer {
-				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
-				org.Value = "mailto:" + att.Email
-				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-				}
-				setOrganizerParams(org, att)
-				vtodo.Props.Set(org)
-			}
-			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
-			attendee.Value = "mailto:" + att.Email
-			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-			}
-			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
-			attendee.Params.Set(ical.ParamRole, att.Role)
-			setAttendeeParams(attendee, att)
-			vtodo.Props.Add(attendee)
-		}
+		emitAttendees(vtodo.Props, t.Attendees)
 
 		cal.Children = append(cal.Children, vtodo)
 	}

--- a/internal/ical/export_valarm.go
+++ b/internal/ical/export_valarm.go
@@ -143,7 +143,7 @@ func buildValarm(alarm model.Alarm, recordTZ string) *ical.Component {
 		p := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
 		p.Value = "mailto:" + att.Email
 		if att.Name != "" {
-			p.Params.Set(ical.ParamCommonName, att.Name)
+			p.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
 		}
 		valarm.Props.Add(p)
 	}
@@ -167,7 +167,7 @@ func buildValarm(alarm model.Alarm, recordTZ string) *ical.Component {
 			p.Value = alarm.AttachURI
 		}
 		if alarm.AttachFmtType != "" {
-			p.Params.Set("FMTTYPE", alarm.AttachFmtType)
+			p.Params.Set("FMTTYPE", safeParamValue(alarm.AttachFmtType))
 		}
 		valarm.Props.Add(p)
 	}

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -393,9 +393,10 @@ func parseDateListFromProps(props ical.Props, propName string, fallback *time.Lo
 	return strings.Join(dates, ",")
 }
 
-// parseAttendeesFromProps reads the attendees of a VTODO or a VJOURNAL.
-// Those two tables accept the wider PARTSTAT set, so the caller passes
-// model.TaskAttendee. The second return value lists the clamps.
+// parseAttendeesFromProps reads the attendees of a VEVENT, a VTODO, or a
+// VJOURNAL. The kind parameter selects the PARTSTAT set that is valid for
+// the component: model.EventAttendee for a VEVENT, model.TaskAttendee for a
+// VTODO and a VJOURNAL. The second return value lists the clamps.
 func parseAttendeesFromProps(props ical.Props, kind model.AttendeeKind) ([]model.Attendee, []string) {
 	var attendees []model.Attendee
 	var warns []string

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/emersion/go-ical"
 
-	"github.com/douglasdemoura/chroncal/internal/duration"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/freebusy"
 	"github.com/douglasdemoura/chroncal/internal/journal"
@@ -241,42 +240,6 @@ func parseDateProp(props ical.Props, kind, name, uid string) (string, string) {
 		return t.Format("2006-01-02"), ""
 	}
 	return t.UTC().Format(time.RFC3339), ""
-}
-
-// parseAttendees reads the attendees of a VEVENT. The second return
-// value lists the parameters attendeeFromProp clamped.
-func parseAttendees(ve ical.Event) ([]model.Attendee, []string) {
-	var attendees []model.Attendee
-	var warns []string
-
-	// ORGANIZER — track email so we can deduplicate against ATTENDEE below.
-	var organizerEmail string
-	if prop := ve.Props.Get(ical.PropOrganizer); prop != nil {
-		organizerEmail = stripMailto(prop.Value)
-		attendees = append(attendees, model.Attendee{
-			Email:      organizerEmail,
-			Name:       prop.Params.Get(ical.ParamCommonName),
-			RSVPStatus: "ACCEPTED",
-			Role:       "CHAIR",
-			Organizer:  true,
-			SentBy:     stripMailto(prop.Params.Get(ical.ParamSentBy)),
-			Dir:        prop.Params.Get(ical.ParamDir),
-			Language:   prop.Params.Get(ical.ParamLanguage),
-		})
-	}
-
-	// ATTENDEE properties — skip duplicates of the ORGANIZER email.
-	for _, prop := range ve.Props.Values(ical.PropAttendee) {
-		email := stripMailto(prop.Value)
-		if organizerEmail != "" && strings.EqualFold(email, organizerEmail) {
-			continue
-		}
-		a, w := attendeeFromProp(&prop, model.EventAttendee)
-		warns = append(warns, w...)
-		attendees = append(attendees, a)
-	}
-
-	return attendees, warns
 }
 
 // stripMailto removes the CAL-ADDRESS scheme prefix in any letter case.
@@ -540,12 +503,6 @@ func floatingOrTZ(floating bool, tz string) string {
 		return "FLOATING"
 	}
 	return tz
-}
-
-// addDuration parses an RFC 5545 duration string and adds it to a time.
-// Format: [+/-]P[nW] or [+/-]P[nD][T[nH][nM][nS]]
-func addDuration(t time.Time, dur string) time.Time {
-	return duration.Add(t, dur)
 }
 
 // decodeInlineAttachment decodes a BASE64 ATTACH value and enforces the inline

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -279,8 +279,12 @@ func parseAttendees(ve ical.Event) ([]model.Attendee, []string) {
 	return attendees, warns
 }
 
+// stripMailto removes the CAL-ADDRESS scheme prefix in any letter case.
 func stripMailto(s string) string {
-	return strings.TrimPrefix(strings.TrimPrefix(s, "mailto:"), "MAILTO:")
+	if len(s) >= 7 && strings.EqualFold(s[:7], "mailto:") {
+		return s[7:]
+	}
+	return s
 }
 
 func paramOrDefault(prop *ical.Prop, param, def string) string {

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -109,6 +109,11 @@ func importFile(r io.Reader, remote bool) (ImportResult, error) {
 	if len(data) > maxImportBytes {
 		return result, fmt.Errorf("ical payload exceeds %d bytes", maxImportBytes)
 	}
+
+	// A UTF-8 BOM prefixes the stream in files that Windows editors write.
+	// The decoder reads the BOM bytes as part of the first BEGIN line and
+	// rejects the whole file. Strip the BOM first.
+	data = bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF})
 	data = stripCommentLines(data)
 
 	dec := ical.NewDecoder(bytes.NewReader(data))

--- a/internal/ical/import_event.go
+++ b/internal/ical/import_event.go
@@ -77,7 +77,7 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 		if prop != nil && duration.ValidateSpan(prop.Value) == nil {
 			// The end must land on a time the database can hold. See
 			// timeutil.Storable for that rule.
-			if end := addDuration(startTime, prop.Value); timeutil.Storable(end) {
+			if end := duration.Add(startTime, prop.Value); timeutil.Storable(end) {
 				durationValue = prop.Value
 				endTime = end
 				explicitEnd = true
@@ -87,7 +87,7 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 		if spanOK {
 			// The DURATION above is the span.
 		} else if prop != nil && duration.Validate(prop.Value) == nil &&
-			addDuration(startTime, prop.Value).Equal(startTime) {
+			duration.Add(startTime, prop.Value).Equal(startTime) {
 			// An exact zero span (DURATION:PT0S). RFC 5545 §3.6.1 gives
 			// the same meaning to a VEVENT with no DTEND and no
 			// DURATION, so store the equivalent zero-length event. Drop
@@ -181,7 +181,7 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 		geo = prop.Value
 	}
 
-	categories := parseCategories(ve)
+	categories := parseCategoriesFromProps(ve.Props)
 	exdates := parseDateListFromProps(ve.Props, ical.PropExceptionDates, dtstartZone(ve.Props))
 	rdates := parseDateListFromProps(ve.Props, ical.PropRecurrenceDates, dtstartZone(ve.Props))
 
@@ -215,7 +215,7 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 	}
 
 	// ATTENDEE + ORGANIZER
-	attendees, attendeeWarnings := parseAttendees(ve)
+	attendees, attendeeWarnings := parseAttendeesFromProps(ve.Props, model.EventAttendee)
 	for _, w := range attendeeWarnings {
 		// Name the owning record: the clamp leaves no other trace.
 		childWarnings = append(childWarnings, fmt.Sprintf("event %q: %s", uid, w))
@@ -289,22 +289,6 @@ func textOrDefault(ve ical.Event, prop, def string) string {
 		return v
 	}
 	return def
-}
-
-func parseCategories(ve ical.Event) string {
-	var cats []string
-	for _, prop := range ve.Props.Values(ical.PropCategories) {
-		// TextList splits on unescaped commas and unescapes each value,
-		// handling both RFC-correct "CATEGORIES:a,b" and legacy
-		// escaped "CATEGORIES:a\,b" inputs.
-		if list, err := prop.TextList(); err == nil {
-			cats = append(cats, list...)
-		}
-	}
-	// Join with comma-escaping so a category value that itself contains a
-	// comma (e.g. "Foo, Bar") stays a single value through the in-memory
-	// comma-joined representation instead of fragmenting on round-trip.
-	return timeutil.JoinCategoryList(cats)
 }
 
 // handledEventProps is the set of property names explicitly parsed by eventFromVEvent.

--- a/internal/ical/import_test.go
+++ b/internal/ical/import_test.go
@@ -142,6 +142,24 @@ func TestImport_MinimalEvent(t *testing.T) {
 	}
 }
 
+// TestImport_UTF8BOMPrefix guards a file that starts with a UTF-8 BOM.
+// Some Windows editors write the BOM before the first BEGIN:VCALENDAR
+// line. The decoder then sees the BOM bytes as part of that line and
+// rejects the whole file.
+func TestImport_UTF8BOMPrefix(t *testing.T) {
+	t.Parallel()
+	result, err := ImportFile(strings.NewReader("\ufeff" + minimalEventICS))
+	if err != nil {
+		t.Fatalf("ImportFile error: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	if result.Events[0].UID != "test-uid-1" {
+		t.Errorf("UID = %q, want %q", result.Events[0].UID, "test-uid-1")
+	}
+}
+
 func TestImport_FullEvent(t *testing.T) {
 	t.Parallel()
 	result, err := ImportFile(strings.NewReader(fullEventICS))

--- a/internal/ical/mailto_test.go
+++ b/internal/ical/mailto_test.go
@@ -1,0 +1,19 @@
+package ical
+
+import "testing"
+
+func TestStripMailtoAnyCase(t *testing.T) {
+	cases := map[string]string{
+		"mailto:ALICE@example.com": "ALICE@example.com",
+		"MAILTO:alice@example.com": "alice@example.com",
+		"Mailto:bob@example.com":   "bob@example.com",
+		"maIlTo:carol@example.com": "carol@example.com",
+		"alice@example.com":        "alice@example.com",
+		"":                         "",
+	}
+	for in, want := range cases {
+		if got := stripMailto(in); got != want {
+			t.Errorf("stripMailto(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/ical/vtimezone.go
+++ b/internal/ical/vtimezone.go
@@ -123,6 +123,9 @@ func parseUTCOffset(s string) (int, error) {
 			return 0, err
 		}
 	}
+	if hours > 23 || minutes > 59 || seconds > 59 {
+		return 0, fmt.Errorf("utc-offset component out of range: %q", s)
+	}
 	return sign * (hours*3600 + minutes*60 + seconds), nil
 }
 

--- a/internal/ical/vtimezone_offset_test.go
+++ b/internal/ical/vtimezone_offset_test.go
@@ -1,0 +1,26 @@
+package ical
+
+import "testing"
+
+func TestParseUTCOffsetRange(t *testing.T) {
+	valid := map[string]int{
+		"+0530":   5*3600 + 30*60,
+		"-0800":   -8 * 3600,
+		"+0000":   0,
+		"+2359":   23*3600 + 59*60,
+		"-233059": -(23*3600 + 30*60 + 59),
+	}
+	for in, want := range valid {
+		got, err := parseUTCOffset(in)
+		if err != nil || got != want {
+			t.Errorf("parseUTCOffset(%q) = %d, %v; want %d, nil", in, got, err, want)
+		}
+	}
+
+	invalid := []string{"+9930", "+0599", "-006099", "+2400"}
+	for _, in := range invalid {
+		if got, err := parseUTCOffset(in); err == nil {
+			t.Errorf("parseUTCOffset(%q) = %d, nil; want out-of-range error", in, got)
+		}
+	}
+}

--- a/internal/icaltransfer/transfer.go
+++ b/internal/icaltransfer/transfer.go
@@ -291,6 +291,10 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 // returned as a warning rather than only logged. Callers can then show
 // partial child-data loss in the import summary. The function does not
 // report success in silence.
+//
+// Replace every child collection unconditionally. A re-import of a UID
+// must remove a child that the new file omits. This mirrors the CalDAV
+// pull path in internal/sync (engine_persist.go).
 func importEventFields(ctx context.Context, svc *event.Service, id int64, e event.Event) []string {
 	var warns []string
 	add := func(field string, err error) {
@@ -298,30 +302,14 @@ func importEventFields(ctx context.Context, svc *event.Service, id int64, e even
 			warns = append(warns, fmt.Sprintf("import event %d: replace %s: %v", id, field, err))
 		}
 	}
-	if len(e.Alarms) > 0 {
-		add("alarms", svc.ReplaceAlarms(ctx, id, e.Alarms))
-	}
-	if len(e.Attendees) > 0 {
-		add("attendees", svc.ReplaceAttendees(ctx, id, e.Attendees))
-	}
-	if len(e.Attachments) > 0 {
-		add("attachments", svc.ReplaceAttachments(ctx, id, e.Attachments))
-	}
-	if len(e.Comments) > 0 {
-		add("comments", svc.ReplaceComments(ctx, id, e.Comments))
-	}
-	if len(e.Contacts) > 0 {
-		add("contacts", svc.ReplaceContacts(ctx, id, e.Contacts))
-	}
-	if len(e.Resources) > 0 {
-		add("resources", svc.ReplaceResources(ctx, id, e.Resources))
-	}
-	if len(e.Relations) > 0 {
-		add("relations", svc.ReplaceRelations(ctx, id, e.Relations))
-	}
-	if len(e.XProperties) > 0 {
-		add("x-properties", svc.ReplaceXProperties(ctx, id, e.XProperties))
-	}
+	add("alarms", svc.ReplaceAlarms(ctx, id, e.Alarms))
+	add("attendees", svc.ReplaceAttendees(ctx, id, e.Attendees))
+	add("attachments", svc.ReplaceAttachments(ctx, id, e.Attachments))
+	add("comments", svc.ReplaceComments(ctx, id, e.Comments))
+	add("contacts", svc.ReplaceContacts(ctx, id, e.Contacts))
+	add("resources", svc.ReplaceResources(ctx, id, e.Resources))
+	add("relations", svc.ReplaceRelations(ctx, id, e.Relations))
+	add("x-properties", svc.ReplaceXProperties(ctx, id, e.XProperties))
 	return warns
 }
 
@@ -333,30 +321,14 @@ func importTodoFields(ctx context.Context, svc *todo.Service, id int64, t todo.T
 			warns = append(warns, fmt.Sprintf("import todo %d: replace %s: %v", id, field, err))
 		}
 	}
-	if len(t.Alarms) > 0 {
-		add("alarms", svc.ReplaceAlarms(ctx, id, t.Alarms))
-	}
-	if len(t.Attendees) > 0 {
-		add("attendees", svc.ReplaceAttendees(ctx, id, t.Attendees))
-	}
-	if len(t.Attachments) > 0 {
-		add("attachments", svc.ReplaceAttachments(ctx, id, t.Attachments))
-	}
-	if len(t.Comments) > 0 {
-		add("comments", svc.ReplaceComments(ctx, id, t.Comments))
-	}
-	if len(t.Contacts) > 0 {
-		add("contacts", svc.ReplaceContacts(ctx, id, t.Contacts))
-	}
-	if len(t.Resources) > 0 {
-		add("resources", svc.ReplaceResources(ctx, id, t.Resources))
-	}
-	if len(t.Relations) > 0 {
-		add("relations", svc.ReplaceRelations(ctx, id, t.Relations))
-	}
-	if len(t.XProperties) > 0 {
-		add("x-properties", svc.ReplaceXProperties(ctx, id, t.XProperties))
-	}
+	add("alarms", svc.ReplaceAlarms(ctx, id, t.Alarms))
+	add("attendees", svc.ReplaceAttendees(ctx, id, t.Attendees))
+	add("attachments", svc.ReplaceAttachments(ctx, id, t.Attachments))
+	add("comments", svc.ReplaceComments(ctx, id, t.Comments))
+	add("contacts", svc.ReplaceContacts(ctx, id, t.Contacts))
+	add("resources", svc.ReplaceResources(ctx, id, t.Resources))
+	add("relations", svc.ReplaceRelations(ctx, id, t.Relations))
+	add("x-properties", svc.ReplaceXProperties(ctx, id, t.XProperties))
 	return warns
 }
 
@@ -368,24 +340,12 @@ func importJournalFields(ctx context.Context, svc *journal.Service, id int64, j 
 			warns = append(warns, fmt.Sprintf("import journal %d: replace %s: %v", id, field, err))
 		}
 	}
-	if len(j.Attendees) > 0 {
-		add("attendees", svc.ReplaceAttendees(ctx, id, j.Attendees))
-	}
-	if len(j.Attachments) > 0 {
-		add("attachments", svc.ReplaceAttachments(ctx, id, j.Attachments))
-	}
-	if len(j.Comments) > 0 {
-		add("comments", svc.ReplaceComments(ctx, id, j.Comments))
-	}
-	if len(j.Contacts) > 0 {
-		add("contacts", svc.ReplaceContacts(ctx, id, j.Contacts))
-	}
-	if len(j.Relations) > 0 {
-		add("relations", svc.ReplaceRelations(ctx, id, j.Relations))
-	}
-	if len(j.XProperties) > 0 {
-		add("x-properties", svc.ReplaceXProperties(ctx, id, j.XProperties))
-	}
+	add("attendees", svc.ReplaceAttendees(ctx, id, j.Attendees))
+	add("attachments", svc.ReplaceAttachments(ctx, id, j.Attachments))
+	add("comments", svc.ReplaceComments(ctx, id, j.Comments))
+	add("contacts", svc.ReplaceContacts(ctx, id, j.Contacts))
+	add("relations", svc.ReplaceRelations(ctx, id, j.Relations))
+	add("x-properties", svc.ReplaceXProperties(ctx, id, j.XProperties))
 	return warns
 }
 

--- a/internal/icaltransfer/transfer.go
+++ b/internal/icaltransfer/transfer.go
@@ -199,7 +199,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import events.
 	for _, e := range result.Events {
-		_, lookupErr := lookupEvent(a.Events, ctx, e.UID, e.RecurrenceID)
+		_, lookupErr := lookupEvent(ctx, a.Events, e.UID, e.RecurrenceID)
 		saved, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
 			UID: e.UID, CalendarID: calendarID,
 			Title: e.Title, Description: e.Description, Location: e.Location,
@@ -228,7 +228,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import todos.
 	for _, t := range result.Todos {
-		_, lookupErr := lookupTodo(a.Todos, ctx, t.UID, t.RecurrenceID)
+		_, lookupErr := lookupTodo(ctx, a.Todos, t.UID, t.RecurrenceID)
 		saved, err := a.Todos.UpsertByUID(ctx, todo.UpsertParams{
 			UID: t.UID, CalendarID: calendarID,
 			Summary: t.Summary, Description: t.Description, Location: t.Location,
@@ -257,7 +257,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import journals.
 	for _, j := range result.Journals {
-		_, lookupErr := lookupJournal(a.Journals, ctx, j.UID, j.RecurrenceID)
+		_, lookupErr := lookupJournal(ctx, a.Journals, j.UID, j.RecurrenceID)
 		saved, err := a.Journals.UpsertByUID(ctx, journal.UpsertParams{
 			UID: j.UID, CalendarID: calendarID,
 			Summary: j.Summary, Description: j.Description,
@@ -480,7 +480,7 @@ func ExportCalendarFile(ctx context.Context, a *app.App, calendarID int64, calen
 // lookupEvent reports whether an imported event row already exists. An
 // override (a non-empty recurrence_id) must match its own row, not the
 // master, so the summary counts a first-time override as new.
-func lookupEvent(svc *event.Service, ctx context.Context, uid, recurrenceID string) (event.Event, error) {
+func lookupEvent(ctx context.Context, svc *event.Service, uid, recurrenceID string) (event.Event, error) {
 	if recurrenceID != "" {
 		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
 	}
@@ -488,7 +488,7 @@ func lookupEvent(svc *event.Service, ctx context.Context, uid, recurrenceID stri
 }
 
 // lookupTodo reports whether an imported todo row already exists.
-func lookupTodo(svc *todo.Service, ctx context.Context, uid, recurrenceID string) (todo.Todo, error) {
+func lookupTodo(ctx context.Context, svc *todo.Service, uid, recurrenceID string) (todo.Todo, error) {
 	if recurrenceID != "" {
 		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
 	}
@@ -496,7 +496,7 @@ func lookupTodo(svc *todo.Service, ctx context.Context, uid, recurrenceID string
 }
 
 // lookupJournal reports whether an imported journal row already exists.
-func lookupJournal(svc *journal.Service, ctx context.Context, uid, recurrenceID string) (journal.Journal, error) {
+func lookupJournal(ctx context.Context, svc *journal.Service, uid, recurrenceID string) (journal.Journal, error) {
 	if recurrenceID != "" {
 		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
 	}

--- a/internal/icaltransfer/transfer.go
+++ b/internal/icaltransfer/transfer.go
@@ -199,7 +199,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import events.
 	for _, e := range result.Events {
-		_, lookupErr := a.Events.GetByUID(ctx, e.UID)
+		_, lookupErr := lookupEvent(a.Events, ctx, e.UID, e.RecurrenceID)
 		saved, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
 			UID: e.UID, CalendarID: calendarID,
 			Title: e.Title, Description: e.Description, Location: e.Location,
@@ -228,7 +228,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import todos.
 	for _, t := range result.Todos {
-		_, lookupErr := a.Todos.GetByUID(ctx, t.UID)
+		_, lookupErr := lookupTodo(a.Todos, ctx, t.UID, t.RecurrenceID)
 		saved, err := a.Todos.UpsertByUID(ctx, todo.UpsertParams{
 			UID: t.UID, CalendarID: calendarID,
 			Summary: t.Summary, Description: t.Description, Location: t.Location,
@@ -257,7 +257,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import journals.
 	for _, j := range result.Journals {
-		_, lookupErr := a.Journals.GetByUID(ctx, j.UID)
+		_, lookupErr := lookupJournal(a.Journals, ctx, j.UID, j.RecurrenceID)
 		saved, err := a.Journals.UpsertByUID(ctx, journal.UpsertParams{
 			UID: j.UID, CalendarID: calendarID,
 			Summary: j.Summary, Description: j.Description,
@@ -475,4 +475,30 @@ func ExportCalendarFile(ctx context.Context, a *app.App, calendarID int64, calen
 		return summary, fmt.Errorf("write file: %w", err)
 	}
 	return summary, nil
+}
+
+// lookupEvent reports whether an imported event row already exists. An
+// override (a non-empty recurrence_id) must match its own row, not the
+// master, so the summary counts a first-time override as new.
+func lookupEvent(svc *event.Service, ctx context.Context, uid, recurrenceID string) (event.Event, error) {
+	if recurrenceID != "" {
+		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
+	}
+	return svc.GetByUID(ctx, uid)
+}
+
+// lookupTodo reports whether an imported todo row already exists.
+func lookupTodo(svc *todo.Service, ctx context.Context, uid, recurrenceID string) (todo.Todo, error) {
+	if recurrenceID != "" {
+		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
+	}
+	return svc.GetByUID(ctx, uid)
+}
+
+// lookupJournal reports whether an imported journal row already exists.
+func lookupJournal(svc *journal.Service, ctx context.Context, uid, recurrenceID string) (journal.Journal, error) {
+	if recurrenceID != "" {
+		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
+	}
+	return svc.GetByUID(ctx, uid)
 }

--- a/internal/icaltransfer/transfer_test.go
+++ b/internal/icaltransfer/transfer_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/ical"
 	"github.com/douglasdemoura/chroncal/internal/icaltransfer"
+	"github.com/douglasdemoura/chroncal/internal/journal"
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/todo"
 )
 
 func newTestApp(t *testing.T) *app.App {
@@ -247,6 +249,79 @@ func TestImport_ChildFieldFailureIsWarningNotFailed(t *testing.T) {
 	}
 	if !containsSubstring(summary.Warnings, "alarms") {
 		t.Errorf("summary.Warnings = %v, want one about dropped alarms", summary.Warnings)
+	}
+}
+
+// TestImport_ReimportRemovesStaleChildren locks in the re-import contract.
+// An import replaces the child collections of a row. It does not merge
+// them. A re-import that omits a child must remove the stored child. The
+// old len>0 guard kept stale alarms and attendees on the row, so a
+// removal on the source never reached the local copy.
+func TestImport_ReimportRemovesStaleChildren(t *testing.T) {
+	ctx := context.Background()
+	a := newTestApp(t)
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC)
+	attendee := model.Attendee{
+		Email: "user@example.com", Name: "User",
+		RSVPStatus: "NEEDS-ACTION", Role: "REQ-PARTICIPANT",
+	}
+	importAll := func(withChildren bool) icaltransfer.Summary {
+		evt := event.Event{
+			UID: "evt-children", Title: "Reimport",
+			StartTime: start, EndTime: start.Add(time.Hour),
+		}
+		td := todo.Todo{UID: "todo-children", Summary: "Reimport todo"}
+		jr := journal.Journal{UID: "jr-children", Summary: "Reimport journal"}
+		if withChildren {
+			evt.Alarms = []model.Alarm{{Action: "DISPLAY", TriggerValue: "-PT15M", Related: "START"}}
+			evt.Attendees = []model.Attendee{attendee}
+			td.Alarms = []model.Alarm{{Action: "DISPLAY", TriggerValue: "-PT30M", Related: "START"}}
+			jr.Attendees = []model.Attendee{attendee}
+		}
+		return icaltransfer.Import(ctx, a, cal.ID, &ical.ImportResult{
+			Events:   []event.Event{evt},
+			Todos:    []todo.Todo{td},
+			Journals: []journal.Journal{jr},
+		})
+	}
+
+	if s := importAll(true); s.Failed != 0 {
+		t.Fatalf("first import Failed = %d, want 0 (warnings: %v)", s.Failed, s.Warnings)
+	}
+	if s := importAll(false); s.Failed != 0 {
+		t.Fatalf("re-import Failed = %d, want 0 (warnings: %v)", s.Failed, s.Warnings)
+	}
+
+	evt, err := a.Events.GetByUID(ctx, "evt-children")
+	if err != nil {
+		t.Fatalf("GetByUID event: %v", err)
+	}
+	if alarms, err := a.Events.ListAlarms(ctx, evt.ID); err != nil || len(alarms) != 0 {
+		t.Errorf("event alarms after re-import = %v (err %v), want none", alarms, err)
+	}
+	if atts, err := a.Events.ListAttendees(ctx, evt.ID); err != nil || len(atts) != 0 {
+		t.Errorf("event attendees after re-import = %v (err %v), want none", atts, err)
+	}
+
+	td, err := a.Todos.GetByUID(ctx, "todo-children")
+	if err != nil {
+		t.Fatalf("GetByUID todo: %v", err)
+	}
+	if alarms, err := a.Todos.ListAlarms(ctx, td.ID); err != nil || len(alarms) != 0 {
+		t.Errorf("todo alarms after re-import = %v (err %v), want none", alarms, err)
+	}
+
+	jr, err := a.Journals.GetByUID(ctx, "jr-children")
+	if err != nil {
+		t.Fatalf("GetByUID journal: %v", err)
+	}
+	if atts, err := a.Journals.ListAttendees(ctx, jr.ID); err != nil || len(atts) != 0 {
+		t.Errorf("journal attendees after re-import = %v (err %v), want none", atts, err)
 	}
 }
 

--- a/internal/icaltransfer/transfer_test.go
+++ b/internal/icaltransfer/transfer_test.go
@@ -368,3 +368,42 @@ func TestExportCalendarFileEmptyCalendarDoesNotCreateFile(t *testing.T) {
 		t.Fatalf("empty export created file: %v", statErr)
 	}
 }
+
+// TestImport_FirstTimeOverrideCountsAsNew extends the UID upsert contract to
+// overrides. A first-time override shares the master's UID, so a plain
+// GetByUID matched it and counted it as updated. The override lookup must
+// match its own row through its recurrence_id.
+func TestImport_FirstTimeOverrideCountsAsNew(t *testing.T) {
+	ctx := context.Background()
+	a := newTestApp(t)
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC)
+	if _, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
+		UID: "evt-series", CalendarID: cal.ID, Title: "Master",
+		StartTime: start, EndTime: start.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed master: %v", err)
+	}
+
+	overrideAt := start.Add(24 * time.Hour)
+	result := &ical.ImportResult{Events: []event.Event{{
+		UID: "evt-series", Title: "Moved instance",
+		StartTime: overrideAt, EndTime: overrideAt.Add(time.Hour),
+		RecurrenceID: overrideAt.Format(time.RFC3339),
+	}}}
+	summary := icaltransfer.Import(ctx, a, cal.ID, result)
+
+	if summary.NewEvents != 1 {
+		t.Errorf("NewEvents = %d, want 1 (first-time override is new, not an update of the master)", summary.NewEvents)
+	}
+	if summary.UpdatedEvents != 0 {
+		t.Errorf("UpdatedEvents = %d, want 0", summary.UpdatedEvents)
+	}
+	if _, err := a.Events.GetByUIDAndRecurrenceID(ctx, "evt-series", overrideAt.Format(time.RFC3339)); err != nil {
+		t.Errorf("override row not persisted: %v", err)
+	}
+}

--- a/internal/journal/attachments.go
+++ b/internal/journal/attachments.go
@@ -42,6 +42,5 @@ func (s *Service) ReplaceAttachments(ctx context.Context, journalID int64, attac
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, journalID)
-	return nil
+	return s.markDirtyByID(ctx, journalID)
 }

--- a/internal/journal/attendees.go
+++ b/internal/journal/attendees.go
@@ -82,6 +82,5 @@ func (s *Service) ReplaceAttendees(ctx context.Context, journalID int64, attende
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, journalID)
-	return nil
+	return s.markDirtyByID(ctx, journalID)
 }

--- a/internal/journal/search.go
+++ b/internal/journal/search.go
@@ -36,7 +36,7 @@ func (s *Service) Search(ctx context.Context, p SearchParams) ([]Journal, error)
 }
 
 func (s *Service) ExportFiltered(ctx context.Context, p ExportParams) ([]Journal, error) {
-	rows, err := s.q.ListJournalsForExport(ctx, storage.ListJournalsForExportParams{
+	rows, err := s.q.ListJournalsForExport(ctx, storage.JournalFilterParams{
 		CalendarID:   p.CalendarID,
 		FromDate:     p.From,
 		ToDate:       p.To,

--- a/internal/journal/service.go
+++ b/internal/journal/service.go
@@ -226,12 +226,16 @@ func (s *Service) GetByUIDAndRecurrenceID(ctx context.Context, uid, recurrenceID
 }
 
 // markDirtyByID looks up a journal by ID and marks its sync resource as dirty.
-func (s *Service) markDirtyByID(ctx context.Context, journalID int64) {
+// The error is surfaced so a dropped dirty flag is never silent.
+func (s *Service) markDirtyByID(ctx context.Context, journalID int64) error {
 	r, err := s.q.GetJournal(ctx, journalID)
 	if err != nil {
-		return
+		return fmt.Errorf("get journal for dirty mark: %w", err)
 	}
-	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "journal")
+	if err := storage.MarkResourceDirty(ctx, s.dirtyExec(), r.CalendarID, r.Uid, "journal"); err != nil {
+		return fmt.Errorf("mark resource dirty: %w", err)
+	}
+	return nil
 }
 
 // ensureWritable guards a user-originated mutation against a read-only or
@@ -321,7 +325,9 @@ func (s *Service) Create(ctx context.Context, p CreateParams) (Journal, error) {
 		return Journal{}, fmt.Errorf("commit create journal: %w", err)
 	}
 	j.Categories = p.Categories
-	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), j.CalendarID, j.UID, "journal")
+	if err := storage.MarkResourceDirty(ctx, s.dirtyExec(), j.CalendarID, j.UID, "journal"); err != nil {
+		return Journal{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	return j, nil
 }
 
@@ -372,7 +378,9 @@ func (s *Service) Update(ctx context.Context, id int64, p UpdateParams) (Journal
 		return Journal{}, fmt.Errorf("commit update journal: %w", err)
 	}
 	j.Categories = p.Categories
-	_ = storage.MarkResourceDirty(ctx, s.dirtyExec(), j.CalendarID, j.UID, "journal")
+	if err := storage.MarkResourceDirty(ctx, s.dirtyExec(), j.CalendarID, j.UID, "journal"); err != nil {
+		return Journal{}, fmt.Errorf("mark resource dirty: %w", err)
+	}
 	return j, nil
 }
 
@@ -512,8 +520,7 @@ func (s *Service) ReplaceComments(ctx context.Context, journalID int64, comments
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, journalID)
-	return nil
+	return s.markDirtyByID(ctx, journalID)
 }
 
 // Contact CRUD
@@ -550,8 +557,7 @@ func (s *Service) ReplaceContacts(ctx context.Context, journalID int64, contacts
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, journalID)
-	return nil
+	return s.markDirtyByID(ctx, journalID)
 }
 
 // Relation CRUD
@@ -588,8 +594,7 @@ func (s *Service) ReplaceRelations(ctx context.Context, journalID int64, relatio
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, journalID)
-	return nil
+	return s.markDirtyByID(ctx, journalID)
 }
 
 // Converters
@@ -699,8 +704,7 @@ func (s *Service) ReplaceXProperties(ctx context.Context, journalID int64, xprop
 	if err := commit(); err != nil {
 		return err
 	}
-	s.markDirtyByID(ctx, journalID)
-	return nil
+	return s.markDirtyByID(ctx, journalID)
 }
 
 func fromStorageSlice(rows []storage.Journal) []Journal {

--- a/internal/recurrence/list_journals.go
+++ b/internal/recurrence/list_journals.go
@@ -175,11 +175,6 @@ func (s *Service) expandRecurringJournalRows(ctx context.Context, rows []storage
 // date range is provided, recurring journals are expanded. Otherwise master
 // entries are returned as-is.
 func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams) ([]journal.Journal, error) {
-	hideCancelled := int64(0)
-	if p.HideCancelled {
-		hideCancelled = 1
-	}
-
 	fromStr := ""
 	toStr := ""
 	hasRange := !p.From.IsZero() || !p.To.IsZero()
@@ -190,10 +185,10 @@ func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams)
 		toStr = p.To.Format("2006-01-02")
 	}
 
-	rows, err := s.q.ListJournalsFiltered(ctx, storage.ListJournalsFilteredParams{
+	rows, err := s.q.ListJournalsFiltered(ctx, storage.JournalFilterParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
-		HideCancelled:  hideCancelled,
+		HideCancelled:  p.HideCancelled,
 		FromDate:       fromStr,
 		ToDate:         toStr,
 		IncludeDeleted: p.IncludeDeleted,
@@ -207,10 +202,10 @@ func (s *Service) ListFilteredJournals(ctx context.Context, p JournalListParams)
 		result = append(result, journalFromRow(row))
 	}
 
-	recurringRows, err := s.q.ListRecurringJournalsFiltered(ctx, storage.ListRecurringJournalsFilteredParams{
+	recurringRows, err := s.q.ListRecurringJournalsFiltered(ctx, storage.JournalFilterParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
-		HideCancelled:  hideCancelled,
+		HideCancelled:  p.HideCancelled,
 		IncludeDeleted: p.IncludeDeleted,
 	})
 	if err != nil {

--- a/internal/recurrence/list_todos.go
+++ b/internal/recurrence/list_todos.go
@@ -256,11 +256,6 @@ type TodoListParams struct {
 // range is provided, recurring todos are expanded. Otherwise master entries
 // are returned as-is.
 func (s *Service) ListFilteredTodos(ctx context.Context, p TodoListParams) ([]todo.Todo, error) {
-	hideCompleted := int64(0)
-	if p.HideCompleted {
-		hideCompleted = 1
-	}
-
 	fromStr := ""
 	toStr := ""
 	hasRange := !p.From.IsZero() || !p.To.IsZero()
@@ -271,10 +266,10 @@ func (s *Service) ListFilteredTodos(ctx context.Context, p TodoListParams) ([]to
 		toStr = p.To.Format("2006-01-02")
 	}
 
-	rows, err := s.q.ListTodosFiltered(ctx, storage.ListTodosFilteredParams{
+	rows, err := s.q.ListTodosFiltered(ctx, storage.TodoFilterParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
-		HideCompleted:  hideCompleted,
+		HideCompleted:  p.HideCompleted,
 		FromDate:       fromStr,
 		ToDate:         toStr,
 		IncludeDeleted: p.IncludeDeleted,
@@ -288,10 +283,10 @@ func (s *Service) ListFilteredTodos(ctx context.Context, p TodoListParams) ([]to
 		result = append(result, todoFromRow(row))
 	}
 
-	recurringRows, err := s.q.ListRecurringTodosFiltered(ctx, storage.ListRecurringTodosFilteredParams{
+	recurringRows, err := s.q.ListRecurringTodosFiltered(ctx, storage.TodoFilterParams{
 		CalendarID:     p.CalendarID,
 		FilterStatus:   p.Status,
-		HideCompleted:  hideCompleted,
+		HideCompleted:  p.HideCompleted,
 		IncludeDeleted: p.IncludeDeleted,
 	})
 	if err != nil {

--- a/internal/retry/backoff.go
+++ b/internal/retry/backoff.go
@@ -6,12 +6,17 @@ import (
 	"time"
 )
 
+// maxBackoffDelay is the maximum sleep between two retries.
+// backoffDuration derives its ceiling from it. retryAfterDelay derives its
+// Retry-After cap from it. One constant keeps both waits in step.
+const maxBackoffDelay = 60 * time.Second
+
 // backoffDuration returns a random duration in [0, 2^attempt) seconds
 // (full jitter). This spreads retries uniformly across the backoff window.
 // It reduces thundering-herd collisions compared to equal or decorrelated jitter.
 func backoffDuration(attempt int) time.Duration {
+	maxBackoff := maxBackoffDelay.Seconds()
 	ceiling := math.Pow(2, float64(attempt)) // seconds
-	const maxBackoff = 60.0
 	if ceiling > maxBackoff {
 		ceiling = maxBackoff
 	}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -75,13 +75,14 @@ func retryDelay(opts RetryOptions, attempt int) time.Duration {
 	return wait
 }
 
-// maxRetryAfterDelay caps a server-requested Retry-After floor. The value
-// matches the 60-second ceiling backoffDuration applies to computed backoff.
-// A hostile or broken server can request an absurd delay (24 hours, for
-// example). The retry caller often holds locks while it waits (the sync
-// push lock is one example), so an uncapped floor would stall the whole
-// account on one bad header.
-const maxRetryAfterDelay = 60 * time.Second
+// maxRetryAfterDelay caps a server-requested Retry-After floor. It equals
+// maxBackoffDelay, the ceiling that backoffDuration applies to computed
+// backoff, so the compiler keeps the two waits in step. A hostile or broken
+// server can request an absurd delay (24 hours, for example). The retry
+// caller often holds locks while it waits (the sync push lock is one
+// example), so an uncapped floor would stall the whole account on one bad
+// header.
+const maxRetryAfterDelay = maxBackoffDelay
 
 // retryAfterDelay returns the server-requested minimum delay for err,
 // capped at maxRetryAfterDelay. Zero means the server gave no usable hint.

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -32,8 +32,9 @@ func Retry[T any](ctx context.Context, opts RetryOptions, fn func(context.Contex
 
 		delay := retryDelay(opts, attempt-1)
 		// Honor a server-requested Retry-After as a floor: never retry
-		// sooner than the server asked, even if it exceeds MaxDelay.
-		if floor := retryAfter(err); floor > delay {
+		// sooner than the server asked, even if it exceeds MaxDelay. The
+		// floor is still capped. See retryAfterDelay for the ceiling.
+		if floor := retryAfterDelay(err); floor > delay {
 			delay = floor
 		}
 		select {
@@ -72,4 +73,22 @@ func retryDelay(opts RetryOptions, attempt int) time.Duration {
 		return opts.MaxDelay
 	}
 	return wait
+}
+
+// maxRetryAfterDelay caps a server-requested Retry-After floor. The value
+// matches the 60-second ceiling backoffDuration applies to computed backoff.
+// A hostile or broken server can request an absurd delay (24 hours, for
+// example). The retry caller often holds locks while it waits (the sync
+// push lock is one example), so an uncapped floor would stall the whole
+// account on one bad header.
+const maxRetryAfterDelay = 60 * time.Second
+
+// retryAfterDelay returns the server-requested minimum delay for err,
+// capped at maxRetryAfterDelay. Zero means the server gave no usable hint.
+func retryAfterDelay(err error) time.Duration {
+	floor := retryAfter(err)
+	if floor > maxRetryAfterDelay {
+		return maxRetryAfterDelay
+	}
+	return floor
 }

--- a/internal/retry/retryafter_test.go
+++ b/internal/retry/retryafter_test.go
@@ -1,0 +1,57 @@
+package retry
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestRetryAfterDelayCapped covers the cap on a server-requested
+// Retry-After floor. A hostile or broken server can request an absurd
+// delay. The retry caller often holds locks (the sync push lock is one
+// example), so the floor must never exceed maxRetryAfterDelay.
+func TestRetryAfterDelayCapped(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{
+			name: "no server hint",
+			err:  errors.New("503 Service Unavailable"),
+			want: 0,
+		},
+		{
+			name: "hint below cap",
+			err:  &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: 30 * time.Second},
+			want: 30 * time.Second,
+		},
+		{
+			name: "hint at cap",
+			err:  &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: 60 * time.Second},
+			want: 60 * time.Second,
+		},
+		{
+			name: "hostile hint above cap",
+			err:  &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: 24 * time.Hour},
+			want: 60 * time.Second,
+		},
+		{
+			name: "negative hint ignored",
+			err:  &TransientError{Err: errors.New("429 Too Many Requests"), RetryAfter: -time.Second},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := retryAfterDelay(tt.err); got != tt.want {
+				t.Fatalf("retryAfterDelay() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/retry/transient.go
+++ b/internal/retry/transient.go
@@ -10,7 +10,11 @@ import (
 	"time"
 )
 
-var httpStatusPattern = regexp.MustCompile(`\b([1-5][0-9][0-9])\b`)
+// The pattern accepts only an explicit status marker: a message that starts
+// with the code ("503 Service Unavailable") or a named prefix ("HTTP 503",
+// "status 503"). A bare \b[0-9]{3}\b scrape also matched batch indices,
+// ports, and host segments, and classified unrelated failures as retryable.
+var httpStatusPattern = regexp.MustCompile(`(?i)(?:^([1-5][0-9][0-9])\b)|(?:\b(?:https?|status)(?: code)?[: =]+([1-5][0-9][0-9]))`)
 
 // TransientError marks an error as retryable. It optionally carries a
 // server-requested minimum delay before the next attempt. One example is the
@@ -103,13 +107,16 @@ func IsTransient(err error) bool {
 		return true
 	}
 
+	// A bare "timeout" substring check is gone. Real timeouts carry the
+	// typed net.Error Timeout method or context.DeadlineExceeded. A text
+	// scrape also matched non-retryable failures whose message merely
+	// mentioned the word.
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "connection reset") ||
 		strings.Contains(msg, "broken pipe") ||
 		strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "no such host") ||
-		strings.Contains(msg, "server misbehaving") ||
-		strings.Contains(msg, "timeout")
+		strings.Contains(msg, "server misbehaving")
 }
 
 // IsRetryableStatus reports whether an HTTP status code is worth a retry:
@@ -145,14 +152,22 @@ func statusCode(err error) int {
 		return httpErr.Status
 	}
 
-	// Fall back to scraping the message for legacy string-only errors.
+	// Fall back to an explicit status marker in the message for legacy
+	// string-only errors. The pattern rejects bare numeric tokens.
 	match := httpStatusPattern.FindStringSubmatch(err.Error())
-	if len(match) != 2 {
+	var token string
+	if len(match) > 1 {
+		token = match[1]
+		if token == "" && len(match) > 2 {
+			token = match[2]
+		}
+	}
+	if token == "" {
 		return 0
 	}
 
 	code := 0
-	for _, r := range match[1] {
+	for _, r := range token {
 		code = (code * 10) + int(r-'0')
 	}
 	return code

--- a/internal/retry/transient_test.go
+++ b/internal/retry/transient_test.go
@@ -119,3 +119,38 @@ func TestIsConflict(t *testing.T) {
 		})
 	}
 }
+
+// TestStatusScrapeRejectsBareTokens pins the tightened scrape. Only an
+// explicit status marker classifies: a leading code or a named prefix.
+// Numeric tokens from ports, batch indices, or hostnames must not count.
+func TestStatusScrapeRejectsBareTokens(t *testing.T) {
+	t.Parallel()
+
+	retryable := []string{
+		"503 Service Unavailable",
+		"http 503 Service Unavailable",
+		"HTTP:429",
+		"status 500 Internal Server Error",
+		"Status Code: 502 Bad Gateway",
+	}
+	for _, msg := range retryable {
+		if !IsRetryableStatus(statusCode(errors.New(msg))) {
+			t.Errorf("statusCode(%q) must classify as a retryable status", msg)
+		}
+	}
+
+	notRetryable := []string{
+		"PUT https://dav.example.com:8443/cal/x.ics failed", // port
+		"multiget batch 100 failed",                         // index
+		"request timeout budget exhausted for item 200",     // prose + number
+		"operation timed out after 300 ms",                  // typed paths cover timeouts; text must not
+	}
+	for _, msg := range notRetryable {
+		if got := IsRetryableStatus(statusCode(errors.New(msg))); got {
+			t.Errorf("statusCode(%q) scraped a retryable status, want 0", msg)
+		}
+		if IsTransient(errors.New(msg)) {
+			t.Errorf("IsTransient(%q) = true via text scrape, want false", msg)
+		}
+	}
+}

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -1062,10 +1062,11 @@ type UpsertEventByUIDParams struct {
 	ConferenceUri  string
 }
 
-// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
-// pull path should be aware this resurrects soft-deleted rows. The sync pull
-// path is safe because tombstoned UIDs are filtered out before this runs
-// (engine.go loads tombstones first and skips them during pull).
+// NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+// soft-deleted rows. Callers outside the pull path in the sync engine
+// must know this. The pull path is safe. The engine excludes
+// tombstoned UIDs before this query runs (engine.go loads tombstones
+// first and skips them during pull).
 func (q *Queries) UpsertEventByUID(ctx context.Context, arg UpsertEventByUIDParams) (Event, error) {
 	row := q.db.QueryRowContext(ctx, upsertEventByUID,
 		arg.Uid,

--- a/internal/storage/fts.go
+++ b/internal/storage/fts.go
@@ -60,7 +60,7 @@ func (q *Queries) SearchEventsFTS(ctx context.Context, query string, calendarID 
 	return q.queryEvents(ctx, where, args, "start_time ASC")
 }
 
-func (q *Queries) SearchTodosFTS(ctx context.Context, query string, calendarID int64, filterStatus string, completedFilter int64) ([]Todo, error) {
+func (q *Queries) SearchTodosFTS(ctx context.Context, query string, calendarID int64, filterStatus string, completedFilter CompletedFilter) ([]Todo, error) {
 	var w whereBuilder
 	w.addSoftDeleteFilter(false, false)
 	w.add("id IN (SELECT rowid FROM todos_fts WHERE todos_fts MATCH ?)", query)
@@ -70,9 +70,10 @@ func (q *Queries) SearchTodosFTS(ctx context.Context, query string, calendarID i
 	if filterStatus != "" {
 		w.add("status = ?", filterStatus)
 	}
-	if completedFilter == 1 {
+	switch completedFilter {
+	case CompletedOnly:
 		w.add("completed_at IS NOT NULL")
-	} else if completedFilter == 2 {
+	case OpenOnly:
 		w.add("completed_at IS NULL")
 	}
 	where, args := w.build()

--- a/internal/storage/journals.sql.go
+++ b/internal/storage/journals.sql.go
@@ -976,10 +976,11 @@ type UpsertJournalByUIDParams struct {
 	Dtstamp        *string
 }
 
-// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
-// pull path should be aware this resurrects soft-deleted rows. The sync pull
-// path is safe because tombstoned UIDs are filtered out before this runs
-// (engine.go loads tombstones first and skips them during pull).
+// NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+// soft-deleted rows. Callers outside the pull path in the sync engine
+// must know this. The pull path is safe. The engine excludes
+// tombstoned UIDs before this query runs (engine.go loads tombstones
+// first and skips them during pull).
 func (q *Queries) UpsertJournalByUID(ctx context.Context, arg UpsertJournalByUIDParams) (Journal, error) {
 	row := q.db.QueryRowContext(ctx, upsertJournalByUID,
 		arg.Uid,

--- a/internal/storage/journals.sql.go
+++ b/internal/storage/journals.sql.go
@@ -976,6 +976,10 @@ type UpsertJournalByUIDParams struct {
 	Dtstamp        *string
 }
 
+// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
+// pull path should be aware this resurrects soft-deleted rows. The sync pull
+// path is safe because tombstoned UIDs are filtered out before this runs
+// (engine.go loads tombstones first and skips them during pull).
 func (q *Queries) UpsertJournalByUID(ctx context.Context, arg UpsertJournalByUIDParams) (Journal, error) {
 	row := q.db.QueryRowContext(ctx, upsertJournalByUID,
 		arg.Uid,

--- a/internal/storage/journals_dynamic.go
+++ b/internal/storage/journals_dynamic.go
@@ -39,6 +39,10 @@ func (w *whereBuilder) addJournalFilters(arg JournalFilterParams) {
 	if arg.HideCancelled {
 		w.add("status != 'CANCELLED'")
 	}
+	// FromDate and ToDate form the half-open range [FromDate, ToDate).
+	// The filter includes a journal dated on FromDate. The filter
+	// excludes a journal dated on ToDate. A journal with no start date
+	// passes the filter.
 	if arg.FromDate != "" {
 		w.add("(start_date IS NULL OR start_date >= ?)", arg.FromDate)
 	}

--- a/internal/storage/journals_dynamic.go
+++ b/internal/storage/journals_dynamic.go
@@ -4,95 +4,70 @@ import "context"
 
 const journalCategoryExists = "EXISTS (SELECT 1 FROM journal_categories jc WHERE jc.journal_id = journals.id AND jc.category = ?)"
 
-// addJournalListFilters appends the calendar / status / hide-cancelled clauses
-// shared verbatim by ListJournalsFiltered and ListRecurringJournalsFiltered, in
-// the same order so positional args line up.
-func (w *whereBuilder) addJournalListFilters(calendarID int64, filterStatus string, hideCancelled int64) {
-	if calendarID != 0 {
-		w.add("calendar_id = ?", calendarID)
-	}
-	if filterStatus != "" {
-		w.add("status = ?", filterStatus)
-	}
-	if hideCancelled != 0 {
-		w.add("status != 'CANCELLED'")
-	}
-}
-
-type ListJournalsFilteredParams struct {
-	CalendarID     int64
-	FilterStatus   string
-	HideCancelled  int64
-	FromDate       string
-	ToDate         string
+// JournalFilterParams holds optional filters for journal queries.
+// Zero values mean "no filter" for that field.
+type JournalFilterParams struct {
+	CalendarID   int64
+	FilterStatus string
+	Category     string
+	// HideCancelled, when true, hides CANCELLED journals.
+	HideCancelled bool
+	FromDate      string
+	ToDate        string
+	// IncludeDeleted, when true, omits the default `deleted_at IS NULL`
+	// filter. Callers that need to see soft-deleted rows (trash views,
+	// --include-deleted flag) set this to true.
 	IncludeDeleted bool
-	DeletedOnly    bool
+	// DeletedOnly, when true, inverts the default filter to
+	// `deleted_at IS NOT NULL`. Implies IncludeDeleted.
+	DeletedOnly bool
 }
 
-func (q *Queries) ListJournalsFiltered(ctx context.Context, arg ListJournalsFilteredParams) ([]Journal, error) {
-	var w whereBuilder
-	// Non-recurring, non-RDATE-only masters (RDATE-only handled by ListRecurringJournalsFiltered).
-	w.add("recurrence_rule IS NULL AND (rdates IS NULL OR rdates = '') AND recurrence_id = ''")
-	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	w.addJournalListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCancelled)
-	if arg.FromDate != "" {
-		w.add("(start_date IS NULL OR start_date >= ?)", arg.FromDate)
-	}
-	if arg.ToDate != "" {
-		w.add("(start_date IS NULL OR start_date < ?)", arg.ToDate)
-	}
-	where, args := w.build()
-	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
-}
-
-type ListRecurringJournalsFilteredParams struct {
-	CalendarID     int64
-	FilterStatus   string
-	HideCancelled  int64
-	IncludeDeleted bool
-	DeletedOnly    bool
-}
-
-func (q *Queries) ListRecurringJournalsFiltered(ctx context.Context, arg ListRecurringJournalsFilteredParams) ([]Journal, error) {
-	var w whereBuilder
-	// RRULE masters and RDATE-only masters (no RRULE but has RDATEs); both need expansion.
-	w.add("(recurrence_rule IS NOT NULL OR (rdates IS NOT NULL AND rdates != '')) AND recurrence_id = ''")
-	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	w.addJournalListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCancelled)
-	where, args := w.build()
-	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
-}
-
-type ListJournalsForExportParams struct {
-	CalendarID     int64
-	Category       string
-	FilterStatus   string
-	FromDate       string
-	ToDate         string
-	IncludeDeleted bool
-	DeletedOnly    bool
-}
-
-func (q *Queries) ListJournalsForExport(ctx context.Context, arg ListJournalsForExportParams) ([]Journal, error) {
-	var w whereBuilder
+// addJournalFilters appends the soft-delete, calendar, status, category, and
+// date clauses shared by every journal query, in one fixed order.
+func (w *whereBuilder) addJournalFilters(arg JournalFilterParams) {
 	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}
-	if arg.Category != "" {
-		w.add(journalCategoryExists, arg.Category)
-	}
 	if arg.FilterStatus != "" {
 		w.add("status = ?", arg.FilterStatus)
 	}
-	// Match the half-open [from, to) date semantics used by
-	// ListJournalsFiltered; dateless journals pass the filter (NULL stays in).
+	if arg.Category != "" {
+		w.add(journalCategoryExists, arg.Category)
+	}
+	if arg.HideCancelled {
+		w.add("status != 'CANCELLED'")
+	}
 	if arg.FromDate != "" {
 		w.add("(start_date IS NULL OR start_date >= ?)", arg.FromDate)
 	}
 	if arg.ToDate != "" {
 		w.add("(start_date IS NULL OR start_date < ?)", arg.ToDate)
 	}
+}
+
+func (q *Queries) ListJournalsFiltered(ctx context.Context, arg JournalFilterParams) ([]Journal, error) {
+	var w whereBuilder
+	// Non-recurring, non-RDATE-only masters (RDATE-only handled by ListRecurringJournalsFiltered).
+	w.add("recurrence_rule IS NULL AND (rdates IS NULL OR rdates = '') AND recurrence_id = ''")
+	w.addJournalFilters(arg)
+	where, args := w.build()
+	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
+}
+
+func (q *Queries) ListRecurringJournalsFiltered(ctx context.Context, arg JournalFilterParams) ([]Journal, error) {
+	var w whereBuilder
+	// RRULE masters and RDATE-only masters (no RRULE but has RDATEs); both need expansion.
+	w.add("(recurrence_rule IS NOT NULL OR (rdates IS NOT NULL AND rdates != '')) AND recurrence_id = ''")
+	w.addJournalFilters(arg)
+	where, args := w.build()
+	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
+}
+
+func (q *Queries) ListJournalsForExport(ctx context.Context, arg JournalFilterParams) ([]Journal, error) {
+	var w whereBuilder
+	w.addJournalFilters(arg)
 	where, args := w.build()
 	return q.queryJournals(ctx, where, args, "start_date ASC, summary ASC")
 }

--- a/internal/storage/migration_registration_test.go
+++ b/internal/storage/migration_registration_test.go
@@ -1,0 +1,81 @@
+package storage
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+// TestProviderRegistersEveryGoMigration guards the manual registration in
+// NewMigrationProvider. goose runs only the migrations that the
+// goose.WithGoMigrations call lists. A new migration_NNN_*.go file that the
+// call omits never runs, and no error reports the skip. The test reads the
+// registered versions from the production provider and compares them with
+// the Go migration files in this package. It also checks that the SQL and
+// Go versions together form one gap-free range.
+func TestProviderRegistersEveryGoMigration(t *testing.T) {
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer conn.Close()
+
+	registered := make(map[int64]bool)
+	all := make(map[int64]struct{})
+	var maxVersion int64
+	for _, s := range migProvider(t, conn).ListSources() {
+		all[s.Version] = struct{}{}
+		if s.Version > maxVersion {
+			maxVersion = s.Version
+		}
+		if s.Type == goose.TypeGo {
+			registered[s.Version] = true
+		}
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate the test source file")
+	}
+	entries, err := os.ReadDir(filepath.Dir(thisFile))
+	if err != nil {
+		t.Fatalf("list the package directory: %v", err)
+	}
+	nameVersion := regexp.MustCompile(`^migration_(\d+)_`)
+	sawGoFile := false
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		m := nameVersion.FindStringSubmatch(name)
+		if m == nil {
+			continue
+		}
+		sawGoFile = true
+		version, err := strconv.ParseInt(m[1], 10, 64)
+		if err != nil {
+			t.Fatalf("parse the version in %s: %v", name, err)
+		}
+		if !registered[version] {
+			t.Errorf("%s carries version %d, but NewMigrationProvider registers no Go migration for it; add the migration to goose.WithGoMigrations so it runs",
+				name, version)
+		}
+	}
+	if !sawGoFile {
+		t.Fatal("find no migration_*.go file in the package; the naming convention changed")
+	}
+
+	for version := int64(1); version <= maxVersion; version++ {
+		if _, ok := all[version]; !ok {
+			t.Errorf("no SQL file and no registered Go migration carries version %d; the migration set has a gap", version)
+		}
+	}
+}

--- a/internal/storage/overrides_dynamic.go
+++ b/internal/storage/overrides_dynamic.go
@@ -2,12 +2,6 @@ package storage
 
 import "context"
 
-// overrideUIDBatch bounds how many UIDs go into a single `uid IN (...)` override
-// query. SQLite (modernc) caps host parameters at 32766. Stay well under that.
-// The batched fetch then does not fail on accounts with very many recurring
-// masters. The cost is a few extra queries instead of one.
-const overrideUIDBatch = 500
-
 // ListOverridesByUIDs returns all recurrence overrides (rows with a non-empty
 // recurrence_id) for the given master UIDs. It is the batched form of
 // ListOverridesByUID, used by recurrence expansion to avoid one SELECT per
@@ -17,7 +11,7 @@ const overrideUIDBatch = 500
 // support.
 func (q *Queries) ListOverridesByUIDs(ctx context.Context, uids []string) ([]Event, error) {
 	var out []Event
-	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, sqliteINBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListOverridesByUIDs */"
 		rows, err := q.queryEvents(ctx, where, args, "uid ASC, recurrence_id ASC")
@@ -32,7 +26,7 @@ func (q *Queries) ListOverridesByUIDs(ctx context.Context, uids []string) ([]Eve
 // ListTodoOverridesByUIDs is the batched form of ListTodoOverridesByUID.
 func (q *Queries) ListTodoOverridesByUIDs(ctx context.Context, uids []string) ([]Todo, error) {
 	var out []Todo
-	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, sqliteINBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListTodoOverridesByUIDs */"
 		rows, err := q.queryTodos(ctx, where, args, "uid ASC, recurrence_id ASC")
@@ -47,7 +41,7 @@ func (q *Queries) ListTodoOverridesByUIDs(ctx context.Context, uids []string) ([
 // ListJournalOverridesByUIDs is the batched form of ListJournalOverridesByUID.
 func (q *Queries) ListJournalOverridesByUIDs(ctx context.Context, uids []string) ([]Journal, error) {
 	var out []Journal
-	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, sqliteINBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListJournalOverridesByUIDs */"
 		rows, err := q.queryJournals(ctx, where, args, "uid ASC, recurrence_id ASC")

--- a/internal/storage/query_builder.go
+++ b/internal/storage/query_builder.go
@@ -51,11 +51,11 @@ func expandInPlaceholders(ids []int64) (string, []interface{}) {
 	return placeholders, args
 }
 
-// loaderIDBatch bounds how many ids go into a single `id IN (...)` batch loader
-// query (categories, attendees). Like overrideUIDBatch it stays well under
-// SQLite's 32766 host-parameter cap. The IN clause then never overflows on wide
-// recurrence expansions. The cost is a few extra queries instead of one.
-const loaderIDBatch = 500
+// sqliteINBatch bounds how many values go into a single `IN (...)` batched
+// query (category/attendee loaders, overrides by UID). SQLite (modernc) caps
+// host parameters at 32766. Stay well under that: the IN clause then never
+// overflows on wide expansions. The cost is a few extra queries instead of one.
+const sqliteINBatch = 500
 
 // dedupeInt64s returns ids with duplicates removed. It keeps first-seen
 // order. Recurrence expansion feeds one id per expanded instance, so the same
@@ -82,7 +82,7 @@ func dedupeInt64s(ids []int64) []int64 {
 // load is small enough for a single `IN (...)` query.
 func loadByIDChunks[T any](ctx context.Context, ids []int64, load func(context.Context, []int64) ([]T, error)) ([]T, error) {
 	var out []T
-	for _, chunk := range chunkSlice(dedupeInt64s(ids), loaderIDBatch) {
+	for _, chunk := range chunkSlice(dedupeInt64s(ids), sqliteINBatch) {
 		rows, err := load(ctx, chunk)
 		if err != nil {
 			return nil, err

--- a/internal/storage/query_builder.go
+++ b/internal/storage/query_builder.go
@@ -111,6 +111,10 @@ func (q *Queries) queryEvents(ctx context.Context, where string, args []interfac
 	if err != nil {
 		return nil, err
 	}
+	if err := checkScanColumns(rows, "events", eventColumns); err != nil {
+		rows.Close()
+		return nil, err
+	}
 	return scanEvents(rows)
 }
 
@@ -120,6 +124,10 @@ func (q *Queries) queryTodos(ctx context.Context, where string, args []interface
 	if err != nil {
 		return nil, err
 	}
+	if err := checkScanColumns(rows, "todos", todoColumns); err != nil {
+		rows.Close()
+		return nil, err
+	}
 	return scanTodos(rows)
 }
 
@@ -127,6 +135,10 @@ func (q *Queries) queryJournals(ctx context.Context, where string, args []interf
 	query := "SELECT * FROM journals " + where + " ORDER BY " + orderBy
 	rows, err := q.db.QueryContext(ctx, query, args...)
 	if err != nil {
+		return nil, err
+	}
+	if err := checkScanColumns(rows, "journals", journalColumns); err != nil {
+		rows.Close()
 		return nil, err
 	}
 	return scanJournals(rows)

--- a/internal/storage/scan_alignment_test.go
+++ b/internal/storage/scan_alignment_test.go
@@ -55,7 +55,7 @@ func TestScanColumnAlignment(t *testing.T) {
 	}
 
 	// Query todos using dynamic function (SELECT * + scanTodos)
-	todos, err := q.ListTodosForExport(ctx, ListTodosForExportParams{CalendarID: calID})
+	todos, err := q.ListTodosForExport(ctx, TodoFilterParams{CalendarID: calID})
 	if err != nil {
 		t.Fatalf("query todos: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestScanColumnAlignment(t *testing.T) {
 	}
 
 	// Query journals using dynamic function (SELECT * + scanJournals)
-	journals, err := q.ListJournalsForExport(ctx, ListJournalsForExportParams{CalendarID: calID})
+	journals, err := q.ListJournalsForExport(ctx, JournalFilterParams{CalendarID: calID})
 	if err != nil {
 		t.Fatalf("query journals: %v", err)
 	}

--- a/internal/storage/scan_alignment_test.go
+++ b/internal/storage/scan_alignment_test.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -68,5 +70,103 @@ func TestScanColumnAlignment(t *testing.T) {
 	}
 	if len(journals) < 1 {
 		t.Error("expected at least one journal")
+	}
+}
+
+// TestExpectedColumnsMatchSchema pins each expected column list to the live
+// schema order. SQLite returns SELECT * columns in migration order. A
+// migration that adds, drops, or moves a column must update the matching
+// list and the scanner together. This test fails until both change.
+func TestExpectedColumnsMatchSchema(t *testing.T) {
+	db, _, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	cases := []struct {
+		table string
+		want  []string
+	}{
+		{"events", eventColumns},
+		{"todos", todoColumns},
+		{"journals", journalColumns},
+	}
+	for _, tc := range cases {
+		rows, err := db.Query("SELECT name FROM pragma_table_info(?)", tc.table)
+		if err != nil {
+			t.Fatalf("table_info %s: %v", tc.table, err)
+		}
+		var got []string
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				t.Fatalf("scan %s column name: %v", tc.table, err)
+			}
+			got = append(got, name)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("iterate %s columns: %v", tc.table, err)
+		}
+		rows.Close()
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("%s schema columns %v do not match the expected list %v; update scan_helpers.go with the migration",
+				tc.table, got, tc.want)
+		}
+	}
+}
+
+// TestQueryRejectsTransposedColumns proves the fail-fast guard. The test
+// swaps two same-type columns through a view, so the row count and the
+// column types stay valid. A plain scan would swap the two values in
+// silence. The guard must return a descriptive error instead.
+func TestQueryRejectsTransposedColumns(t *testing.T) {
+	db, q, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	transposed := func(cols []string) string {
+		swapped := slices.Clone(cols)
+		// Index 3 and 4 hold title/summary and description in every list.
+		// Both columns are TEXT in all three tables.
+		swapped[3], swapped[4] = swapped[4], swapped[3]
+		return strings.Join(swapped, ", ")
+	}
+
+	steps := []struct {
+		table string
+		cols  []string
+		query func() error
+	}{
+		{"events", eventColumns, func() error {
+			_, err := q.queryEvents(ctx, "WHERE 1=0", nil, "id")
+			return err
+		}},
+		{"todos", todoColumns, func() error {
+			_, err := q.queryTodos(ctx, "WHERE 1=0", nil, "id")
+			return err
+		}},
+		{"journals", journalColumns, func() error {
+			_, err := q.queryJournals(ctx, "WHERE 1=0", nil, "id")
+			return err
+		}},
+	}
+	for _, s := range steps {
+		if _, err := db.Exec("ALTER TABLE " + s.table + " RENAME TO " + s.table + "_probe"); err != nil {
+			t.Fatalf("rename %s: %v", s.table, err)
+		}
+		if _, err := db.Exec("CREATE VIEW " + s.table + " AS SELECT " + transposed(s.cols) + " FROM " + s.table + "_probe"); err != nil {
+			t.Fatalf("create %s view: %v", s.table, err)
+		}
+		err := s.query()
+		if err == nil {
+			t.Fatalf("query through the transposed %s view returned no error", s.table)
+		}
+		if !strings.Contains(err.Error(), "scan expects") {
+			t.Errorf("%s transposition error lacks the expected column list: %v", s.table, err)
+		}
 	}
 }

--- a/internal/storage/scan_helpers.go
+++ b/internal/storage/scan_helpers.go
@@ -1,6 +1,62 @@
 package storage
 
-import "database/sql"
+import (
+	"database/sql"
+	"fmt"
+	"slices"
+)
+
+// eventColumns lists the events table columns in migration order. The
+// dynamic queries read the table with SELECT *, and SQLite returns the
+// columns in the order the migrations defined them. scanEvents scans by
+// position, so this list pins that order.
+var eventColumns = []string{
+	"id", "uid", "calendar_id", "title", "description",
+	"location", "start_time", "end_time", "all_day",
+	"recurrence_rule", "timezone", "status", "transp",
+	"sequence", "priority", "class", "url", "exdates",
+	"rdates", "recurrence_id", "geo", "created_at",
+	"updated_at", "duration", "dtstamp", "conference_uri",
+	"deleted_at",
+}
+
+// todoColumns lists the todos table columns in migration order. See
+// eventColumns for why the order matters.
+var todoColumns = []string{
+	"id", "uid", "calendar_id", "summary", "description",
+	"location", "due_date", "start_date", "duration",
+	"completed_at", "percent_complete", "status", "priority",
+	"class", "url", "recurrence_rule", "timezone",
+	"sequence", "exdates", "rdates", "recurrence_id",
+	"geo", "created_at", "updated_at", "dtstamp",
+	"deleted_at",
+}
+
+// journalColumns lists the journals table columns in migration order. See
+// eventColumns for why the order matters.
+var journalColumns = []string{
+	"id", "uid", "calendar_id", "summary", "description",
+	"start_date", "status", "class", "url",
+	"recurrence_rule", "timezone", "sequence",
+	"exdates", "rdates", "recurrence_id", "dtstamp",
+	"created_at", "updated_at",
+	"deleted_at",
+}
+
+// checkScanColumns verifies that rows carry the expected columns in the
+// expected order. A schema change that moves a same-type column then fails
+// the first read with a descriptive error. Without the check, the scan
+// swaps such values in silence.
+func checkScanColumns(rows *sql.Rows, table string, want []string) error {
+	got, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("read %s columns: %w", table, err)
+	}
+	if !slices.Equal(got, want) {
+		return fmt.Errorf("%s query returned columns %v; scan expects %v", table, got, want)
+	}
+	return nil
+}
 
 // scanEvents reads rows into []Event. Column order must match the events table.
 // Columns:

--- a/internal/storage/todos.sql.go
+++ b/internal/storage/todos.sql.go
@@ -1173,6 +1173,10 @@ type UpsertTodoByUIDParams struct {
 	Dtstamp         *string
 }
 
+// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
+// pull path should be aware this resurrects soft-deleted rows. The sync pull
+// path is safe because tombstoned UIDs are filtered out before this runs
+// (engine.go loads tombstones first and skips them during pull).
 func (q *Queries) UpsertTodoByUID(ctx context.Context, arg UpsertTodoByUIDParams) (Todo, error) {
 	row := q.db.QueryRowContext(ctx, upsertTodoByUID,
 		arg.Uid,

--- a/internal/storage/todos.sql.go
+++ b/internal/storage/todos.sql.go
@@ -1173,10 +1173,11 @@ type UpsertTodoByUIDParams struct {
 	Dtstamp         *string
 }
 
-// NOTE: ON CONFLICT UPDATE clears deleted_at. Callers outside the sync engine
-// pull path should be aware this resurrects soft-deleted rows. The sync pull
-// path is safe because tombstoned UIDs are filtered out before this runs
-// (engine.go loads tombstones first and skips them during pull).
+// NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
+// soft-deleted rows. Callers outside the pull path in the sync engine
+// must know this. The pull path is safe. The engine excludes
+// tombstoned UIDs before this query runs (engine.go loads tombstones
+// first and skips them during pull).
 func (q *Queries) UpsertTodoByUID(ctx context.Context, arg UpsertTodoByUIDParams) (Todo, error) {
 	row := q.db.QueryRowContext(ctx, upsertTodoByUID,
 		arg.Uid,

--- a/internal/storage/todos_dynamic.go
+++ b/internal/storage/todos_dynamic.go
@@ -4,6 +4,19 @@ import "context"
 
 const todoCategoryExists = "EXISTS (SELECT 1 FROM todo_categories tc WHERE tc.todo_id = todos.id AND tc.category = ?)"
 
+// CompletedFilter selects todos by completion state. The zero value
+// (CompletionAny) adds no clause.
+type CompletedFilter int64
+
+const (
+	// CompletionAny keeps completed and open todos.
+	CompletionAny CompletedFilter = iota
+	// CompletedOnly keeps todos with a completion time.
+	CompletedOnly
+	// OpenOnly keeps todos without a completion time.
+	OpenOnly
+)
+
 // TodoFilterParams holds optional filters for todo queries.
 // Zero values mean "no filter" for that field.
 type TodoFilterParams struct {
@@ -12,9 +25,9 @@ type TodoFilterParams struct {
 	Category     string
 	// HideCompleted, when true, hides COMPLETED and CANCELLED todos.
 	HideCompleted bool
-	// CompletedFilter selects rows by completed_at. The value 1 keeps
-	// only completed todos, and the value 2 keeps only open todos.
-	CompletedFilter int64
+	// CompletedFilter selects rows by completed_at. CompletedOnly keeps
+	// only completed todos, and OpenOnly keeps only open todos.
+	CompletedFilter CompletedFilter
 	FromDate        string
 	ToDate          string
 	// IncludeDeleted, when true, omits the default `deleted_at IS NULL`
@@ -42,11 +55,15 @@ func (w *whereBuilder) addTodoFilters(arg TodoFilterParams) {
 	if arg.HideCompleted {
 		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
 	}
-	if arg.CompletedFilter == 1 {
+	switch arg.CompletedFilter {
+	case CompletedOnly:
 		w.add("completed_at IS NOT NULL")
-	} else if arg.CompletedFilter == 2 {
+	case OpenOnly:
 		w.add("completed_at IS NULL")
 	}
+	// FromDate and ToDate form the half-open range [FromDate, ToDate).
+	// The filter includes a todo due on FromDate. The filter excludes a
+	// todo due on ToDate. A todo with no due date passes the filter.
 	if arg.FromDate != "" {
 		w.add("(due_date IS NULL OR due_date >= ?)", arg.FromDate)
 	}

--- a/internal/storage/todos_dynamic.go
+++ b/internal/storage/todos_dynamic.go
@@ -4,101 +4,78 @@ import "context"
 
 const todoCategoryExists = "EXISTS (SELECT 1 FROM todo_categories tc WHERE tc.todo_id = todos.id AND tc.category = ?)"
 
-// addTodoListFilters appends the calendar / status / hide-completed clauses
-// shared verbatim by ListTodosFiltered and ListRecurringTodosFiltered, in the
-// same order so positional args line up.
-func (w *whereBuilder) addTodoListFilters(calendarID int64, filterStatus string, hideCompleted int64) {
-	if calendarID != 0 {
-		w.add("calendar_id = ?", calendarID)
-	}
-	if filterStatus != "" {
-		w.add("status = ?", filterStatus)
-	}
-	if hideCompleted != 0 {
-		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
-	}
-}
-
-type ListTodosFilteredParams struct {
-	CalendarID     int64
-	FilterStatus   string
-	HideCompleted  int64
-	FromDate       string
-	ToDate         string
-	IncludeDeleted bool
-	DeletedOnly    bool
-}
-
-func (q *Queries) ListTodosFiltered(ctx context.Context, arg ListTodosFilteredParams) ([]Todo, error) {
-	var w whereBuilder
-	// Non-recurring, non-RDATE-only masters (RDATE-only handled by ListRecurringTodosFiltered).
-	w.add("recurrence_rule IS NULL AND (rdates IS NULL OR rdates = '') AND recurrence_id = ''")
-	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	w.addTodoListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCompleted)
-	if arg.FromDate != "" {
-		w.add("(due_date IS NULL OR due_date >= ?)", arg.FromDate)
-	}
-	if arg.ToDate != "" {
-		w.add("(due_date IS NULL OR due_date < ?)", arg.ToDate)
-	}
-	where, args := w.build()
-	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
-}
-
-type ListRecurringTodosFilteredParams struct {
-	CalendarID     int64
-	FilterStatus   string
-	HideCompleted  int64
-	IncludeDeleted bool
-	DeletedOnly    bool
-}
-
-func (q *Queries) ListRecurringTodosFiltered(ctx context.Context, arg ListRecurringTodosFilteredParams) ([]Todo, error) {
-	var w whereBuilder
-	// RRULE masters and RDATE-only masters (no RRULE but has RDATEs); both need expansion.
-	w.add("(recurrence_rule IS NOT NULL OR (rdates IS NOT NULL AND rdates != '')) AND recurrence_id = ''")
-	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
-	w.addTodoListFilters(arg.CalendarID, arg.FilterStatus, arg.HideCompleted)
-	where, args := w.build()
-	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
-}
-
-type ListTodosForExportParams struct {
-	CalendarID      int64
-	Category        string
-	FilterStatus    string
+// TodoFilterParams holds optional filters for todo queries.
+// Zero values mean "no filter" for that field.
+type TodoFilterParams struct {
+	CalendarID   int64
+	FilterStatus string
+	Category     string
+	// HideCompleted, when true, hides COMPLETED and CANCELLED todos.
+	HideCompleted bool
+	// CompletedFilter selects rows by completed_at. The value 1 keeps
+	// only completed todos, and the value 2 keeps only open todos.
 	CompletedFilter int64
 	FromDate        string
 	ToDate          string
-	IncludeDeleted  bool
-	DeletedOnly     bool
+	// IncludeDeleted, when true, omits the default `deleted_at IS NULL`
+	// filter. Callers that need to see soft-deleted rows (trash views,
+	// --include-deleted flag) set this to true.
+	IncludeDeleted bool
+	// DeletedOnly, when true, inverts the default filter to
+	// `deleted_at IS NOT NULL`. Implies IncludeDeleted.
+	DeletedOnly bool
 }
 
-func (q *Queries) ListTodosForExport(ctx context.Context, arg ListTodosForExportParams) ([]Todo, error) {
-	var w whereBuilder
+// addTodoFilters appends the soft-delete, calendar, status, category, and
+// date clauses shared by every todo query, in one fixed order.
+func (w *whereBuilder) addTodoFilters(arg TodoFilterParams) {
 	w.addSoftDeleteFilter(arg.IncludeDeleted, arg.DeletedOnly)
 	if arg.CalendarID != 0 {
 		w.add("calendar_id = ?", arg.CalendarID)
 	}
+	if arg.FilterStatus != "" {
+		w.add("status = ?", arg.FilterStatus)
+	}
 	if arg.Category != "" {
 		w.add(todoCategoryExists, arg.Category)
 	}
-	if arg.FilterStatus != "" {
-		w.add("status = ?", arg.FilterStatus)
+	if arg.HideCompleted {
+		w.add("status != 'COMPLETED' AND status != 'CANCELLED'")
 	}
 	if arg.CompletedFilter == 1 {
 		w.add("completed_at IS NOT NULL")
 	} else if arg.CompletedFilter == 2 {
 		w.add("completed_at IS NULL")
 	}
-	// Match the half-open [from, to) date semantics used by
-	// ListTodosFiltered; dateless todos pass the filter (NULL stays in).
 	if arg.FromDate != "" {
 		w.add("(due_date IS NULL OR due_date >= ?)", arg.FromDate)
 	}
 	if arg.ToDate != "" {
 		w.add("(due_date IS NULL OR due_date < ?)", arg.ToDate)
 	}
+}
+
+func (q *Queries) ListTodosFiltered(ctx context.Context, arg TodoFilterParams) ([]Todo, error) {
+	var w whereBuilder
+	// Non-recurring, non-RDATE-only masters (RDATE-only handled by ListRecurringTodosFiltered).
+	w.add("recurrence_rule IS NULL AND (rdates IS NULL OR rdates = '') AND recurrence_id = ''")
+	w.addTodoFilters(arg)
+	where, args := w.build()
+	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
+}
+
+func (q *Queries) ListRecurringTodosFiltered(ctx context.Context, arg TodoFilterParams) ([]Todo, error) {
+	var w whereBuilder
+	// RRULE masters and RDATE-only masters (no RRULE but has RDATEs); both need expansion.
+	w.add("(recurrence_rule IS NOT NULL OR (rdates IS NOT NULL AND rdates != '')) AND recurrence_id = ''")
+	w.addTodoFilters(arg)
+	where, args := w.build()
+	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
+}
+
+func (q *Queries) ListTodosForExport(ctx context.Context, arg TodoFilterParams) ([]Todo, error) {
+	var w whereBuilder
+	w.addTodoFilters(arg)
 	where, args := w.build()
 	return q.queryTodos(ctx, where, args, "due_date ASC, summary ASC")
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -399,7 +399,11 @@ func (e *Engine) SyncCalendar(ctx context.Context, calendarID int64, strategy Co
 	// permanently failing calendar (issue #416).
 	attemptedAt := time.Now().UTC().Format(time.RFC3339)
 	defer func() {
-		if updateErr := e.updateSyncHealth(ctx, calendarID, attemptedAt, result, err); updateErr != nil {
+		// The sync context can be expired when this defer runs. One example
+		// is the per-calendar deadline that SyncAll enforces. The health
+		// write must still record the failed attempt, so it uses a context
+		// with the cancellation removed.
+		if updateErr := e.updateSyncHealth(context.WithoutCancel(ctx), calendarID, attemptedAt, result, err); updateErr != nil {
 			e.logger.Warn("update sync health failed", "calendar_id", calendarID, "error", updateErr)
 			if result != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("update sync health: %w", updateErr))

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -897,22 +897,28 @@ func resolvePushIdentity(cal storage.Calendar, account storage.Account) string {
 // PUT this event. Returns true when the event has no organizer attendee
 // (locally-created event) or when the organizer's email matches identity
 // (case-insensitive, mailto: prefix tolerated). Returns false only when
-// we can prove the user is just an attendee.
-func (e *Engine) userOrganizesEvent(ctx context.Context, uid, identity string) bool {
+// we can prove the user is just an attendee. A missing master row counts
+// as "no organizer" so an orphaned dirty row can still push. Any other
+// failed lookup returns an error; the caller keeps the row dirty instead
+// of guessing.
+func (e *Engine) userOrganizesEvent(ctx context.Context, uid, identity string) (bool, error) {
 	row, err := e.q.GetEventByUID(ctx, uid)
 	if err != nil {
-		return true
+		if errors.Is(err, sql.ErrNoRows) {
+			return true, nil
+		}
+		return false, fmt.Errorf("get event: %w", err)
 	}
 	attendees, err := e.q.ListAttendeesByEventID(ctx, row.ID)
 	if err != nil {
-		return true
+		return false, fmt.Errorf("list attendees: %w", err)
 	}
 	for _, a := range attendees {
 		if a.Organizer == 1 {
-			return strings.EqualFold(stripMailtoPrefix(a.Email), stripMailtoPrefix(identity))
+			return strings.EqualFold(stripMailtoPrefix(a.Email), stripMailtoPrefix(identity)), nil
 		}
 	}
-	return true
+	return true, nil
 }
 
 func stripMailtoPrefix(s string) string {

--- a/internal/sync/engine_push.go
+++ b/internal/sync/engine_push.go
@@ -203,6 +203,10 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 			Rev:        res.Rev,
 		}); err != nil {
 			e.logger.Error("finalize pushed resource failed", "uid", res.Uid, "error", err)
+			// The body reached the server, but the row keeps the old ETag
+			// and the dirty flag. The next push would replay a phantom 412
+			// on this resource. Report the failure in the sync result.
+			result.errors = append(result.errors, fmt.Errorf("finalize push %s: %w", res.Uid, err))
 		}
 		// The body reached the server, so this attempt succeeded. Reset the
 		// failure bookkeeping even when the finalize write above failed.
@@ -220,6 +224,11 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 				SyncStrategy: res.SyncStrategy,
 			}); err != nil {
 				e.logger.Error("update sync resource URL", "uid", res.Uid, "error", err)
+				// The object exists on the server, but the row still has no
+				// remote URL. The next push would PUT to a new path and
+				// create a duplicate object. Report the failure in the sync
+				// result.
+				result.errors = append(result.errors, fmt.Errorf("record remote href for %s: %w", res.Uid, err))
 			}
 		}
 

--- a/internal/sync/engine_push.go
+++ b/internal/sync/engine_push.go
@@ -49,16 +49,28 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 		// PUTs with HTTP 400 / 500 and a vague <D:error/> body. Skipping
 		// foreign-organized events here clears the dirty flag so we stop
 		// retrying every sync; the local row is left untouched.
-		if pushIdentity != "" && res.OwnerType == ownerTypeEvent && !e.userOrganizesEvent(ctx, res.Uid, pushIdentity) {
-			e.logger.Info("skip push: not the organizer", "uid", res.Uid, "owner", pushIdentity)
-			if err := e.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
-				CalendarID: calendarID,
-				Uid:        res.Uid,
-				Etag:       res.Etag,
-			}); err != nil {
-				e.logger.Error("clear non-owned dirty", "uid", res.Uid, "error", err)
+		if pushIdentity != "" && res.OwnerType == ownerTypeEvent {
+			organizes, oErr := e.userOrganizesEvent(ctx, res.Uid, pushIdentity)
+			if oErr != nil {
+				// A failed lookup proves nothing. Keep the row dirty and
+				// retry on the next pass rather than guess in either
+				// direction: a false skip clears the dirty flag forever,
+				// a true push sends a guaranteed-rejected PUT.
+				result.errors = append(result.errors,
+					fmt.Errorf("organizer lookup for %s: %w", res.Uid, oErr))
+				continue
 			}
-			continue
+			if !organizes {
+				e.logger.Info("skip push: not the organizer", "uid", res.Uid, "owner", pushIdentity)
+				if err := e.q.ClearSyncResourceDirty(ctx, storage.ClearSyncResourceDirtyParams{
+					CalendarID: calendarID,
+					Uid:        res.Uid,
+					Etag:       res.Etag,
+				}); err != nil {
+					e.logger.Error("clear non-owned dirty", "uid", res.Uid, "error", err)
+				}
+				continue
+			}
 		}
 
 		// In a full prompt-mode pass, skip resources that already have an

--- a/internal/sync/engine_push.go
+++ b/internal/sync/engine_push.go
@@ -56,8 +56,9 @@ func (e *Engine) push(ctx context.Context, client *caldav.Client, calendarID int
 				// retry on the next pass rather than guess in either
 				// direction: a false skip clears the dirty flag forever,
 				// a true push sends a guaranteed-rejected PUT.
-				result.errors = append(result.errors,
-					fmt.Errorf("organizer lookup for %s: %w", res.Uid, oErr))
+				gateErr := fmt.Errorf("organizer lookup for %s: %w", res.Uid, oErr)
+				result.errors = append(result.errors, gateErr)
+				e.recordPushFailure(ctx, calendarID, res.Uid, gateErr)
 				continue
 			}
 			if !organizes {

--- a/internal/sync/engine_push_test.go
+++ b/internal/sync/engine_push_test.go
@@ -1,0 +1,171 @@
+package sync
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/storage"
+)
+
+// TestEnginePushSurfacesFinalizeFailure is the regression test for the
+// silent finalize failure. FinalizePushedResource records the new server
+// ETag and clears the dirty flag after a successful PUT. When that write
+// fails, the row keeps the old ETag and stays dirty. The next push then
+// replays a phantom 412 on a body the server already accepted. The push
+// result must report the failure.
+func TestEnginePushSurfacesFinalizeFailure(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	insertTestEvent(t, db, calendarID, "finalize-fail")
+
+	// Fail only the finalize write. It is the sole statement that advances
+	// the ETag of a dirty row. Every other bookkeeping write (for example
+	// clearPushFailure) keeps the ETag, so the trigger leaves it alone.
+	if _, err := db.ExecContext(ctx, `
+		CREATE TRIGGER block_finalize BEFORE UPDATE ON sync_resources
+		FOR EACH ROW WHEN NEW.etag != OLD.etag
+		BEGIN
+			SELECT RAISE(ABORT, 'forced finalize failure');
+		END
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/calendar/finalize-fail.ics" {
+			return newResponse(http.StatusCreated, map[string]string{"ETag": `"etag-new"`}), nil
+		}
+		t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		return newResponse(http.StatusInternalServerError, nil), nil
+	})
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "finalize-fail",
+		OwnerType:    "event",
+		RemoteUrl:    "/calendar/finalize-fail.ics",
+		Etag:         `"etag-old"`,
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	result, err := engine.push(ctx, client, calendarID, "", "", ConflictServerWins, false)
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if result.pushed != 1 {
+		t.Fatalf("pushed = %d, want 1: the PUT itself succeeded", result.pushed)
+	}
+	if len(result.errors) != 1 {
+		t.Fatalf("errors = %v, want one finalize failure", result.errors)
+	}
+	if got := result.errors[0].Error(); !strings.Contains(got, "finalize-fail") || !strings.Contains(got, "forced finalize failure") {
+		t.Fatalf("error = %q, want the finalize failure for finalize-fail", got)
+	}
+
+	// The aborted statement leaves the row dirty with the old ETag. That is
+	// the wedged state the surfaced error must make visible.
+	dirty, err := q.ListDirtySyncResources(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("ListDirtySyncResources: %v", err)
+	}
+	if len(dirty) != 1 || dirty[0].Uid != "finalize-fail" {
+		t.Fatalf("dirty resources = %+v, want the finalize-fail row", dirty)
+	}
+}
+
+// TestEnginePushSurfacesRemoteHrefFailure is the regression test for the
+// silent remote-URL write. A first-time push leaves RemoteUrl empty until
+// UpsertSyncResource records the href the server just accepted. When that
+// write fails, the next push PUTs the same body to a new path. The server
+// then holds a duplicate object. The push result must report the failure.
+func TestEnginePushSurfacesRemoteHrefFailure(t *testing.T) {
+	t.Parallel()
+
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	insertTestEvent(t, db, calendarID, "new-href")
+
+	// Fail only the remote-URL write. It is the sole statement that changes
+	// remote_url. FinalizePushedResource and clearPushFailure leave the
+	// column alone, so the trigger lets them pass.
+	if _, err := db.ExecContext(ctx, `
+		CREATE TRIGGER block_href_update BEFORE UPDATE ON sync_resources
+		FOR EACH ROW WHEN NEW.remote_url != OLD.remote_url
+		BEGIN
+			SELECT RAISE(ABORT, 'forced href failure');
+		END
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	overrideRemoteObjectNameGenerator(t, "new-href.ics")
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPut && r.URL.Path == "/calendar/new-href.ics" {
+			return newResponse(http.StatusCreated, map[string]string{"ETag": `"etag-new"`}), nil
+		}
+		t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		return newResponse(http.StatusInternalServerError, nil), nil
+	})
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "new-href",
+		OwnerType:    "event",
+		RemoteUrl:    "",
+		Etag:         "",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	result, err := engine.push(ctx, client, calendarID, "/calendar/", "", ConflictServerWins, false)
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if result.pushed != 1 {
+		t.Fatalf("pushed = %d, want 1: the PUT itself succeeded", result.pushed)
+	}
+	if len(result.errors) != 1 {
+		t.Fatalf("errors = %v, want one remote-href failure", result.errors)
+	}
+	if got := result.errors[0].Error(); !strings.Contains(got, "new-href") || !strings.Contains(got, "forced href failure") {
+		t.Fatalf("error = %q, want the remote-href failure for new-href", got)
+	}
+
+	// The aborted upsert leaves RemoteUrl empty. A later push would mint a
+	// second path for the same UID. That is the duplicate-object state the
+	// surfaced error must make visible.
+	sr, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{
+		CalendarID: calendarID,
+		Uid:        "new-href",
+	})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if sr.RemoteUrl != "" {
+		t.Fatalf("RemoteUrl = %q, want empty: the href write must not land", sr.RemoteUrl)
+	}
+}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1150,6 +1150,76 @@ func TestEngineSyncCalendarRecordsHealthOnEarlyClientFailure(t *testing.T) {
 	}
 }
 
+// TestEngineSyncCalendarRecordsHealthAfterContextExpiry is the regression
+// test for the stale health bookkeeping on a timed-out sync. SyncAll gives
+// each calendar a deadline. When the context expires mid-sync, the deferred
+// updateSyncHealth ran with the expired context. The write failed, so
+// LastSyncError stayed empty and the ambient ⚠ glyph never lit up for the
+// timed-out calendar. The health write must ignore the expiry.
+func TestEngineSyncCalendarRecordsHealthAfterContextExpiry(t *testing.T) {
+	t.Parallel()
+
+	engine, _, q := newTestEngine(t)
+	ctx := context.Background()
+
+	syncCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// The server cancels the sync context on the first request it sees.
+	// That imitates the per-calendar deadline hitting mid-sync, after
+	// loadCalendarClient already succeeded.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cancel()
+		http.Error(w, "deadline exceeded", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	remoteAccount, err := q.CreateAccount(ctx, storage.CreateAccountParams{
+		Name: "deadline", ServerUrl: server.URL, AuthType: "basic", Username: "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+	remoteURL := server.URL + "/calendar"
+	if err := q.LinkCalendarToAccount(ctx, storage.LinkCalendarToAccountParams{
+		ID: calendarID, AccountID: &remoteAccount.ID, RemoteUrl: &remoteURL,
+	}); err != nil {
+		t.Fatalf("LinkCalendarToAccount: %v", err)
+	}
+	engine.credStore.(*mockCredStore).creds[remoteAccount.ID] = auth.Credential{
+		AccountID: remoteAccount.ID, Username: "user", Password: "secret",
+	}
+
+	result, err := engine.SyncCalendar(syncCtx, calendarID, ConflictServerWins)
+	if err != nil {
+		t.Fatalf("SyncCalendar: %v", err)
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("sync errors empty: the canceled sync must report failures")
+	}
+	for _, syncErr := range result.Errors {
+		if strings.Contains(syncErr.Error(), "update sync health") {
+			t.Fatalf("sync errors = %v, want no health-write failure", result.Errors)
+		}
+	}
+
+	calRow, err := q.GetCalendar(ctx, calendarID)
+	if err != nil {
+		t.Fatalf("GetCalendar: %v", err)
+	}
+	if got := storage.NullableToString(calRow.LastSyncError); got == "" {
+		t.Fatal("LastSyncError empty: the timed-out sync still shows healthy")
+	}
+	if got := storage.NullableToString(calRow.LastSyncAttemptedAt); got == "" {
+		t.Fatal("LastSyncAttemptedAt empty: the failed attempt was not recorded")
+	}
+}
+
 // TestEnginePushSerializesConcurrentNewResourceCreate is the regression test
 // for issue #225. Two concurrent push runs for the same calendar (e.g. an
 // opportunistic save-time PushLocalEdits racing a periodic SyncCalendar) must not

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2266,8 +2266,6 @@ END:VCALENDAR
 func TestEnginePushNormalizesNewResourcePath(t *testing.T) {
 	engine, db, q := newTestEngine(t)
 	ctx := context.Background()
-	overrideRemoteObjectNameGenerator(t, "opaque-resource.ics")
-
 	cals, err := q.ListCalendars(ctx)
 	if err != nil {
 		t.Fatalf("ListCalendars: %v", err)
@@ -2291,8 +2289,8 @@ func TestEnginePushNormalizesNewResourcePath(t *testing.T) {
 	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
 		switch r.Method {
 		case http.MethodPut:
-			if r.URL.Path != "/calendar/opaque-resource.ics" {
-				t.Fatalf("PUT path = %s, want /calendar/opaque-resource.ics", r.URL.Path)
+			if r.URL.Path != "/calendar/normalized-new.ics" {
+				t.Fatalf("PUT path = %s, want /calendar/normalized-new.ics", r.URL.Path)
 			}
 			return &http.Response{
 				StatusCode: http.StatusCreated,
@@ -2312,7 +2310,7 @@ func TestEnginePushNormalizesNewResourcePath(t *testing.T) {
 				Body: io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="utf-8"?>
 <d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
   <d:response>
-    <d:href>/calendar/opaque-resource.ics</d:href>
+    <d:href>/calendar/normalized-new.ics</d:href>
     <d:propstat>
       <d:prop>
         <d:getetag>&quot;etag-new&quot;</d:getetag>
@@ -2356,8 +2354,8 @@ END:VCALENDAR
 	if err != nil {
 		t.Fatalf("GetSyncResource: %v", err)
 	}
-	if res.RemoteUrl != "/calendar/opaque-resource.ics" {
-		t.Fatalf("RemoteUrl = %q, want /calendar/opaque-resource.ics", res.RemoteUrl)
+	if res.RemoteUrl != "/calendar/normalized-new.ics" {
+		t.Fatalf("RemoteUrl = %q, want /calendar/normalized-new.ics", res.RemoteUrl)
 	}
 
 	pullResult, err := engine.pull(ctx, client, calendarID, "/calendar/")
@@ -2378,16 +2376,14 @@ END:VCALENDAR
 	if err != nil {
 		t.Fatalf("GetSyncResource after pull: %v", err)
 	}
-	if res.RemoteUrl != "/calendar/opaque-resource.ics" {
-		t.Fatalf("RemoteUrl after pull = %q, want /calendar/opaque-resource.ics", res.RemoteUrl)
+	if res.RemoteUrl != "/calendar/normalized-new.ics" {
+		t.Fatalf("RemoteUrl after pull = %q, want /calendar/normalized-new.ics", res.RemoteUrl)
 	}
 }
 
-func TestEnginePushIgnoresUIDWhenAssigningNewResourcePath(t *testing.T) {
+func TestEnginePushFlattensHostileUIDInNewResourcePath(t *testing.T) {
 	engine, db, q := newTestEngine(t)
 	ctx := context.Background()
-	overrideRemoteObjectNameGenerator(t, "opaque-malicious.ics")
-
 	cals, err := q.ListCalendars(ctx)
 	if err != nil {
 		t.Fatalf("ListCalendars: %v", err)
@@ -2412,8 +2408,8 @@ func TestEnginePushIgnoresUIDWhenAssigningNewResourcePath(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		if r.URL.Path != "/calendar/opaque-malicious.ics" {
-			t.Fatalf("PUT path = %s, want /calendar/opaque-malicious.ics", r.URL.Path)
+		if r.URL.Path != "/calendar/.._.._escape.ics" {
+			t.Fatalf("PUT path = %s, want /calendar/.._.._escape.ics (traversal flattened into one segment)", r.URL.Path)
 		}
 		return &http.Response{
 			StatusCode: http.StatusCreated,
@@ -2439,8 +2435,8 @@ func TestEnginePushIgnoresUIDWhenAssigningNewResourcePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSyncResource: %v", err)
 	}
-	if res.RemoteUrl != "/calendar/opaque-malicious.ics" {
-		t.Fatalf("RemoteUrl = %q, want /calendar/opaque-malicious.ics", res.RemoteUrl)
+	if res.RemoteUrl != "/calendar/.._.._escape.ics" {
+		t.Fatalf("RemoteUrl = %q, want /calendar/.._.._escape.ics", res.RemoteUrl)
 	}
 }
 

--- a/internal/sync/organizer_gate_test.go
+++ b/internal/sync/organizer_gate_test.go
@@ -3,8 +3,11 @@ package sync
 import (
 	"context"
 	"errors"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/douglasdemoura/chroncal/internal/storage"
 	"github.com/douglasdemoura/chroncal/internal/testutil"
 )
 
@@ -41,5 +44,71 @@ func TestUserOrganizesEvent_LookupFailurePropagates(t *testing.T) {
 	}
 	if errors.Is(err, errors.ErrUnsupported) {
 		t.Errorf("unexpected sentinel: %v", err)
+	}
+}
+
+// A failed organizer lookup in the push loop must also record a failed
+// push attempt. push_fail_count and last_push_error then keep the same
+// contract as every other failure path in push, and the sync doctor can
+// report the wedge.
+func TestEnginePushRecordsFailureWhenOrganizerLookupFails(t *testing.T) {
+	engine, db, q := newTestEngine(t)
+	ctx := context.Background()
+
+	cals, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+	calendarID := cals[0].ID
+
+	if err := q.UpsertSyncResource(ctx, storage.UpsertSyncResourceParams{
+		CalendarID:   calendarID,
+		Uid:          "gate-lookup-fail",
+		OwnerType:    "event",
+		RemoteUrl:    "",
+		Etag:         "",
+		Dirty:        1,
+		SyncStrategy: "sync-token",
+	}); err != nil {
+		t.Fatalf("UpsertSyncResource: %v", err)
+	}
+
+	// Rename the events table after the dirty list seed. The organizer
+	// lookup then fails with a real query error, not with ErrNoRows.
+	if _, err := db.ExecContext(ctx, "ALTER TABLE events RENAME TO events_gone"); err != nil {
+		t.Fatalf("rename events table: %v", err)
+	}
+
+	client := newTestCalDAVClient(t, func(r *http.Request) (*http.Response, error) {
+		t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		return nil, nil
+	})
+
+	pushResult, err := engine.push(ctx, client, calendarID, "/calendar/", "me@example.com", ConflictServerWins, false)
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if len(pushResult.errors) != 1 {
+		t.Fatalf("errors = %v, want exactly the organizer lookup error", pushResult.errors)
+	}
+	if !strings.Contains(pushResult.errors[0].Error(), "organizer lookup for gate-lookup-fail") {
+		t.Fatalf("error = %v, want the organizer lookup error", pushResult.errors[0])
+	}
+
+	res, err := q.GetSyncResource(ctx, storage.GetSyncResourceParams{
+		CalendarID: calendarID,
+		Uid:        "gate-lookup-fail",
+	})
+	if err != nil {
+		t.Fatalf("GetSyncResource: %v", err)
+	}
+	if res.PushFailCount != 1 {
+		t.Errorf("PushFailCount = %d, want 1", res.PushFailCount)
+	}
+	if !strings.Contains(res.LastPushError, "organizer lookup") {
+		t.Errorf("LastPushError = %q, want the organizer lookup error", res.LastPushError)
+	}
+	if res.Dirty != 1 {
+		t.Errorf("Dirty = %d, want 1 so the next pass retries", res.Dirty)
 	}
 }

--- a/internal/sync/organizer_gate_test.go
+++ b/internal/sync/organizer_gate_test.go
@@ -1,0 +1,45 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/testutil"
+)
+
+// A missing master row means "no organizer known". The gate must answer
+// true so an orphaned dirty row can still push.
+func TestUserOrganizesEvent_MissingRowIsNoOrganizer(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	e := NewEngine(db, q, nil, nil, nil, nil, nil, nil)
+	ctx := context.Background()
+
+	got, err := e.userOrganizesEvent(ctx, "no-such-uid", "owner@example.com")
+	if err != nil {
+		t.Fatalf("userOrganizesEvent: %v", err)
+	}
+	if !got {
+		t.Errorf("userOrganizesEvent = false for a missing row, want true")
+	}
+}
+
+// Any lookup failure other than ErrNoRows must surface as an error. The
+// caller keeps the row dirty; the gate must not guess in either direction.
+func TestUserOrganizesEvent_LookupFailurePropagates(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	e := NewEngine(db, q, nil, nil, nil, nil, nil, nil)
+	ctx := context.Background()
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	_, err := e.userOrganizesEvent(ctx, "some-uid", "owner@example.com")
+	if err == nil {
+		t.Fatal("userOrganizesEvent returned no error on a failed lookup, want error")
+	}
+	if errors.Is(err, errors.ErrUnsupported) {
+		t.Errorf("unexpected sentinel: %v", err)
+	}
+}

--- a/internal/todo/search_test.go
+++ b/internal/todo/search_test.go
@@ -61,7 +61,7 @@ func TestService_Search(t *testing.T) {
 		{"summary and description match", SearchParams{Query: "budget"}, 2},
 		{"category match", SearchParams{Query: "personal"}, 2},
 		{"no results", SearchParams{Query: "nonexistent"}, 0},
-		{"filter incomplete only", SearchParams{Query: "budget", Completed: 2}, 2},
+		{"filter incomplete only", SearchParams{Query: "budget", Completed: storage.OpenOnly}, 2},
 	}
 
 	for _, tt := range tests {
@@ -138,7 +138,7 @@ func TestService_ExportFiltered(t *testing.T) {
 	}{
 		{"export all", ExportParams{}, 2},
 		{"export by category", ExportParams{Category: "work"}, 1},
-		{"export incomplete only", ExportParams{Completed: 2}, 2},
+		{"export incomplete only", ExportParams{Completed: storage.OpenOnly}, 2},
 	}
 
 	for _, tt := range tests {

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -252,7 +252,7 @@ func (s *Service) Search(ctx context.Context, p SearchParams) ([]Todo, error) {
 }
 
 func (s *Service) ExportFiltered(ctx context.Context, p ExportParams) ([]Todo, error) {
-	rows, err := s.q.ListTodosForExport(ctx, storage.ListTodosForExportParams{
+	rows, err := s.q.ListTodosForExport(ctx, storage.TodoFilterParams{
 		CalendarID:      p.CalendarID,
 		FromDate:        p.From,
 		ToDate:          p.To,

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -20,7 +20,7 @@ type SearchParams struct {
 	Query      string
 	CalendarID int64  // 0 = all
 	Status     string // empty = all
-	Completed  int    // 0 = all, 1 = completed only, 2 = incomplete only
+	Completed  storage.CompletedFilter
 }
 
 type ExportParams struct {
@@ -29,7 +29,7 @@ type ExportParams struct {
 	To         string // date-only ("YYYY-MM-DD") or empty
 	Category   string // empty = all
 	Status     string // empty = all
-	Completed  int    // 0 = all, 1 = completed, 2 = incomplete
+	Completed  storage.CompletedFilter
 }
 
 type Service struct {
@@ -242,7 +242,7 @@ func (s *Service) Search(ctx context.Context, p SearchParams) ([]Todo, error) {
 	if ftsQuery == "" {
 		return nil, nil
 	}
-	rows, err := s.q.SearchTodosFTS(ctx, ftsQuery, p.CalendarID, p.Status, int64(p.Completed))
+	rows, err := s.q.SearchTodosFTS(ctx, ftsQuery, p.CalendarID, p.Status, p.Completed)
 	if err != nil {
 		return nil, fmt.Errorf("search todos: %w", err)
 	}
@@ -258,7 +258,7 @@ func (s *Service) ExportFiltered(ctx context.Context, p ExportParams) ([]Todo, e
 		ToDate:          p.To,
 		Category:        p.Category,
 		FilterStatus:    p.Status,
-		CompletedFilter: int64(p.Completed),
+		CompletedFilter: p.Completed,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("export todos: %w", err)

--- a/internal/tui/app_nav.go
+++ b/internal/tui/app_nav.go
@@ -96,6 +96,7 @@ func (m Model) clearConfirmPending() Model {
 	m.pendingPurgeTitle = ""
 	m.pendingCalendarDelete = 0
 	m.pendingCalendarDeleteName = ""
+	m.pendingCalendarKeepLocal = 0
 	m.pendingCalendarPromote = 0
 	m.pendingCalendarPromoteName = ""
 	m.pendingCalendarPromoteCands = nil

--- a/internal/tui/app_update.go
+++ b/internal/tui/app_update.go
@@ -691,6 +691,12 @@ func (m Model) handleConfirmDialogResult(msg ConfirmDialogResultMsg) (tea.Model,
 		}
 	}
 	ev := m.pendingDelete
+	if ev.ID == 0 {
+		// No branch above matched: nothing destructive waits behind this
+		// confirm. Do not delete event 0. That call always fails and shows
+		// a spurious error toast.
+		return m, nil
+	}
 	return m, func() tea.Msg {
 		meta, err := m.app.Events.DeleteWithUndo(context.Background(), ev.ID)
 		return eventDeletedMsg{

--- a/internal/tui/calendar_manager_view.go
+++ b/internal/tui/calendar_manager_view.go
@@ -159,7 +159,6 @@ func fingerprintTheme(t Theme) string {
 		fmt.Fprintf(&b, "|%d,%d,%d,%d;", r, g, bl, a)
 	}
 	fp("primary", t.Primary)
-	fp("secondary", t.Secondary)
 	fp("accent", t.Accent)
 	fp("muted", t.Muted)
 	fp("text", t.Text)

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -451,12 +451,6 @@ func (f Form) BodyView() string {
 	return lipgloss.JoinVertical(lipgloss.Left, f.fieldParts()...)
 }
 
-// ActionsView renders the form action separator and buttons without the
-// blank line at the start used by the full form view.
-func (f Form) ActionsView() string {
-	return lipgloss.JoinVertical(lipgloss.Left, f.buttonParts()...)
-}
-
 // ButtonRowView renders only the form buttons. Scrollable dialogs use this
 // with their own separator so they can include scroll state in the rule.
 func (f Form) ButtonRowView() string {

--- a/internal/tui/form_button.go
+++ b/internal/tui/form_button.go
@@ -1,6 +1,9 @@
 package tui
 
 import (
+	"image/color"
+	"math"
+
 	lipgloss "charm.land/lipgloss/v2"
 
 	"github.com/douglasdemoura/chroncal/internal/tui/oklch"
@@ -45,21 +48,17 @@ func (bs ButtonStyles) Get(v ButtonVariant) ButtonStyle {
 // DefaultButtonStyles returns button styles driven by the active theme.
 //
 // At rest, Danger is a quiet variant of Normal: same pill shape and
-// background, only the label is bold red (Theme.Error). This matches
-// Apple's iOS pattern of red text on a neutral pill rather than a
-// flash of a red button.
-//
-// On focus, the two variants diverge deliberately. Normal flips to
-// FormHighlight (the theme's selection accent). Danger inverts to a
-// red pill with a contrast fg. That divergence costs "single focus
-// signal" uniformity. It is the only way to keep destructive intent
-// readable across themes whose FormHighlight lands in the warm/red
-// end of the spectrum. That includes Dracula's pink, Osaka's orange,
-// and Flexoki's coral. Red text on a warm highlight is unreadable.
-// Put the red on the background. Compute a contrast label via
-// oklch.ContrastingFg. That guarantees legibility on every theme. It
-// emphasizes the destructive signal exactly when the user is about to
-// commit it.
+// background, only the label is bold red. On focus, the two variants
+// diverge deliberately. Normal flips to FormHighlight (the theme's
+// selection accent). Danger inverts to a red pill with a contrast fg.
+// That divergence costs "single focus signal" uniformity. It is the only
+// way to keep destructive intent readable across themes whose
+// FormHighlight lands in the warm/red end of the spectrum. That includes
+// Dracula's pink, Osaka's orange, and Flexoki's coral. Red text on a warm
+// highlight is unreadable. Put the red on the background. Compute a
+// contrast label via oklch.ContrastingFg. That guarantees legibility on
+// every theme. It emphasizes the destructive signal exactly when the user
+// is about to commit it.
 func DefaultButtonStyles() ButtonStyles {
 	base := lipgloss.NewStyle().Padding(0, 2).MarginRight(1)
 	t := activeTheme
@@ -69,10 +68,61 @@ func DefaultButtonStyles() ButtonStyles {
 			Focused: base.Background(t.FormHighlight).Foreground(oklch.ContrastingFg(t.FormHighlight)),
 		},
 		Danger: ButtonStyle{
-			Normal:  base.Background(t.ButtonBg).Foreground(t.Error).Bold(true),
+			Normal:  base.Background(t.ButtonBg).Foreground(dangerRestingLabel(t.ButtonBg, t.Error)).Bold(true),
 			Focused: base.Background(t.Error).Foreground(oklch.ContrastingFg(t.Error)).Bold(true),
 		},
 	}
+}
+
+// dangerRestingMinRatio is the contrast floor for the resting danger
+// label. The label renders bold. WCAG treats bold text at this size as
+// large text, so 3:1 is the floor.
+const dangerRestingMinRatio = 3.0
+
+// dangerRestingMinDeltaL is the smallest OKLCh lightness gap the label
+// keeps from the pill. Red carries little WCAG luminance, so a ratio
+// target alone cannot always separate the label from a mid-gray pill.
+const dangerRestingMinDeltaL = 0.25
+
+// dangerRestingLabel returns the resting label color for ButtonDanger.
+// The pill stays Theme.ButtonBg; only the label moves. The label keeps
+// the hue and chroma of Theme.Error, so it still reads red. The lightness
+// moves away from the pill until the pair reaches dangerRestingMinRatio.
+// The gap is at least dangerRestingMinDeltaL. Theme.Error itself wins
+// when it already satisfies both. A saturated red cannot always reach
+// 4.5:1 on a mid-gray pill; 3:1 for bold text plus the lightness gap
+// keeps the label readable on every shipped theme.
+func dangerRestingLabel(pill, err color.Color) color.Color {
+	pillL, _, _, pillOK := oklch.FromColor(pill)
+	errL, errC, errH, errOK := oklch.FromColor(err)
+	if !pillOK || !errOK {
+		return err
+	}
+	if oklch.ContrastRatio(err, pill) >= dangerRestingMinRatio &&
+		math.Abs(errL-pillL) >= dangerRestingMinDeltaL {
+		return err
+	}
+	const (
+		hiL  = 0.90
+		loL  = 0.15
+		step = 0.01
+	)
+	if pillL < 0.55 {
+		// Dark pill: push the label lighter.
+		for l := math.Max(errL, pillL+dangerRestingMinDeltaL); l <= hiL; l += step {
+			if c := oklch.ToColor(l, errC, errH); oklch.ContrastRatio(c, pill) >= dangerRestingMinRatio {
+				return c
+			}
+		}
+		return oklch.ToColor(hiL, errC, errH)
+	}
+	// Light pill: push the label darker.
+	for l := math.Min(errL, pillL-dangerRestingMinDeltaL); l >= loL; l -= step {
+		if c := oklch.ToColor(l, errC, errH); oklch.ContrastRatio(c, pill) >= dangerRestingMinRatio {
+			return c
+		}
+	}
+	return oklch.ToColor(loL, errC, errH)
 }
 
 // ButtonAlign controls horizontal placement of the button row.

--- a/internal/tui/form_button.go
+++ b/internal/tui/form_button.go
@@ -92,7 +92,42 @@ const dangerRestingMinDeltaL = 0.25
 // when it already satisfies both. A saturated red cannot always reach
 // 4.5:1 on a mid-gray pill; 3:1 for bold text plus the lightness gap
 // keeps the label readable on every shipped theme.
+//
+// The clamp reads only the RGBA of the two colors, so the result depends
+// only on that pair. The pair is constant per theme, and many View paths
+// call DefaultButtonStyles on every render frame. Memoize the clamp on
+// the RGBA pair. A repeated pair returns the cached label. SetActiveTheme
+// installs a new pair, and the key check invalidates the slot then.
 func dangerRestingLabel(pill, err color.Color) color.Color {
+	pr, pg, pb, pa := pill.RGBA()
+	er, eg, eb, ea := err.RGBA()
+	m := &dangerRestingMemo
+	if m.label != nil &&
+		m.pillR == pr && m.pillG == pg && m.pillB == pb && m.pillA == pa &&
+		m.errR == er && m.errG == eg && m.errB == eb && m.errA == ea {
+		return m.label
+	}
+	label := clampDangerRestingLabel(pill, err)
+	m.pillR, m.pillG, m.pillB, m.pillA = pr, pg, pb, pa
+	m.errR, m.errG, m.errB, m.errA = er, eg, eb, ea
+	m.label = label
+	return label
+}
+
+// dangerRestingMemo holds the last dangerRestingLabel result. The key is
+// the RGBA of the (pill, error) pair. One slot is enough: only the active
+// theme feeds the clamp, and the tests that swap themes run in sequence.
+var dangerRestingMemo struct {
+	pillR, pillG, pillB, pillA uint32
+	errR, errG, errB, errA     uint32
+	label                      color.Color
+}
+
+// clampDangerRestingLabel runs the OKLCh gamut search that
+// dangerRestingLabel caches. It walks the label lightness away from the
+// pill in 0.01 steps. That costs up to ~75 OKLCh conversions, so the
+// memoized wrapper pays it once per (pill, error) pair.
+func clampDangerRestingLabel(pill, err color.Color) color.Color {
 	pillL, _, _, pillOK := oklch.FromColor(pill)
 	errL, errC, errH, errOK := oklch.FromColor(err)
 	if !pillOK || !errOK {

--- a/internal/tui/form_button_test.go
+++ b/internal/tui/form_button_test.go
@@ -1,0 +1,93 @@
+package tui
+
+import (
+	"image/color"
+	"math"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/tui/oklch"
+)
+
+// The resting Danger label must stay readable on its pill. On the default
+// light theme, Theme.Error #DC2626 sat directly on the ANSI 240 pill
+// (#585858): 1.47:1. The label keeps the error hue and chroma, but its
+// lightness moves away from the pill until the pair reaches 3:1 (bold
+// text) with at least 0.25 OKLCh L of separation.
+func TestDangerRestingLabelReadable(t *testing.T) {
+	// NOT t.Parallel(): DefaultButtonStyles reads the package-global
+	// activeTheme, and this test swaps it.
+	prev := ActiveTheme()
+	t.Cleanup(func() { SetActiveTheme(prev) })
+
+	for _, name := range BuiltinThemeNames() {
+		for _, dark := range []bool{true, false} {
+			th, err := LoadBuiltinTheme(name, dark)
+			if err != nil {
+				t.Fatalf("LoadBuiltinTheme(%q, dark=%v): %v", name, dark, err)
+			}
+			label := dangerRestingLabel(th.ButtonBg, th.Error)
+			ratio := oklch.ContrastRatio(th.ButtonBg, label)
+			if ratio < dangerRestingMinRatio {
+				t.Errorf("%s dark=%v: resting danger pair reads %.2f:1, want >= %.1f:1",
+					name, dark, ratio, dangerRestingMinRatio)
+			}
+			pillL, _, _, _ := oklch.FromColor(th.ButtonBg)
+			labelL, _, _, _ := oklch.FromColor(label)
+			if math.Abs(labelL-pillL) < dangerRestingMinDeltaL {
+				t.Errorf("%s dark=%v: label L %.3f sits within %.2f of pill L %.3f",
+					name, dark, labelL, dangerRestingMinDeltaL, pillL)
+			}
+
+			// The label must keep the error hue and enough chroma
+			// to read as red, not as white or pink.
+			_, _, errH, _ := oklch.FromColor(th.Error)
+			_, labelC, labelH, _ := oklch.FromColor(label)
+			if math.Abs(labelH-errH) > 0.05 {
+				t.Errorf("%s dark=%v: label hue %.3f drifted from error hue %.3f",
+					name, dark, labelH, errH)
+			}
+			// The gamut clamp reduces chroma at high lightness. Red at
+			// L 0.75 carries about 0.13. The label must still hold
+			// enough chroma to read as red, not as white or pink.
+			if labelC < 0.08 {
+				t.Errorf("%s dark=%v: label chroma %.3f is too low to read as red",
+					name, dark, labelC)
+			}
+		}
+	}
+}
+
+// DefaultButtonStyles must wire the clamped label into the resting
+// Danger style. A readable helper that the style never uses fixes nothing.
+func TestDefaultButtonStylesDangerRestingWired(t *testing.T) {
+	// NOT t.Parallel(): SetActiveTheme writes the package-global theme.
+	prev := ActiveTheme()
+	t.Cleanup(func() { SetActiveTheme(prev) })
+
+	th, err := LoadBuiltinTheme(DefaultThemeName, false)
+	if err != nil {
+		t.Fatalf("LoadBuiltinTheme: %v", err)
+	}
+	SetActiveTheme(th)
+
+	styles := DefaultButtonStyles()
+	bg := styles.Danger.Normal.GetBackground()
+	fg := styles.Danger.Normal.GetForeground()
+	if bg == nil || fg == nil {
+		t.Fatal("resting Danger style lacks a background or foreground")
+	}
+	if ratio := oklch.ContrastRatio(bg, fg); ratio < dangerRestingMinRatio {
+		t.Errorf("wired resting pair reads %.2f:1, want >= %.1f:1", ratio, dangerRestingMinRatio)
+	}
+}
+
+// Theme.Error that already reads well passes through untouched. The clamp
+// must not shift a good label.
+func TestDangerRestingLabelKeepsGoodError(t *testing.T) {
+	// White pill with a dark red: ratio 5.9:1, L gap 0.62. Keep it.
+	pill := color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+	err := color.RGBA{R: 0x99, G: 0x22, B: 0x22, A: 0xff}
+	if got := dangerRestingLabel(pill, err); got != color.Color(err) {
+		t.Errorf("readable error was adjusted: got %v, want the original %v", got, err)
+	}
+}

--- a/internal/tui/form_checkbox.go
+++ b/internal/tui/form_checkbox.go
@@ -17,7 +17,6 @@ type CheckboxField struct {
 	checked     bool
 	autoChecked bool // true when checked was set by the form, not the user
 	focused     bool
-	quietFocus  bool // when true, focus does not apply reverse styling
 	disabledFn  func() (disabled bool, text string)
 }
 
@@ -51,11 +50,6 @@ func (f *CheckboxField) SetDisabledWhen(fn func() (disabled bool, text string)) 
 	f.disabledFn = fn
 }
 
-// SetQuietFocus suppresses the default reverse-style highlight the checkbox
-// applies when focused. Useful for non-primary toggles where the focus
-// affordance comes from the form's focus marker.
-func (f *CheckboxField) SetQuietFocus(v bool) { f.quietFocus = v }
-
 func (f *CheckboxField) Toggle() {
 	if f.disabledFn != nil {
 		if disabled, _ := f.disabledFn(); disabled {
@@ -85,10 +79,9 @@ func (f *CheckboxField) View() string {
 	if f.checked {
 		glyph = Glyphs["checkbox.on"]
 	}
+	// The focus affordance comes from the form's focus marker, so the
+	// checkbox itself never applies a reverse-style highlight.
 	style := lipgloss.NewStyle()
-	if f.focused && !f.quietFocus {
-		style = style.Reverse(true)
-	}
 
 	var out string
 	if len(f.content) > 0 {

--- a/internal/tui/form_text.go
+++ b/internal/tui/form_text.go
@@ -163,8 +163,6 @@ func (f *TextField) SetDisabled(v bool) {
 	}
 }
 
-// SetDimStyle sets the style used to render the value when disabled.
-// Defaults to the zero style (no visual change beyond a skip of the cursor).
 // FilterDigits allows only digit characters (0-9).
 // Every rune in the key text must be a digit; a multi-rune event (e.g. a
 // paste) is rejected if any rune fails the check.

--- a/internal/tui/form_text.go
+++ b/internal/tui/form_text.go
@@ -19,7 +19,6 @@ type TextField struct {
 	filter   func(tea.Key) bool
 	suffix   string
 	disabled bool
-	dimStyle lipgloss.Style
 	validate func(string) string
 }
 
@@ -119,7 +118,7 @@ func (f *TextField) View() string {
 		if val == "" {
 			val = f.input.Placeholder
 		}
-		out := f.dimStyle.Render(val)
+		out := val
 		if f.suffix != "" {
 			out += " " + f.suffix
 		}
@@ -166,8 +165,6 @@ func (f *TextField) SetDisabled(v bool) {
 
 // SetDimStyle sets the style used to render the value when disabled.
 // Defaults to the zero style (no visual change beyond a skip of the cursor).
-func (f *TextField) SetDimStyle(s lipgloss.Style) { f.dimStyle = s }
-
 // FilterDigits allows only digit characters (0-9).
 // Every rune in the key text must be a digit; a multi-rune event (e.g. a
 // paste) is rejected if any rune fails the check.

--- a/internal/tui/glyphs.go
+++ b/internal/tui/glyphs.go
@@ -6,7 +6,6 @@ package tui
 var Glyphs = map[string]string{
 	// Focus / navigation
 	"focus":    ">",
-	"ellipsis": "…",
 
 	// Checkbox
 	"checkbox.on":  "[x]",
@@ -14,7 +13,6 @@ var Glyphs = map[string]string{
 
 	// Status
 	"status.ok":     "✓",
-	"status.danger": "✗",
 
 	// Select
 	"select.prev": "◀",
@@ -27,7 +25,6 @@ var Glyphs = map[string]string{
 	"time.arrow": "→",
 
 	// Separators
-	"separator.vertical":   "│",
 	"separator.horizontal": "─",
 	"separator.dot":        " · ",
 }

--- a/internal/tui/harness_test.go
+++ b/internal/tui/harness_test.go
@@ -234,3 +234,53 @@ func TestHarness_CreateSave_WritesAlarmRows(t *testing.T) {
 	require.Equal(t, "DISPLAY", stored[0].Action)
 	require.Equal(t, "-PT10M", stored[0].TriggerValue)
 }
+
+// TestHarness_CtrlCSupersede_KeepLocalNotFiredLater drives the full supersede
+// path. The user opens the keep-local confirm, then presses ctrl+c, then
+// cancels the quit confirm. The abandoned keep-local ID must not survive.
+// The next confirmed dialog must then perform its own action. Before the
+// fix, a confirmed delete fired Disconnect on the stale calendar ID and
+// never deleted the event.
+func TestHarness_CtrlCSupersede_KeepLocalNotFiredLater(t *testing.T) {
+	m, a := newDBBackedModel(t)
+	ctx := context.Background()
+
+	seeded, err := a.Events.Create(ctx, event.CreateParams{
+		CalendarID: 1,
+		Title:      "Standup",
+		StartTime:  time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+
+	// Open the keep-local confirm the way the calendar manager does.
+	updated, _ := m.Update(CalendarKeepLocalRequestedMsg{ID: 1, Name: "Personal"})
+	m = updated.(Model)
+	require.True(t, m.confirmOpen, "the keep-local confirm did not open")
+	require.EqualValues(t, 1, m.pendingCalendarKeepLocal)
+
+	// ctrl+c replaces the open confirm with the quit confirm.
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+	updated, _ = m.Update(ctrlC)
+	m = updated.(Model)
+	require.True(t, m.pendingQuit, "ctrl+c should open the quit confirm")
+	require.Zero(t, m.pendingCalendarKeepLocal, "ctrl+c must drop the abandoned keep-local ID")
+
+	// Cancel the quit, then confirm an unrelated event delete.
+	updated, _ = m.Update(ConfirmDialogResultMsg{Confirmed: false})
+	m = updated.(Model)
+	require.False(t, m.pendingQuit, "quit cancel did not clear the quit marker")
+	m.pendingDelete = event.Event{ID: seeded.ID, CalendarID: 1, Title: "Standup"}
+	m.confirmOpen = true
+
+	updated, cmd := m.Update(ConfirmDialogResultMsg{Confirmed: true})
+	m = updated.(Model)
+	require.NotNil(t, cmd, "the confirmed delete dispatched no command")
+	result := cmd()
+	done, ok := result.(eventDeletedMsg)
+	require.True(t, ok, "confirmed delete dispatched %T; stale keep-local state hijacked the dialog", result)
+	require.NoError(t, done.err)
+
+	_, err = a.Events.Get(ctx, seeded.ID)
+	require.Error(t, err, "the confirmed delete did not remove the event")
+}

--- a/internal/tui/harness_test.go
+++ b/internal/tui/harness_test.go
@@ -284,3 +284,19 @@ func TestHarness_CtrlCSupersede_KeepLocalNotFiredLater(t *testing.T) {
 	_, err = a.Events.Get(ctx, seeded.ID)
 	require.Error(t, err, "the confirmed delete did not remove the event")
 }
+
+// TestHarness_EmptyConfirmResult_NoDelete guards the confirm fallback. A
+// confirmed result that no pending branch owns must do nothing. Before the
+// guard, the fallback called DeleteWithUndo with ID 0. That call always
+// failed and set m.err, so the user saw an error toast for an empty
+// confirm.
+func TestHarness_EmptyConfirmResult_NoDelete(t *testing.T) {
+	m, _ := newDBBackedModel(t)
+
+	m.confirmOpen = true
+	updated, cmd := m.Update(ConfirmDialogResultMsg{Confirmed: true})
+	m = updated.(Model)
+	require.False(t, m.confirmOpen, "the confirm dialog must still close")
+	require.Nil(t, cmd, "an empty confirm must not dispatch a delete")
+	require.NoError(t, m.err, "an empty confirm must not raise an error")
+}

--- a/internal/tui/oklch/oklch.go
+++ b/internal/tui/oklch/oklch.go
@@ -142,6 +142,30 @@ func ContrastingFg(bg color.Color) color.Color {
 	return ToColor(L, C, H)
 }
 
+// ContrastRatio returns the WCAG 2 contrast ratio of a against b. Equal
+// colors give 1. Black on white gives 21. Use this to check a
+// foreground/background pair in tests and theme guards. A nil color
+// counts as black.
+func ContrastRatio(a, b color.Color) float64 {
+	la, lb := relativeLuminance(a), relativeLuminance(b)
+	if la < lb {
+		la, lb = lb, la
+	}
+	return (la + 0.05) / (lb + 0.05)
+}
+
+// relativeLuminance computes the WCAG relative luminance of c. See
+// https://www.w3.org/TR/WCAG21/#dfn-relative-luminance.
+func relativeLuminance(c color.Color) float64 {
+	if c == nil {
+		return 0
+	}
+	r, g, b, _ := c.RGBA()
+	return 0.2126*srgbToLinear(float64(r)/0xffff) +
+		0.7152*srgbToLinear(float64(g)/0xffff) +
+		0.0722*srgbToLinear(float64(b)/0xffff)
+}
+
 func srgbToLinear(v float64) float64 {
 	if v <= 0.04045 {
 		return v / 12.92

--- a/internal/tui/oklch/oklch_test.go
+++ b/internal/tui/oklch/oklch_test.go
@@ -1,0 +1,226 @@
+package oklch
+
+import (
+	"fmt"
+	"image/color"
+	"math"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+func hexColor(s string) color.RGBA {
+	var r, g, b uint8
+	fmt.Sscanf(s, "#%02x%02x%02x", &r, &g, &b)
+	return color.RGBA{R: r, G: g, B: b, A: 0xff}
+}
+
+func hexString(c color.Color) string {
+	r, g, b, _ := c.RGBA()
+	return fmt.Sprintf("#%02x%02x%02x", r>>8, g>>8, b>>8)
+}
+
+// FromRGB followed by ToRGB must reproduce an in-gamut sRGB byte exactly.
+// Theme contrast math and fallback derivation both depend on that lossless
+// round trip.
+func TestFromRGBToRGBRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	colors := []string{
+		"#000000", // black
+		"#ffffff", // white
+		"#ff0000", // pure red
+		"#00ff00", // pure green
+		"#0000ff", // pure blue
+		"#767676", // the lightest gray that passes 4.5:1 on white
+		"#123456", // arbitrary dark blue
+		"#7c3aed", // default light theme primary
+		"#a78bfa", // default dark theme primary
+		"#dc2626", // default light theme error
+		"#111827", // default dark theme surface
+		"#585858", // xterm 240, the default theme button pill
+	}
+	for _, hex := range colors {
+		c := hexColor(hex)
+		L, C, H := FromRGB(c.R, c.G, c.B)
+		r, g, b := ToRGB(L, C, H)
+		if r != c.R || g != c.G || b != c.B {
+			t.Errorf("round trip %s = #%02x%02x%02x; want the same bytes back", hex, r, g, b)
+		}
+	}
+}
+
+func TestToRGBGamutClamp(t *testing.T) {
+	t.Parallel()
+
+	_, greenC, greenH := FromRGB(0x00, 0xff, 0x00)
+
+	t.Run("in-gamut green stays exact", func(t *testing.T) {
+		greenL, _, _ := FromRGB(0x00, 0xff, 0x00)
+		r, g, b := ToRGB(greenL, greenC, greenH)
+		if r != 0 || g != 0xff || b != 0 {
+			t.Errorf("in-gamut pure green clamped: got #%02x%02x%02x", r, g, b)
+		}
+	})
+
+	t.Run("out-of-gamut chroma reduces, L and H stay", func(t *testing.T) {
+		r, g, b := ToRGB(0.8, 0.4, greenH)
+		L, C, H := FromRGB(r, g, b)
+		if math.Abs(L-0.8) > 0.01 {
+			t.Errorf("lightness drifted: got L=%.3f, want 0.800", L)
+		}
+		if math.Abs(H-greenH) > 0.01 {
+			t.Errorf("hue drifted: got H=%.3f, want %.3f", H, greenH)
+		}
+		if C >= 0.4 {
+			t.Errorf("chroma not reduced: got C=%.3f, want < 0.400", C)
+		}
+	})
+
+	t.Run("impossible L falls back to achromatic", func(t *testing.T) {
+		// L=1 admits only white. Chroma reduction can not fit any
+		// chroma, so the documented achromatic fallback must kick in.
+		r, g, b := ToRGB(1.0, 0.5, greenH)
+		if r != 0xff || g != 0xff || b != 0xff {
+			t.Errorf("achromatic fallback: got #%02x%02x%02x, want #ffffff", r, g, b)
+		}
+	})
+}
+
+// ContrastingFg must flip polarity around L=0.55 and always land far from
+// the background lightness. Buttons, badges, and chips draw their
+// foreground from it, so a same-side result is unreadable.
+func TestContrastingFgPolarity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dark backgrounds get a light foreground", func(t *testing.T) {
+		for _, hex := range []string{"#000000", "#111827", "#1e293b", "#44475a", "#585858"} {
+			bg := hexColor(hex)
+			fg := ContrastingFg(bg)
+			fgL, _, _, ok := FromColor(fg)
+			if !ok {
+				t.Fatalf("%s: foreground not opaque: %v", hex, fg)
+			}
+			if fgL < 0.9 {
+				t.Errorf("%s: foreground L=%.3f, want >= 0.900", hex, fgL)
+			}
+			if ratio := ContrastRatio(bg, fg); ratio < 4.5 {
+				t.Errorf("%s: ratio %.2f, want >= 4.50", hex, ratio)
+			}
+		}
+	})
+
+	t.Run("light backgrounds get a dark foreground", func(t *testing.T) {
+		for _, hex := range []string{"#ffffff", "#f9fafb", "#ede9fe", "#cfcfde", "#b8b8b8"} {
+			bg := hexColor(hex)
+			fg := ContrastingFg(bg)
+			fgL, _, _, ok := FromColor(fg)
+			if !ok {
+				t.Fatalf("%s: foreground not opaque: %v", hex, fg)
+			}
+			if fgL > 0.25 {
+				t.Errorf("%s: foreground L=%.3f, want <= 0.250", hex, fgL)
+			}
+			if ratio := ContrastRatio(bg, fg); ratio < 4.5 {
+				t.Errorf("%s: ratio %.2f, want >= 4.50", hex, ratio)
+			}
+		}
+	})
+
+	t.Run("boundary red keeps the documented worst case", func(t *testing.T) {
+		// #dc2626 sits just above L=0.55. It must take the dark
+		// foreground. The worst-case delta-L of 0.37 gives about 3.9:1
+		// for red because red carries little WCAG luminance.
+		bg := hexColor("#dc2626")
+		fg := ContrastingFg(bg)
+		fgL, _, _, _ := FromColor(fg)
+		if fgL > 0.25 {
+			t.Errorf("foreground L=%.3f, want <= 0.250", fgL)
+		}
+		if ratio := ContrastRatio(bg, fg); ratio < 3.5 {
+			t.Errorf("ratio %.2f, want >= 3.50", ratio)
+		}
+	})
+
+	t.Run("hue stays with the background", func(t *testing.T) {
+		bg := hexColor("#7c3aed")
+		_, _, bgH, _ := FromColor(bg)
+		_, _, fgH, _ := FromColor(ContrastingFg(bg))
+		if math.Abs(fgH-bgH) > 0.05 {
+			t.Errorf("foreground hue %.3f drifted from background hue %.3f", fgH, bgH)
+		}
+	})
+
+	t.Run("transparent background falls back to white", func(t *testing.T) {
+		fg := ContrastingFg(color.RGBA{})
+		if hexString(fg) != "#ffffff" {
+			t.Errorf("transparent bg: got %s, want #ffffff", hexString(fg))
+		}
+	})
+}
+
+func TestContrastRatioKnownPairs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a, b string
+		want float64
+	}{
+		{"#000000", "#ffffff", 21.0},
+		{"#ffffff", "#000000", 21.0}, // order independent
+		{"#ffffff", "#ffffff", 1.0},
+		{"#767676", "#ffffff", 4.54}, // the lightest gray that passes 4.5:1 on white
+		{"#585858", "#f9fafb", 6.81}, // default light theme: form label on surface
+		{"#585858", "#111827", 2.49}, // default dark theme: the failure G4 fixes
+	}
+	for _, tc := range cases {
+		got := ContrastRatio(hexColor(tc.a), hexColor(tc.b))
+		if math.Abs(got-tc.want) > 0.01 {
+			t.Errorf("ContrastRatio(%s, %s) = %.4f, want %.2f", tc.a, tc.b, got, tc.want)
+		}
+	}
+	if got := ContrastRatio(nil, hexColor("#ffffff")); got != 21.0 {
+		t.Errorf("ContrastRatio(nil, white) = %.4f, want 21.00 (nil counts as black)", got)
+	}
+}
+
+func TestMixEndpoints(t *testing.T) {
+	t.Parallel()
+
+	a := hexColor("#dc2626")
+	b := hexColor("#f9fafb")
+	if got := hexString(Mix(a, b, 0)); got != "#dc2626" {
+		t.Errorf("Mix(a, b, 0) = %s, want a (#dc2626)", got)
+	}
+	if got := hexString(Mix(a, b, 1)); got != "#f9fafb" {
+		t.Errorf("Mix(a, b, 1) = %s, want b (#f9fafb)", got)
+	}
+}
+
+func TestShiftLightnessClamps(t *testing.T) {
+	t.Parallel()
+
+	c := hexColor("#585858")
+	if got := hexString(ShiftLightness(c, 10)); got != "#ffffff" {
+		t.Errorf("overshoot up: got %s, want #ffffff", got)
+	}
+	if got := hexString(ShiftLightness(c, -10)); got != "#000000" {
+		t.Errorf("overshoot down: got %s, want #000000", got)
+	}
+	// A transparent color passes through untouched.
+	transparent := color.RGBA{}
+	if got := ShiftLightness(transparent, 0.2); got != color.Color(transparent) {
+		t.Errorf("transparent input must pass through, got %v", got)
+	}
+}
+
+func TestFromColorRejectsTransparent(t *testing.T) {
+	t.Parallel()
+
+	if _, _, _, ok := FromColor(color.RGBA{}); ok {
+		t.Error("FromColor(transparent) reported ok, want ok=false")
+	}
+	if _, _, _, ok := FromColor(lipgloss.Color("#abc123")); !ok {
+		t.Error("FromColor(hex) reported not ok, want ok=true")
+	}
+}

--- a/internal/tui/quit_confirm_test.go
+++ b/internal/tui/quit_confirm_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -108,6 +110,89 @@ func TestCtrlCClearsAccountRemovalPendingState(t *testing.T) {
 	if next.pendingAccountRemoveID != 0 || next.pendingAccountRemoveName != "" {
 		t.Fatalf("abandoned account removal remains armed: id=%d name=%q",
 			next.pendingAccountRemoveID, next.pendingAccountRemoveName)
+	}
+}
+
+// TestCtrlCClearsKeepLocalPendingState guards the keep-local variant of the
+// ctrl+c supersede. The keep-local confirm arms pendingCalendarKeepLocal.
+// ctrl+c must drop that ID with the other wait state. A stale ID survives
+// the canceled quit confirm. The next confirmed dialog then fires Disconnect
+// instead of its own action (handleConfirmDialogResult consumes the field
+// before the delete fallback).
+func TestCtrlCClearsKeepLocalPendingState(t *testing.T) {
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+
+	m := Model{
+		confirmOpen:              true,
+		pendingCalendarKeepLocal: 42,
+	}
+
+	next, _, handled := m.interceptGlobalKeys(ctrlC)
+	if !handled || !next.pendingQuit {
+		t.Fatalf("ctrl+c did not replace the keep-local confirm with quit: handled=%v quit=%v",
+			handled, next.pendingQuit)
+	}
+	if next.pendingCalendarKeepLocal != 0 {
+		t.Fatalf("abandoned keep-local ID remains armed: %d", next.pendingCalendarKeepLocal)
+	}
+}
+
+// pendingFieldsOutsideConfirmClear lists Model fields with a "pending"
+// prefix that clearConfirmPending does not own. Each entry drains through
+// its own lifecycle. Every other "pending" field holds wait state for a
+// confirm or choice dialog, so clearConfirmPending must reset it.
+var pendingFieldsOutsideConfirmClear = map[string]bool{
+	"pendingOrder":               true, // calendar order save; the order-saved message drains it
+	"pendingAccountOrder":        true, // account order save; the order-saved message drains it
+	"pendingAccountOrderIDs":     true, // account order save; the order-saved message drains it
+	"pendingOpenEvent":           true, // event view request; the view loader drains it
+	"pendingEditSave":            true, // recurring edit save; the form drains it
+	"pendingAccountManagementID": true, // account management routing; the manager drains it
+	"pendingDiscoveryAccountID":  true, // OAuth discovery target; the flow drains it
+	"pendingDiscoveryCreated":    true, // OAuth discovery result; the flow drains it
+	"pendingSyncCalendar":        true, // queued sync; syncFinishedMsg drains it
+	"pendingQuit":                true, // quit confirm marker; the quit result drains it
+	"pendingCalendarMove":        true, // move choice state; the choice dialog drains it
+	"pendingScopeKind":           true, // choice scope; the reset writes pendingScopeNone, not zero
+}
+
+// TestClearConfirmPendingResetsAllConfirmWaitFields arms every owned
+// "pending" field, then requires the zero value after the call. Extend the
+// arm literal below when you add a confirm wait field. The reflective check
+// then fails until clearConfirmPending resets the new field too.
+func TestClearConfirmPendingResetsAllConfirmWaitFields(t *testing.T) {
+	m := Model{
+		pendingDelete:                   event.Event{ID: 7, Title: "Standup"},
+		pendingPurgeEntries:             []trash.Entry{{Kind: trash.KindEvent}},
+		pendingPurgeTitle:               "1 item",
+		pendingCalendarDelete:           3,
+		pendingCalendarDeleteName:       "Work",
+		pendingCalendarKeepLocal:        42,
+		pendingCalendarPromote:          9,
+		pendingCalendarPromoteName:      "Home",
+		pendingCalendarPromoteCands:     []int64{3, 9},
+		pendingAccountSelection:         &accountCalendarSelection{},
+		pendingAccountDefaultCandidates: []accountDefaultCandidate{{id: 9, name: "Home"}},
+		pendingAccountRemoveID:          7,
+		pendingAccountRemoveName:        "Personal Google",
+	}
+
+	m = m.clearConfirmPending()
+
+	mv := reflect.ValueOf(m)
+	mt := mv.Type()
+	var stale []string
+	for i := 0; i < mt.NumField(); i++ {
+		f := mt.Field(i)
+		if !strings.HasPrefix(f.Name, "pending") || pendingFieldsOutsideConfirmClear[f.Name] {
+			continue
+		}
+		if !mv.Field(i).IsZero() {
+			stale = append(stale, f.Name)
+		}
+	}
+	if len(stale) > 0 {
+		t.Fatalf("clearConfirmPending left confirm wait state armed: %v", stale)
 	}
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -23,15 +23,14 @@ const DefaultThemeName = "system"
 // Do not hunt hardcoded values.
 type Theme struct {
 	// Structural chrome
-	Primary   color.Color
-	Secondary color.Color
-	Accent    color.Color
-	Muted     color.Color
-	Text      color.Color
-	TextDim   color.Color
-	Border    color.Color
-	Today     color.Color
-	Selected  color.Color
+	Primary  color.Color
+	Accent   color.Color
+	Muted    color.Color
+	Text     color.Color
+	TextDim  color.Color
+	Border   color.Color
+	Today    color.Color
+	Selected color.Color
 	// SelectedText is the foreground color to use when painting text on
 	// top of Selected. On themes where Selected and Text may converge
 	// (e.g. Base16 system themes where both resolve to dark indices),

--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -283,8 +283,8 @@ func resolveTheme(r *rawTheme, hasDarkBG bool) (Theme, error) {
 
 // isAutoSentinel reports whether a raw TOML color value is the string
 // literal "auto", which signals "compute me at theme-load time from
-// Text and Surface". Currently honored for the text_dim and muted
-// tokens; other fields fall through resolveColor as-is.
+// Text and Surface". Only the text_dim and muted tokens accept "auto".
+// Any other token set to "auto" fails the load with an authoring error.
 func isAutoSentinel(v any) bool {
 	s, ok := v.(string)
 	return ok && s == "auto"

--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image/color"
 	"io/fs"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 	toml "github.com/pelletier/go-toml/v2"
 
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/tui/oklch"
 )
 
@@ -78,8 +78,10 @@ func LoadBuiltinTheme(name string, hasDarkBG bool) (Theme, error) {
 
 // LoadTheme resolves a theme by name with a safe fallback to the default.
 // An empty name is treated as the default. Unknown or malformed themes log
-// the error and fall back to the default so a typo in config.toml cannot
-// make the TUI unusable.
+// a warning to the state-dir log file and fall back to the default so a
+// typo in config.toml cannot make the TUI unusable. The warning must not
+// go to stderr. LoadTheme runs while the TUI owns the terminal, and a
+// stderr write prints over the display.
 func LoadTheme(name string, hasDarkBG bool) Theme {
 	if name == "" {
 		name = DefaultThemeName
@@ -88,8 +90,8 @@ func LoadTheme(name string, hasDarkBG bool) Theme {
 	if err == nil {
 		return t
 	}
-	fmt.Fprintf(os.Stderr, "theme %q failed to load (%v); falling back to %q\n",
-		name, err, DefaultThemeName)
+	config.SharedStateDirLogger().Warn("theme failed to load; falling back to the default theme",
+		"theme", name, "error", err.Error(), "fallback", DefaultThemeName)
 	def, err := LoadBuiltinTheme(DefaultThemeName, hasDarkBG)
 	if err != nil {
 		panic("built-in default theme failed to load: " + err.Error())

--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -207,6 +207,17 @@ func resolveTheme(r *rawTheme, hasDarkBG bool) (Theme, error) {
 		// "auto" is a sentinel for "derive me at the end from other
 		// resolved tokens". Returning nil here lets the post-process
 		// step below fill it in once Text and Surface are known.
+		//
+		// Only text_dim and muted have a derivation. An "auto" value on
+		// any other token is a theme authoring error: reject it loudly
+		// instead of leaving a nil token behind.
+		if isAutoSentinel(v) && field != "text_dim" && field != "muted" {
+			err := fmt.Errorf("field %q: \"auto\" is not supported; only text_dim and muted derive their value", field)
+			if firstErr == nil {
+				firstErr = err
+			}
+			return nil
+		}
 		if isAutoSentinel(v) {
 			return nil
 		}

--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -28,7 +28,6 @@ type rawTheme struct {
 
 	// Structural chrome.
 	Primary      any `toml:"primary"`
-	Secondary    any `toml:"secondary"`
 	Accent       any `toml:"accent"`
 	Muted        any `toml:"muted"`
 	Text         any `toml:"text"`
@@ -267,7 +266,6 @@ func resolveTheme(r *rawTheme, hasDarkBG bool) (Theme, error) {
 
 	t := Theme{
 		Primary:      pick("primary", r.Primary),
-		Secondary:    pick("secondary", r.Secondary),
 		Accent:       pick("accent", r.Accent),
 		Muted:        pick("muted", r.Muted),
 		Text:         pick("text", r.Text),

--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -150,12 +150,14 @@ func readBuiltinRaw(name string) (*rawTheme, error) {
 // ANSI indices 0..15 are translated to the terminal's actually-rendered
 // RGB via activePalette when an OSC 4 response is available. Themes can
 // then lean on ANSI references (primary = "4"). Exact OKLCh contrast
-// computations still work against real hex values. Indices 16..255 and
-// unrecognized strings fall through to lipgloss.Color.
+// computations still work against real hex values. When the terminal
+// reports no palette entry, a static Base16-style hex for the current
+// background polarity stands in (see assumedPaletteDark). Indices 16..255
+// and unrecognized strings fall through to lipgloss.Color.
 func resolveColor(v any, hasDarkBG bool, field string) (color.Color, error) {
 	switch x := v.(type) {
 	case string:
-		return resolveString(x), nil
+		return resolveString(x, hasDarkBG), nil
 	case map[string]any:
 		key := "light"
 		if hasDarkBG {
@@ -165,7 +167,7 @@ func resolveColor(v any, hasDarkBG bool, field string) (color.Color, error) {
 		if !ok {
 			return nil, fmt.Errorf("field %q variant missing %q string", field, key)
 		}
-		return resolveString(s), nil
+		return resolveString(s, hasDarkBG), nil
 	case nil:
 		return nil, fmt.Errorf("field %q is missing", field)
 	default:
@@ -173,14 +175,58 @@ func resolveColor(v any, hasDarkBG bool, field string) (color.Color, error) {
 	}
 }
 
-// resolveString turns a single TOML color string into a color.Color. If
-// it is an ANSI index 0..15 and the queried terminal palette has a value
-// for that slot, the palette's hex wins. Otherwise lipgloss handles it.
-func resolveString(s string) color.Color {
+// assumedPaletteDark and assumedPaletteLight hold the ANSI 16-color
+// values the loader substitutes when the terminal reported no palette
+// entry for a slot. The values follow the Base16 convention that
+// system.toml documents: slot 0 is the background, slot 7 the foreground,
+// slot 8 the dim line, and slots 9..14 mirror slots 1..6. Slot 1 uses a
+// slightly darker red than the Base16 default. That keeps the
+// computed-foreground ratio above 4.5.
+//
+// The loader returns these hexes instead of ANSI indices. The terminal
+// then renders the exact value the OKLCh contrast math used. A pill and
+// its computed label can no longer disagree about polarity.
+var assumedPaletteDark = Palette{
+	rgbColor("#181818"), rgbColor("#a03e35"), rgbColor("#a1b56c"), rgbColor("#ba823f"),
+	rgbColor("#7cafc2"), rgbColor("#aa759f"), rgbColor("#86c1b9"), rgbColor("#d8d8d8"),
+	rgbColor("#585858"), rgbColor("#a03e35"), rgbColor("#a1b56c"), rgbColor("#ba823f"),
+	rgbColor("#7cafc2"), rgbColor("#aa759f"), rgbColor("#86c1b9"), rgbColor("#f8f8f8"),
+}
+
+var assumedPaletteLight = Palette{
+	rgbColor("#f8f8f8"), rgbColor("#a03e35"), rgbColor("#a1b56c"), rgbColor("#ba823f"),
+	rgbColor("#7cafc2"), rgbColor("#aa759f"), rgbColor("#86c1b9"), rgbColor("#383838"),
+	rgbColor("#b8b8b8"), rgbColor("#a03e35"), rgbColor("#a1b56c"), rgbColor("#ba823f"),
+	rgbColor("#7cafc2"), rgbColor("#aa759f"), rgbColor("#86c1b9"), rgbColor("#181818"),
+}
+
+// rgbColor parses a "#rrggbb" literal into a color. The assumed palettes
+// call it at package init. A malformed literal would silently decode to
+// black, so keep the literals valid. The tests exercise every slot.
+func rgbColor(hex string) color.RGBA {
+	var c color.RGBA
+	_, _ = fmt.Sscanf(hex, "#%02x%02x%02x", &c.R, &c.G, &c.B)
+	c.A = 0xff
+	return c
+}
+
+// resolveString turns a single TOML color string into a color.Color. An
+// ANSI index 0..15 first asks the terminal palette. Without a palette
+// answer, the assumed Base16-style hex for the current background
+// polarity stands in. The terminal then renders the exact value the
+// contrast math used. An index must not fall through to lipgloss here:
+// lipgloss answers with its VGA defaults. Those defaults sit on the wrong
+// lightness side for themed terminals, so every computed foreground
+// flipped polarity against the rendered color.
+func resolveString(s string, hasDarkBG bool) color.Color {
 	if idx, ok := ansi16Index(s); ok {
 		if c := activePalette.Lookup(idx); c != nil {
 			return c
 		}
+		if hasDarkBG {
+			return assumedPaletteDark.Lookup(idx)
+		}
+		return assumedPaletteLight.Lookup(idx)
 	}
 	return lipgloss.Color(s)
 }

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -214,6 +214,31 @@ func TestResolveStringWithoutPaletteKeepsContrastPolarity(t *testing.T) {
 	})
 }
 
+// The default theme's form_label must read on its surface in both
+// polarities. A flat "240" (#585858) gave 6.8:1 on the light surface
+// #F9FAFB but only 2.49:1 on the dark surface #111827.
+func TestDefaultThemeFormLabelContrast(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		dark bool
+		min  float64
+	}{
+		{false, 6.8}, // light keeps ANSI 240: 6.81:1 on #F9FAFB
+		{true, 4.5},  // dark takes ANSI 245: 5.14:1 on #111827
+	}
+	for _, tc := range cases {
+		th, err := LoadBuiltinTheme("default", tc.dark)
+		if err != nil {
+			t.Fatalf("LoadBuiltinTheme(default, dark=%v): %v", tc.dark, err)
+		}
+		if ratio := oklch.ContrastRatio(th.Surface, th.FormLabel); ratio < tc.min {
+			t.Errorf("dark=%v: form_label reads %.2f:1 on the surface, want >= %.1f:1",
+				tc.dark, ratio, tc.min)
+		}
+	}
+}
+
 func TestAutoSentinelDerivesFromTextAndSurface(t *testing.T) {
 	// Force palette so "7" and "0" resolve to known hex values.
 	prev := ActivePalette()

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"io"
+	"os"
 	"testing"
 
 	lipgloss "charm.land/lipgloss/v2"
@@ -215,5 +217,33 @@ func TestAnsi16IndexBoundaries(t *testing.T) {
 		if ok != tc.wantOK || (ok && idx != tc.idx) {
 			t.Errorf("ansi16Index(%q) = (%d, %v); want (%d, %v)", tc.in, idx, ok, tc.idx, tc.wantOK)
 		}
+	}
+}
+
+// LoadTheme runs while the TUI owns the terminal. The fallback for an
+// unknown theme must not write to stderr. A stderr write prints over the
+// alternate screen. The warning goes to the state-dir log file instead
+// (see config.SharedStateDirLogger).
+func TestLoadThemeFallbackDoesNotWriteToStderr(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	th := LoadTheme("does-not-exist", true)
+	os.Stderr = old
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("LoadTheme wrote to stderr: %q", data)
+	}
+	if th.Primary == nil {
+		t.Fatal("fallback theme should still populate tokens")
 	}
 }

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -217,3 +217,22 @@ func TestAnsi16IndexBoundaries(t *testing.T) {
 		}
 	}
 }
+
+// TestAutoSentinelRejectedOnNonDerivedTokens pins the authoring guard. The
+// "auto" sentinel has a derivation only for text_dim and muted. Any other
+// token set to "auto" must fail the load instead of leaving a nil color.
+func TestAutoSentinelRejectedOnNonDerivedTokens(t *testing.T) {
+	r := rawTheme{Accent: "auto", Muted: "auto"}
+	if _, err := resolveTheme(&r, true); err == nil {
+		t.Fatal("resolveTheme accepted \"auto\" on accent, want an authoring error")
+	}
+
+	// The derived tokens themselves stay accepted on a real theme.
+	th, err := LoadBuiltinTheme("system", true)
+	if err != nil {
+		t.Fatalf("LoadBuiltinTheme(system): %v", err)
+	}
+	if th.TextDim == nil || th.Muted == nil {
+		t.Error("text_dim/muted did not resolve from the auto sentinel")
+	}
+}

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -3,9 +3,12 @@ package tui
 import (
 	"io"
 	"os"
+	"strconv"
 	"testing"
 
 	lipgloss "charm.land/lipgloss/v2"
+
+	"github.com/douglasdemoura/chroncal/internal/tui/oklch"
 )
 
 func TestLoadBuiltinDefault(t *testing.T) {
@@ -133,32 +136,82 @@ func TestResolveStringHonorsActivePalette(t *testing.T) {
 	pal[4] = lipgloss.Color("#123456")
 	SetActivePalette(&pal)
 
-	got := resolveString("4")
+	got := resolveString("4", true)
 	r, g, b, _ := got.RGBA()
 	if r>>8 != 0x12 || g>>8 != 0x34 || b>>8 != 0x56 {
 		t.Errorf("expected palette[4] hex #123456, got rgb(%02x, %02x, %02x)", r>>8, g>>8, b>>8)
 	}
+	// The palette wins in both polarities.
+	got = resolveString("4", false)
+	r, g, b, _ = got.RGBA()
+	if r>>8 != 0x12 || g>>8 != 0x34 || b>>8 != 0x56 {
+		t.Errorf("light mode: expected palette[4] hex #123456, got rgb(%02x, %02x, %02x)", r>>8, g>>8, b>>8)
+	}
 
 	// Out-of-range ANSI indices fall through to lipgloss.
-	if c := resolveString("240"); c == nil {
+	if c := resolveString("240", true); c == nil {
 		t.Errorf("ANSI 240 should fall through to lipgloss, not panic or return nil")
 	}
 	// Hex strings always fall through to lipgloss regardless of palette.
-	hex := resolveString("#abcdef")
+	hex := resolveString("#abcdef", true)
 	hr, hg, hb, _ := hex.RGBA()
 	if hr>>8 != 0xab || hg>>8 != 0xcd || hb>>8 != 0xef {
 		t.Errorf("hex string should not be palette-translated, got rgb(%02x, %02x, %02x)", hr>>8, hg>>8, hb>>8)
 	}
 }
 
-func TestResolveStringWithoutPaletteFallsBack(t *testing.T) {
+// A terminal that does not answer OSC 4 (older terminals, tmux without
+// passthrough) must still get readable accent pairs. Index 8 used to fall
+// through to lipgloss's VGA gray #808080. That gray sits at OKLCh L 0.60,
+// so ContrastingFg picked a dark foreground while themed terminals render
+// slot 8 on the dark side. The button pair then read 1.62:1.
+func TestResolveStringWithoutPaletteKeepsContrastPolarity(t *testing.T) {
 	prev := ActivePalette()
 	t.Cleanup(func() { SetActivePalette(prev) })
 	SetActivePalette(nil)
 
-	if c := resolveString("4"); c == nil {
-		t.Fatal("nil palette must not turn ANSI 4 into a nil color")
+	t.Run("reported bug: dark-mode slot 8", func(t *testing.T) {
+		bg := resolveString("8", true)
+		r, g, b, _ := bg.RGBA()
+		if r>>8 == 0x80 && g>>8 == 0x80 && b>>8 == 0x80 {
+			t.Fatal("slot 8 resolved to the VGA default #808080; want an assumed dark Base16 hex")
+		}
+		bgL, _, _, ok := oklch.FromColor(bg)
+		if !ok || bgL >= 0.55 {
+			t.Fatalf("dark-mode slot 8 L=%.3f, want < 0.550 so the pill reads dark", bgL)
+		}
+		fg := oklch.ContrastingFg(bg)
+		if ratio := oklch.ContrastRatio(bg, fg); ratio < 4.5 {
+			t.Errorf("slot 8 pair reads %.2f:1, want >= 4.50:1", ratio)
+		}
+	})
+
+	// Every ANSI reference a theme may carry, in both polarities. A slot
+	// with a computed foreground must stay readable in degraded mode.
+	for _, tc := range []struct {
+		mode string
+		dark bool
+	}{
+		{"dark", true},
+		{"light", false},
+	} {
+		for idx := range assumedPaletteDark {
+			bg := resolveString(strconv.Itoa(idx), tc.dark)
+			fg := oklch.ContrastingFg(bg)
+			if ratio := oklch.ContrastRatio(bg, fg); ratio < 4.5 {
+				t.Errorf("%s mode: slot %d pair reads %.2f:1, want >= 4.50:1", tc.mode, idx, ratio)
+			}
+		}
 	}
+
+	t.Run("non-ANSI strings still fall through", func(t *testing.T) {
+		if c := resolveString("4", true); c == nil {
+			t.Fatal("nil palette must not turn ANSI 4 into a nil color")
+		}
+		if c := resolveString("240", true); c == nil {
+			t.Error("ANSI 240 should fall through to lipgloss, not panic or return nil")
+		}
+	})
 }
 
 func TestAutoSentinelDerivesFromTextAndSurface(t *testing.T) {

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -225,6 +225,12 @@ func TestAnsi16IndexBoundaries(t *testing.T) {
 // alternate screen. The warning goes to the state-dir log file instead
 // (see config.SharedStateDirLogger).
 func TestLoadThemeFallbackDoesNotWriteToStderr(t *testing.T) {
+	// The fallback warning goes through the memoized
+	// config.SharedStateDirLogger. Point XDG_STATE_HOME at a scratch
+	// dir so the test never writes to the developer's real
+	// chroncal.log (see sync_warnings_test.go for the same guard).
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)

--- a/internal/tui/theme_tokens_test.go
+++ b/internal/tui/theme_tokens_test.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"image/color"
+	"reflect"
+	"testing"
+)
+
+// TestBuiltinThemesResolveEveryToken guards the theme token registry. The
+// Theme struct, the raw TOML mapping, the resolve picks, the fingerprint, and
+// every themes/*.toml are hand-synced. A forgotten key or a missed wiring used
+// to surface only as a silent runtime fallback to the default theme. This test
+// fails instead: every color.Color field of both built-in themes must resolve,
+// in dark and light variants.
+func TestBuiltinThemesResolveEveryToken(t *testing.T) {
+	colorType := reflect.TypeFor[color.Color]()
+	for _, name := range BuiltinThemeNames() {
+		for _, dark := range []bool{true, false} {
+			theme, err := LoadBuiltinTheme(name, dark)
+			if err != nil {
+				t.Fatalf("LoadBuiltinTheme(%q, dark=%v): %v", name, dark, err)
+			}
+			v := reflect.ValueOf(theme)
+			typ := v.Type()
+			for i := 0; i < v.NumField(); i++ {
+				field := typ.Field(i)
+				if field.Type != colorType {
+					continue
+				}
+				if v.Field(i).IsNil() {
+					t.Errorf("%s (dark=%v): token %s did not resolve", name, dark, field.Name)
+				}
+			}
+		}
+	}
+}

--- a/internal/tui/themes/default.toml
+++ b/internal/tui/themes/default.toml
@@ -46,7 +46,10 @@ badge_neutral = "240"
 # Form internals
 # ---------------------------------------------------------------------------
 
-form_label     = "240"
+# Labels must read on the surface below them. Flat "240" (#585858) gives
+# 6.8:1 on the light surface #F9FAFB but only 2.5:1 on the dark surface
+# #111827. Keep 240 for light. Use 245 (#8a8a8a, 5.1:1) for dark.
+form_label     = { light = "240", dark = "245" }
 form_required  = "9"
 form_error     = "9"
 form_highlight = "63"

--- a/internal/tui/themes/default.toml
+++ b/internal/tui/themes/default.toml
@@ -33,7 +33,8 @@ surface        = { light = "#F9FAFB", dark = "#111827" }
 error          = { light = "#DC2626", dark = "#F87171" }
 
 # ---------------------------------------------------------------------------
-# Badges (BadgeText is the shared foreground)
+# Badges. The text-on-badge foreground is computed at render time via
+# oklch.ContrastingFg, so there is no badge text token.
 # ---------------------------------------------------------------------------
 
 badge_ok      = "28"
@@ -52,7 +53,8 @@ form_error     = "9"
 form_highlight = "63"
 
 # ---------------------------------------------------------------------------
-# Buttons (ButtonText is the shared foreground)
+# Buttons. The label foreground comes from Text or Error, so there is
+# no separate button text token.
 # ---------------------------------------------------------------------------
 
 button_bg = "240"

--- a/internal/tui/themes/default.toml
+++ b/internal/tui/themes/default.toml
@@ -18,7 +18,6 @@ description = "Default tcal theme — structural chrome adapts to terminal backg
 # ---------------------------------------------------------------------------
 
 primary   = { light = "#7C3AED", dark = "#A78BFA" }
-secondary = { light = "#0284C7", dark = "#38BDF8" }
 accent    = { light = "#059669", dark = "#34D399" }
 muted     = { light = "#9CA3AF", dark = "#6B7280" }
 text      = { light = "#1F2937", dark = "#F9FAFB" }

--- a/internal/tui/themes/system.toml
+++ b/internal/tui/themes/system.toml
@@ -68,7 +68,6 @@ selected_text = "7"   # base05 reads on a neutral gray on both modes
 # ---------------------------------------------------------------------------
 
 primary   = "4"   # base0D blue — brand accent (calendar selected cell border)
-secondary = "6"   # base0C cyan
 accent    = "2"   # base0B green — positive actions
 today     = "1"   # base08 red — "now line", today indicator
 error     = "1"   # base08 red

--- a/internal/tui/themes/system.toml
+++ b/internal/tui/themes/system.toml
@@ -25,7 +25,7 @@
 #
 #   0 base00  background           4 base0D  blue   (primary accent)
 #   1 base08  red    (danger)      5 base0E  magenta (focus highlight)
-#   2 base0B  green  (positive)    6 base0C  cyan   (secondary accent)
+#   2 base0B  green  (positive)    6 base0C  cyan   (cyan accent)
 #   3 base0A  yellow (warning)     7 base05  default foreground
 #   8 base03  comment/dim         15 base07  inverted bg / brightest
 #

--- a/internal/tui/themes/system.toml
+++ b/internal/tui/themes/system.toml
@@ -40,8 +40,8 @@ description = "Terminal ANSI palette for every chrome and accent slot"
 # ---------------------------------------------------------------------------
 
 text     = "7"      # base05 — default foreground (always contrasts with bg)
-text_dim = "auto"   # OKLab mix of text+surface (60/40); see note below
-muted    = "auto"   # OKLab mix of text+surface (45/55) — a notch dimmer
+text_dim = "auto"   # OKLab mix of text+surface (70/30); see note below
+muted    = "auto"   # OKLab mix of text+surface (55/45) — a notch dimmer
 border   = "8"      # base03 — panel borders (acceptable to be dim, structural line)
 surface  = "0"      # base00 — panel background, matches terminal default
 

--- a/internal/tui/themes/system.toml
+++ b/internal/tui/themes/system.toml
@@ -13,10 +13,12 @@
 #     rather than guessed from lipgloss's default ANSI table.
 #
 # When the terminal doesn't answer OSC 4 (older terminals, tmux without
-# passthrough), lipgloss renders the ANSI references directly — still
-# correct, just without the OKLCh-on-real-hex precision. Text-on-accent
-# foregrounds are computed at render time via oklch.ContrastingFg, so we
-# no longer ship button_text / badge_text tokens.
+# passthrough), the loader substitutes static Base16-style hexes for the
+# ANSI references. The terminal then renders the exact value the OKLCh
+# contrast math used, so a background and its computed foreground cannot
+# disagree about polarity. Text-on-accent foregrounds are computed at
+# render time via oklch.ContrastingFg, so we no longer ship
+# button_text / badge_text tokens.
 #
 # Base16-aligned palette assumptions (de-facto standard across Omarchy,
 # Catppuccin, Gruvbox, Tokyo Night, Nord, etc.):


### PR DESCRIPTION
## Problem
`userOrganizesEvent` collapsed every lookup error into `true`. A SQLITE_BUSY (or any read failure) during the organizer check pushed an attendee's meeting into a PUT that RFC 4791 lets the server reject — a guaranteed-failing push that repeated every cycle and wedged the resource. Fail-closed would be equally wrong: it would clear the dirty flag for a legitimate event on a transient error.

## Fix
The gate returns `(bool, error)`: `sql.ErrNoRows` still means "no organizer known" (orphaned dirty rows stay pushable); any other failure propagates. The push loop records the error and keeps the row dirty for the next pass.

## Verification
New tests cover both paths (missing row → true; closed DB → propagated error). Full `internal/sync` package passes.

Assisted-by: opencode-zen:x-preview-f-free