### PR TITLE
fix(ical): strip the mailto prefix in any letter case

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -279,8 +279,12 @@ func parseAttendees(ve ical.Event) ([]model.Attendee, []string) {
 	return attendees, warns
 }
 
+// stripMailto removes the CAL-ADDRESS scheme prefix in any letter case.
 func stripMailto(s string) string {
-	return strings.TrimPrefix(strings.TrimPrefix(s, "mailto:"), "MAILTO:")
+	if len(s) >= 7 && strings.EqualFold(s[:7], "mailto:") {
+		return s[7:]
+	}
+	return s
 }
 
 func paramOrDefault(prop *ical.Prop, param, def string) string {

--- a/internal/ical/mailto_test.go
+++ b/internal/ical/mailto_test.go
@@ -1,0 +1,19 @@
+package ical
+
+import "testing"
+
+func TestStripMailtoAnyCase(t *testing.T) {
+	cases := map[string]string{
+		"mailto:ALICE@example.com": "ALICE@example.com",
+		"MAILTO:alice@example.com": "alice@example.com",
+		"Mailto:bob@example.com":   "bob@example.com",
+		"maIlTo:carol@example.com": "carol@example.com",
+		"alice@example.com":        "alice@example.com",
+		"":                         "",
+	}
+	for in, want := range cases {
+		if got := stripMailto(in); got != want {
+			t.Errorf("stripMailto(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`stripMailto` handled only `mailto:` and `MAILTO:`. Mixed case (`Mailto:`, emitted by several producers) kept its prefix, so attendee/organizer emails and export URIs were malformed.

## Fix
Case-insensitive prefix check, matching `stripMailtoPrefix` in internal/sync.

## Verification
New table test over mixed-case, upper-case, bare, and empty inputs. Full `internal/ical` package passes.

Assisted-by: opencode-zen:x-preview-f-free