### PR TITLE
fix(ical): reject out-of-range UTC-OFFSET components

### DIFF
--- a/internal/ical/vtimezone.go
+++ b/internal/ical/vtimezone.go
@@ -123,6 +123,9 @@ func parseUTCOffset(s string) (int, error) {
 			return 0, err
 		}
 	}
+	if hours > 23 || minutes > 59 || seconds > 59 {
+		return 0, fmt.Errorf("utc-offset component out of range: %q", s)
+	}
 	return sign * (hours*3600 + minutes*60 + seconds), nil
 }
 

--- a/internal/ical/vtimezone_offset_test.go
+++ b/internal/ical/vtimezone_offset_test.go
@@ -1,0 +1,26 @@
+package ical
+
+import "testing"
+
+func TestParseUTCOffsetRange(t *testing.T) {
+	valid := map[string]int{
+		"+0530":   5*3600 + 30*60,
+		"-0800":   -8 * 3600,
+		"+0000":   0,
+		"+2359":   23*3600 + 59*60,
+		"-233059": -(23*3600 + 30*60 + 59),
+	}
+	for in, want := range valid {
+		got, err := parseUTCOffset(in)
+		if err != nil || got != want {
+			t.Errorf("parseUTCOffset(%q) = %d, %v; want %d, nil", in, got, err, want)
+		}
+	}
+
+	invalid := []string{"+9930", "+0599", "-006099", "+2400"}
+	for _, in := range invalid {
+		if got, err := parseUTCOffset(in); err == nil {
+			t.Errorf("parseUTCOffset(%q) = %d, nil; want out-of-range error", in, got)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`parseUTCOffset` validated length and digits only. Values such as `+9930`, `+0599`, or `-006099` parsed fine and produced nonsense `time.FixedZone` offsets.

## Fix
Reject hours > 23, minutes > 59, seconds > 59. Callers already skip a failed definition, so behavior degrades to the existing path.

## Verification
Table test over valid boundaries (+2359, -233059) and out-of-range inputs. Full `internal/ical` package passes.

Assisted-by: opencode-zen:x-preview-f-free