### PR TITLE
fix(icaltransfer): count a first-time override as a new row

### DIFF
--- a/internal/icaltransfer/transfer.go
+++ b/internal/icaltransfer/transfer.go
@@ -199,7 +199,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import events.
 	for _, e := range result.Events {
-		_, lookupErr := lookupEvent(a.Events, ctx, e.UID, e.RecurrenceID)
+		_, lookupErr := lookupEvent(ctx, a.Events, e.UID, e.RecurrenceID)
 		saved, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
 			UID: e.UID, CalendarID: calendarID,
 			Title: e.Title, Description: e.Description, Location: e.Location,
@@ -228,7 +228,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import todos.
 	for _, t := range result.Todos {
-		_, lookupErr := lookupTodo(a.Todos, ctx, t.UID, t.RecurrenceID)
+		_, lookupErr := lookupTodo(ctx, a.Todos, t.UID, t.RecurrenceID)
 		saved, err := a.Todos.UpsertByUID(ctx, todo.UpsertParams{
 			UID: t.UID, CalendarID: calendarID,
 			Summary: t.Summary, Description: t.Description, Location: t.Location,
@@ -257,7 +257,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import journals.
 	for _, j := range result.Journals {
-		_, lookupErr := lookupJournal(a.Journals, ctx, j.UID, j.RecurrenceID)
+		_, lookupErr := lookupJournal(ctx, a.Journals, j.UID, j.RecurrenceID)
 		saved, err := a.Journals.UpsertByUID(ctx, journal.UpsertParams{
 			UID: j.UID, CalendarID: calendarID,
 			Summary: j.Summary, Description: j.Description,
@@ -480,7 +480,7 @@ func ExportCalendarFile(ctx context.Context, a *app.App, calendarID int64, calen
 // lookupEvent reports whether an imported event row already exists. An
 // override (a non-empty recurrence_id) must match its own row, not the
 // master, so the summary counts a first-time override as new.
-func lookupEvent(svc *event.Service, ctx context.Context, uid, recurrenceID string) (event.Event, error) {
+func lookupEvent(ctx context.Context, svc *event.Service, uid, recurrenceID string) (event.Event, error) {
 	if recurrenceID != "" {
 		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
 	}
@@ -488,7 +488,7 @@ func lookupEvent(svc *event.Service, ctx context.Context, uid, recurrenceID stri
 }
 
 // lookupTodo reports whether an imported todo row already exists.
-func lookupTodo(svc *todo.Service, ctx context.Context, uid, recurrenceID string) (todo.Todo, error) {
+func lookupTodo(ctx context.Context, svc *todo.Service, uid, recurrenceID string) (todo.Todo, error) {
 	if recurrenceID != "" {
 		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
 	}
@@ -496,7 +496,7 @@ func lookupTodo(svc *todo.Service, ctx context.Context, uid, recurrenceID string
 }
 
 // lookupJournal reports whether an imported journal row already exists.
-func lookupJournal(svc *journal.Service, ctx context.Context, uid, recurrenceID string) (journal.Journal, error) {
+func lookupJournal(ctx context.Context, svc *journal.Service, uid, recurrenceID string) (journal.Journal, error) {
 	if recurrenceID != "" {
 		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
 	}

--- a/internal/icaltransfer/transfer.go
+++ b/internal/icaltransfer/transfer.go
@@ -199,7 +199,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import events.
 	for _, e := range result.Events {
-		_, lookupErr := a.Events.GetByUID(ctx, e.UID)
+		_, lookupErr := lookupEvent(a.Events, ctx, e.UID, e.RecurrenceID)
 		saved, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
 			UID: e.UID, CalendarID: calendarID,
 			Title: e.Title, Description: e.Description, Location: e.Location,
@@ -228,7 +228,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import todos.
 	for _, t := range result.Todos {
-		_, lookupErr := a.Todos.GetByUID(ctx, t.UID)
+		_, lookupErr := lookupTodo(a.Todos, ctx, t.UID, t.RecurrenceID)
 		saved, err := a.Todos.UpsertByUID(ctx, todo.UpsertParams{
 			UID: t.UID, CalendarID: calendarID,
 			Summary: t.Summary, Description: t.Description, Location: t.Location,
@@ -257,7 +257,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import journals.
 	for _, j := range result.Journals {
-		_, lookupErr := a.Journals.GetByUID(ctx, j.UID)
+		_, lookupErr := lookupJournal(a.Journals, ctx, j.UID, j.RecurrenceID)
 		saved, err := a.Journals.UpsertByUID(ctx, journal.UpsertParams{
 			UID: j.UID, CalendarID: calendarID,
 			Summary: j.Summary, Description: j.Description,
@@ -475,4 +475,30 @@ func ExportCalendarFile(ctx context.Context, a *app.App, calendarID int64, calen
 		return summary, fmt.Errorf("write file: %w", err)
 	}
 	return summary, nil
+}
+
+// lookupEvent reports whether an imported event row already exists. An
+// override (a non-empty recurrence_id) must match its own row, not the
+// master, so the summary counts a first-time override as new.
+func lookupEvent(svc *event.Service, ctx context.Context, uid, recurrenceID string) (event.Event, error) {
+	if recurrenceID != "" {
+		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
+	}
+	return svc.GetByUID(ctx, uid)
+}
+
+// lookupTodo reports whether an imported todo row already exists.
+func lookupTodo(svc *todo.Service, ctx context.Context, uid, recurrenceID string) (todo.Todo, error) {
+	if recurrenceID != "" {
+		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
+	}
+	return svc.GetByUID(ctx, uid)
+}
+
+// lookupJournal reports whether an imported journal row already exists.
+func lookupJournal(svc *journal.Service, ctx context.Context, uid, recurrenceID string) (journal.Journal, error) {
+	if recurrenceID != "" {
+		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
+	}
+	return svc.GetByUID(ctx, uid)
 }

--- a/internal/icaltransfer/transfer_test.go
+++ b/internal/icaltransfer/transfer_test.go
@@ -368,3 +368,42 @@ func TestExportCalendarFileEmptyCalendarDoesNotCreateFile(t *testing.T) {
 		t.Fatalf("empty export created file: %v", statErr)
 	}
 }
+
+// TestImport_FirstTimeOverrideCountsAsNew extends the UID upsert contract to
+// overrides. A first-time override shares the master's UID, so a plain
+// GetByUID matched it and counted it as updated. The override lookup must
+// match its own row through its recurrence_id.
+func TestImport_FirstTimeOverrideCountsAsNew(t *testing.T) {
+	ctx := context.Background()
+	a := newTestApp(t)
+	cal, err := a.Calendars.Create(ctx, "Work", "", "")
+	if err != nil {
+		t.Fatalf("create calendar: %v", err)
+	}
+
+	start := time.Date(2026, 4, 21, 9, 0, 0, 0, time.UTC)
+	if _, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
+		UID: "evt-series", CalendarID: cal.ID, Title: "Master",
+		StartTime: start, EndTime: start.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed master: %v", err)
+	}
+
+	overrideAt := start.Add(24 * time.Hour)
+	result := &ical.ImportResult{Events: []event.Event{{
+		UID: "evt-series", Title: "Moved instance",
+		StartTime: overrideAt, EndTime: overrideAt.Add(time.Hour),
+		RecurrenceID: overrideAt.Format(time.RFC3339),
+	}}}
+	summary := icaltransfer.Import(ctx, a, cal.ID, result)
+
+	if summary.NewEvents != 1 {
+		t.Errorf("NewEvents = %d, want 1 (first-time override is new, not an update of the master)", summary.NewEvents)
+	}
+	if summary.UpdatedEvents != 0 {
+		t.Errorf("UpdatedEvents = %d, want 0", summary.UpdatedEvents)
+	}
+	if _, err := a.Events.GetByUIDAndRecurrenceID(ctx, "evt-series", overrideAt.Format(time.RFC3339)); err != nil {
+		t.Errorf("override row not persisted: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem
The import summary looked rows up with plain `GetByUID`. A first-time override (same UID as its master, own `recurrence_id`) matched the master, so it was reported as **updated** instead of new — import summaries understated additions for any file carrying recurring overrides.

## Fix
Small per-domain lookup helpers: a non-empty recurrence_id resolves through `GetByUIDAndRecurrenceID`, otherwise plain `GetByUID`.

## Verification
New `TestImport_FirstTimeOverrideCountsAsNew` asserts New=1 / Updated=0 and that the override row persisted. Full `internal/icaltransfer` + `internal/ical` packages pass.

Assisted-by: opencode-zen:x-preview-f-free