### PR TITLE
refactor(ical): dedupe event attendee/category parsing, drop addDuration wrapper

### DIFF
--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -393,9 +393,10 @@ func parseDateListFromProps(props ical.Props, propName string, fallback *time.Lo
 	return strings.Join(dates, ",")
 }
 
-// parseAttendeesFromProps reads the attendees of a VTODO or a VJOURNAL.
-// Those two tables accept the wider PARTSTAT set, so the caller passes
-// model.TaskAttendee. The second return value lists the clamps.
+// parseAttendeesFromProps reads the attendees of a VEVENT, a VTODO, or a
+// VJOURNAL. The kind parameter selects the PARTSTAT set that is valid for
+// the component: model.EventAttendee for a VEVENT, model.TaskAttendee for a
+// VTODO and a VJOURNAL. The second return value lists the clamps.
 func parseAttendeesFromProps(props ical.Props, kind model.AttendeeKind) ([]model.Attendee, []string) {
 	var attendees []model.Attendee
 	var warns []string

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/emersion/go-ical"
 
-	"github.com/douglasdemoura/chroncal/internal/duration"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/freebusy"
 	"github.com/douglasdemoura/chroncal/internal/journal"
@@ -241,42 +240,6 @@ func parseDateProp(props ical.Props, kind, name, uid string) (string, string) {
 		return t.Format("2006-01-02"), ""
 	}
 	return t.UTC().Format(time.RFC3339), ""
-}
-
-// parseAttendees reads the attendees of a VEVENT. The second return
-// value lists the parameters attendeeFromProp clamped.
-func parseAttendees(ve ical.Event) ([]model.Attendee, []string) {
-	var attendees []model.Attendee
-	var warns []string
-
-	// ORGANIZER — track email so we can deduplicate against ATTENDEE below.
-	var organizerEmail string
-	if prop := ve.Props.Get(ical.PropOrganizer); prop != nil {
-		organizerEmail = stripMailto(prop.Value)
-		attendees = append(attendees, model.Attendee{
-			Email:      organizerEmail,
-			Name:       prop.Params.Get(ical.ParamCommonName),
-			RSVPStatus: "ACCEPTED",
-			Role:       "CHAIR",
-			Organizer:  true,
-			SentBy:     stripMailto(prop.Params.Get(ical.ParamSentBy)),
-			Dir:        prop.Params.Get(ical.ParamDir),
-			Language:   prop.Params.Get(ical.ParamLanguage),
-		})
-	}
-
-	// ATTENDEE properties — skip duplicates of the ORGANIZER email.
-	for _, prop := range ve.Props.Values(ical.PropAttendee) {
-		email := stripMailto(prop.Value)
-		if organizerEmail != "" && strings.EqualFold(email, organizerEmail) {
-			continue
-		}
-		a, w := attendeeFromProp(&prop, model.EventAttendee)
-		warns = append(warns, w...)
-		attendees = append(attendees, a)
-	}
-
-	return attendees, warns
 }
 
 // stripMailto removes the CAL-ADDRESS scheme prefix in any letter case.
@@ -540,12 +503,6 @@ func floatingOrTZ(floating bool, tz string) string {
 		return "FLOATING"
 	}
 	return tz
-}
-
-// addDuration parses an RFC 5545 duration string and adds it to a time.
-// Format: [+/-]P[nW] or [+/-]P[nD][T[nH][nM][nS]]
-func addDuration(t time.Time, dur string) time.Time {
-	return duration.Add(t, dur)
 }
 
 // decodeInlineAttachment decodes a BASE64 ATTACH value and enforces the inline

--- a/internal/ical/import_event.go
+++ b/internal/ical/import_event.go
@@ -77,7 +77,7 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 		if prop != nil && duration.ValidateSpan(prop.Value) == nil {
 			// The end must land on a time the database can hold. See
 			// timeutil.Storable for that rule.
-			if end := addDuration(startTime, prop.Value); timeutil.Storable(end) {
+			if end := duration.Add(startTime, prop.Value); timeutil.Storable(end) {
 				durationValue = prop.Value
 				endTime = end
 				explicitEnd = true
@@ -87,7 +87,7 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 		if spanOK {
 			// The DURATION above is the span.
 		} else if prop != nil && duration.Validate(prop.Value) == nil &&
-			addDuration(startTime, prop.Value).Equal(startTime) {
+			duration.Add(startTime, prop.Value).Equal(startTime) {
 			// An exact zero span (DURATION:PT0S). RFC 5545 §3.6.1 gives
 			// the same meaning to a VEVENT with no DTEND and no
 			// DURATION, so store the equivalent zero-length event. Drop
@@ -181,7 +181,7 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 		geo = prop.Value
 	}
 
-	categories := parseCategories(ve)
+	categories := parseCategoriesFromProps(ve.Props)
 	exdates := parseDateListFromProps(ve.Props, ical.PropExceptionDates, dtstartZone(ve.Props))
 	rdates := parseDateListFromProps(ve.Props, ical.PropRecurrenceDates, dtstartZone(ve.Props))
 
@@ -215,7 +215,7 @@ func eventFromVEvent(ve ical.Event, remote bool) (event.Event, []string, error) 
 	}
 
 	// ATTENDEE + ORGANIZER
-	attendees, attendeeWarnings := parseAttendees(ve)
+	attendees, attendeeWarnings := parseAttendeesFromProps(ve.Props, model.EventAttendee)
 	for _, w := range attendeeWarnings {
 		// Name the owning record: the clamp leaves no other trace.
 		childWarnings = append(childWarnings, fmt.Sprintf("event %q: %s", uid, w))
@@ -289,22 +289,6 @@ func textOrDefault(ve ical.Event, prop, def string) string {
 		return v
 	}
 	return def
-}
-
-func parseCategories(ve ical.Event) string {
-	var cats []string
-	for _, prop := range ve.Props.Values(ical.PropCategories) {
-		// TextList splits on unescaped commas and unescapes each value,
-		// handling both RFC-correct "CATEGORIES:a,b" and legacy
-		// escaped "CATEGORIES:a\,b" inputs.
-		if list, err := prop.TextList(); err == nil {
-			cats = append(cats, list...)
-		}
-	}
-	// Join with comma-escaping so a category value that itself contains a
-	// comma (e.g. "Foo, Bar") stays a single value through the in-memory
-	// comma-joined representation instead of fragmenting on round-trip.
-	return timeutil.JoinCategoryList(cats)
 }
 
 // handledEventProps is the set of property names explicitly parsed by eventFromVEvent.


### PR DESCRIPTION
## Problem
`parseAttendees` (import.go) duplicated `parseAttendeesFromProps` line-for-line except for the AttendeeKind constant; `parseCategories` likewise duplicated `parseCategoriesFromProps` including its escaping commentary. A future organizer field would land in one copy only. `addDuration` restated `duration.Add` verbatim.

## Fix
VEVENT parsing delegates to the FromProps variants (`model.EventAttendee`). Both wrappers deleted; call sites updated.

## Verification
Behavior-preserving: full `internal/ical` package passes unchanged, including round-trip golden tests.

Assisted-by: opencode-zen:x-preview-f-free