### PR TITLE
fix(auth): write plaintext credentials atomically and enforce 0600

### DIFF
--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -275,12 +275,28 @@ func (s *PlaintextFileStore) Set(cred Credential) error {
 		tmp.Close()
 		return fmt.Errorf("write credential: %w", err)
 	}
+	// Sync the data before the rename. Without the sync, a power loss can
+	// persist the rename and lose the data blocks. The write then destroys
+	// the previous secret.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync credential temp file: %w", err)
+	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close credential file: %w", err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
 		return fmt.Errorf("replace credential file: %w", err)
 	}
+	// Sync the directory so the rename survives a power loss. Some
+	// platforms do not support a sync on a directory handle. Ignore that
+	// failure.
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return fmt.Errorf("open credential dir: %w", err)
+	}
+	dir.Sync()
+	dir.Close()
 	w := s.warnWriter()
 	fmt.Fprintf(w, "Warning: credentials stored in plaintext at %s\n", path)
 	if cred.OAuthClientSecret != "" {

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -256,8 +256,30 @@ func (s *PlaintextFileStore) Set(cred Credential) error {
 		return fmt.Errorf("marshal credential: %w", err)
 	}
 	path := s.path(cred.AccountID)
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	// Write through a temp file in the same directory and rename. A crash
+	// or a full disk then leaves the old file intact instead of a truncated
+	// secret. The rename is atomic within one filesystem.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".credential-*")
+	if err != nil {
+		return fmt.Errorf("create credential temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	// os.WriteFile keeps the mode of an existing file. Enforce 0600 on every
+	// write so a pre-existing loose file cannot survive forever.
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("restrict credential file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
 		return fmt.Errorf("write credential: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close credential file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("replace credential file: %w", err)
 	}
 	w := s.warnWriter()
 	fmt.Fprintf(w, "Warning: credentials stored in plaintext at %s\n", path)

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -713,3 +713,39 @@ func TestPlaintextFileStore_WarningsRouteToInjectedWriter(t *testing.T) {
 		t.Errorf("missing OAuth-secret warning; got %q", out)
 	}
 }
+
+// TestPlaintextFileStore_SetTightensLoosePermissions guards the contract
+// that every Set enforces 0600. os.WriteFile keeps the mode of an existing
+// file, so a file created loose once stayed loose forever before the
+// temp-file rename.
+func TestPlaintextFileStore_SetTightensLoosePermissions(t *testing.T) {
+	dir := t.TempDir()
+	store := &PlaintextFileStore{dir: dir, warn: io.Discard}
+
+	path := filepath.Join(dir, "account_7.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("seed loose file: %v", err)
+	}
+
+	if err := store.Set(Credential{AccountID: 7, Username: "bob", Password: "pw"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credential file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file permissions after Set = %o, want 0600", perm)
+	}
+
+	// The atomic rename must leave no temp files behind.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".credential-") {
+			t.Errorf("temp file %s survived Set", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`PlaintextFileStore.Set` wrote directly to the credential file: a crash or full disk could leave a truncated secret, and because `os.WriteFile` preserves an existing file's mode, a file created with loose permissions once stayed loose across every later write.

## Fix
Temp file in the same directory → chmod 0600 → atomic rename; temp files removed on failure.

## Verification
New `TestPlaintextFileStore_SetTightensLoosePermissions` seeds a 0644 file, asserts 0600 after `Set`, and checks no `.credential-*` temp residue. Full `internal/auth` package passes.

Assisted-by: opencode-zen:x-preview-f-free