### PR TITLE
fix(retry): classify transient errors on explicit markers only

### DIFF
--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -283,7 +283,10 @@ func exchangeGoogleCode(ctx context.Context, clientID, clientSecret, code, redir
 
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode != 200 {
-			return nil, fmt.Errorf("token exchange failed (%d): %s", resp.StatusCode, body)
+			// The typed status lets retry.IsTransient classify a transient
+			// exchange failure without scraping the message text.
+			return nil, retry.NewHTTPError(resp.StatusCode,
+				fmt.Errorf("token exchange failed (%d): %s", resp.StatusCode, body))
 		}
 
 		var result struct {
@@ -333,7 +336,10 @@ func RefreshGoogleToken(ctx context.Context, clientID, clientSecret, refreshToke
 
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode != 200 {
-			return nil, fmt.Errorf("token refresh failed (%d): %s", resp.StatusCode, body)
+			// The typed status lets retry.IsTransient classify a transient
+			// refresh failure without scraping the message text.
+			return nil, retry.NewHTTPError(resp.StatusCode,
+				fmt.Errorf("token refresh failed (%d): %s", resp.StatusCode, body))
 		}
 
 		var result struct {

--- a/internal/caldav/auth_test.go
+++ b/internal/caldav/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/douglasdemoura/chroncal/internal/retry"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -151,7 +152,9 @@ func TestOAuth2HTTPClient_FailsFastOnNonTransientRefreshError(t *testing.T) {
 func TestOAuth2HTTPClient_ProceedsWithStaleTokenOnTransientRefreshError(t *testing.T) {
 	prevRefresh := refreshGoogleTokenFn
 	refreshGoogleTokenFn = func(ctx context.Context, clientID, clientSecret, refreshToken string) (*auth.GoogleOAuthResult, error) {
-		return nil, errors.New("token refresh failed (503): Service Unavailable")
+		// Match the production contract: google.go returns a typed status
+		// so IsTransient classifies without scraping the message.
+		return nil, retry.NewHTTPError(503, errors.New("token refresh failed (503): Service Unavailable"))
 	}
 	t.Cleanup(func() { refreshGoogleTokenFn = prevRefresh })
 

--- a/internal/retry/transient.go
+++ b/internal/retry/transient.go
@@ -10,7 +10,11 @@ import (
 	"time"
 )
 
-var httpStatusPattern = regexp.MustCompile(`\b([1-5][0-9][0-9])\b`)
+// The pattern accepts only an explicit status marker: a message that starts
+// with the code ("503 Service Unavailable") or a named prefix ("HTTP 503",
+// "status 503"). A bare \b[0-9]{3}\b scrape also matched batch indices,
+// ports, and host segments, and classified unrelated failures as retryable.
+var httpStatusPattern = regexp.MustCompile(`(?i)(?:^([1-5][0-9][0-9])\b)|(?:\b(?:https?|status)(?: code)?[: =]+([1-5][0-9][0-9]))`)
 
 // TransientError marks an error as retryable. It optionally carries a
 // server-requested minimum delay before the next attempt. One example is the
@@ -103,13 +107,16 @@ func IsTransient(err error) bool {
 		return true
 	}
 
+	// A bare "timeout" substring check is gone. Real timeouts carry the
+	// typed net.Error Timeout method or context.DeadlineExceeded. A text
+	// scrape also matched non-retryable failures whose message merely
+	// mentioned the word.
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "connection reset") ||
 		strings.Contains(msg, "broken pipe") ||
 		strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "no such host") ||
-		strings.Contains(msg, "server misbehaving") ||
-		strings.Contains(msg, "timeout")
+		strings.Contains(msg, "server misbehaving")
 }
 
 // IsRetryableStatus reports whether an HTTP status code is worth a retry:
@@ -145,14 +152,22 @@ func statusCode(err error) int {
 		return httpErr.Status
 	}
 
-	// Fall back to scraping the message for legacy string-only errors.
+	// Fall back to an explicit status marker in the message for legacy
+	// string-only errors. The pattern rejects bare numeric tokens.
 	match := httpStatusPattern.FindStringSubmatch(err.Error())
-	if len(match) != 2 {
+	var token string
+	if len(match) > 1 {
+		token = match[1]
+		if token == "" && len(match) > 2 {
+			token = match[2]
+		}
+	}
+	if token == "" {
 		return 0
 	}
 
 	code := 0
-	for _, r := range match[1] {
+	for _, r := range token {
 		code = (code * 10) + int(r-'0')
 	}
 	return code

--- a/internal/retry/transient_test.go
+++ b/internal/retry/transient_test.go
@@ -119,3 +119,38 @@ func TestIsConflict(t *testing.T) {
 		})
 	}
 }
+
+// TestStatusScrapeRejectsBareTokens pins the tightened scrape. Only an
+// explicit status marker classifies: a leading code or a named prefix.
+// Numeric tokens from ports, batch indices, or hostnames must not count.
+func TestStatusScrapeRejectsBareTokens(t *testing.T) {
+	t.Parallel()
+
+	retryable := []string{
+		"503 Service Unavailable",
+		"http 503 Service Unavailable",
+		"HTTP:429",
+		"status 500 Internal Server Error",
+		"Status Code: 502 Bad Gateway",
+	}
+	for _, msg := range retryable {
+		if !IsRetryableStatus(statusCode(errors.New(msg))) {
+			t.Errorf("statusCode(%q) must classify as a retryable status", msg)
+		}
+	}
+
+	notRetryable := []string{
+		"PUT https://dav.example.com:8443/cal/x.ics failed", // port
+		"multiget batch 100 failed",                         // index
+		"request timeout budget exhausted for item 200",     // prose + number
+		"operation timed out after 300 ms",                  // typed paths cover timeouts; text must not
+	}
+	for _, msg := range notRetryable {
+		if got := IsRetryableStatus(statusCode(errors.New(msg))); got {
+			t.Errorf("statusCode(%q) scraped a retryable status, want 0", msg)
+		}
+		if IsTransient(errors.New(msg)) {
+			t.Errorf("IsTransient(%q) = true via text scrape, want false", msg)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
Two text scrapes over-classified failures as retryable: `statusCode` matched the first 3-digit token anywhere in a message (ports like `:8443`, batch indices, host segments), and `IsTransient` matched any message containing "timeout", including non-retryable failures that merely mention the word. The OAuth refresh path also emitted a string-only error whose `(503)` only a scrape could read.

## Fix
- The scrape now requires an explicit status marker — leading code (`503 ...`) or named prefix (`HTTP 503`, `status code: 429`).
- The bare "timeout" substring is removed; real timeouts are already covered by `net.Error.Timeout()` and `context.DeadlineExceeded`.
- `google.go` token exchange and refresh failures now return typed `retry.HTTPError`, so classification no longer depends on message text at all.

## Verification
New `TestStatusScrapeRejectsBareTokens` pins both directions; existing exchange/refresh retry tests updated to the typed contract and pass. `internal/auth`, `internal/retry`, `internal/caldav`, `internal/sync` all green.

Assisted-by: opencode-zen:x-preview-f-free