### PR TITLE
refactor(storage): use one batch constant for IN-clause chunking

### DIFF
--- a/internal/storage/overrides_dynamic.go
+++ b/internal/storage/overrides_dynamic.go
@@ -2,12 +2,6 @@ package storage
 
 import "context"
 
-// overrideUIDBatch bounds how many UIDs go into a single `uid IN (...)` override
-// query. SQLite (modernc) caps host parameters at 32766. Stay well under that.
-// The batched fetch then does not fail on accounts with very many recurring
-// masters. The cost is a few extra queries instead of one.
-const overrideUIDBatch = 500
-
 // ListOverridesByUIDs returns all recurrence overrides (rows with a non-empty
 // recurrence_id) for the given master UIDs. It is the batched form of
 // ListOverridesByUID, used by recurrence expansion to avoid one SELECT per
@@ -17,7 +11,7 @@ const overrideUIDBatch = 500
 // support.
 func (q *Queries) ListOverridesByUIDs(ctx context.Context, uids []string) ([]Event, error) {
 	var out []Event
-	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, sqliteINBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListOverridesByUIDs */"
 		rows, err := q.queryEvents(ctx, where, args, "uid ASC, recurrence_id ASC")
@@ -32,7 +26,7 @@ func (q *Queries) ListOverridesByUIDs(ctx context.Context, uids []string) ([]Eve
 // ListTodoOverridesByUIDs is the batched form of ListTodoOverridesByUID.
 func (q *Queries) ListTodoOverridesByUIDs(ctx context.Context, uids []string) ([]Todo, error) {
 	var out []Todo
-	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, sqliteINBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListTodoOverridesByUIDs */"
 		rows, err := q.queryTodos(ctx, where, args, "uid ASC, recurrence_id ASC")
@@ -47,7 +41,7 @@ func (q *Queries) ListTodoOverridesByUIDs(ctx context.Context, uids []string) ([
 // ListJournalOverridesByUIDs is the batched form of ListJournalOverridesByUID.
 func (q *Queries) ListJournalOverridesByUIDs(ctx context.Context, uids []string) ([]Journal, error) {
 	var out []Journal
-	for _, chunk := range chunkSlice(uids, overrideUIDBatch) {
+	for _, chunk := range chunkSlice(uids, sqliteINBatch) {
 		placeholders, args := expandStringPlaceholders(chunk)
 		where := "WHERE uid IN (" + placeholders + ") AND recurrence_id != '' AND deleted_at IS NULL /* ListJournalOverridesByUIDs */"
 		rows, err := q.queryJournals(ctx, where, args, "uid ASC, recurrence_id ASC")

--- a/internal/storage/query_builder.go
+++ b/internal/storage/query_builder.go
@@ -51,11 +51,11 @@ func expandInPlaceholders(ids []int64) (string, []interface{}) {
 	return placeholders, args
 }
 
-// loaderIDBatch bounds how many ids go into a single `id IN (...)` batch loader
-// query (categories, attendees). Like overrideUIDBatch it stays well under
-// SQLite's 32766 host-parameter cap. The IN clause then never overflows on wide
-// recurrence expansions. The cost is a few extra queries instead of one.
-const loaderIDBatch = 500
+// sqliteINBatch bounds how many values go into a single `IN (...)` batched
+// query (category/attendee loaders, overrides by UID). SQLite (modernc) caps
+// host parameters at 32766. Stay well under that: the IN clause then never
+// overflows on wide expansions. The cost is a few extra queries instead of one.
+const sqliteINBatch = 500
 
 // dedupeInt64s returns ids with duplicates removed. It keeps first-seen
 // order. Recurrence expansion feeds one id per expanded instance, so the same
@@ -82,7 +82,7 @@ func dedupeInt64s(ids []int64) []int64 {
 // load is small enough for a single `IN (...)` query.
 func loadByIDChunks[T any](ctx context.Context, ids []int64, load func(context.Context, []int64) ([]T, error)) ([]T, error) {
 	var out []T
-	for _, chunk := range chunkSlice(dedupeInt64s(ids), loaderIDBatch) {
+	for _, chunk := range chunkSlice(dedupeInt64s(ids), sqliteINBatch) {
 		rows, err := load(ctx, chunk)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Problem
`loaderIDBatch` (query_builder.go) and `overrideUIDBatch` (overrides_dynamic.go) were two names for the same job — bounding `IN (...)` chunk size under SQLite's 32766 host-parameter cap. Both 500, drifting independently, with the cap rationale duplicated.

## Fix
One shared `sqliteINBatch` constant in query_builder.go carries the documentation once; both call sites consume it.

## Verification
Full `internal/storage` + `internal/recurrence` packages pass unchanged (behavior-preserving).

Note: the category-parity finding is already subsumed by #694's unified params structs, which include Category across list/recurring/export for all three domains.

Assisted-by: opencode-zen:x-preview-f-free