### PR TITLE
docs(tui): correct theme comments and reject stray auto sentinels

### DIFF
--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -283,8 +283,8 @@ func resolveTheme(r *rawTheme, hasDarkBG bool) (Theme, error) {
 
 // isAutoSentinel reports whether a raw TOML color value is the string
 // literal "auto", which signals "compute me at theme-load time from
-// Text and Surface". Currently honored for the text_dim and muted
-// tokens; other fields fall through resolveColor as-is.
+// Text and Surface". Only the text_dim and muted tokens accept "auto".
+// Any other token set to "auto" fails the load with an authoring error.
 func isAutoSentinel(v any) bool {
 	s, ok := v.(string)
 	return ok && s == "auto"

--- a/internal/tui/theme_loader.go
+++ b/internal/tui/theme_loader.go
@@ -207,6 +207,17 @@ func resolveTheme(r *rawTheme, hasDarkBG bool) (Theme, error) {
 		// "auto" is a sentinel for "derive me at the end from other
 		// resolved tokens". Returning nil here lets the post-process
 		// step below fill it in once Text and Surface are known.
+		//
+		// Only text_dim and muted have a derivation. An "auto" value on
+		// any other token is a theme authoring error: reject it loudly
+		// instead of leaving a nil token behind.
+		if isAutoSentinel(v) && field != "text_dim" && field != "muted" {
+			err := fmt.Errorf("field %q: \"auto\" is not supported; only text_dim and muted derive their value", field)
+			if firstErr == nil {
+				firstErr = err
+			}
+			return nil
+		}
 		if isAutoSentinel(v) {
 			return nil
 		}

--- a/internal/tui/theme_loader_test.go
+++ b/internal/tui/theme_loader_test.go
@@ -217,3 +217,22 @@ func TestAnsi16IndexBoundaries(t *testing.T) {
 		}
 	}
 }
+
+// TestAutoSentinelRejectedOnNonDerivedTokens pins the authoring guard. The
+// "auto" sentinel has a derivation only for text_dim and muted. Any other
+// token set to "auto" must fail the load instead of leaving a nil color.
+func TestAutoSentinelRejectedOnNonDerivedTokens(t *testing.T) {
+	r := rawTheme{Accent: "auto", Muted: "auto"}
+	if _, err := resolveTheme(&r, true); err == nil {
+		t.Fatal("resolveTheme accepted \"auto\" on accent, want an authoring error")
+	}
+
+	// The derived tokens themselves stay accepted on a real theme.
+	th, err := LoadBuiltinTheme("system", true)
+	if err != nil {
+		t.Fatalf("LoadBuiltinTheme(system): %v", err)
+	}
+	if th.TextDim == nil || th.Muted == nil {
+		t.Error("text_dim/muted did not resolve from the auto sentinel")
+	}
+}

--- a/internal/tui/themes/default.toml
+++ b/internal/tui/themes/default.toml
@@ -33,7 +33,8 @@ surface        = { light = "#F9FAFB", dark = "#111827" }
 error          = { light = "#DC2626", dark = "#F87171" }
 
 # ---------------------------------------------------------------------------
-# Badges (BadgeText is the shared foreground)
+# Badges. The text-on-badge foreground is computed at render time via
+# oklch.ContrastingFg, so there is no badge text token.
 # ---------------------------------------------------------------------------
 
 badge_ok      = "28"
@@ -52,7 +53,8 @@ form_error     = "9"
 form_highlight = "63"
 
 # ---------------------------------------------------------------------------
-# Buttons (ButtonText is the shared foreground)
+# Buttons. The label foreground comes from Text or Error, so there is
+# no separate button text token.
 # ---------------------------------------------------------------------------
 
 button_bg = "240"

--- a/internal/tui/themes/system.toml
+++ b/internal/tui/themes/system.toml
@@ -40,8 +40,8 @@ description = "Terminal ANSI palette for every chrome and accent slot"
 # ---------------------------------------------------------------------------
 
 text     = "7"      # base05 — default foreground (always contrasts with bg)
-text_dim = "auto"   # OKLab mix of text+surface (60/40); see note below
-muted    = "auto"   # OKLab mix of text+surface (45/55) — a notch dimmer
+text_dim = "auto"   # OKLab mix of text+surface (70/30); see note below
+muted    = "auto"   # OKLab mix of text+surface (55/45) — a notch dimmer
 border   = "8"      # base03 — panel borders (acceptable to be dim, structural line)
 surface  = "0"      # base00 — panel background, matches terminal default
 


### PR DESCRIPTION
## Problem
Three small theme-layer defects: (1) `default.toml` comments referenced removed `BadgeText`/`ButtonText` tokens; (2) `system.toml` documented mix ratios (60/40, 45/55) that contradict the loader's implementation (70/30, 55/45); (3) `resolveTheme` silently accepted the `auto` sentinel on *every* token while deriving only `text_dim`/`muted`, leaving nil tokens on any other field.

## Fix
Comments aligned with code; `auto` on a non-derived token is now a load error naming the field. Swatch-dedup finding skipped: no fallback exists for a missing `calendar_swatches`, so removal would change behavior.

## Verification
New `TestAutoSentinelRejectedOnNonDerivedTokens` covers rejection + derivation paths; full `internal/tui` package green.

Assisted-by: opencode-zen:x-preview-f-free