### PR TITLE
refactor(config): consolidate XDG directory resolution into one helper

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/alarm"
 	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/calendar"
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/fileid"
 	"github.com/douglasdemoura/chroncal/internal/journal"
@@ -127,15 +128,7 @@ func DefaultDBPath() (string, error) {
 // On Linux this follows XDG: $XDG_DATA_HOME or ~/.local/share.
 // On macOS and Windows, config and data share the same path.
 func userDataDir() (string, error) {
-	if runtime.GOOS == "linux" {
-		if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
-			return dir, nil
-		}
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".local", "share"), nil
-	}
-	return os.UserConfigDir()
+	// The env variable now wins on every OS, matching the config and state
+	// resolvers. Previously only Linux read XDG_DATA_HOME.
+	return config.BaseDir("XDG_DATA_HOME", runtime.GOOS, ".local", "share")
 }

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/zalando/go-keyring"
 )
 
@@ -282,26 +283,13 @@ func (s *PlaintextFileStore) path(accountID int64) string {
 	return filepath.Join(s.dir, "db_"+s.namespace, fmt.Sprintf("account_%d.json", accountID))
 }
 
-// appConfigBaseDir returns the OS base config directory. It honours
-// XDG_CONFIG_HOME on every platform. That matches the behaviour of the config
-// loader's configDir. goos is a runtime.GOOS value. It is a parameter so
-// tests can call it with a non-current GOOS to verify cross-platform behaviour.
+// appConfigBaseDir returns the OS base config directory for the credential
+// store. It delegates to config.BaseDir so the config loader and the
+// credential store share one resolver. goos is a runtime.GOOS value. It is
+// a parameter so tests can call it with a non-current GOOS to verify
+// cross-platform behaviour.
 func appConfigBaseDir(goos string) (string, error) {
-	// XDG_CONFIG_HOME takes precedence on every OS, not just Linux.
-	// Many CLI tools adopt this so users on macOS/Windows can relocate
-	// config with a single env var. Checking it first here matches the
-	// behaviour of the config loader (internal/config.configDir).
-	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-		return dir, nil
-	}
-	if goos == "linux" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".config"), nil
-	}
-	return os.UserConfigDir()
+	return config.BaseDir("XDG_CONFIG_HOME", goos, ".config")
 }
 
 func credentialDir() (string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -154,17 +153,5 @@ func newViper() *viper.Viper {
 }
 
 func configDir() (string, error) {
-	// Honour XDG_CONFIG_HOME on every OS. Many CLI tools do this so users
-	// on macOS/Windows can override the default config location.
-	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-		return dir, nil
-	}
-	if runtime.GOOS == "linux" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".config"), nil
-	}
-	return os.UserConfigDir()
+	return BaseDir("XDG_CONFIG_HOME", runtime.GOOS, ".config")
 }

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -85,15 +85,5 @@ func stateFile() (string, error) {
 // stateDir resolves XDG_STATE_HOME. It falls back to ~/.local/state on
 // Linux and os.UserConfigDir() on platforms without a state convention.
 func stateDir() (string, error) {
-	if dir := os.Getenv("XDG_STATE_HOME"); dir != "" {
-		return dir, nil
-	}
-	if runtime.GOOS == "linux" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".local", "state"), nil
-	}
-	return os.UserConfigDir()
+	return BaseDir("XDG_STATE_HOME", runtime.GOOS, ".local", "state")
 }

--- a/internal/config/xdg.go
+++ b/internal/config/xdg.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// BaseDir resolves an XDG-style base directory. env is the XDG variable (for
+// example XDG_STATE_HOME). linuxFallback is the spec path under $HOME for
+// Linux, as relative path segments (for example ".local/state").
+//
+// The env variable wins on every OS, not just Linux. Many CLI tools adopt
+// this so users on macOS and Windows relocate a directory with one setting.
+// On Linux the fallback is the XDG spec path. Other platforms have no
+// convention for that category, so they fall back to os.UserConfigDir.
+func BaseDir(env string, goos string, linuxFallback ...string) (string, error) {
+	if dir := os.Getenv(env); dir != "" {
+		return dir, nil
+	}
+	if goos == "linux" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(append([]string{home}, linuxFallback...)...), nil
+	}
+	return os.UserConfigDir()
+}


### PR DESCRIPTION
## Problem
XDG base-directory resolution lived in four places (`config.configDir`, `config.stateDir`, `app.userDataDir`, `auth.appConfigBaseDir`) with copy-pasted ladders that had already drifted: `userDataDir` honored `XDG_DATA_HOME` only on Linux, while the others honored their variables on every OS.

## Fix
New `config.BaseDir(env, goos, linuxFallback...)`. All four resolvers delegate. The explicit `goos` parameter preserves auth's existing cross-platform tests. One deliberate alignment: `XDG_DATA_HOME` now wins on every OS, matching the documented convention of its siblings.

## Verification
`internal/config`, `internal/app`, `internal/auth` packages pass unchanged — including the existing XDG precedence tests.

Assisted-by: opencode-zen:x-preview-f-free