### PR TITLE
refactor(ical): emit attendees through one shared helper

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -323,3 +323,31 @@ func emitAttachment(props ical.Props, att model.Attachment) {
 	}
 	props.Add(p)
 }
+
+// emitAttendees writes the ORGANIZER and ATTENDEE properties for one
+// component. The organizer uses Set (one per component); attendees append.
+// Text in the CN parameter passes through safeParamValue, because the
+// encoder rejects parameter values that carry a double quote.
+func emitAttendees(props ical.Props, attendees []model.Attendee) {
+	for _, att := range attendees {
+		if att.Organizer {
+			org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
+			org.Value = "mailto:" + att.Email
+			if att.Name != "" {
+				org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
+			}
+			setOrganizerParams(org, att)
+			props.Set(org)
+		}
+
+		attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
+		attendee.Value = "mailto:" + att.Email
+		if att.Name != "" {
+			attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
+		}
+		attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
+		attendee.Params.Set(ical.ParamRole, att.Role)
+		setAttendeeParams(attendee, att)
+		props.Add(attendee)
+	}
+}

--- a/internal/ical/export_events.go
+++ b/internal/ical/export_events.go
@@ -173,28 +173,7 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 			}
 		}
 
-		// ATTENDEE / ORGANIZER
-		for _, att := range e.Attendees {
-			if att.Organizer {
-				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
-				org.Value = "mailto:" + att.Email
-				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-				}
-				setOrganizerParams(org, att)
-				vevent.Props.Set(org)
-			}
-
-			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
-			attendee.Value = "mailto:" + att.Email
-			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-			}
-			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
-			attendee.Params.Set(ical.ParamRole, att.Role)
-			setAttendeeParams(attendee, att)
-			vevent.Props.Add(attendee)
-		}
+		emitAttendees(vevent.Props, e.Attendees)
 
 		cal.Children = append(cal.Children, vevent.Component)
 	}

--- a/internal/ical/export_journals.go
+++ b/internal/ical/export_journals.go
@@ -170,27 +170,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 		// X-Properties (round-trip preservation)
 		emitXProperties(vjournal, j.XProperties)
 
-		// ATTENDEE / ORGANIZER
-		for _, att := range j.Attendees {
-			if att.Organizer {
-				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
-				org.Value = "mailto:" + att.Email
-				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-				}
-				setOrganizerParams(org, att)
-				vjournal.Props.Set(org)
-			}
-			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
-			attendee.Value = "mailto:" + att.Email
-			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-			}
-			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
-			attendee.Params.Set(ical.ParamRole, att.Role)
-			setAttendeeParams(attendee, att)
-			vjournal.Props.Add(attendee)
-		}
+		emitAttendees(vjournal.Props, j.Attendees)
 
 		cal.Children = append(cal.Children, vjournal)
 	}

--- a/internal/ical/export_todos.go
+++ b/internal/ical/export_todos.go
@@ -237,27 +237,7 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			}
 		}
 
-		// ATTENDEE / ORGANIZER
-		for _, att := range t.Attendees {
-			if att.Organizer {
-				org := &ical.Prop{Name: ical.PropOrganizer, Params: make(ical.Params)}
-				org.Value = "mailto:" + att.Email
-				if att.Name != "" {
-					org.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-				}
-				setOrganizerParams(org, att)
-				vtodo.Props.Set(org)
-			}
-			attendee := &ical.Prop{Name: ical.PropAttendee, Params: make(ical.Params)}
-			attendee.Value = "mailto:" + att.Email
-			if att.Name != "" {
-				attendee.Params.Set(ical.ParamCommonName, safeParamValue(att.Name))
-			}
-			attendee.Params.Set(ical.ParamParticipationStatus, att.RSVPStatus)
-			attendee.Params.Set(ical.ParamRole, att.Role)
-			setAttendeeParams(attendee, att)
-			vtodo.Props.Add(attendee)
-		}
+		emitAttendees(vtodo.Props, t.Attendees)
 
 		cal.Children = append(cal.Children, vtodo)
 	}


### PR DESCRIPTION
## Problem
The 30-line ORGANIZER/ATTENDEE block was copy-pasted verbatim into `export_events.go`, `export_todos.go`, and `export_journals.go`. A future organizer field or escaping rule would land in one of three copies.

## Fix
`emitAttendees(props, attendees)` in export.go, called from all three exporters. Mirrors the existing `emitAttachment` precedent.

## Verification
Byte-for-byte output preserved: full `internal/ical` + `internal/icaltransfer` packages (incl. round-trip goldens) pass unchanged.

Assisted-by: opencode-zen:x-preview-f-free