### PR TITLE
refactor(ical): share timestamp/text/relation emission helpers

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -351,3 +351,47 @@ func emitAttendees(props ical.Props, attendees []model.Attendee) {
 		props.Add(attendee)
 	}
 }
+
+// emitTimestamps writes DTSTAMP, CREATED, and LAST-MODIFIED. A parseable
+// dtstamp wins; otherwise the updated timestamp stands in for DTSTAMP.
+func emitTimestamps(props ical.Props, dtstamp string, createdAt, updatedAt time.Time) {
+	if ts, err := time.Parse(time.RFC3339, dtstamp); err == nil {
+		props.SetDateTime(ical.PropDateTimeStamp, ts.UTC())
+	} else {
+		props.SetDateTime(ical.PropDateTimeStamp, updatedAt.UTC())
+	}
+	props.SetDateTime(ical.PropCreated, createdAt.UTC())
+	props.SetDateTime(ical.PropLastModified, updatedAt.UTC())
+}
+
+// emitTextProps appends one TEXT property per value (COMMENT, CONTACT).
+func emitTextProps(props ical.Props, name string, values []string) {
+	for _, c := range values {
+		p := &ical.Prop{Name: name}
+		p.SetText(c)
+		props.Add(p)
+	}
+}
+
+// emitResources writes the comma-separated RESOURCES list property. It skips
+// an empty list, because a bare RESOURCES carries no information.
+func emitResources(props ical.Props, resources []string) {
+	if len(resources) > 0 {
+		resProp := &ical.Prop{Name: ical.PropResources}
+		resProp.SetTextList(resources)
+		props.Set(resProp)
+	}
+}
+
+// emitRelations appends one RELATED-TO property per relation. The RELTYPE
+// parameter is omitted for the default PARENT type.
+func emitRelations(props ical.Props, relations []model.Relation) {
+	for _, r := range relations {
+		p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}
+		p.Value = r.RelUID
+		if r.RelType != "" && r.RelType != "PARENT" {
+			p.Params.Set("RELTYPE", r.RelType)
+		}
+		props.Add(p)
+	}
+}

--- a/internal/ical/export_events.go
+++ b/internal/ical/export_events.go
@@ -112,53 +112,22 @@ func ExportEvents(events []event.Event, calName string) ([]byte, error) {
 			vevent.Props.Set(p)
 		}
 
-		if e.DtStamp != "" {
-			if ts, err := time.Parse(time.RFC3339, e.DtStamp); err == nil {
-				vevent.Props.SetDateTime(ical.PropDateTimeStamp, ts.UTC())
-			} else {
-				vevent.Props.SetDateTime(ical.PropDateTimeStamp, e.UpdatedAt.UTC())
-			}
-		} else {
-			vevent.Props.SetDateTime(ical.PropDateTimeStamp, e.UpdatedAt.UTC())
-		}
-		vevent.Props.SetDateTime(ical.PropCreated, e.CreatedAt.UTC())
-		vevent.Props.SetDateTime(ical.PropLastModified, e.UpdatedAt.UTC())
+		emitTimestamps(vevent.Props, e.DtStamp, e.CreatedAt, e.UpdatedAt)
 
 		// ATTACH
 		for _, att := range e.Attachments {
 			emitAttachment(vevent.Props, att)
 		}
 
-		// COMMENT
-		for _, c := range e.Comments {
-			p := &ical.Prop{Name: ical.PropComment}
-			p.SetText(c)
-			vevent.Props.Add(p)
-		}
+		emitTextProps(vevent.Props, ical.PropComment, e.Comments)
 
-		// CONTACT
-		for _, c := range e.Contacts {
-			p := &ical.Prop{Name: ical.PropContact}
-			p.SetText(c)
-			vevent.Props.Add(p)
-		}
+		emitTextProps(vevent.Props, ical.PropContact, e.Contacts)
 
 		// RESOURCES (comma-separated list, like CATEGORIES)
-		if len(e.Resources) > 0 {
-			resProp := &ical.Prop{Name: ical.PropResources}
-			resProp.SetTextList(e.Resources)
-			vevent.Props.Set(resProp)
-		}
+		emitResources(vevent.Props, e.Resources)
 
 		// RELATED-TO
-		for _, r := range e.Relations {
-			p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}
-			p.Value = r.RelUID
-			if r.RelType != "" && r.RelType != "PARENT" {
-				p.Params.Set("RELTYPE", r.RelType)
-			}
-			vevent.Props.Add(p)
-		}
+		emitRelations(vevent.Props, e.Relations)
 
 		// X-Properties (round-trip preservation)
 		emitXProperties(vevent.Component, e.XProperties)

--- a/internal/ical/export_journals.go
+++ b/internal/ical/export_journals.go
@@ -126,17 +126,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 			emitRecurrenceID(vjournal.Props, j.RecurrenceID, timeutil.IsDateOnly(j.StartDate), j.Timezone == "FLOATING")
 		}
 
-		if j.DtStamp != "" {
-			if ts, err := time.Parse(time.RFC3339, j.DtStamp); err == nil {
-				vjournal.Props.SetDateTime(ical.PropDateTimeStamp, ts.UTC())
-			} else {
-				vjournal.Props.SetDateTime(ical.PropDateTimeStamp, j.UpdatedAt.UTC())
-			}
-		} else {
-			vjournal.Props.SetDateTime(ical.PropDateTimeStamp, j.UpdatedAt.UTC())
-		}
-		vjournal.Props.SetDateTime(ical.PropCreated, j.CreatedAt.UTC())
-		vjournal.Props.SetDateTime(ical.PropLastModified, j.UpdatedAt.UTC())
+		emitTimestamps(vjournal.Props, j.DtStamp, j.CreatedAt, j.UpdatedAt)
 
 		// ATTACH
 		for _, att := range j.Attachments {
@@ -144,28 +134,13 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 		}
 
 		// COMMENT
-		for _, c := range j.Comments {
-			p := &ical.Prop{Name: ical.PropComment}
-			p.SetText(c)
-			vjournal.Props.Add(p)
-		}
+		emitTextProps(vjournal.Props, ical.PropComment, j.Comments)
 
 		// CONTACT
-		for _, c := range j.Contacts {
-			p := &ical.Prop{Name: ical.PropContact}
-			p.SetText(c)
-			vjournal.Props.Add(p)
-		}
+		emitTextProps(vjournal.Props, ical.PropContact, j.Contacts)
 
 		// RELATED-TO
-		for _, r := range j.Relations {
-			p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}
-			p.Value = r.RelUID
-			if r.RelType != "" && r.RelType != "PARENT" {
-				p.Params.Set("RELTYPE", r.RelType)
-			}
-			vjournal.Props.Add(p)
-		}
+		emitRelations(vjournal.Props, j.Relations)
 
 		// X-Properties (round-trip preservation)
 		emitXProperties(vjournal, j.XProperties)

--- a/internal/ical/export_todos.go
+++ b/internal/ical/export_todos.go
@@ -176,53 +176,22 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			vtodo.Props.Set(p)
 		}
 
-		if t.DtStamp != "" {
-			if ts, err := time.Parse(time.RFC3339, t.DtStamp); err == nil {
-				vtodo.Props.SetDateTime(ical.PropDateTimeStamp, ts.UTC())
-			} else {
-				vtodo.Props.SetDateTime(ical.PropDateTimeStamp, t.UpdatedAt.UTC())
-			}
-		} else {
-			vtodo.Props.SetDateTime(ical.PropDateTimeStamp, t.UpdatedAt.UTC())
-		}
-		vtodo.Props.SetDateTime(ical.PropCreated, t.CreatedAt.UTC())
-		vtodo.Props.SetDateTime(ical.PropLastModified, t.UpdatedAt.UTC())
+		emitTimestamps(vtodo.Props, t.DtStamp, t.CreatedAt, t.UpdatedAt)
 
 		// ATTACH
 		for _, att := range t.Attachments {
 			emitAttachment(vtodo.Props, att)
 		}
 
-		// COMMENT
-		for _, c := range t.Comments {
-			p := &ical.Prop{Name: ical.PropComment}
-			p.SetText(c)
-			vtodo.Props.Add(p)
-		}
+		emitTextProps(vtodo.Props, ical.PropComment, t.Comments)
 
-		// CONTACT
-		for _, c := range t.Contacts {
-			p := &ical.Prop{Name: ical.PropContact}
-			p.SetText(c)
-			vtodo.Props.Add(p)
-		}
+		emitTextProps(vtodo.Props, ical.PropContact, t.Contacts)
 
 		// RESOURCES (comma-separated list, like CATEGORIES)
-		if len(t.Resources) > 0 {
-			resProp := &ical.Prop{Name: ical.PropResources}
-			resProp.SetTextList(t.Resources)
-			vtodo.Props.Set(resProp)
-		}
+		emitResources(vtodo.Props, t.Resources)
 
 		// RELATED-TO
-		for _, r := range t.Relations {
-			p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}
-			p.Value = r.RelUID
-			if r.RelType != "" && r.RelType != "PARENT" {
-				p.Params.Set("RELTYPE", r.RelType)
-			}
-			vtodo.Props.Add(p)
-		}
+		emitRelations(vtodo.Props, t.Relations)
 
 		// X-Properties (round-trip preservation)
 		emitXProperties(vtodo, t.XProperties)


### PR DESCRIPTION
## Problem
The DTSTAMP fallback block (9 lines), COMMENT loop, CONTACT loop, RESOURCES block, and RELATED-TO loop were each copy-pasted across the event/todo/journal exporters (~60 lines of copies per exporter). A future escaping or timestamp rule change would land in one of three copies.

## Fix
Four helpers in export.go: `emitTimestamps`, `emitTextProps`, `emitResources`, `emitRelations`. Journals legitimately carry no RESOURCES property, so that exporter keeps no resources call.

## Verification
Byte-for-byte output preserved: full `internal/ical` + `internal/icaltransfer` packages (incl. round-trip goldens) pass unchanged.

Assisted-by: opencode-zen:x-preview-f-free