### PR TITLE
refactor(ical): one emitter for the zoned datetime ladder

### DIFF
--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -395,3 +395,25 @@ func emitRelations(props ical.Props, relations []model.Relation) {
 		props.Add(p)
 	}
 }
+
+// setZonedDateTime writes one datetime property under the shared timezone
+// rules. A "FLOATING" timezone emits bare wall-clock numbers (no Z, no TZID),
+// matching the stored floating semantics. A resolvable IANA timezone emits
+// the zone-local wall clock plus the TZID parameter. An empty or
+// unresolvable timezone falls back to UTC.
+func setZonedDateTime(props ical.Props, name string, t time.Time, timezone string) {
+	if timezone == "FLOATING" {
+		p := &ical.Prop{Name: name}
+		p.Value = t.UTC().Format("20060102T150405")
+		props.Set(p)
+		return
+	}
+	if loc, err := time.LoadLocation(timezone); timezone != "" && err == nil {
+		props.SetDateTime(name, t.In(loc))
+		if p := props.Get(name); p != nil {
+			p.Params.Set(ical.ParamTimezoneID, timezone)
+		}
+		return
+	}
+	props.SetDateTime(name, t.UTC())
+}

--- a/internal/ical/export_journals.go
+++ b/internal/ical/export_journals.go
@@ -69,22 +69,7 @@ func ExportJournals(journals []journal.Journal, calName string) ([]byte, error) 
 			if d, err := time.Parse("2006-01-02", j.StartDate); err == nil {
 				vjournal.Props.SetDate(ical.PropDateTimeStart, d)
 			} else if start, err := time.Parse(time.RFC3339, j.StartDate); err == nil {
-				if j.Timezone == "FLOATING" {
-					p := &ical.Prop{Name: ical.PropDateTimeStart}
-					p.Value = start.UTC().Format("20060102T150405")
-					vjournal.Props.Set(p)
-				} else if j.Timezone != "" {
-					if loc, lerr := time.LoadLocation(j.Timezone); lerr == nil {
-						vjournal.Props.SetDateTime(ical.PropDateTimeStart, start.In(loc))
-						if p := vjournal.Props.Get(ical.PropDateTimeStart); p != nil {
-							p.Params.Set(ical.ParamTimezoneID, j.Timezone)
-						}
-					} else {
-						vjournal.Props.SetDateTime(ical.PropDateTimeStart, start.UTC())
-					}
-				} else {
-					vjournal.Props.SetDateTime(ical.PropDateTimeStart, start.UTC())
-				}
+				setZonedDateTime(vjournal.Props, ical.PropDateTimeStart, start, j.Timezone)
 			}
 		}
 

--- a/internal/ical/export_todos.go
+++ b/internal/ical/export_todos.go
@@ -54,44 +54,14 @@ func ExportTodos(todos []todo.Todo, calName string) ([]byte, error) {
 			if d, err := time.Parse("2006-01-02", t.DueDate); err == nil {
 				vtodo.Props.SetDate(ical.PropDue, d)
 			} else if due, err := time.Parse(time.RFC3339, t.DueDate); err == nil {
-				if t.Timezone == "FLOATING" {
-					p := &ical.Prop{Name: ical.PropDue}
-					p.Value = due.UTC().Format("20060102T150405")
-					vtodo.Props.Set(p)
-				} else if t.Timezone != "" {
-					if loc, lerr := time.LoadLocation(t.Timezone); lerr == nil {
-						vtodo.Props.SetDateTime(ical.PropDue, due.In(loc))
-						if p := vtodo.Props.Get(ical.PropDue); p != nil {
-							p.Params.Set(ical.ParamTimezoneID, t.Timezone)
-						}
-					} else {
-						vtodo.Props.SetDateTime(ical.PropDue, due.UTC())
-					}
-				} else {
-					vtodo.Props.SetDateTime(ical.PropDue, due.UTC())
-				}
+				setZonedDateTime(vtodo.Props, ical.PropDue, due, t.Timezone)
 			}
 		}
 		if t.StartDate != "" {
 			if d, err := time.Parse("2006-01-02", t.StartDate); err == nil {
 				vtodo.Props.SetDate(ical.PropDateTimeStart, d)
 			} else if start, err := time.Parse(time.RFC3339, t.StartDate); err == nil {
-				if t.Timezone == "FLOATING" {
-					p := &ical.Prop{Name: ical.PropDateTimeStart}
-					p.Value = start.UTC().Format("20060102T150405")
-					vtodo.Props.Set(p)
-				} else if t.Timezone != "" {
-					if loc, lerr := time.LoadLocation(t.Timezone); lerr == nil {
-						vtodo.Props.SetDateTime(ical.PropDateTimeStart, start.In(loc))
-						if p := vtodo.Props.Get(ical.PropDateTimeStart); p != nil {
-							p.Params.Set(ical.ParamTimezoneID, t.Timezone)
-						}
-					} else {
-						vtodo.Props.SetDateTime(ical.PropDateTimeStart, start.UTC())
-					}
-				} else {
-					vtodo.Props.SetDateTime(ical.PropDateTimeStart, start.UTC())
-				}
+				setZonedDateTime(vtodo.Props, ical.PropDateTimeStart, start, t.Timezone)
 			}
 		}
 		// RFC 5545 (and go-ical's encoder) only accept DURATION on a VTODO when


### PR DESCRIPTION
## Problem
The timezone ladder (FLOATING wall-clock / IANA zone + TZID / UTC fallback) was copy-pasted three times verbatim — todo DUE, todo DTSTART, journal DTSTART — plus two structural variants (event `setEventTimes`, `emitDateListOnComponent`). The floating format string had five emitters.

## Fix
New `setZonedDateTime(props, name, t, timezone)` consolidates the three identical ladders. The event exporter intentionally keeps its own shape: its DURATION-vs-DTEND decision interleaves with each branch. `emitDateListOnComponent` keeps its Add-based form: EXDATE/RDATE values carry their own type-matching rules documented against issues #421/#492.

## Verification
Byte-for-byte output preserved: full `internal/ical` + `internal/icaltransfer` packages (incl. round-trip goldens) pass unchanged.

Assisted-by: opencode-zen:x-preview-f-free