### PR TITLE
refactor(caldav): decode every multistatus through one shared envelope

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -196,34 +196,33 @@ func propfindCalendarCollections(ctx context.Context, httpClient webdav.HTTPClie
 
 	out := make([]RemoteCalendar, 0, len(ms.Responses))
 	for _, r := range ms.Responses {
-		if len(r.PropStats) == 0 {
-			continue
-		}
 		isCalendar := false
 		remote := RemoteCalendar{}
-		ps, ok := firstOKPropstat(r)
-		if !ok {
-			continue
-		}
-		if remote.Name == "" {
-			remote.Name = strings.TrimSpace(ps.DisplayName)
-		}
-		if remote.Description == "" {
-			remote.Description = strings.TrimSpace(ps.CalendarDescription)
-		}
-		if remote.Color == "" {
-			remote.Color = NormalizeCalendarColor(ps.CalendarColor)
-		}
-		if len(remote.SupportedComponentSet) == 0 {
-			remote.SupportedComponentSet = componentNames(ps.SupportedComponents)
-		}
-		// calendarAccessFromPrivileges never returns "", so the first
-		// successful propstat wins — matching the verify path.
-		if remote.Access == "" {
-			remote.Access = calendarAccessFromPrivileges(ps.CurrentPrivileges)
-		}
-		if ps.ResourceType.Calendar != nil {
-			isCalendar = true
+		// RFC 4918 §9.1.2 lets a server split the properties of one
+		// response across several 2xx propstats. Merge every 2xx
+		// propstat per field; the first propstat that fills a field
+		// wins.
+		for _, ps := range allOKPropstats(r) {
+			if remote.Name == "" {
+				remote.Name = strings.TrimSpace(ps.DisplayName)
+			}
+			if remote.Description == "" {
+				remote.Description = strings.TrimSpace(ps.CalendarDescription)
+			}
+			if remote.Color == "" {
+				remote.Color = NormalizeCalendarColor(ps.CalendarColor)
+			}
+			if len(remote.SupportedComponentSet) == 0 {
+				remote.SupportedComponentSet = componentNames(ps.SupportedComponents)
+			}
+			// calendarAccessFromPrivileges never returns "", so the first
+			// successful propstat wins — matching the verify path.
+			if remote.Access == "" {
+				remote.Access = calendarAccessFromPrivileges(ps.CurrentPrivileges)
+			}
+			if ps.ResourceType.Calendar != nil {
+				isCalendar = true
+			}
 		}
 		if !isCalendar {
 			continue

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -189,7 +189,7 @@ func propfindCalendarCollections(ctx context.Context, httpClient webdav.HTTPClie
 		return nil, httpError(resp)
 	}
 
-	var ms verifyMultiStatus
+	var ms davMultiStatus[verifyProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return nil, fmt.Errorf("decode discovery PROPFIND response: %w", err)
 	}
@@ -201,30 +201,29 @@ func propfindCalendarCollections(ctx context.Context, httpClient webdav.HTTPClie
 		}
 		isCalendar := false
 		remote := RemoteCalendar{}
-		for _, ps := range r.PropStats {
-			if code := parseStatusCode(ps.Status); code < 200 || code >= 300 {
-				continue
-			}
-			if remote.Name == "" {
-				remote.Name = strings.TrimSpace(ps.Prop.DisplayName)
-			}
-			if remote.Description == "" {
-				remote.Description = strings.TrimSpace(ps.Prop.CalendarDescription)
-			}
-			if remote.Color == "" {
-				remote.Color = NormalizeCalendarColor(ps.Prop.CalendarColor)
-			}
-			if len(remote.SupportedComponentSet) == 0 {
-				remote.SupportedComponentSet = componentNames(ps.Prop.SupportedComponents)
-			}
-			// calendarAccessFromPrivileges never returns "", so the first
-			// successful propstat wins — matching the verify path.
-			if remote.Access == "" {
-				remote.Access = calendarAccessFromPrivileges(ps.Prop.CurrentPrivileges)
-			}
-			if ps.Prop.ResourceType.Calendar != nil {
-				isCalendar = true
-			}
+		ps, ok := firstOKPropstat(r)
+		if !ok {
+			continue
+		}
+		if remote.Name == "" {
+			remote.Name = strings.TrimSpace(ps.DisplayName)
+		}
+		if remote.Description == "" {
+			remote.Description = strings.TrimSpace(ps.CalendarDescription)
+		}
+		if remote.Color == "" {
+			remote.Color = NormalizeCalendarColor(ps.CalendarColor)
+		}
+		if len(remote.SupportedComponentSet) == 0 {
+			remote.SupportedComponentSet = componentNames(ps.SupportedComponents)
+		}
+		// calendarAccessFromPrivileges never returns "", so the first
+		// successful propstat wins — matching the verify path.
+		if remote.Access == "" {
+			remote.Access = calendarAccessFromPrivileges(ps.CurrentPrivileges)
+		}
+		if ps.ResourceType.Calendar != nil {
+			isCalendar = true
 		}
 		if !isCalendar {
 			continue

--- a/internal/caldav/discovery_test.go
+++ b/internal/caldav/discovery_test.go
@@ -117,6 +117,76 @@ func TestDiscoverCalendarsReturnsCollectionMetadata(t *testing.T) {
 	}
 }
 
+// TestPropfindCalendarCollections_MergesSplitPropstats covers RFC 4918
+// §9.1.2: a server may split the properties of one response across several
+// 2xx propstats. The work calendar carries resourcetype only in the second
+// 200 propstat. Discovery must still see the calendar and must merge its
+// fields across both propstats. The first propstat that fills a field wins
+// (the shadowed displayname in the second propstat must not overwrite Work).
+// calendarAccessFromPrivileges never returns an empty value, so the first
+// 200 propstat decides the access field.
+func TestPropfindCalendarCollections_MergesSplitPropstats(t *testing.T) {
+	const fixture = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:ic="http://apple.com/ns/ical/">
+  <d:response>
+    <d:href>/cal/work/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>Work</d:displayname>
+        <ic:calendar-color>#123456FF</ic:calendar-color>
+        <d:current-user-privilege-set><d:privilege><d:read/></d:privilege></d:current-user-privilege-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop><d:getetag/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>Shadowed</d:displayname>
+        <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+        <c:supported-calendar-component-set><c:comp name="VTODO"/></c:supported-calendar-component-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PROPFIND" {
+			t.Errorf("method = %s, want PROPFIND", r.Method)
+		}
+		w.WriteHeader(http.StatusMultiStatus)
+		_, _ = w.Write([]byte(fixture))
+	}))
+	t.Cleanup(srv.Close)
+
+	found, err := propfindCalendarCollections(context.Background(), srv.Client(), srv.URL+"/cal/")
+	if err != nil {
+		t.Fatalf("propfindCalendarCollections: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("calendar count = %d, want 1 (resourcetype sits in the second 200 propstat and must not hide the calendar)", len(found))
+	}
+	work := found[0]
+	if work.Path != "/cal/work/" {
+		t.Errorf("path = %q, want /cal/work/", work.Path)
+	}
+	if work.Name != "Work" {
+		t.Errorf("name = %q, want Work (the first propstat that fills the field wins)", work.Name)
+	}
+	if work.Color != "#123456" {
+		t.Errorf("color = %q, want #123456 from the first propstat", work.Color)
+	}
+	if work.Access != CalendarAccessRead {
+		t.Errorf("access = %q, want read from the first propstat", work.Access)
+	}
+	if len(work.SupportedComponentSet) != 1 || work.SupportedComponentSet[0] != "VTODO" {
+		t.Errorf("components = %v, want [VTODO] from the second 200 propstat", work.SupportedComponentSet)
+	}
+}
+
 func multistatus(href, prop string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
 <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">

--- a/internal/caldav/multiget.go
+++ b/internal/caldav/multiget.go
@@ -57,7 +57,7 @@ func (c *Client) MultiGetTolerant(ctx context.Context, calendarPath string, href
 		return nil, fmt.Errorf("REPORT calendar-multiget: %w", httpError(resp))
 	}
 
-	var ms multiGetMultiStatus
+	var ms davMultiStatus[multiGetProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return nil, fmt.Errorf("decode multiget response: %w", err)
 	}
@@ -73,20 +73,9 @@ func (c *Client) MultiGetTolerant(ctx context.Context, calendarPath string, href
 			result.Missing = append(result.Missing, href)
 			continue
 		}
-		var etag, data string
-		var ok bool
-		for _, ps := range r.PropStats {
-			code := parseStatusCode(ps.Status)
-			if code == http.StatusNotFound {
-				continue
-			}
-			if code >= 200 && code < 300 {
-				etag = normalizeETag(ps.Prop.ETag)
-				data = ps.Prop.CalendarData
-				ok = true
-				break
-			}
-		}
+		ps, ok := firstOKPropstat(r)
+		etag := normalizeETag(ps.ETag)
+		data := ps.CalendarData
 		if !ok || data == "" {
 			result.Missing = append(result.Missing, href)
 			continue
@@ -123,21 +112,8 @@ func buildMultiGetBody(hrefs []string) string {
 %s</c:calendar-multiget>`, hrefXML.String())
 }
 
-type multiGetMultiStatus struct {
-	XMLName   xml.Name           `xml:"DAV: multistatus"`
-	Responses []multiGetResponse `xml:"DAV: response"`
-}
-
-type multiGetResponse struct {
-	Href      string             `xml:"DAV: href"`
-	Status    string             `xml:"DAV: status"`
-	PropStats []multiGetPropStat `xml:"DAV: propstat"`
-}
-
-type multiGetPropStat struct {
-	Status string `xml:"DAV: status"`
-	Prop   struct {
-		ETag         string `xml:"DAV: getetag"`
-		CalendarData string `xml:"urn:ietf:params:xml:ns:caldav calendar-data"`
-	} `xml:"DAV: prop"`
+// multiGetProps is the DAV: prop payload of a calendar-multiget REPORT.
+type multiGetProps struct {
+	ETag         string `xml:"DAV: getetag"`
+	CalendarData string `xml:"urn:ietf:params:xml:ns:caldav calendar-data"`
 }

--- a/internal/caldav/multistatus.go
+++ b/internal/caldav/multistatus.go
@@ -1,0 +1,47 @@
+package caldav
+
+import "encoding/xml"
+
+// This file carries the one shared WebDAV multistatus envelope. Every
+// REPORT/PROPFIND response decodes through it. Before the consolidation, four
+// packages-private struct hierarchies restated the same
+// multistatus → response → propstat shape with per-call-site Prop payloads,
+// and drifted independently.
+//
+// A call site defines only its Prop payload type and instantiates the generic
+// envelope with it.
+
+// davMultiStatus decodes a DAV: multistatus document. P is the call site's
+// expected DAV: prop payload.
+type davMultiStatus[P any] struct {
+	XMLName   xml.Name         `xml:"DAV: multistatus"`
+	Responses []davResponse[P] `xml:"DAV: response"`
+	// SyncToken is present only in sync-collection responses; other reports
+	// leave it empty.
+	SyncToken string `xml:"DAV: sync-token"`
+}
+
+// davResponse is one DAV: response element.
+type davResponse[P any] struct {
+	Href      string           `xml:"DAV: href"`
+	Status    string           `xml:"DAV: status"`
+	PropStats []davPropStat[P] `xml:"DAV: propstat"`
+}
+
+// davPropStat pairs a status line with its property payload.
+type davPropStat[P any] struct {
+	Status string `xml:"DAV: status"`
+	Prop   P      `xml:"DAV: prop"`
+}
+
+// firstOKPropstat returns the first 2xx propstat of a response. ok is false
+// when the response carries no 2xx propstat.
+func firstOKPropstat[P any](r davResponse[P]) (P, bool) {
+	for _, ps := range r.PropStats {
+		if code := parseStatusCode(ps.Status); code >= 200 && code < 300 {
+			return ps.Prop, true
+		}
+	}
+	var zero P
+	return zero, false
+}

--- a/internal/caldav/multistatus.go
+++ b/internal/caldav/multistatus.go
@@ -2,14 +2,11 @@ package caldav
 
 import "encoding/xml"
 
-// This file carries the one shared WebDAV multistatus envelope. Every
-// REPORT/PROPFIND response decodes through it. Before the consolidation, four
-// packages-private struct hierarchies restated the same
-// multistatus → response → propstat shape with per-call-site Prop payloads,
-// and drifted independently.
-//
-// A call site defines only its Prop payload type and instantiates the generic
-// envelope with it.
+// This file carries the single shared WebDAV multistatus envelope. The
+// package decodes every REPORT and PROPFIND response through this envelope.
+// A call site defines only its Prop payload type and instantiates the
+// generic envelope with it. The envelope owns the multistatus, response,
+// and propstat shape, so all call sites decode that shape in the same way.
 
 // davMultiStatus decodes a DAV: multistatus document. P is the call site's
 // expected DAV: prop payload.
@@ -44,4 +41,20 @@ func firstOKPropstat[P any](r davResponse[P]) (P, bool) {
 	}
 	var zero P
 	return zero, false
+}
+
+// allOKPropstats returns the prop payload of every 2xx propstat, in
+// document order. RFC 4918 §9.1.2 lets a server split the properties of one
+// response across several 2xx propstats, so a caller that merges fields
+// iterates all of them. The slice is empty when the response carries no 2xx
+// propstat. A caller that needs only the first 2xx propstat uses
+// firstOKPropstat instead.
+func allOKPropstats[P any](r davResponse[P]) []P {
+	var props []P
+	for _, ps := range r.PropStats {
+		if code := parseStatusCode(ps.Status); code >= 200 && code < 300 {
+			props = append(props, ps.Prop)
+		}
+	}
+	return props
 }

--- a/internal/caldav/multistatus_test.go
+++ b/internal/caldav/multistatus_test.go
@@ -1,0 +1,64 @@
+package caldav
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+// TestDavMultiStatusDecodesCanonicalSample pins the shared envelope against a
+// canonical multistatus body: one 404 propstat, then a 200 propstat. The
+// decoder must keep both and firstOKPropstat must select the 200 one.
+func TestDavMultiStatusDecodesCanonicalSample(t *testing.T) {
+	body := `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:ic="http://apple.com/ns/ical/">
+  <d:response>
+    <d:href>/cal/one/</d:href>
+    <d:propstat>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+      <d:prop><d:getetag/></d:prop>
+    </d:propstat>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop>
+        <d:getetag>"abc"</d:getetag>
+        <ic:calendar-color>#FF0000AA</ic:calendar-color>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	var ms davMultiStatus[multiGetProps]
+	if err := xml.NewDecoder(strings.NewReader(body)).Decode(&ms); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(ms.Responses) != 1 {
+		t.Fatalf("responses = %d, want 1", len(ms.Responses))
+	}
+	r := ms.Responses[0]
+	if r.Href != "/cal/one/" {
+		t.Errorf("href = %q, want /cal/one/", r.Href)
+	}
+	if len(r.PropStats) != 2 {
+		t.Fatalf("propstats = %d, want 2 (the envelope must keep non-2xx propstats)", len(r.PropStats))
+	}
+
+	ps, ok := firstOKPropstat(r)
+	if !ok {
+		t.Fatal("firstOKPropstat found no 2xx propstat")
+	}
+	if ps.ETag != `"abc"` {
+		t.Errorf("etag = %q, want %q", ps.ETag, `"abc"`)
+	}
+
+	// A response with only error propstats yields ok == false, not an error.
+	var ms2 davMultiStatus[multiGetProps]
+	bad := strings.Replace(body, "200 OK", "500 Server Error", 1)
+	bad = strings.Replace(bad, "404 Not Found", "500 Server Error", 1)
+	if err := xml.NewDecoder(strings.NewReader(bad)).Decode(&ms2); err != nil {
+		t.Fatalf("decode bad: %v", err)
+	}
+	if _, ok := firstOKPropstat(ms2.Responses[0]); ok {
+		t.Error("firstOKPropstat accepted a 500 propstat")
+	}
+}

--- a/internal/caldav/multistatus_test.go
+++ b/internal/caldav/multistatus_test.go
@@ -62,3 +62,54 @@ func TestDavMultiStatusDecodesCanonicalSample(t *testing.T) {
 		t.Error("firstOKPropstat accepted a 500 propstat")
 	}
 }
+
+// TestAllOKPropstatsReturnsEvery2xxPayload pins the helper that the discovery
+// and verify paths use. RFC 4918 §9.1.2 lets a server split the properties of
+// one response across several 2xx propstats. The helper must return every 2xx
+// payload in document order and skip every non-2xx propstat.
+func TestAllOKPropstatsReturnsEvery2xxPayload(t *testing.T) {
+	const body = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/cal/one/</d:href>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop><d:getetag>"first"</d:getetag></d:prop>
+    </d:propstat>
+    <d:propstat>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+      <d:prop><d:getetag>"dropped"</d:getetag></d:prop>
+    </d:propstat>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop><c:calendar-data>BEGIN:VCALENDAR
+END:VCALENDAR</c:calendar-data></d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	var ms davMultiStatus[multiGetProps]
+	if err := xml.NewDecoder(strings.NewReader(body)).Decode(&ms); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	props := allOKPropstats(ms.Responses[0])
+	if len(props) != 2 {
+		t.Fatalf("2xx payloads = %d, want 2 (the 404 propstat must be skipped)", len(props))
+	}
+	if props[0].ETag != `"first"` || props[1].ETag != "" {
+		t.Errorf("payload order = [%q, %q], want the 200 propstats in document order", props[0].ETag, props[1].ETag)
+	}
+	if !strings.Contains(props[1].CalendarData, "BEGIN:VCALENDAR") {
+		t.Errorf("second payload calendar-data = %q, want the VCALENDAR text from the third propstat", props[1].CalendarData)
+	}
+
+	// A response with only error propstats yields an empty slice, not an error.
+	bad := strings.ReplaceAll(body, "200 OK", "500 Server Error")
+	var ms2 davMultiStatus[multiGetProps]
+	if err := xml.NewDecoder(strings.NewReader(bad)).Decode(&ms2); err != nil {
+		t.Fatalf("decode bad: %v", err)
+	}
+	if props := allOKPropstats(ms2.Responses[0]); len(props) != 0 {
+		t.Errorf("allOKPropstats accepted a 500 propstat: %+v", props)
+	}
+}

--- a/internal/caldav/properties.go
+++ b/internal/caldav/properties.go
@@ -11,19 +11,9 @@ import (
 	"github.com/emersion/go-webdav"
 )
 
-type calendarColorMultiStatus struct {
-	Responses []calendarColorResponse `xml:"DAV: response"`
-}
-
-type calendarColorResponse struct {
-	PropStats []calendarColorPropStat `xml:"DAV: propstat"`
-}
-
-type calendarColorPropStat struct {
-	Status string `xml:"DAV: status"`
-	Prop   struct {
-		CalendarColor string `xml:"http://apple.com/ns/ical/ calendar-color"`
-	} `xml:"DAV: prop"`
+// calendarColorProps is the DAV: prop payload of the calendar-color PROPFIND.
+type calendarColorProps struct {
+	CalendarColor string `xml:"http://apple.com/ns/ical/ calendar-color"`
 }
 
 // GetCalendarColor fetches the current calendar-color property for a calendar.
@@ -55,7 +45,7 @@ func GetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 		return "", fmt.Errorf("PROPFIND calendar-color: %w", httpError(resp))
 	}
 
-	var ms calendarColorMultiStatus
+	var ms davMultiStatus[calendarColorProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return "", fmt.Errorf("decode PROPFIND response: %w", err)
 	}
@@ -146,7 +136,7 @@ func SetCalendarColor(ctx context.Context, httpClient webdav.HTTPClient, calenda
 	case http.StatusOK, http.StatusNoContent:
 		return nil
 	case http.StatusMultiStatus:
-		var ms calendarColorMultiStatus
+		var ms davMultiStatus[calendarColorProps]
 		if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 			return fmt.Errorf("decode PROPPATCH response: %w", err)
 		}

--- a/internal/caldav/sync_collection.go
+++ b/internal/caldav/sync_collection.go
@@ -96,7 +96,7 @@ func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncTo
 		return nil, fmt.Errorf("REPORT sync-collection: %w", httpError(resp))
 	}
 
-	var ms syncCollectionMultiStatus
+	var ms davMultiStatus[syncCollectionProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return nil, fmt.Errorf("decode sync-collection response: %w", err)
 	}
@@ -124,12 +124,8 @@ func (c *Client) SyncCollection(ctx context.Context, calendarPath string, syncTo
 			continue
 		}
 		var etag string
-		for _, ps := range r.PropStats {
-			code := parseStatusCode(ps.Status)
-			if code >= 200 && code < 300 {
-				etag = normalizeETag(ps.Prop.ETag)
-				break
-			}
+		if ps, ok := firstOKPropstat(r); ok {
+			etag = normalizeETag(ps.ETag)
 		}
 		result.Changes = append(result.Changes, SyncChange{Path: href, ETag: etag})
 	}
@@ -147,21 +143,7 @@ func buildSyncCollectionBody(syncToken string) string {
 </d:sync-collection>`, xmlEscape(syncToken))
 }
 
-type syncCollectionMultiStatus struct {
-	XMLName   xml.Name                 `xml:"DAV: multistatus"`
-	Responses []syncCollectionResponse `xml:"DAV: response"`
-	SyncToken string                   `xml:"DAV: sync-token"`
-}
-
-type syncCollectionResponse struct {
-	Href      string                   `xml:"DAV: href"`
-	Status    string                   `xml:"DAV: status"`
-	PropStats []syncCollectionPropStat `xml:"DAV: propstat"`
-}
-
-type syncCollectionPropStat struct {
-	Status string `xml:"DAV: status"`
-	Prop   struct {
-		ETag string `xml:"DAV: getetag"`
-	} `xml:"DAV: prop"`
+// syncCollectionProps is the DAV: prop payload of a sync-collection REPORT.
+type syncCollectionProps struct {
+	ETag string `xml:"DAV: getetag"`
 }

--- a/internal/caldav/verify.go
+++ b/internal/caldav/verify.go
@@ -164,24 +164,26 @@ func fetchCalendarMetadata(ctx context.Context, calendarURL string, httpClient w
 	meta := CalendarMetadata{}
 	isCalendar := false
 	for _, r := range ms.Responses {
-		prop, ok := firstOKPropstat(r)
-		if !ok {
-			continue
-		}
-		if meta.DisplayName == "" {
-			meta.DisplayName = strings.TrimSpace(prop.DisplayName)
-		}
-		if meta.Color == "" {
-			meta.Color = NormalizeCalendarColor(prop.CalendarColor)
-		}
-		if meta.Access == "" {
-			meta.Access = calendarAccessFromPrivileges(prop.CurrentPrivileges)
-		}
-		if meta.SupportedComponents == nil && len(prop.SupportedComponents.Components) > 0 {
-			meta.SupportedComponents = componentNames(prop.SupportedComponents)
-		}
-		if prop.ResourceType.Calendar != nil {
-			isCalendar = true
+		// RFC 4918 §9.1.2 lets a server split the properties of one
+		// response across several 2xx propstats. Merge every 2xx
+		// propstat per field; the first propstat that fills a field
+		// wins.
+		for _, prop := range allOKPropstats(r) {
+			if meta.DisplayName == "" {
+				meta.DisplayName = strings.TrimSpace(prop.DisplayName)
+			}
+			if meta.Color == "" {
+				meta.Color = NormalizeCalendarColor(prop.CalendarColor)
+			}
+			if meta.Access == "" {
+				meta.Access = calendarAccessFromPrivileges(prop.CurrentPrivileges)
+			}
+			if meta.SupportedComponents == nil && len(prop.SupportedComponents.Components) > 0 {
+				meta.SupportedComponents = componentNames(prop.SupportedComponents)
+			}
+			if prop.ResourceType.Calendar != nil {
+				isCalendar = true
+			}
 		}
 	}
 	if meta.Access == "" {

--- a/internal/caldav/verify.go
+++ b/internal/caldav/verify.go
@@ -11,21 +11,8 @@ import (
 	"github.com/emersion/go-webdav"
 )
 
-type verifyMultiStatus struct {
-	Responses []verifyResponse `xml:"DAV: response"`
-}
-
-type verifyResponse struct {
-	Href      string           `xml:"DAV: href"`
-	PropStats []verifyPropStat `xml:"DAV: propstat"`
-}
-
-type verifyPropStat struct {
-	Status string        `xml:"DAV: status"`
-	Prop   verifyPropSet `xml:"DAV: prop"`
-}
-
-type verifyPropSet struct {
+// verifyProps is the DAV: prop payload of the calendar-home-set PROPFIND.
+type verifyProps struct {
 	DisplayName         string                              `xml:"DAV: displayname"`
 	ResourceType        verifyResourceTypeEl                `xml:"DAV: resourcetype"`
 	CalendarDescription string                              `xml:"urn:ietf:params:xml:ns:caldav calendar-description"`
@@ -169,7 +156,7 @@ func fetchCalendarMetadata(ctx context.Context, calendarURL string, httpClient w
 		return CalendarMetadata{}, httpError(resp)
 	}
 
-	var ms verifyMultiStatus
+	var ms davMultiStatus[verifyProps]
 	if err := xml.NewDecoder(resp.Body).Decode(&ms); err != nil {
 		return CalendarMetadata{}, fmt.Errorf("decode PROPFIND response: %w", err)
 	}
@@ -177,26 +164,24 @@ func fetchCalendarMetadata(ctx context.Context, calendarURL string, httpClient w
 	meta := CalendarMetadata{}
 	isCalendar := false
 	for _, r := range ms.Responses {
-		for _, ps := range r.PropStats {
-			code := parseStatusCode(ps.Status)
-			if code < 200 || code >= 300 {
-				continue
-			}
-			if meta.DisplayName == "" {
-				meta.DisplayName = strings.TrimSpace(ps.Prop.DisplayName)
-			}
-			if meta.Color == "" {
-				meta.Color = NormalizeCalendarColor(ps.Prop.CalendarColor)
-			}
-			if meta.Access == "" {
-				meta.Access = calendarAccessFromPrivileges(ps.Prop.CurrentPrivileges)
-			}
-			if meta.SupportedComponents == nil && len(ps.Prop.SupportedComponents.Components) > 0 {
-				meta.SupportedComponents = componentNames(ps.Prop.SupportedComponents)
-			}
-			if ps.Prop.ResourceType.Calendar != nil {
-				isCalendar = true
-			}
+		prop, ok := firstOKPropstat(r)
+		if !ok {
+			continue
+		}
+		if meta.DisplayName == "" {
+			meta.DisplayName = strings.TrimSpace(prop.DisplayName)
+		}
+		if meta.Color == "" {
+			meta.Color = NormalizeCalendarColor(prop.CalendarColor)
+		}
+		if meta.Access == "" {
+			meta.Access = calendarAccessFromPrivileges(prop.CurrentPrivileges)
+		}
+		if meta.SupportedComponents == nil && len(prop.SupportedComponents.Components) > 0 {
+			meta.SupportedComponents = componentNames(prop.SupportedComponents)
+		}
+		if prop.ResourceType.Calendar != nil {
+			isCalendar = true
 		}
 	}
 	if meta.Access == "" {

--- a/internal/caldav/verify_test.go
+++ b/internal/caldav/verify_test.go
@@ -114,6 +114,63 @@ func TestFetchCalendarMetadata_DoesNotRequireCalendarResourceType(t *testing.T) 
 	}
 }
 
+// TestFetchCalendarMetadata_MergesSplitPropstats covers RFC 4918 §9.1.2: a
+// server may split the properties of one response across several 2xx
+// propstats. Here the first 200 propstat carries displayname, color, and the
+// ACL, and the second carries resourcetype and the component set. The
+// metadata must merge all of them, and the first propstat that fills a field
+// wins (the shadowed displayname in the second propstat must not overwrite
+// Work).
+func TestFetchCalendarMetadata_MergesSplitPropstats(t *testing.T) {
+	t.Parallel()
+
+	const fixture = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:ic="http://apple.com/ns/ical/">
+  <d:response>
+    <d:href>/cal/work/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>Work</d:displayname>
+        <ic:calendar-color>#9FE1E7FF</ic:calendar-color>
+        <d:current-user-privilege-set><d:privilege><d:write/></d:privilege></d:current-user-privilege-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>Shadowed</d:displayname>
+        <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+        <c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMultiStatus)
+		_, _ = w.Write([]byte(fixture))
+	}))
+	t.Cleanup(srv.Close)
+
+	meta, err := VerifyCalendarURL(context.Background(), srv.URL+"/cal/work/", "user", "pass", "basic", true)
+	if err != nil {
+		t.Fatalf("VerifyCalendarURL: %v", err)
+	}
+	if meta.DisplayName != "Work" {
+		t.Errorf("DisplayName = %q, want Work (the first propstat that fills the field wins)", meta.DisplayName)
+	}
+	if meta.Color != "#9FE1E7" {
+		t.Errorf("Color = %q, want #9FE1E7 from the first propstat", meta.Color)
+	}
+	if meta.Access != CalendarAccessWrite {
+		t.Errorf("Access = %q, want %q from the first propstat", meta.Access, CalendarAccessWrite)
+	}
+	if got := strings.Join(meta.SupportedComponents, ","); got != "VEVENT" {
+		t.Errorf("SupportedComponents = %q, want VEVENT from the second propstat", got)
+	}
+}
+
 func priv(names ...string) verifyCurrentUserPrivilegeSet {
 	set := verifyCurrentUserPrivilegeSet{}
 	for _, n := range names {


### PR DESCRIPTION
## Problem
Four hand-rolled WebDAV multistatus parsers (`verifyMultiStatus`, `calendarColorMultiStatus`, `multiGetMultiStatus`, `syncCollectionMultiStatus`) duplicated the same XML shape, each with its own response/propstat structs and its own copy of the 2xx-propstat walk. They drifted independently — exactly the class of server-facing code where silent divergence hides longest.

## Fix
One generic `davMultiStatus[P]` / `davResponse[P]` / `davPropStat[P]` envelope + `firstOKPropstat` helper in a new multistatus.go. Call sites define only their Prop payload. Per-site walk semantics are preserved exactly: calendar-color's 404/403 tolerance (issue #628), multiget's missing-body handling, sync-collection's top-level status switch.

## Verification
New `TestDavMultiStatusDecodesCanonicalSample` pins decoding + selection incl. all-error responses; full `internal/caldav` and `internal/sync` packages pass unchanged.

Assisted-by: opencode-zen:x-preview-f-free