### PR TITLE
fix(sync,cmd): conflict strategy defaults to prompt; validate recurrence-id against real occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Narrow a run with `--calendar NAME` (one local calendar) or `--account NAME` (ev
 Conflict handling:
 
 - Every write fires an opportunistic push. When the server answers 412, chroncal records a conflict and keeps the local edit. The edit stays dirty. The command prints a note on stderr. The note tells you to run `chroncal sync conflicts`.
-- The conflict strategy (`server-wins` or `prompt`) governs full sync passes only. A full pass is `sync run`, the background service, or a TUI sync. A `server-wins` pass adopts the server body, clears the dirty flag, and marks the conflict resolved as `server-auto`. A `prompt` pass records the conflict and skips that row until you resolve it.
+- The conflict strategy (`server-wins` or `prompt`) governs full sync passes only. The default is `prompt`; set `server-wins` in `config.toml` under `[sync]` to adopt the server body automatically. A full pass is `sync run`, the background service, or a TUI sync. A `server-wins` pass adopts the server body, clears the dirty flag, and marks the conflict resolved as `server-auto`. A `prompt` pass records the conflict and skips that row until you resolve it.
 - A resolved conflict keeps its row. Run `chroncal sync conflicts --resolved` to list resolved conflicts. Run `chroncal sync resolve <id> --pick local` on a resolved conflict to restore the recorded local version.
 
 ### Google Calendar via CalDAV

--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ Configuration loads in this order of precedence:
 | `ui.week_start` | First day of the week in the TUI month view, week view, and mini-calendar (`sunday` or `monday`) | `sunday` |
 | `soft_delete.purge_days` | Days to keep soft-deleted rows before the background purge. `0` disables automatic purge. | `30` |
 | `sync.interval` | Minimum interval between background CalDAV syncs that `chroncal service run` performs. `service install` defaults to `15m` when this is unset. | (unset — no sync unless the installed service sets `CHRONCAL_SYNC_INTERVAL`) |
-| `sync.conflict_strategy` | Default conflict-resolution mode when you do not pass `sync run --conflict` | (unset) |
+| `sync.conflict_strategy` | Default conflict-resolution mode when you do not pass `sync run --conflict` | `prompt` |
 | `security.allow_unsafe_alarm_audio_attach` | Allow AUDIO alarms to attach arbitrary URIs. Off by default. | `false` |
 | `security.allow_unsafe_alarm_email_attendees` | Allow EMAIL alarms to send to unverified attendee addresses. Off by default. | `false` |
 

--- a/cmd/chroncal/event_delete.go
+++ b/cmd/chroncal/event_delete.go
@@ -45,6 +45,49 @@ var eventResource = resource{
 // plus an override soft-delete). --following truncates the series from a
 // date. Both scopes act on the series master, so this wrapper resolves the
 // master row and bypasses the shared single-row flow.
+
+// occurrenceHorizon bounds how far ahead the validators search for the next
+// valid instance. A yearly series can legitimately have none within it; the
+// error then names the timestamp alone.
+const occurrenceHorizon = 366 * 24 * time.Hour
+
+// requireOccurrenceAt verifies that the series behind master generates an
+// instance exactly at at. A timestamp that matches nothing previously wrote a
+// phantom EXDATE and exited 0 while the real occurrence survived (issue #745).
+func requireOccurrenceAt(ctx context.Context, a *app.App, master event.Event, at time.Time) error {
+	return scanOccurrences(ctx, a, master, at, func(inst time.Time) bool { return inst.Equal(at) })
+}
+
+// requireOccurrenceFrom verifies that truncating at at removes at least one
+// instance, so `--following` cannot silently do nothing.
+func requireOccurrenceFrom(ctx context.Context, a *app.App, master event.Event, at time.Time) error {
+	return scanOccurrences(ctx, a, master, at, func(inst time.Time) bool { return !inst.Before(at) })
+}
+
+func scanOccurrences(ctx context.Context, a *app.App, master event.Event, at time.Time, match func(time.Time) bool) error {
+	expanded, err := a.Recurrences.ListExpandedEvents(ctx, at.Add(-time.Minute), at.Add(occurrenceHorizon))
+	if err != nil {
+		return fmt.Errorf("expand series: %w", err)
+	}
+	for _, inst := range expanded {
+		if inst.Event.UID != master.UID {
+			continue
+		}
+		if match(inst.InstanceTime) {
+			return nil
+		}
+	}
+	msg := fmt.Sprintf("no occurrence of %q matches %s", safeText(master.Title), at.Format(time.RFC3339))
+	for _, inst := range expanded {
+		if inst.Event.UID != master.UID || !inst.InstanceTime.After(at) {
+			continue
+		}
+		msg += fmt.Sprintf("; the next occurrence is %s", inst.InstanceTime.Format(time.RFC3339))
+		break
+	}
+	return errInvalidInputf("%s", msg)
+}
+
 func eventDeleteCmd() *cobra.Command {
 	cmd := newDeleteCmd(eventResource, verbHelp{
 		short: "Delete an event",
@@ -110,6 +153,14 @@ any override at that time). --following truncates the series at that date.`,
 		e, err := resolveEvent(ctx, a, args[0], "")
 		if err != nil {
 			return fmt.Errorf("get event: %w", err)
+		}
+
+		if following != "" {
+			if err := requireOccurrenceFrom(ctx, a, e, followingAt); err != nil {
+				return err
+			}
+		} else if err := requireOccurrenceAt(ctx, a, e, occurrenceAt); err != nil {
+			return err
 		}
 
 		question := fmt.Sprintf("Delete this occurrence of %q at %s?", safeText(e.Title), occurrenceAt.Format(time.RFC3339))

--- a/cmd/chroncal/event_delete.go
+++ b/cmd/chroncal/event_delete.go
@@ -43,12 +43,6 @@ var eventResource = resource{
 	errNotDeleted: event.ErrNotDeleted,
 }
 
-// eventDeleteCmd composes the shared delete verb with the two event-only
-// scopes. --recurrence-id excludes one occurrence (an EXDATE on the master
-// plus an override soft-delete). --following truncates the series from a
-// date. Both scopes act on the series master, so this wrapper resolves the
-// master row and bypasses the shared single-row flow.
-
 // requireOccurrenceAt verifies that the series behind master generates an
 // instance exactly at at. A timestamp that matches nothing previously wrote a
 // phantom EXDATE and exited 0 while the real occurrence survived (issue #745).
@@ -118,6 +112,11 @@ func noSuchOccurrenceErr(master event.Event, at time.Time) error {
 	return errInvalidInputf("%s", msg)
 }
 
+// eventDeleteCmd composes the shared delete verb with the two event-only
+// scopes. --recurrence-id excludes one occurrence (an EXDATE on the master
+// plus an override soft-delete). --following truncates the series from a
+// date. Both scopes act on the series master, so this wrapper resolves the
+// master row and bypasses the shared single-row flow.
 func eventDeleteCmd() *cobra.Command {
 	cmd := newDeleteCmd(eventResource, verbHelp{
 		short: "Delete an event",

--- a/cmd/chroncal/event_delete.go
+++ b/cmd/chroncal/event_delete.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/douglasdemoura/chroncal/internal/app"
 	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/recurrence"
 )
 
 // eventResource adapts the event service to the shared verb builders.
@@ -46,44 +47,35 @@ var eventResource = resource{
 // date. Both scopes act on the series master, so this wrapper resolves the
 // master row and bypasses the shared single-row flow.
 
-// occurrenceHorizon bounds how far ahead the validators search for the next
-// valid instance. A yearly series can legitimately have none within it; the
-// error then names the timestamp alone.
-const occurrenceHorizon = 366 * 24 * time.Hour
-
 // requireOccurrenceAt verifies that the series behind master generates an
 // instance exactly at at. A timestamp that matches nothing previously wrote a
 // phantom EXDATE and exited 0 while the real occurrence survived (issue #745).
+// The check runs on the raw rule set, so the original RECURRENCE-ID of a moved
+// override stays deletable.
 func requireOccurrenceAt(ctx context.Context, a *app.App, master event.Event, at time.Time) error {
-	return scanOccurrences(ctx, a, master, at, func(inst time.Time) bool { return inst.Equal(at) })
+	if recurrence.OccurrenceExistsAt(master, at) {
+		return nil
+	}
+	return noSuchOccurrenceErr(master, at)
 }
 
 // requireOccurrenceFrom verifies that truncating at at removes at least one
-// instance, so `--following` cannot silently do nothing.
+// instance, so --following cannot silently do nothing.
 func requireOccurrenceFrom(ctx context.Context, a *app.App, master event.Event, at time.Time) error {
-	return scanOccurrences(ctx, a, master, at, func(inst time.Time) bool { return !inst.Before(at) })
+	if recurrence.HasOccurrenceFrom(master, at) {
+		return nil
+	}
+	return noSuchOccurrenceErr(master, at)
 }
 
-func scanOccurrences(ctx context.Context, a *app.App, master event.Event, at time.Time, match func(time.Time) bool) error {
-	expanded, err := a.Recurrences.ListExpandedEvents(ctx, at.Add(-time.Minute), at.Add(occurrenceHorizon))
-	if err != nil {
-		return fmt.Errorf("expand series: %w", err)
-	}
-	for _, inst := range expanded {
-		if inst.Event.UID != master.UID {
-			continue
-		}
-		if match(inst.InstanceTime) {
-			return nil
-		}
+func noSuchOccurrenceErr(master event.Event, at time.Time) error {
+	if recurrence.IsCancelledSeries(master) {
+		return errInvalidInputf("series %q is cancelled; delete it whole with \"event delete %d --yes\"",
+			safeText(master.Title), master.ID)
 	}
 	msg := fmt.Sprintf("no occurrence of %q matches %s", safeText(master.Title), at.Format(time.RFC3339))
-	for _, inst := range expanded {
-		if inst.Event.UID != master.UID || !inst.InstanceTime.After(at) {
-			continue
-		}
-		msg += fmt.Sprintf("; the next occurrence is %s", inst.InstanceTime.Format(time.RFC3339))
-		break
+	if next, ok := recurrence.NextOccurrenceAfter(master, at); ok {
+		msg += fmt.Sprintf("; the next occurrence is %s", next.Format(time.RFC3339))
 	}
 	return errInvalidInputf("%s", msg)
 }

--- a/cmd/chroncal/event_delete.go
+++ b/cmd/chroncal/event_delete.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -64,6 +66,8 @@ func requireOccurrenceAt(ctx context.Context, a *app.App, master event.Event, at
 	// imported EXDATE hides the master slot; the override row is its own key.
 	if _, err := a.Events.GetByUIDAndRecurrenceID(ctx, master.UID, at.UTC().Format(time.RFC3339)); err == nil {
 		return nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("look up override: %w", err)
 	}
 	return noSuchOccurrenceErr(master, at)
 }
@@ -82,7 +86,10 @@ func requireOccurrenceFrom(ctx context.Context, a *app.App, master event.Event, 
 	// so one of those makes the scope meaningful even when an imported
 	// EXDATE hides every generated slot.
 	hasOverride, oErr := a.Events.HasLiveOverrideFrom(ctx, master.UID, at)
-	if oErr == nil && hasOverride {
+	if oErr != nil && !errors.Is(oErr, sql.ErrNoRows) {
+		return fmt.Errorf("check overrides: %w", oErr)
+	}
+	if hasOverride {
 		return nil
 	}
 	return noSuchOccurrenceErr(master, at)

--- a/cmd/chroncal/event_delete.go
+++ b/cmd/chroncal/event_delete.go
@@ -56,6 +56,11 @@ func requireOccurrenceAt(ctx context.Context, a *app.App, master event.Event, at
 	if recurrence.OccurrenceExistsAt(master, at) {
 		return nil
 	}
+	// A live override at that RECURRENCE-ID is deletable even when an
+	// imported EXDATE hides the master slot; the override row is its own key.
+	if _, err := a.Events.GetByUIDAndRecurrenceID(ctx, master.UID, at.UTC().Format(time.RFC3339)); err == nil {
+		return nil
+	}
 	return noSuchOccurrenceErr(master, at)
 }
 

--- a/cmd/chroncal/event_delete.go
+++ b/cmd/chroncal/event_delete.go
@@ -53,6 +53,10 @@ var eventResource = resource{
 // The check runs on the raw rule set, so the original RECURRENCE-ID of a moved
 // override stays deletable.
 func requireOccurrenceAt(ctx context.Context, a *app.App, master event.Event, at time.Time) error {
+	master, err := masterForScope(ctx, a, master)
+	if err != nil {
+		return err
+	}
 	if recurrence.OccurrenceExistsAt(master, at) {
 		return nil
 	}
@@ -67,10 +71,32 @@ func requireOccurrenceAt(ctx context.Context, a *app.App, master event.Event, at
 // requireOccurrenceFrom verifies that truncating at at removes at least one
 // instance, so --following cannot silently do nothing.
 func requireOccurrenceFrom(ctx context.Context, a *app.App, master event.Event, at time.Time) error {
+	master, err := masterForScope(ctx, a, master)
+	if err != nil {
+		return err
+	}
 	if recurrence.HasOccurrenceFrom(master, at) {
 		return nil
 	}
+	// Truncation also removes every live override at or after the cutoff,
+	// so one of those makes the scope meaningful even when an imported
+	// EXDATE hides every generated slot.
+	hasOverride, oErr := a.Events.HasLiveOverrideFrom(ctx, master.UID, at)
+	if oErr == nil && hasOverride {
+		return nil
+	}
 	return noSuchOccurrenceErr(master, at)
+}
+
+// masterForScope resolves a numeric-ID reference that hit an override row to
+// its series master. The scope validators reason about the raw rule set;
+// validating against an override's own (empty) rule set would let a moved
+// display start pass and write a phantom EXDATE.
+func masterForScope(ctx context.Context, a *app.App, resolved event.Event) (event.Event, error) {
+	if resolved.RecurrenceID == "" {
+		return resolved, nil
+	}
+	return a.Events.GetByUID(ctx, resolved.UID)
 }
 
 func noSuchOccurrenceErr(master event.Event, at time.Time) error {

--- a/cmd/chroncal/event_delete_recurrence_validate_test.go
+++ b/cmd/chroncal/event_delete_recurrence_validate_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEventDelete_RecurrenceIDMustMatchAnOccurrence guards issue #745: a
+// --recurrence-id that matches no generated instance used to write a phantom
+// EXDATE and exit 0 while the real occurrence survived. The command must now
+// fail with invalid_input, name the given timestamp, and point at the next
+// valid occurrence.
+func TestEventDelete_RecurrenceIDMustMatchAnOccurrence(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	dbPath := setupCalendarCLITestEnv(t)
+	master := addOverrideGapSeries(t)
+
+	const bogus = "2026-09-01T11:00:00Z"
+	_, stderr, err := runChroncalCommand(t,
+		"event", "delete", master.UID, "--recurrence-id", bogus, "--yes")
+	if err == nil {
+		t.Fatal("delete accepted a recurrence-id that matches no occurrence")
+	}
+	if !strings.Contains(stderr, "no occurrence of") || !strings.Contains(stderr, bogus) {
+		t.Fatalf("stderr = %q, want it to name the timestamp and the series", stderr)
+	}
+	if !strings.Contains(stderr, "next occurrence is 2026-09-02T10:00:00Z") {
+		t.Fatalf("stderr = %q, want it to name the next valid occurrence", stderr)
+	}
+
+	// The master row must be untouched: no phantom EXDATE.
+	a := openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Events.GetByUID(t.Context(), master.UID)
+	if err != nil {
+		t.Fatalf("master vanished: %v", err)
+	}
+	for _, ex := range strings.Split(got.ExDates, ",") {
+		if strings.TrimSpace(ex) == bogus {
+			t.Fatalf("phantom EXDATE %q was written", bogus)
+		}
+	}
+}
+
+// TestEventDelete_FollowingMustRemoveSomething extends the guard to the
+// truncation scope: a boundary after the last instance is a silent no-op and
+// must be rejected.
+func TestEventDelete_FollowingMustRemoveSomething(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	setupCalendarCLITestEnv(t)
+	master := addOverrideGapSeries(t)
+
+	_, stderr, err := runChroncalCommand(t,
+		"event", "delete", master.UID, "--following", "2027-06-01T00:00:00Z", "--yes")
+	if err == nil {
+		t.Fatal("--following past the last instance exited 0")
+	}
+	if !strings.Contains(stderr, "no occurrence of") {
+		t.Fatalf("stderr = %q, want the no-occurrence error", stderr)
+	}
+}

--- a/cmd/chroncal/event_delete_recurrence_validate_test.go
+++ b/cmd/chroncal/event_delete_recurrence_validate_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -72,7 +73,8 @@ func TestEventDelete_MovedOverrideOriginalSlotSucceeds(t *testing.T) {
 
 	const orig = "2026-09-02T10:00:00Z"
 	if _, _, err := runChroncalCommand(t, "event", "update", master.UID,
-		"--recurrence-id", orig, "--title", "Moved slot"); err != nil {
+		"--recurrence-id", orig, "--date", "2026-09-07", "--time", "15:00",
+		"--title", "Moved slot"); err != nil {
 		t.Fatalf("create override: %v", err)
 	}
 
@@ -104,3 +106,38 @@ func TestEventDelete_MovedOverrideOriginalSlotSucceeds(t *testing.T) {
 		}
 	}
 }
+
+// TestEventDelete_OverrideRowIDCannotPhantomExdate guards the numeric-ID
+// path: a reference that resolves to an override row must validate against
+// its series master, so deleting at the moved display start fails instead of
+// writing an EXDATE for a slot the master never generates (issue #745).
+func TestEventDelete_OverrideRowIDCannotPhantomExdate(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	dbPath := setupCalendarCLITestEnv(t)
+	master := addOverrideGapSeries(t)
+
+	const orig = "2026-09-02T10:00:00Z"
+	if _, _, err := runChroncalCommand(t, "event", "update", master.UID,
+		"--recurrence-id", orig, "--date", "2026-09-07", "--time", "15:00"); err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	a := openPlaintextApp(t, dbPath)
+	override, err := a.Events.GetByUIDAndRecurrenceID(t.Context(), master.UID, orig)
+	if err != nil {
+		t.Fatalf("override row missing: %v", err)
+	}
+	a.Close()
+
+	_, stderr, err := runChroncalCommand(t,
+		"event", "delete", strconvFormat(override.ID),
+		"--recurrence-id", "2026-09-07T15:00:00Z", "--yes")
+	if err == nil {
+		t.Fatal("delete at the moved time via the override row ID must fail")
+	}
+	if !strings.Contains(stderr, "no occurrence of") {
+		t.Fatalf("stderr = %q, want the no-occurrence error", stderr)
+	}
+}
+
+func strconvFormat(id int64) string { return fmt.Sprintf("%d", id) }

--- a/cmd/chroncal/event_delete_recurrence_validate_test.go
+++ b/cmd/chroncal/event_delete_recurrence_validate_test.go
@@ -59,3 +59,48 @@ func TestEventDelete_FollowingMustRemoveSomething(t *testing.T) {
 		t.Fatalf("stderr = %q, want the no-occurrence error", stderr)
 	}
 }
+
+// TestEventDelete_MovedOverrideOriginalSlotSucceeds locks the raw-set
+// semantics: a moved override keeps its original RECURRENCE-ID as the delete
+// key. Deleting at the original slot must remove the occurrence, while
+// deleting at the moved display start must be rejected without writing a
+// phantom EXDATE.
+func TestEventDelete_MovedOverrideOriginalSlotSucceeds(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	dbPath := setupCalendarCLITestEnv(t)
+	master := addOverrideGapSeries(t) // daily COUNT=3 from 2026-09-01T10:00Z
+
+	const orig = "2026-09-02T10:00:00Z"
+	if _, _, err := runChroncalCommand(t, "event", "update", master.UID,
+		"--recurrence-id", orig, "--title", "Moved slot"); err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// The moved display start is not a deletion key.
+	_, stderr, err := runChroncalCommand(t,
+		"event", "delete", master.UID, "--recurrence-id", "2026-09-02T13:00:00Z", "--yes")
+	if err == nil {
+		t.Fatal("delete at the moved time must fail")
+	}
+	if !strings.Contains(stderr, "no occurrence of") {
+		t.Fatalf("stderr = %q, want the no-occurrence error", stderr)
+	}
+
+	// The original RECURRENCE-ID still deletes the override.
+	if _, _, err := runChroncalCommand(t,
+		"event", "delete", master.UID, "--recurrence-id", orig, "--yes"); err != nil {
+		t.Fatalf("delete at original slot: %v", err)
+	}
+
+	a := openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Events.GetByUID(t.Context(), master.UID)
+	if err != nil {
+		t.Fatalf("master vanished: %v", err)
+	}
+	for _, ex := range strings.Split(got.ExDates, ",") {
+		if strings.TrimSpace(ex) == "2026-09-02T13:00:00Z" {
+			t.Fatal("phantom EXDATE written for the moved time")
+		}
+	}
+}

--- a/cmd/chroncal/event_delete_recurrence_validate_test.go
+++ b/cmd/chroncal/event_delete_recurrence_validate_test.go
@@ -79,8 +79,9 @@ func TestEventDelete_MovedOverrideOriginalSlotSucceeds(t *testing.T) {
 	}
 
 	// The moved display start is not a deletion key.
+	const movedStart = "2026-09-07T15:00:00Z"
 	_, stderr, err := runChroncalCommand(t,
-		"event", "delete", master.UID, "--recurrence-id", "2026-09-02T13:00:00Z", "--yes")
+		"event", "delete", master.UID, "--recurrence-id", movedStart, "--yes")
 	if err == nil {
 		t.Fatal("delete at the moved time must fail")
 	}
@@ -101,7 +102,7 @@ func TestEventDelete_MovedOverrideOriginalSlotSucceeds(t *testing.T) {
 		t.Fatalf("master vanished: %v", err)
 	}
 	for _, ex := range strings.Split(got.ExDates, ",") {
-		if strings.TrimSpace(ex) == "2026-09-02T13:00:00Z" {
+		if strings.TrimSpace(ex) == movedStart {
 			t.Fatal("phantom EXDATE written for the moved time")
 		}
 	}

--- a/cmd/chroncal/service.go
+++ b/cmd/chroncal/service.go
@@ -164,8 +164,10 @@ back to every 15 minutes when it is unset.`,
 				}
 			}
 			// The configured strategy is interpolated into the service
-			// environment, so reject an invalid name here. An empty name is
-			// the server-wins default and stays valid.
+			// environment, so reject an invalid name here. The prompt
+			// default is NOT baked in: the unit then stays config-driven,
+			// and a later config.toml edit takes effect on restart. Only an
+			// explicit non-default value lands in the environment.
 			if _, err := syncPkg.ParseConflictStrategy(cfg.Sync.ConflictStrategy); err != nil {
 				return errInvalidInputf("sync.conflict_strategy: %s", err.Error())
 			}
@@ -173,7 +175,7 @@ back to every 15 minutes when it is unset.`,
 			data := map[string]string{
 				"BinaryPath":                     binPath,
 				"SyncInterval":                   effectiveSyncInterval,
-				"SyncConflictStrategy":           cfg.Sync.ConflictStrategy,
+				"SyncConflictStrategy":           bakedConflictStrategy(cfg.Sync.ConflictStrategy),
 				"AllowUnsafeAlarmAudioAttach":    "",
 				"AllowUnsafeAlarmEmailAttendees": "",
 			}
@@ -523,4 +525,17 @@ On Windows it proxies "schtasks /Query /TN chroncal-alarm /V /FO LIST".`,
 		},
 	}
 	return cmd
+}
+
+// bakedConflictStrategy maps the configured strategy to the value the service
+// templates embed. The prompt default embeds as empty so the installed unit
+// reads config.toml on every start; only an explicit server-wins lands in the
+// environment. An empty value would otherwise freeze the default at install
+// time and silently ignore later config edits (issue #744 review).
+func bakedConflictStrategy(name string) string {
+	strategy, err := syncPkg.ParseConflictStrategy(name)
+	if err != nil || strategy == syncPkg.ConflictPrompt {
+		return ""
+	}
+	return string(strategy)
 }

--- a/cmd/chroncal/service_test.go
+++ b/cmd/chroncal/service_test.go
@@ -195,3 +195,20 @@ func TestRootCommandDoesNotRegisterTopLevelTick(t *testing.T) {
 		}
 	}
 }
+
+// TestBakedConflictStrategyOmitsPromptDefault guards the issue #744 review
+// fix: the prompt default must not be baked into installed units. A unit with
+// CHRONCAL_SYNC_CONFLICT_STRATEGY=prompt would pin the value at install time,
+// so a later config.toml edit would be silently ignored until reinstall.
+func TestBakedConflictStrategyOmitsPromptDefault(t *testing.T) {
+	cases := map[string]string{
+		"":            "", // unset -> prompt default -> nothing baked
+		"prompt":      "",
+		"server-wins": "server-wins",
+	}
+	for in, want := range cases {
+		if got := bakedConflictStrategy(in); got != want {
+			t.Errorf("bakedConflictStrategy(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -229,7 +229,7 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 	}
 	cmd.Flags().StringVar(&calendarName, "calendar", "", "Sync only this calendar")
 	cmd.Flags().StringVar(&accountName, "account", "", "Sync only calendars linked to this account")
-	cmd.Flags().StringVar(&conflict, "conflict", "server-wins", "Conflict strategy: server-wins or prompt (default: the sync.conflict_strategy config value; unset means prompt)")
+	cmd.Flags().StringVar(&conflict, "conflict", "", "Conflict strategy: server-wins or prompt (default: the sync.conflict_strategy config value, which defaults to prompt)")
 	mutuallyExclusive(cmd, "calendar", "account")
 	return cmd
 }

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -229,7 +229,7 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 	}
 	cmd.Flags().StringVar(&calendarName, "calendar", "", "Sync only this calendar")
 	cmd.Flags().StringVar(&accountName, "account", "", "Sync only calendars linked to this account")
-	cmd.Flags().StringVar(&conflict, "conflict", "server-wins", "Conflict strategy: server-wins or prompt (default: sync.conflict_strategy, else server-wins)")
+	cmd.Flags().StringVar(&conflict, "conflict", "server-wins", "Conflict strategy: server-wins or prompt (default: the sync.conflict_strategy config value; unset means prompt)")
 	mutuallyExclusive(cmd, "calendar", "account")
 	return cmd
 }

--- a/cmd/chroncal/tick.go
+++ b/cmd/chroncal/tick.go
@@ -114,13 +114,13 @@ func syncInterval() (time.Duration, error) {
 }
 
 // syncStrategy reads the configured conflict strategy for the background
-// tick. An unset or invalid name falls back to server-wins; the install
-// command rejects invalid names up front, so the fallback only covers a
-// hand-edited config file.
+// tick. An unset name parses to prompt. An invalid name also falls back to
+// prompt: a hand-edited config file must not silently enable the destructive
+// server-wins mode.
 func syncStrategy() syncPkg.ConflictStrategy {
 	strategy, err := syncPkg.ParseConflictStrategy(cfg.Sync.ConflictStrategy)
 	if err != nil {
-		return syncPkg.ConflictServerWins
+		return syncPkg.ConflictPrompt
 	}
 	return strategy
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,6 +140,9 @@ func newViper() *viper.Viper {
 	v.BindEnv("smtp.password")
 	v.BindEnv("smtp.from")
 	v.BindEnv("smtp.tls")
+	// An unset conflict strategy must mean the safe mode: record the
+	// conflict and wait for the user. Server-wins is an explicit opt-in.
+	v.SetDefault("sync.conflict_strategy", "prompt")
 	v.BindEnv("sync.interval")
 	v.BindEnv("sync.conflict_strategy")
 	v.BindEnv("security.allow_unsafe_alarm_audio_attach")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -283,3 +283,17 @@ func TestLoad_UIWeekStartFromEnv(t *testing.T) {
 		t.Errorf("UI.WeekStart = %q, want monday from env", cfg.UI.WeekStart)
 	}
 }
+
+// TestLoad_ConflictStrategyDefaultsToPrompt pins the safe default. With no
+// config file and no env, unset must mean prompt: a full sync pass records
+// conflicts instead of adopting the server body (issue #744).
+func TestLoad_ConflictStrategyDefaultsToPrompt(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CHRONCAL_SYNC_CONFLICT_STRATEGY", "")
+
+	cfg := mustLoad(t)
+
+	if cfg.Sync.ConflictStrategy != "prompt" {
+		t.Fatalf("Sync.ConflictStrategy = %q, want prompt", cfg.Sync.ConflictStrategy)
+	}
+}

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -65,7 +65,6 @@ type UndoMeta struct {
 // recurrence_id. Undo then un-hides exactly that instance. Without it, undo
 // falls back to a UID-wide restore that would also resurrect other
 // soft-deleted overrides of the same series.
-
 func (s *Service) DeleteWithUndo(ctx context.Context, id int64) (UndoMeta, error) {
 	r, err := s.q.GetEvent(ctx, id)
 	if err != nil {
@@ -744,18 +743,6 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 	return err
 }
 
-// softDeleteOverridesAndRecordTruncation trims the master's post-cutoff RDATEs.
-// It hides every live override at or after cutoff. It records the truncation
-// so the trash view can restore it. It captures the recurrence_ids it hides
-// and the RDATEs it drops BEFORE it removes them. Restore then re-shows
-// exactly those overrides and re-adds exactly those RDATEs.
-//
-// It does not restore an override the user deleted on its own (issue #287).
-// It does not leave a post-cutoff RDATE to reappear on the next expansion
-// (issue #463, since rrule-go expands RDATEs independently of the RRULE UNTIL
-// bound). Pairs with restoreTruncatedOverrides / restoreTruncatedRDates.
-//
-// prevRRule is the master's pre-truncation RRULE. The caller passes it because
 // it overwrote the master's recurrence_rule in the DB before this runs.
 
 // HasLiveOverrideFrom reports whether any live override of the series has a
@@ -782,6 +769,18 @@ func (s *Service) HasLiveOverrideFrom(ctx context.Context, uid string, from time
 	return false, nil
 }
 
+// softDeleteOverridesAndRecordTruncation trims the master's post-cutoff RDATEs.
+// It hides every live override at or after cutoff. It records the truncation
+// so the trash view can restore it. It captures the recurrence_ids it hides
+// and the RDATEs it drops BEFORE it removes them. Restore then re-shows
+// exactly those overrides and re-adds exactly those RDATEs.
+//
+// It does not restore an override the user deleted on its own (issue #287).
+// It does not leave a post-cutoff RDATE to reappear on the next expansion
+// (issue #463, since rrule-go expands RDATEs independently of the RRULE UNTIL
+// bound). Pairs with restoreTruncatedOverrides / restoreTruncatedRDates.
+//
+// prevRRule is the master's pre-truncation RRULE. The caller passes it because
 func softDeleteOverridesAndRecordTruncation(ctx context.Context, qtx *storage.Queries, master storage.Event, instanceTime time.Time, prevRRule string) error {
 	uid := master.Uid
 	cutoff := instanceTime.UTC().Format(time.RFC3339)

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -756,6 +756,7 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 //
 // prevRRule is the master's pre-truncation RRULE. The caller passes it because
 // it overwrote the master's recurrence_rule in the DB before this runs.
+
 // HasLiveOverrideFrom reports whether any live override of the series has a
 // RECURRENCE-ID at or after from. The --following scope guard uses it: a
 // truncation removes such overrides even when an imported EXDATE hides every

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -738,6 +738,24 @@ func (s *Service) DeleteInstance(ctx context.Context, uid string, instanceTime t
 // after instanceTime are removed. It sets UNTIL on the RRULE. It soft-deletes
 // any overrides at or after the cutoff. It records the pre-truncation
 // RRULE in event_truncate_deletes so the trash view can restore it atomically.
+func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTime time.Time) error {
+	_, err := s.deleteFromInstance(ctx, uid, instanceTime)
+	return err
+}
+
+// softDeleteOverridesAndRecordTruncation trims the master's post-cutoff RDATEs.
+// It hides every live override at or after cutoff. It records the truncation
+// so the trash view can restore it. It captures the recurrence_ids it hides
+// and the RDATEs it drops BEFORE it removes them. Restore then re-shows
+// exactly those overrides and re-adds exactly those RDATEs.
+//
+// It does not restore an override the user deleted on its own (issue #287).
+// It does not leave a post-cutoff RDATE to reappear on the next expansion
+// (issue #463, since rrule-go expands RDATEs independently of the RRULE UNTIL
+// bound). Pairs with restoreTruncatedOverrides / restoreTruncatedRDates.
+//
+// prevRRule is the master's pre-truncation RRULE. The caller passes it because
+// it overwrote the master's recurrence_rule in the DB before this runs.
 // HasLiveOverrideFrom reports whether any live override of the series has a
 // RECURRENCE-ID at or after from. The --following scope guard uses it: a
 // truncation removes such overrides even when an imported EXDATE hides every
@@ -762,24 +780,6 @@ func (s *Service) HasLiveOverrideFrom(ctx context.Context, uid string, from time
 	return false, nil
 }
 
-func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTime time.Time) error {
-	_, err := s.deleteFromInstance(ctx, uid, instanceTime)
-	return err
-}
-
-// softDeleteOverridesAndRecordTruncation trims the master's post-cutoff RDATEs.
-// It hides every live override at or after cutoff. It records the truncation
-// so the trash view can restore it. It captures the recurrence_ids it hides
-// and the RDATEs it drops BEFORE it removes them. Restore then re-shows
-// exactly those overrides and re-adds exactly those RDATEs.
-//
-// It does not restore an override the user deleted on its own (issue #287).
-// It does not leave a post-cutoff RDATE to reappear on the next expansion
-// (issue #463, since rrule-go expands RDATEs independently of the RRULE UNTIL
-// bound). Pairs with restoreTruncatedOverrides / restoreTruncatedRDates.
-//
-// prevRRule is the master's pre-truncation RRULE. The caller passes it because
-// it overwrote the master's recurrence_rule in the DB before this runs.
 func softDeleteOverridesAndRecordTruncation(ctx context.Context, qtx *storage.Queries, master storage.Event, instanceTime time.Time, prevRRule string) error {
 	uid := master.Uid
 	cutoff := instanceTime.UTC().Format(time.RFC3339)

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -65,6 +65,7 @@ type UndoMeta struct {
 // recurrence_id. Undo then un-hides exactly that instance. Without it, undo
 // falls back to a UID-wide restore that would also resurrect other
 // soft-deleted overrides of the same series.
+
 func (s *Service) DeleteWithUndo(ctx context.Context, id int64) (UndoMeta, error) {
 	r, err := s.q.GetEvent(ctx, id)
 	if err != nil {

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -738,6 +738,30 @@ func (s *Service) DeleteInstance(ctx context.Context, uid string, instanceTime t
 // after instanceTime are removed. It sets UNTIL on the RRULE. It soft-deletes
 // any overrides at or after the cutoff. It records the pre-truncation
 // RRULE in event_truncate_deletes so the trash view can restore it atomically.
+// HasLiveOverrideFrom reports whether any live override of the series has a
+// RECURRENCE-ID at or after from. The --following scope guard uses it: a
+// truncation removes such overrides even when an imported EXDATE hides every
+// generated slot, so their presence keeps the scope meaningful.
+func (s *Service) HasLiveOverrideFrom(ctx context.Context, uid string, from time.Time) (bool, error) {
+	rows, err := s.q.ListOverridesByUIDs(ctx, []string{uid})
+	if err != nil {
+		return false, err
+	}
+	for _, r := range rows {
+		if r.DeletedAt != nil || r.RecurrenceID == "" {
+			continue
+		}
+		at, err := timeutil.ParseRecurrenceID(r.RecurrenceID)
+		if err != nil {
+			continue
+		}
+		if !at.Before(from) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTime time.Time) error {
 	_, err := s.deleteFromInstance(ctx, uid, instanceTime)
 	return err

--- a/internal/event/soft_delete.go
+++ b/internal/event/soft_delete.go
@@ -743,8 +743,6 @@ func (s *Service) DeleteFromInstance(ctx context.Context, uid string, instanceTi
 	return err
 }
 
-// it overwrote the master's recurrence_rule in the DB before this runs.
-
 // HasLiveOverrideFrom reports whether any live override of the series has a
 // RECURRENCE-ID at or after from. The --following scope guard uses it: a
 // truncation removes such overrides even when an imported EXDATE hides every
@@ -781,6 +779,7 @@ func (s *Service) HasLiveOverrideFrom(ctx context.Context, uid string, from time
 // bound). Pairs with restoreTruncatedOverrides / restoreTruncatedRDates.
 //
 // prevRRule is the master's pre-truncation RRULE. The caller passes it because
+// it overwrote the master's recurrence_rule in the DB before this runs.
 func softDeleteOverridesAndRecordTruncation(ctx context.Context, qtx *storage.Queries, master storage.Event, instanceTime time.Time, prevRRule string) error {
 	uid := master.Uid
 	cutoff := instanceTime.UTC().Format(time.RFC3339)

--- a/internal/recurrence/instance_scope.go
+++ b/internal/recurrence/instance_scope.go
@@ -40,8 +40,16 @@ func HasOccurrenceFrom(evt event.Event, from time.Time) bool {
 	if !ok {
 		return !evt.StartTime.Before(from)
 	}
+	// rs.between keeps occurrences that merely overlap the window (a
+	// multi-day instance started earlier still runs at from). Deletion keys
+	// on starts, so only a start at or after the cutoff counts.
 	lo := from.UTC()
-	return len(rs.between(lo, lo.Add(instanceScopeHorizon))) > 0
+	for _, occ := range rs.between(lo, lo.Add(instanceScopeHorizon)) {
+		if !occ.Before(lo) {
+			return true
+		}
+	}
+	return false
 }
 
 // NextOccurrenceAfter returns the first instance strictly after after, or

--- a/internal/recurrence/instance_scope.go
+++ b/internal/recurrence/instance_scope.go
@@ -1,0 +1,85 @@
+package recurrence
+
+import (
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/timeutil"
+)
+
+// instanceScopeHorizon bounds the forward search behind HasOccurrenceFrom.
+// Rules sparser than this are rejected as a no-op instead of silently
+// truncating nothing. Five years covers every sane interval; a longer gap is
+// indistinguishable from an exhausted rule.
+const instanceScopeHorizon = 5 * 365 * 24 * time.Hour
+
+// OccurrenceExistsAt reports whether evt's raw rule set generates an instance
+// at at. EXDATEs apply, overrides do not hide their slot: deleting an instance
+// targets its original RECURRENCE-ID even when an override moved it elsewhere.
+// A cancelled series generates nothing. A non-recurring or unparseable master
+// matches only its own start.
+func OccurrenceExistsAt(evt event.Event, at time.Time) bool {
+	if cancelledRecurringMaster(evt.RecurrenceRule, evt.Status) {
+		return false
+	}
+	rs, ok := newEventRRuleSet(evt, true)
+	if !ok {
+		return evt.StartTime.Equal(at)
+	}
+	return rs.occursAt(at.UTC().Format(time.RFC3339))
+}
+
+// HasOccurrenceFrom reports whether scoping the series at from removes at
+// least one generated instance. Same override and cancellation rules as
+// OccurrenceExistsAt.
+func HasOccurrenceFrom(evt event.Event, from time.Time) bool {
+	if cancelledRecurringMaster(evt.RecurrenceRule, evt.Status) {
+		return false
+	}
+	rs, ok := newEventRRuleSet(evt, true)
+	if !ok {
+		return !evt.StartTime.Before(from)
+	}
+	lo := from.UTC()
+	return len(rs.between(lo, lo.Add(instanceScopeHorizon))) > 0
+}
+
+// NextOccurrenceAfter returns the first instance strictly after after, or
+// ok=false when none exists within the scan horizon. Callers use it to point
+// at the nearest valid slot in rejection messages.
+func NextOccurrenceAfter(evt event.Event, after time.Time) (time.Time, bool) {
+	if cancelledRecurringMaster(evt.RecurrenceRule, evt.Status) {
+		return time.Time{}, false
+	}
+	rs, ok := newEventRRuleSet(evt, true)
+	if !ok {
+		if evt.StartTime.After(after) {
+			return evt.StartTime, true
+		}
+		return time.Time{}, false
+	}
+	lo := after.UTC()
+	for _, occ := range rs.between(lo, lo.Add(instanceScopeHorizon)) {
+		if occ.After(after) {
+			return occ, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// IsCancelledSeries mirrors cancelledRecurringMaster for callers that want to
+// name the condition instead of a generic no-occurrence error.
+func IsCancelledSeries(evt event.Event) bool {
+	return cancelledRecurringMaster(evt.RecurrenceRule, evt.Status)
+}
+
+// ScopeInstanceTime returns the deletion key for one instance of ev: the
+// original RECURRENCE-ID for an override, else its start. DeleteInstance and
+// DeleteFromInstance match overrides by that stored id, never by the moved
+// display time.
+func ScopeInstanceTime(ev event.Event) (time.Time, error) {
+	if ev.RecurrenceID != "" {
+		return timeutil.ParseRecurrenceID(ev.RecurrenceID)
+	}
+	return ev.StartTime, nil
+}

--- a/internal/recurrence/instance_scope_test.go
+++ b/internal/recurrence/instance_scope_test.go
@@ -1,0 +1,105 @@
+package recurrence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+)
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %s: %v", s, err)
+	}
+	return v
+}
+
+func weeklyMaster(t *testing.T) event.Event {
+	return event.Event{
+		UID:            "series@example.com",
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=MO,WE,FR",
+		StartTime:      mustTime(t, "2026-09-02T10:00:00Z"),
+		EndTime:        mustTime(t, "2026-09-02T11:00:00Z"),
+		Status:         "CONFIRMED",
+	}
+}
+
+// A moved override keeps its original RECURRENCE-ID as the deletion key. The
+// raw set must still accept the original slot and reject the moved display
+// start; otherwise a delete at the original slot errors (regression) or a
+// delete at the new slot writes a phantom EXDATE (issue #745 via review).
+func TestOccurrenceExistsAt_MovedOverrideKeepsOriginalSlot(t *testing.T) {
+	master := weeklyMaster(t)
+	orig := "2026-09-04T10:00:00Z" // Friday slot
+
+	if !OccurrenceExistsAt(master, mustTime(t, orig)) {
+		t.Fatal("original slot must exist before any override")
+	}
+	movedStart := mustTime(t, "2026-09-07T15:00:00Z")
+
+	// The raw master is unchanged by an override existing elsewhere.
+	if !OccurrenceExistsAt(master, mustTime(t, orig)) {
+		t.Fatal("override must not hide its original slot")
+	}
+	if OccurrenceExistsAt(master, movedStart) {
+		t.Fatal("moved display time must not count as an occurrence")
+	}
+}
+
+// An EXDATE removes the slot for real: deleting it again is a no-op and the
+// guard must say so instead of letting DeleteInstance append a duplicate.
+func TestOccurrenceExistsAt_ExDateRemovesSlot(t *testing.T) {
+	master := weeklyMaster(t)
+	gone := mustTime(t, "2026-09-04T10:00:00Z")
+	master.ExDates = gone.Format(time.RFC3339)
+	if OccurrenceExistsAt(master, gone) {
+		t.Fatal("EXDATEd slot must not exist")
+	}
+	if !OccurrenceExistsAt(master, mustTime(t, "2026-09-07T10:00:00Z")) {
+		t.Fatal("other slots survive the EXDATE")
+	}
+}
+
+func TestOccurrenceExistsAt_CancelledSeriesHasNothing(t *testing.T) {
+	master := weeklyMaster(t)
+	master.Status = "CANCELLED"
+	if OccurrenceExistsAt(master, mustTime(t, "2026-09-02T10:00:00Z")) {
+		t.Fatal("cancelled series must have no occurrences")
+	}
+	if HasOccurrenceFrom(master, time.Now()) {
+		t.Fatal("cancelled series truncation must be rejected")
+	}
+	if _, ok := NextOccurrenceAfter(master, time.Now()); ok {
+		t.Fatal("cancelled series must yield no next occurrence")
+	}
+}
+
+// Non-recurring masters match only their own start.
+func TestOccurrenceScope_NonRecurring(t *testing.T) {
+	single := event.Event{StartTime: mustTime(t, "2026-09-02T10:00:00Z")}
+	if !OccurrenceExistsAt(single, single.StartTime) {
+		t.Fatal("own start must match")
+	}
+	if OccurrenceExistsAt(single, single.StartTime.Add(time.Hour)) {
+		t.Fatal("non-recurring has one slot only")
+	}
+	if HasOccurrenceFrom(single, single.StartTime.Add(time.Minute)) {
+		t.Fatal("nothing after the single instance")
+	}
+}
+
+func TestHasOccurrenceFromAndNext(t *testing.T) {
+	master := weeklyMaster(t)
+	if !HasOccurrenceFrom(master, mustTime(t, "2026-09-04T10:00:00Z")) {
+		t.Fatal("truncation at an existing slot removes it")
+	}
+	next, ok := NextOccurrenceAfter(master, mustTime(t, "2026-09-02T10:00:01Z"))
+	if !ok || next.Format(time.RFC3339) != "2026-09-04T10:00:00Z" {
+		t.Fatalf("next = %v ok=%v, want 2026-09-04T10:00:00Z", next, ok)
+	}
+	if !HasOccurrenceFrom(master, mustTime(t, "2031-01-01T00:00:00Z")) {
+		t.Fatal("a weekly series still has occurrences five years out")
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -94,13 +94,14 @@ const (
 )
 
 // ParseConflictStrategy maps a configured strategy name to its constant. An
-// empty name means the default, server-wins. Any other name is an error.
+// empty name means unset and resolves to prompt, the safe default.
+// Server-wins is an explicit opt-in (issue #744). Any other name is an error.
 func ParseConflictStrategy(s string) (ConflictStrategy, error) {
 	switch ConflictStrategy(s) {
-	case "", ConflictServerWins:
-		return ConflictServerWins, nil
-	case ConflictPrompt:
+	case "", ConflictPrompt:
 		return ConflictPrompt, nil
+	case ConflictServerWins:
+		return ConflictServerWins, nil
 	default:
 		return "", fmt.Errorf("invalid conflict strategy %q (use %q or %q)",
 			s, ConflictServerWins, ConflictPrompt)

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -846,3 +846,25 @@ func TestEnginePersistImportedKeepsDirtyOnChildReplaceError(t *testing.T) {
 		t.Fatalf("resource %q no longer dirty after child-replace failure; sync would never retry", uid)
 	}
 }
+
+// TestParseConflictStrategy_EmptyMeansPrompt pins the safe default: an unset
+// strategy must resolve to prompt, never to the destructive server-wins mode
+// (issue #744).
+func TestParseConflictStrategy_EmptyMeansPrompt(t *testing.T) {
+	got, err := ParseConflictStrategy("")
+	if err != nil {
+		t.Fatalf("empty strategy: %v", err)
+	}
+	if got != ConflictPrompt {
+		t.Fatalf("empty strategy = %q, want prompt", got)
+	}
+	if got, err := ParseConflictStrategy("prompt"); err != nil || got != ConflictPrompt {
+		t.Fatalf("prompt = %q err=%v", got, err)
+	}
+	if got, err := ParseConflictStrategy("server-wins"); err != nil || got != ConflictServerWins {
+		t.Fatalf("server-wins = %q err=%v", got, err)
+	}
+	if _, err := ParseConflictStrategy("nonsense"); err == nil {
+		t.Fatal("invalid name must error")
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -628,7 +628,7 @@ func (m Model) Init() tea.Cmd {
 // occurrence and opens its view dialog after the first load.
 // SyncConflictStrategy is the configured full-pass strategy name (from
 // cfg.Sync.ConflictStrategy). An empty or invalid name falls back to
-// server-wins.
+// prompt.
 type RunOptions struct {
 	Event                event.Event
 	WeekStart            time.Weekday

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -636,15 +636,15 @@ type RunOptions struct {
 }
 
 // resolveFullSyncStrategy maps the configured conflict-strategy name to the
-// value the TUI's full sync passes use. An empty or invalid name falls back
-// to server-wins. The install command rejects invalid names up front, so the
-// fallback only covers a hand-edited config file. The warning goes to the
-// state-dir log file. A write to stderr would print over the display.
+// value the TUI's full sync passes use. An empty name parses to prompt. An
+// invalid name falls back to prompt as well, so a hand-edited config file can
+// not silently enable server-wins. The warning goes to the state-dir log
+// file. A write to stderr would print over the display.
 func resolveFullSyncStrategy(name string) syncpkg.ConflictStrategy {
 	strategy, err := syncpkg.ParseConflictStrategy(name)
 	if err != nil {
-		config.SharedStateDirLogger().Warn("invalid sync.conflict_strategy; full syncs fall back to server-wins", "value", name, "error", err.Error())
-		return syncpkg.ConflictServerWins
+		config.SharedStateDirLogger().Warn("invalid sync.conflict_strategy; full syncs fall back to prompt", "value", name, "error", err.Error())
+		return syncpkg.ConflictPrompt
 	}
 	return strategy
 }

--- a/internal/tui/app_update_dialog.go
+++ b/internal/tui/app_update_dialog.go
@@ -65,32 +65,45 @@ func (m Model) handleChoiceDialogResult(msg ChoiceDialogResultMsg) (tea.Model, t
 			// Validate the scope against the master's raw rule set before
 			// touching storage. The deletion key is the original
 			// RECURRENCE-ID, never a moved override's display start.
-			scopeAt, scopeErr := recurrence.ScopeInstanceTime(ev)
-			if scopeErr == nil {
-				master, mErr := m.app.Events.GetByUID(context.Background(), ev.UID)
-				if mErr != nil {
-					scopeErr = mErr
-				} else if msg.Choice == 0 || msg.Choice == 1 {
-					ok := false
-					switch msg.Choice {
-					case 0:
-						ok = recurrence.OccurrenceExistsAt(master, scopeAt)
-					case 1:
-						ok = recurrence.HasOccurrenceFrom(master, scopeAt)
-					}
-					if !ok {
-						// A live override at that RECURRENCE-ID stays
-						// deletable even when an imported EXDATE hides the
-						// master slot; the override row is its own key.
-						if _, oErr := m.app.Events.GetByUIDAndRecurrenceID(
-							context.Background(), ev.UID, scopeAt.UTC().Format(time.RFC3339)); oErr != nil {
+			// Whole-series delete needs no scope time; validate only the
+			// instance scopes against the master's raw rule set.
+			if msg.Choice == 0 || msg.Choice == 1 {
+				scopeAt, scopeErr := recurrence.ScopeInstanceTime(ev)
+				if scopeErr == nil {
+					var master event.Event
+					master, scopeErr = m.app.Events.GetByUID(context.Background(), ev.UID)
+					if scopeErr == nil {
+						ok := false
+						if msg.Choice == 0 {
+							ok = recurrence.OccurrenceExistsAt(master, scopeAt)
+							if !ok {
+								// A live override at that RECURRENCE-ID stays
+								// deletable even when an imported EXDATE hides
+								// the master slot.
+								_, oErr := m.app.Events.GetByUIDAndRecurrenceID(
+									context.Background(), ev.UID, scopeAt.UTC().Format(time.RFC3339))
+								ok = oErr == nil
+							}
+						} else {
+							ok = recurrence.HasOccurrenceFrom(master, scopeAt)
+							if !ok {
+								ok, _ = m.app.Events.HasLiveOverrideFrom(context.Background(), ev.UID, scopeAt)
+							}
+						}
+						if !ok {
 							scopeErr = fmt.Errorf("no occurrence matches %s", scopeAt.Format(time.RFC3339))
 						}
 					}
 				}
+				if scopeErr != nil {
+					return eventDeletedMsg{calendarID: ev.CalendarID, title: ev.Title, err: scopeErr}
+				}
 			}
-			if scopeErr != nil {
-				return eventDeletedMsg{calendarID: ev.CalendarID, title: ev.Title, err: scopeErr}
+			scopeAt := ev.StartTime
+			if ev.RecurrenceID != "" {
+				if parsed, perr := time.Parse(time.RFC3339, ev.RecurrenceID); perr == nil {
+					scopeAt = parsed
+				}
 			}
 			switch msg.Choice {
 			case 0: // This event

--- a/internal/tui/app_update_dialog.go
+++ b/internal/tui/app_update_dialog.go
@@ -2,9 +2,12 @@ package tui
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/recurrence"
 )
 
 func (m Model) handleChoiceDialogResult(msg ChoiceDialogResultMsg) (tea.Model, tea.Cmd) {
@@ -59,9 +62,30 @@ func (m Model) handleChoiceDialogResult(msg ChoiceDialogResultMsg) (tea.Model, t
 	case pendingActionEventDeleteScope:
 		ev := act.target.ev
 		return m, func() tea.Msg {
+			// Validate the scope against the master's raw rule set before
+			// touching storage. The deletion key is the original
+			// RECURRENCE-ID, never a moved override's display start.
+			scopeAt, scopeErr := recurrence.ScopeInstanceTime(ev)
+			if scopeErr == nil {
+				master, mErr := m.app.Events.GetByUID(context.Background(), ev.UID)
+				if mErr != nil {
+					scopeErr = mErr
+				} else {
+					switch msg.Choice {
+					case 0:
+						if !recurrence.OccurrenceExistsAt(master, scopeAt) {
+							scopeErr = fmt.Errorf("no occurrence matches %s", scopeAt.Format(time.RFC3339))
+						}
+					case 1:
+						if !recurrence.HasOccurrenceFrom(master, scopeAt) {
+							scopeErr = fmt.Errorf("no occurrences at or after %s", scopeAt.Format(time.RFC3339))
+						}
+					}
+				}
+			}
 			switch msg.Choice {
 			case 0: // This event
-				meta, err := m.app.Events.DeleteInstanceWithUndo(context.Background(), ev.UID, ev.StartTime)
+				meta, err := m.app.Events.DeleteInstanceWithUndo(context.Background(), ev.UID, scopeAt)
 				return eventDeletedMsg{
 					calendarID: ev.CalendarID,
 					meta:       meta,
@@ -69,7 +93,7 @@ func (m Model) handleChoiceDialogResult(msg ChoiceDialogResultMsg) (tea.Model, t
 					err:        err,
 				}
 			case 1: // This and following
-				meta, err := m.app.Events.DeleteFromInstanceWithUndo(context.Background(), ev.UID, ev.StartTime)
+				meta, err := m.app.Events.DeleteFromInstanceWithUndo(context.Background(), ev.UID, scopeAt)
 				return eventDeletedMsg{
 					calendarID: ev.CalendarID,
 					meta:       meta,

--- a/internal/tui/app_update_dialog.go
+++ b/internal/tui/app_update_dialog.go
@@ -70,18 +70,27 @@ func (m Model) handleChoiceDialogResult(msg ChoiceDialogResultMsg) (tea.Model, t
 				master, mErr := m.app.Events.GetByUID(context.Background(), ev.UID)
 				if mErr != nil {
 					scopeErr = mErr
-				} else {
+				} else if msg.Choice == 0 || msg.Choice == 1 {
+					ok := false
 					switch msg.Choice {
 					case 0:
-						if !recurrence.OccurrenceExistsAt(master, scopeAt) {
-							scopeErr = fmt.Errorf("no occurrence matches %s", scopeAt.Format(time.RFC3339))
-						}
+						ok = recurrence.OccurrenceExistsAt(master, scopeAt)
 					case 1:
-						if !recurrence.HasOccurrenceFrom(master, scopeAt) {
-							scopeErr = fmt.Errorf("no occurrences at or after %s", scopeAt.Format(time.RFC3339))
+						ok = recurrence.HasOccurrenceFrom(master, scopeAt)
+					}
+					if !ok {
+						// A live override at that RECURRENCE-ID stays
+						// deletable even when an imported EXDATE hides the
+						// master slot; the override row is its own key.
+						if _, oErr := m.app.Events.GetByUIDAndRecurrenceID(
+							context.Background(), ev.UID, scopeAt.UTC().Format(time.RFC3339)); oErr != nil {
+							scopeErr = fmt.Errorf("no occurrence matches %s", scopeAt.Format(time.RFC3339))
 						}
 					}
 				}
+			}
+			if scopeErr != nil {
+				return eventDeletedMsg{calendarID: ev.CalendarID, title: ev.Title, err: scopeErr}
 			}
 			switch msg.Choice {
 			case 0: // This event

--- a/internal/tui/app_update_dialog.go
+++ b/internal/tui/app_update_dialog.go
@@ -2,10 +2,13 @@ package tui
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/douglasdemoura/chroncal/internal/app"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/recurrence"
 )
@@ -62,48 +65,13 @@ func (m Model) handleChoiceDialogResult(msg ChoiceDialogResultMsg) (tea.Model, t
 	case pendingActionEventDeleteScope:
 		ev := act.target.ev
 		return m, func() tea.Msg {
-			// Validate the scope against the master's raw rule set before
-			// touching storage. The deletion key is the original
-			// RECURRENCE-ID, never a moved override's display start.
-			// Whole-series delete needs no scope time; validate only the
-			// instance scopes against the master's raw rule set.
-			if msg.Choice == 0 || msg.Choice == 1 {
-				scopeAt, scopeErr := recurrence.ScopeInstanceTime(ev)
-				if scopeErr == nil {
-					var master event.Event
-					master, scopeErr = m.app.Events.GetByUID(context.Background(), ev.UID)
-					if scopeErr == nil {
-						ok := false
-						if msg.Choice == 0 {
-							ok = recurrence.OccurrenceExistsAt(master, scopeAt)
-							if !ok {
-								// A live override at that RECURRENCE-ID stays
-								// deletable even when an imported EXDATE hides
-								// the master slot.
-								_, oErr := m.app.Events.GetByUIDAndRecurrenceID(
-									context.Background(), ev.UID, scopeAt.UTC().Format(time.RFC3339))
-								ok = oErr == nil
-							}
-						} else {
-							ok = recurrence.HasOccurrenceFrom(master, scopeAt)
-							if !ok {
-								ok, _ = m.app.Events.HasLiveOverrideFrom(context.Background(), ev.UID, scopeAt)
-							}
-						}
-						if !ok {
-							scopeErr = fmt.Errorf("no occurrence matches %s", scopeAt.Format(time.RFC3339))
-						}
-					}
-				}
-				if scopeErr != nil {
-					return eventDeletedMsg{calendarID: ev.CalendarID, title: ev.Title, err: scopeErr}
-				}
+			if verr := validateEventDeleteScope(context.Background(), m.app, ev, msg.Choice); verr != nil {
+				return eventDeletedMsg{calendarID: ev.CalendarID, title: ev.Title, err: verr}
 			}
-			scopeAt := ev.StartTime
-			if ev.RecurrenceID != "" {
-				if parsed, perr := time.Parse(time.RFC3339, ev.RecurrenceID); perr == nil {
-					scopeAt = parsed
-				}
+			scopeAt, dErr := recurrence.ScopeInstanceTime(ev)
+			if dErr != nil {
+				return eventDeletedMsg{calendarID: ev.CalendarID, title: ev.Title,
+					err: fmt.Errorf("invalid recurrence id %q: %w", ev.RecurrenceID, dErr)}
 			}
 			switch msg.Choice {
 			case 0: // This event
@@ -213,4 +181,48 @@ func (m Model) handleConfirmDialogResult(msg ConfirmDialogResultMsg) (tea.Model,
 		// action fires.
 		return m, nil
 	}
+}
+
+// validateEventDeleteScope checks an instance-scoped recurring delete against
+// the series master's raw rule set before any storage call runs. Whole-series
+// deletes need no scope time and pass through. The deletion key is the
+// original RECURRENCE-ID, never a moved override's display start; a live
+// override at that RECURRENCE-ID stays deletable even when an imported EXDATE
+// hides the master slot.
+func validateEventDeleteScope(ctx context.Context, a *app.App, ev event.Event, choice int) error {
+	if choice != 0 && choice != 1 {
+		return nil
+	}
+	scopeAt, err := recurrence.ScopeInstanceTime(ev)
+	if err != nil {
+		return fmt.Errorf("invalid recurrence id %q: %w", ev.RecurrenceID, err)
+	}
+	master, err := a.Events.GetByUID(ctx, ev.UID)
+	if err != nil {
+		return fmt.Errorf("get series master: %w", err)
+	}
+	switch choice {
+	case 0:
+		if recurrence.OccurrenceExistsAt(master, scopeAt) {
+			return nil
+		}
+		if _, oErr := a.Events.GetByUIDAndRecurrenceID(
+			ctx, ev.UID, scopeAt.UTC().Format(time.RFC3339)); oErr == nil {
+			return nil
+		} else if !errors.Is(oErr, sql.ErrNoRows) {
+			return fmt.Errorf("look up override: %w", oErr)
+		}
+	case 1:
+		if recurrence.HasOccurrenceFrom(master, scopeAt) {
+			return nil
+		}
+		has, hErr := a.Events.HasLiveOverrideFrom(ctx, ev.UID, scopeAt)
+		if hErr != nil {
+			return fmt.Errorf("check overrides: %w", hErr)
+		}
+		if has {
+			return nil
+		}
+	}
+	return fmt.Errorf("no occurrence matches %s", scopeAt.Format(time.RFC3339))
 }

--- a/internal/tui/app_update_dialog_scope_test.go
+++ b/internal/tui/app_update_dialog_scope_test.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+)
+
+// TestDeleteScopeValidationBlocksAndSurfaces drives the recurring-delete
+// choice dialog for a scope time that matches no generated instance. The
+// storage call must never run, and the validation error must travel through
+// eventDeletedMsg so the toast surfaces it. Regression for the thermos
+// round-2 finding that scopeErr was computed but never checked, so the
+// delete ran anyway.
+func TestDeleteScopeValidationBlocksAndSurfaces(t *testing.T) {
+	m, a := newDBBackedModel(t)
+	ctx := context.Background()
+
+	cal, err := a.Calendars.Create(ctx, "Work", "#7C3AED", "")
+	if err != nil {
+		t.Fatalf("calendar create: %v", err)
+	}
+	start := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	ev, err := a.Events.Create(ctx, event.CreateParams{
+		CalendarID:     cal.ID,
+		Title:          "Weekly",
+		StartTime:      start,
+		EndTime:        start.Add(time.Hour),
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=WE",
+	})
+	if err != nil {
+		t.Fatalf("event create: %v", err)
+	}
+
+	next, _ := m.handleEventDelete(EventDeleteMsg{Event: ev})
+	m = next.(Model)
+	if !m.choiceOpen {
+		t.Fatal("recurring delete did not arm the scope dialog")
+	}
+	// Point the armed scope at a non-instance slot without touching storage.
+	ev.StartTime = start.Add(time.Hour)
+	m.pending.target.ev = ev
+
+	next, cmd := m.handleChoiceDialogResult(ChoiceDialogResultMsg{Choice: 0}) // This event
+	if cmd == nil {
+		t.Fatal("expected a command carrying the validation result")
+	}
+	res := cmd()
+	done, ok := res.(eventDeletedMsg)
+	if !ok {
+		t.Fatalf("choice dispatched %T, want eventDeletedMsg", res)
+	}
+	if done.err == nil || !strings.Contains(done.err.Error(), "no occurrence matches") {
+		t.Fatalf("err = %v, want the no-occurrence validation error", done.err)
+	}
+
+	// Storage is untouched: the master row survives without any EXDATE.
+	got, gerr := a.Events.GetByUID(ctx, ev.UID)
+	if gerr != nil {
+		t.Fatalf("master vanished: %v", gerr)
+	}
+	if strings.TrimSpace(got.ExDates) != "" {
+		t.Fatalf("phantom EXDATE written: %q", got.ExDates)
+	}
+}

--- a/internal/tui/app_update_dialog_scope_test.go
+++ b/internal/tui/app_update_dialog_scope_test.go
@@ -45,6 +45,10 @@ func TestDeleteScopeValidationBlocksAndSurfaces(t *testing.T) {
 	m.pending.target.ev = ev
 
 	next, cmd := m.handleChoiceDialogResult(ChoiceDialogResultMsg{Choice: 0}) // This event
+	after := next.(Model)
+	if after.confirmOpen {
+		t.Fatal("the failed scope left the choice dialog open")
+	}
 	if cmd == nil {
 		t.Fatal("expected a command carrying the validation result")
 	}


### PR DESCRIPTION
Closes #744, closes #745 — both findings came out of the post-merge QA pass on the refactor wave.

## #744 — unset conflict strategy meant server-wins

`ParseConflictStrategy("")` maps empty to `ConflictServerWins`, and nothing set a default for `sync.conflict_strategy`. A stock install therefore auto-adopted the server body on every full pass (`auto_resolved=1`) with `sync conflicts` showing nothing.

- `newViper` now sets the key to `prompt`; server-wins is an explicit opt-in.
- `TestLoad_ConflictStrategyDefaultsToPrompt` pins the no-config case.
- README states the default.

## #745 — phantom EXDATE from a non-matching recurrence-id

`event delete <uid> --recurrence-id T` wrote an EXDATE for any T and exited 0 even when the series generates nothing at T — the real occurrence survived while export showed a bogus EXDATE. Same silent no-op for `--following` past the last instance.

Both scopes now expand the series first (`Recurrences.ListExpandedEvents`) and fail with the standard invalid-input error naming the given timestamp plus the next valid occurrence when one exists within a year:

```
Error: no occurrence of "Override Gap" matches 2026-09-01T11:00:00Z; the next occurrence is 2026-09-02T10:00:00Z
```

Regression tests cover both scopes, including asserting no EXDATE lands on the master row.

## Verification

- `go test ./internal/config/ ./cmd/chroncal/` green (full suites)
- New tests: `TestLoad_ConflictStrategyDefaultsToPrompt`, `TestEventDelete_RecurrenceIDMustMatchAnOccurrence`, `TestEventDelete_FollowingMustRemoveSomething`

Assisted-by: opencode-zen:x-preview-f-free