### PR TITLE
fix(notify): show Chroncal as the notification sender

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -27,6 +27,15 @@ type ExecutionPolicy struct {
 	AllowUnsafeEmailAttendees bool
 }
 
+// appName is the name the desktop notification daemon shows as the sender.
+// beeep defaults to "DefaultAppName"; the daemon renders that string
+// verbatim, so set the product name before any notification goes out.
+const appName = "Chroncal"
+
+func init() {
+	beeep.AppName = appName
+}
+
 // FormatNotification formats a DueAlarm into a title and body suitable for display.
 // Title is the event title. Body contains the formatted time and, when present,
 // the location. The description is included only when it is not generic reminder boilerplate.

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/gen2brain/beeep"
 )
 
 func TestFormatNotification_Basic(t *testing.T) {
@@ -656,4 +657,13 @@ func runMinimalSMTPDialog(conn net.Conn) error {
 		return fmt.Errorf("expected QUIT, got %q", line)
 	}
 	return send("221 Bye")
+}
+
+// TestAppNameIsChroncal pins the sender name the notification daemon shows.
+// beeep defaults to "DefaultAppName"; users see that string verbatim in every
+// desktop notification unless the package overrides it (issue found in QA).
+func TestAppNameIsChroncal(t *testing.T) {
+	if beeep.AppName != "Chroncal" {
+		t.Fatalf("beeep.AppName = %q, want Chroncal", beeep.AppName)
+	}
 }


### PR DESCRIPTION
Desktop notifications showed **DefaultAppName** because beeep's `AppName` package variable ships with that literal default and the daemon renders it verbatim (`internal/notify/notify.go` calls `beeep.Notify` with no way to pass a sender name).

Set `beeep.AppName = "Chroncal"` in the notify package init, so every entry point that fires alarms (alarm daemon, service run, TUI) sends the product name. A test pins the value.

Found in QA on the user's desktop (screenshot: notification header reads `DefaultAppName`).

Assisted-by: opencode-zen:x-preview-f-free