### PR TITLE
fix(sync): handle iCloud collection responses

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -35,6 +35,12 @@ type Resource struct {
 	Path string
 	ETag string
 	Data *ical.Calendar
+	// RawData is the calendar-data payload exactly as the server returned it.
+	// An iCloud REPORT response can omit VCALENDAR PRODID.
+	// go-ical decodes such a payload but cannot encode it again.
+	// A pull imports RawData to avoid data loss.
+	// QueryAll and GetResource can leave it empty.
+	RawData string
 }
 
 // Change represents a changed or deleted resource from a sync-collection report.
@@ -473,9 +479,16 @@ func (c *Client) CanonicalObjectRef(calendarRef, objectRef string) (string, erro
 	if !sameOrigin(endpointURL, resolved) {
 		return "", fmt.Errorf("calendar object href must stay on the configured CalDAV origin")
 	}
+	// Check the resolved URL before path.Clean removes its final slash.
+	// An RFC 6578 response can include the calendar collection with changed resources.
+	// Apple iCloud does this during the initial sync.
+	// A calendar-multiget request with this href does not return on iCloud.
+	if escapedPath := resolved.EscapedPath(); escapedPath == "" || strings.HasSuffix(escapedPath, "/") {
+		return "", fmt.Errorf("calendar object href must point to a resource, not a collection")
+	}
 
 	objectPath := normalizePath(resolved.Path)
-	if objectPath == "" || strings.HasSuffix(objectPath, "/") {
+	if objectPath == "" || objectPath == normalizePath(collectionPath) {
 		return "", fmt.Errorf("calendar object href must point to a resource, not a collection")
 	}
 	return objectPath, nil

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -126,6 +126,34 @@ func TestNormalizeAndFormatIfMatch(t *testing.T) {
 	}
 }
 
+func TestCanonicalObjectRefRejectsCollectionHrefsBeforeCleaning(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(http.DefaultClient, "https://example.com")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	for _, objectRef := range []string{
+		"/calendars/work/",
+		"/calendars/work",
+		"/calendars/work/.",
+		"https://example.com/calendars/work/",
+	} {
+		if got, err := client.CanonicalObjectRef("/calendars/work/", objectRef); err == nil {
+			t.Errorf("CanonicalObjectRef(%q) = %q, want collection error", objectRef, got)
+		}
+	}
+
+	got, err := client.CanonicalObjectRef("/calendars/work/", "/calendars/work/event.ics")
+	if err != nil {
+		t.Fatalf("CanonicalObjectRef(event): %v", err)
+	}
+	if got != "/calendars/work/event.ics" {
+		t.Fatalf("CanonicalObjectRef(event) = %q, want /calendars/work/event.ics", got)
+	}
+}
+
 // TestClientPutResourceWeakETagOmitsIfMatch verifies that a weak validator is
 // not echoed into If-Match as a strong tag. Doing so makes the strong
 // comparison fail server-side and produces perpetual 412s.

--- a/internal/caldav/multiget.go
+++ b/internal/caldav/multiget.go
@@ -88,9 +88,10 @@ func (c *Client) MultiGetTolerant(ctx context.Context, calendarPath string, href
 			continue
 		}
 		result.Resources = append(result.Resources, Resource{
-			Path: href,
-			ETag: etag,
-			Data: cal,
+			Path:    href,
+			ETag:    etag,
+			Data:    cal,
+			RawData: data,
 		})
 	}
 	return result, nil

--- a/internal/caldav/multiget_test.go
+++ b/internal/caldav/multiget_test.go
@@ -89,6 +89,9 @@ END:VCALENDAR
 	if result.Resources[0].ETag != "etag-alive" {
 		t.Fatalf("alive etag = %q, want etag-alive", result.Resources[0].ETag)
 	}
+	if !strings.Contains(result.Resources[0].RawData, "UID:alive-uid") {
+		t.Fatalf("alive raw data missing UID: %q", result.Resources[0].RawData)
+	}
 	if len(result.Missing) != 2 {
 		t.Fatalf("Missing = %v, want 2 entries", result.Missing)
 	}

--- a/internal/sync/engine_apply.go
+++ b/internal/sync/engine_apply.go
@@ -144,6 +144,7 @@ func (e *Engine) applySyncCollection(ctx context.Context, client *caldav.Client,
 				href: res.Path,
 				etag: res.ETag,
 				data: res.Data,
+				raw:  res.RawData,
 			})
 			result.warnings = append(result.warnings, warnings...)
 			if uid != "" {

--- a/internal/sync/engine_persist.go
+++ b/internal/sync/engine_persist.go
@@ -496,12 +496,14 @@ func (e *Engine) importICal(ctx context.Context, calendarID int64, data string) 
 // fetchedResource is one remote resource body queued for import during a
 // pull: the canonical remote path (the bookkeeping key for
 // UpsertSyncResource), the href exactly as the server reported it (the log
-// label), the etag, and the parsed iCal body.
+// label), the etag, and the parsed iCal body. It also keeps the exact
+// calendar-data payload when the server supplies it.
 type fetchedResource struct {
 	path string
 	href string
 	etag string
 	data *ical.Calendar
+	raw  string
 }
 
 // importFetchedResource imports one fetched remote body and persists it with
@@ -518,13 +520,17 @@ type fetchedResource struct {
 // persistImported and the persist failed; the caller must then treat the
 // pull as incomplete and withhold the sync-token.
 func (e *Engine) importFetchedResource(ctx context.Context, calendarID int64, tombstonedUIDs map[string]bool, res fetchedResource) (uid string, imported bool, warnings []ImportWarning, err error) {
-	var buf bytes.Buffer
-	enc := ical.NewEncoder(&buf)
-	if encErr := enc.Encode(res.data); encErr != nil {
-		e.logger.Warn("encode fetched resource failed", "path", res.href, "error", encErr)
-		return "", false, nil, nil
+	body := res.raw
+	if body == "" {
+		var buf bytes.Buffer
+		enc := ical.NewEncoder(&buf)
+		if encErr := enc.Encode(res.data); encErr != nil {
+			e.logger.Warn("encode fetched resource failed", "path", res.href, "error", encErr)
+			return "", false, nil, nil
+		}
+		body = buf.String()
 	}
-	importResult, impErr := icalPkg.ImportFileRemote(strings.NewReader(buf.String()))
+	importResult, impErr := icalPkg.ImportFileRemote(strings.NewReader(body))
 	if impErr != nil {
 		e.logger.Warn("import fetched resource failed", "path", res.href, "error", impErr)
 		return "", false, nil, nil
@@ -546,7 +552,7 @@ func (e *Engine) importFetchedResource(ctx context.Context, calendarID int64, to
 		// The fetched body is newer than the recorded one. Record it so a
 		// later resolve picks current server data. The sync-token may then
 		// advance: the row, not the token, carries the obligation.
-		e.refreshConflictServerBody(ctx, calendarID, uid, buf.String(), res.etag)
+		e.refreshConflictServerBody(ctx, calendarID, uid, body, res.etag)
 		return uid, false, warnings, nil
 	}
 

--- a/internal/sync/engine_pull.go
+++ b/internal/sync/engine_pull.go
@@ -170,6 +170,7 @@ func (e *Engine) pullFullSnapshot(ctx context.Context, client *caldav.Client, ca
 			href: res.Path,
 			etag: res.ETag,
 			data: res.Data,
+			raw:  res.RawData,
 		})
 		result.warnings = append(result.warnings, warnings...)
 		if uid != "" {

--- a/internal/sync/engine_raw_resource_test.go
+++ b/internal/sync/engine_raw_resource_test.go
@@ -1,0 +1,52 @@
+package sync
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-ical"
+)
+
+func TestImportFetchedResourceUsesRawCalendarDataWithoutPRODID(t *testing.T) {
+	t.Parallel()
+
+	engine, _, q := newTestEngine(t)
+	ctx := context.Background()
+	calendars, err := q.ListCalendars(ctx)
+	if err != nil {
+		t.Fatalf("ListCalendars: %v", err)
+	}
+
+	const raw = "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:icloud-no-prodid\r\n" +
+		"DTSTAMP:20260829T080000Z\r\n" +
+		"DTSTART:20260829T090000Z\r\n" +
+		"DTEND:20260829T100000Z\r\n" +
+		"SUMMARY:iCloud payload\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+	parsed, err := ical.NewDecoder(strings.NewReader(raw)).Decode()
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	uid, imported, _, err := engine.importFetchedResource(ctx, calendars[0].ID, nil, fetchedResource{
+		path: "/calendar/icloud-no-prodid.ics",
+		href: "/calendar/icloud-no-prodid.ics",
+		etag: "etag-icloud",
+		data: parsed,
+		raw:  raw,
+	})
+	if err != nil {
+		t.Fatalf("importFetchedResource: %v", err)
+	}
+	if uid != "icloud-no-prodid" || !imported {
+		t.Fatalf("uid = %q, imported = %t; want icloud-no-prodid, true", uid, imported)
+	}
+	if _, err := engine.events.GetByUID(ctx, uid); err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+}


### PR DESCRIPTION
Reject calendar collection hrefs before path normalization removes the final slash. Preserve raw calendar-data from multiget responses so iCloud objects without PRODID can still import.

Assisted-by: Codex:gpt-5 [web]

## Summary

<!-- What does this PR change, and why? -->

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Lint reports no issues (`make lint`)
- [ ] Add new tests for new functions
- [ ] Update the documentation when the change needs it
