### PR TITLE
fix(event): keep the same UID on two calendars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ SQLite pragmas in `open.go:openDB()`:
 
 ### Recurrence
 
-The database stores a recurring event as one row with `recurrence_rule`. Each override is a separate row with the same `uid` and a non-empty `recurrence_id`. EXDATEs and RDATEs are comma-separated RFC 3339 strings. The service expands recurrences at query time with `recurrence.ListExpandedEvents()`. Time ranges are half-open everywhere: `[start, end)`.
+The database stores a recurring event as one row with `recurrence_rule`. Each override is a separate row with the same `uid` and a non-empty `recurrence_id`. The unique key is `(calendar_id, uid, recurrence_id)`, so two calendars can store the same UID. EXDATEs and RDATEs are comma-separated RFC 3339 strings. The service expands recurrences at query time with `recurrence.ListExpandedEvents()`. Time ranges are half-open everywhere: `[start, end)`.
 
 ### Alarms
 
@@ -130,6 +130,7 @@ Confirm dialogs focus Cancel by default (`form.FocusCancel()`). A quick Enter ca
 ```go
 evt, err := svc.Get(ctx, id)                                        // numeric ID
 evt, err := svc.GetByUID(ctx, uid)                                  // string UID
+evt, err := svc.GetByCalendarUID(ctx, calendarID, uid)              // UID on one calendar
 evt, err := svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)     // override instance
 ```
 

--- a/cmd/chroncal/ical_import_test.go
+++ b/cmd/chroncal/ical_import_test.go
@@ -208,8 +208,8 @@ func TestEnsureICalImportAllowedRejectsCollectionPolicyViolations(t *testing.T) 
 	sourceResult := ical.ImportResult{Events: []event.Event{sourceEvent}}
 	sourcePreview := icaltransfer.Preview{Result: sourceResult}
 	sourcePreview.Events = len(sourceResult.Events)
-	if err := icaltransfer.ValidateDestination(ctx, a, target.ID, sourcePreview); err == nil || !strings.Contains(err.Error(), "read-only") {
-		t.Fatalf("read-only source import error = %v, want source rejection", err)
+	if err := icaltransfer.ValidateDestination(ctx, a, target.ID, sourcePreview); err != nil {
+		t.Fatalf("cross-calendar event UID import: %v", err)
 	}
 }
 

--- a/db/migrations/050_events_uid_unique_per_calendar.sql
+++ b/db/migrations/050_events_uid_unique_per_calendar.sql
@@ -1,0 +1,354 @@
+-- +goose Up
+-- RFC 5545 makes UID unique inside one calendar, not across calendars.
+-- UNIQUE(uid, recurrence_id) made a second CalDAV collection's copy of the
+-- same meeting overwrite the first (issue #756). Scope uniqueness to
+-- (calendar_id, uid, recurrence_id). SQLite cannot drop a table UNIQUE
+-- constraint, so rebuild the events table.
+--
+-- Foreign keys are ON. DROP TABLE events deletes child rows through
+-- ON DELETE CASCADE. Back up each child table first. Restore it after
+-- the rebuild. Drop FTS and x_properties DELETE triggers first so a
+-- cascade does not rewrite events_fts or erase x_properties rows.
+
+DROP TRIGGER IF EXISTS events_fts_ai;
+DROP TRIGGER IF EXISTS events_fts_au;
+DROP TRIGGER IF EXISTS events_fts_bd;
+DROP TRIGGER IF EXISTS events_x_properties_ad;
+DROP TRIGGER IF EXISTS event_alarms_x_properties_ad;
+DROP TRIGGER IF EXISTS x_properties_event_owner_exists;
+DROP TRIGGER IF EXISTS event_categories_fts_ai;
+DROP TRIGGER IF EXISTS event_categories_fts_ad;
+
+CREATE TABLE event_categories_backup AS SELECT * FROM event_categories;
+CREATE TABLE event_alarms_backup AS SELECT * FROM event_alarms;
+CREATE TABLE event_alarm_attendees_backup AS SELECT * FROM event_alarm_attendees;
+CREATE TABLE alarm_state_backup AS SELECT * FROM alarm_state;
+CREATE TABLE event_attendees_backup AS SELECT * FROM event_attendees;
+CREATE TABLE event_attachments_backup AS SELECT * FROM event_attachments;
+CREATE TABLE event_comments_backup AS SELECT * FROM event_comments;
+CREATE TABLE event_contacts_backup AS SELECT * FROM event_contacts;
+CREATE TABLE event_resources_backup AS SELECT * FROM event_resources;
+CREATE TABLE event_relations_backup AS SELECT * FROM event_relations;
+
+CREATE TABLE events_new (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    uid             TEXT    NOT NULL,
+    calendar_id     INTEGER NOT NULL REFERENCES calendars(id) ON DELETE CASCADE,
+    title           TEXT    NOT NULL,
+    description     TEXT,
+    location        TEXT,
+    start_time      TEXT    NOT NULL,
+    end_time        TEXT    NOT NULL,
+    all_day         INTEGER NOT NULL DEFAULT 0
+        CHECK(all_day IN (0, 1)),
+    recurrence_rule TEXT,
+    timezone        TEXT,
+    status          TEXT    NOT NULL DEFAULT 'CONFIRMED'
+        CHECK(status IN ('TENTATIVE','CONFIRMED','CANCELLED')),
+    transp          TEXT    NOT NULL DEFAULT 'OPAQUE'
+        CHECK(transp IN ('OPAQUE','TRANSPARENT')),
+    sequence        INTEGER NOT NULL DEFAULT 0
+        CHECK(sequence >= 0),
+    priority        INTEGER NOT NULL DEFAULT 0
+        CHECK(priority BETWEEN 0 AND 9),
+    class           TEXT    NOT NULL DEFAULT 'PUBLIC'
+        CHECK(class IN ('PUBLIC','PRIVATE','CONFIDENTIAL')),
+    url             TEXT,
+    exdates         TEXT,
+    rdates          TEXT,
+    recurrence_id   TEXT    NOT NULL DEFAULT '',
+    geo             TEXT,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    duration        TEXT,
+    dtstamp         TEXT,
+    conference_uri  TEXT    NOT NULL DEFAULT '',
+    deleted_at      TEXT,
+    UNIQUE(calendar_id, uid, recurrence_id)
+);
+
+INSERT INTO events_new (
+    id, uid, calendar_id, title, description, location,
+    start_time, end_time, all_day, recurrence_rule, timezone,
+    status, transp, sequence, priority, class, url, exdates, rdates,
+    recurrence_id, geo, created_at, updated_at, duration, dtstamp,
+    conference_uri, deleted_at
+)
+SELECT
+    id, uid, calendar_id, title, description, location,
+    start_time, end_time, all_day, recurrence_rule, timezone,
+    status, transp, sequence, priority, class, url, exdates, rdates,
+    recurrence_id, geo, created_at, updated_at, duration, dtstamp,
+    conference_uri, deleted_at
+FROM events;
+
+DROP TABLE events;
+ALTER TABLE events_new RENAME TO events;
+
+CREATE INDEX idx_events_cal_start  ON events(calendar_id, start_time);
+CREATE INDEX idx_events_start_time ON events(start_time);
+CREATE INDEX idx_events_end_time   ON events(end_time);
+CREATE INDEX idx_events_deleted_at ON events(deleted_at) WHERE deleted_at IS NOT NULL;
+
+INSERT INTO event_categories SELECT * FROM event_categories_backup;
+INSERT INTO event_alarms SELECT * FROM event_alarms_backup;
+INSERT INTO event_alarm_attendees SELECT * FROM event_alarm_attendees_backup;
+INSERT INTO alarm_state SELECT * FROM alarm_state_backup;
+INSERT INTO event_attendees SELECT * FROM event_attendees_backup;
+INSERT INTO event_attachments SELECT * FROM event_attachments_backup;
+INSERT INTO event_comments SELECT * FROM event_comments_backup;
+INSERT INTO event_contacts SELECT * FROM event_contacts_backup;
+INSERT INTO event_resources SELECT * FROM event_resources_backup;
+INSERT INTO event_relations SELECT * FROM event_relations_backup;
+
+DROP TABLE event_categories_backup;
+DROP TABLE event_alarms_backup;
+DROP TABLE event_alarm_attendees_backup;
+DROP TABLE alarm_state_backup;
+DROP TABLE event_attendees_backup;
+DROP TABLE event_attachments_backup;
+DROP TABLE event_comments_backup;
+DROP TABLE event_contacts_backup;
+DROP TABLE event_resources_backup;
+DROP TABLE event_relations_backup;
+
+-- +goose StatementBegin
+CREATE TRIGGER events_fts_ai AFTER INSERT ON events BEGIN
+    INSERT INTO events_fts(rowid, title, description, location, categories)
+    VALUES (NEW.id, NEW.title, COALESCE(NEW.description, ''), COALESCE(NEW.location, ''), '');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER events_fts_au AFTER UPDATE ON events BEGIN
+    DELETE FROM events_fts WHERE rowid = OLD.id;
+    INSERT INTO events_fts(rowid, title, description, location, categories)
+    VALUES (NEW.id, NEW.title, COALESCE(NEW.description, ''), COALESCE(NEW.location, ''),
+        COALESCE((SELECT GROUP_CONCAT(ec.category, ' ')
+                  FROM event_categories ec WHERE ec.event_id = NEW.id), ''));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER events_fts_bd BEFORE DELETE ON events BEGIN
+    DELETE FROM events_fts WHERE rowid = OLD.id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER event_categories_fts_ai AFTER INSERT ON event_categories BEGIN
+    DELETE FROM events_fts WHERE rowid = NEW.event_id;
+    INSERT INTO events_fts(rowid, title, description, location, categories)
+    SELECT e.id, e.title, COALESCE(e.description, ''), COALESCE(e.location, ''),
+        COALESCE((SELECT GROUP_CONCAT(ec.category, ' ')
+                  FROM event_categories ec WHERE ec.event_id = e.id), '')
+    FROM events e WHERE e.id = NEW.event_id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER event_categories_fts_ad AFTER DELETE ON event_categories
+WHEN EXISTS (SELECT 1 FROM events WHERE id = OLD.event_id) BEGIN
+    DELETE FROM events_fts WHERE rowid = OLD.event_id;
+    INSERT INTO events_fts(rowid, title, description, location, categories)
+    SELECT e.id, e.title, COALESCE(e.description, ''), COALESCE(e.location, ''),
+        COALESCE((SELECT GROUP_CONCAT(ec.category, ' ')
+                  FROM event_categories ec WHERE ec.event_id = e.id), '')
+    FROM events e WHERE e.id = OLD.event_id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER events_x_properties_ad
+AFTER DELETE ON events BEGIN
+    DELETE FROM x_properties WHERE owner_type = 'event' AND owner_id = OLD.id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER x_properties_event_owner_exists
+BEFORE INSERT ON x_properties
+WHEN NEW.owner_type = 'event'
+ AND NOT EXISTS (SELECT 1 FROM events WHERE id = NEW.owner_id) BEGIN
+    SELECT RAISE(ABORT, 'x_properties owner does not exist');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER event_alarms_x_properties_ad
+AFTER DELETE ON event_alarms BEGIN
+    DELETE FROM x_properties WHERE owner_type = 'event_alarm' AND owner_id = OLD.id;
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TRIGGER IF EXISTS events_fts_ai;
+DROP TRIGGER IF EXISTS events_fts_au;
+DROP TRIGGER IF EXISTS events_fts_bd;
+DROP TRIGGER IF EXISTS events_x_properties_ad;
+DROP TRIGGER IF EXISTS event_alarms_x_properties_ad;
+DROP TRIGGER IF EXISTS x_properties_event_owner_exists;
+DROP TRIGGER IF EXISTS event_categories_fts_ai;
+DROP TRIGGER IF EXISTS event_categories_fts_ad;
+
+CREATE TABLE event_categories_backup AS SELECT * FROM event_categories;
+CREATE TABLE event_alarms_backup AS SELECT * FROM event_alarms;
+CREATE TABLE event_alarm_attendees_backup AS SELECT * FROM event_alarm_attendees;
+CREATE TABLE alarm_state_backup AS SELECT * FROM alarm_state;
+CREATE TABLE event_attendees_backup AS SELECT * FROM event_attendees;
+CREATE TABLE event_attachments_backup AS SELECT * FROM event_attachments;
+CREATE TABLE event_comments_backup AS SELECT * FROM event_comments;
+CREATE TABLE event_contacts_backup AS SELECT * FROM event_contacts;
+CREATE TABLE event_resources_backup AS SELECT * FROM event_resources;
+CREATE TABLE event_relations_backup AS SELECT * FROM event_relations;
+
+CREATE TABLE events_old (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    uid             TEXT    NOT NULL,
+    calendar_id     INTEGER NOT NULL REFERENCES calendars(id) ON DELETE CASCADE,
+    title           TEXT    NOT NULL,
+    description     TEXT,
+    location        TEXT,
+    start_time      TEXT    NOT NULL,
+    end_time        TEXT    NOT NULL,
+    all_day         INTEGER NOT NULL DEFAULT 0
+        CHECK(all_day IN (0, 1)),
+    recurrence_rule TEXT,
+    timezone        TEXT,
+    status          TEXT    NOT NULL DEFAULT 'CONFIRMED'
+        CHECK(status IN ('TENTATIVE','CONFIRMED','CANCELLED')),
+    transp          TEXT    NOT NULL DEFAULT 'OPAQUE'
+        CHECK(transp IN ('OPAQUE','TRANSPARENT')),
+    sequence        INTEGER NOT NULL DEFAULT 0
+        CHECK(sequence >= 0),
+    priority        INTEGER NOT NULL DEFAULT 0
+        CHECK(priority BETWEEN 0 AND 9),
+    class           TEXT    NOT NULL DEFAULT 'PUBLIC'
+        CHECK(class IN ('PUBLIC','PRIVATE','CONFIDENTIAL')),
+    url             TEXT,
+    exdates         TEXT,
+    rdates          TEXT,
+    recurrence_id   TEXT    NOT NULL DEFAULT '',
+    geo             TEXT,
+    created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    duration        TEXT,
+    dtstamp         TEXT,
+    conference_uri  TEXT    NOT NULL DEFAULT '',
+    deleted_at      TEXT,
+    UNIQUE(uid, recurrence_id)
+);
+
+INSERT INTO events_old (
+    id, uid, calendar_id, title, description, location,
+    start_time, end_time, all_day, recurrence_rule, timezone,
+    status, transp, sequence, priority, class, url, exdates, rdates,
+    recurrence_id, geo, created_at, updated_at, duration, dtstamp,
+    conference_uri, deleted_at
+)
+SELECT
+    id, uid, calendar_id, title, description, location,
+    start_time, end_time, all_day, recurrence_rule, timezone,
+    status, transp, sequence, priority, class, url, exdates, rdates,
+    recurrence_id, geo, created_at, updated_at, duration, dtstamp,
+    conference_uri, deleted_at
+FROM events;
+
+DROP TABLE events;
+ALTER TABLE events_old RENAME TO events;
+
+CREATE INDEX idx_events_cal_start  ON events(calendar_id, start_time);
+CREATE INDEX idx_events_start_time ON events(start_time);
+CREATE INDEX idx_events_end_time   ON events(end_time);
+CREATE INDEX idx_events_deleted_at ON events(deleted_at) WHERE deleted_at IS NOT NULL;
+
+INSERT INTO event_categories SELECT * FROM event_categories_backup;
+INSERT INTO event_alarms SELECT * FROM event_alarms_backup;
+INSERT INTO event_alarm_attendees SELECT * FROM event_alarm_attendees_backup;
+INSERT INTO alarm_state SELECT * FROM alarm_state_backup;
+INSERT INTO event_attendees SELECT * FROM event_attendees_backup;
+INSERT INTO event_attachments SELECT * FROM event_attachments_backup;
+INSERT INTO event_comments SELECT * FROM event_comments_backup;
+INSERT INTO event_contacts SELECT * FROM event_contacts_backup;
+INSERT INTO event_resources SELECT * FROM event_resources_backup;
+INSERT INTO event_relations SELECT * FROM event_relations_backup;
+
+DROP TABLE event_categories_backup;
+DROP TABLE event_alarms_backup;
+DROP TABLE event_alarm_attendees_backup;
+DROP TABLE alarm_state_backup;
+DROP TABLE event_attendees_backup;
+DROP TABLE event_attachments_backup;
+DROP TABLE event_comments_backup;
+DROP TABLE event_contacts_backup;
+DROP TABLE event_resources_backup;
+DROP TABLE event_relations_backup;
+
+-- +goose StatementBegin
+CREATE TRIGGER events_fts_ai AFTER INSERT ON events BEGIN
+    INSERT INTO events_fts(rowid, title, description, location, categories)
+    VALUES (NEW.id, NEW.title, COALESCE(NEW.description, ''), COALESCE(NEW.location, ''), '');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER events_fts_au AFTER UPDATE ON events BEGIN
+    DELETE FROM events_fts WHERE rowid = OLD.id;
+    INSERT INTO events_fts(rowid, title, description, location, categories)
+    VALUES (NEW.id, NEW.title, COALESCE(NEW.description, ''), COALESCE(NEW.location, ''),
+        COALESCE((SELECT GROUP_CONCAT(ec.category, ' ')
+                  FROM event_categories ec WHERE ec.event_id = NEW.id), ''));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER events_fts_bd BEFORE DELETE ON events BEGIN
+    DELETE FROM events_fts WHERE rowid = OLD.id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER event_categories_fts_ai AFTER INSERT ON event_categories BEGIN
+    DELETE FROM events_fts WHERE rowid = NEW.event_id;
+    INSERT INTO events_fts(rowid, title, description, location, categories)
+    SELECT e.id, e.title, COALESCE(e.description, ''), COALESCE(e.location, ''),
+        COALESCE((SELECT GROUP_CONCAT(ec.category, ' ')
+                  FROM event_categories ec WHERE ec.event_id = e.id), '')
+    FROM events e WHERE e.id = NEW.event_id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER event_categories_fts_ad AFTER DELETE ON event_categories
+WHEN EXISTS (SELECT 1 FROM events WHERE id = OLD.event_id) BEGIN
+    DELETE FROM events_fts WHERE rowid = OLD.event_id;
+    INSERT INTO events_fts(rowid, title, description, location, categories)
+    SELECT e.id, e.title, COALESCE(e.description, ''), COALESCE(e.location, ''),
+        COALESCE((SELECT GROUP_CONCAT(ec.category, ' ')
+                  FROM event_categories ec WHERE ec.event_id = e.id), '')
+    FROM events e WHERE e.id = OLD.event_id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER events_x_properties_ad
+AFTER DELETE ON events BEGIN
+    DELETE FROM x_properties WHERE owner_type = 'event' AND owner_id = OLD.id;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER x_properties_event_owner_exists
+BEFORE INSERT ON x_properties
+WHEN NEW.owner_type = 'event'
+ AND NOT EXISTS (SELECT 1 FROM events WHERE id = NEW.owner_id) BEGIN
+    SELECT RAISE(ABORT, 'x_properties owner does not exist');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER event_alarms_x_properties_ad
+AFTER DELETE ON event_alarms BEGIN
+    DELETE FROM x_properties WHERE owner_type = 'event_alarm' AND owner_id = OLD.id;
+END;
+-- +goose StatementEnd

--- a/db/queries/events.sql
+++ b/db/queries/events.sql
@@ -24,8 +24,14 @@ SELECT * FROM events WHERE id = ? AND deleted_at IS NULL;
 -- name: GetEventByUID :one
 SELECT * FROM events WHERE uid = ? AND recurrence_id = '' AND deleted_at IS NULL;
 
+-- name: GetEventByCalendarUID :one
+SELECT * FROM events WHERE calendar_id = ? AND uid = ? AND recurrence_id = '' AND deleted_at IS NULL;
+
 -- name: GetEventByUIDAndRecurrenceID :one
 SELECT * FROM events WHERE uid = ? AND recurrence_id = ? AND deleted_at IS NULL;
+
+-- name: GetEventByCalendarUIDAndRecurrenceID :one
+SELECT * FROM events WHERE calendar_id = ? AND uid = ? AND recurrence_id = ? AND deleted_at IS NULL;
 
 -- name: GetEventIncludingDeleted :one
 SELECT * FROM events WHERE id = ?;
@@ -58,11 +64,12 @@ UPDATE events SET
 WHERE id = ? RETURNING *;
 
 -- name: UpsertEventByUID :one
--- NOTE: ON CONFLICT UPDATE clears deleted_at. This query resurrects
--- soft-deleted rows. Callers outside the pull path in the sync engine
--- must know this. The pull path is safe. The engine excludes
--- tombstoned UIDs before this query runs (engine.go loads tombstones
--- first and skips them during pull).
+-- NOTE: ON CONFLICT matches (calendar_id, uid, recurrence_id). The same
+-- UID on a second calendar inserts a new row (issue #756). ON CONFLICT
+-- UPDATE clears deleted_at. This query resurrects soft-deleted rows.
+-- Callers outside the pull path in the sync engine must know this. The
+-- pull path is safe. The engine excludes tombstoned UIDs before this
+-- query runs (engine.go loads tombstones first and skips them during pull).
 INSERT INTO events (
     uid, calendar_id, title, description, location,
     start_time, end_time, all_day, recurrence_rule,
@@ -70,8 +77,7 @@ INSERT INTO events (
     class, url, exdates, rdates, recurrence_id, geo, duration, dtstamp,
     conference_uri
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(uid, recurrence_id) DO UPDATE SET
-    calendar_id = excluded.calendar_id,
+ON CONFLICT(calendar_id, uid, recurrence_id) DO UPDATE SET
     title = excluded.title, description = excluded.description,
     location = excluded.location, start_time = excluded.start_time,
     end_time = excluded.end_time, all_day = excluded.all_day,

--- a/internal/event/cross_calendar_uid_test.go
+++ b/internal/event/cross_calendar_uid_test.go
@@ -1,0 +1,110 @@
+package event
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func insertCalendar(t *testing.T, svc *Service, name string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	res, err := svc.db.ExecContext(ctx, `INSERT INTO calendars (name) VALUES (?)`, name)
+	if err != nil {
+		t.Fatalf("insert calendar %q: %v", name, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("calendar id: %v", err)
+	}
+	return id
+}
+
+// TestUpsertByUID_SameUIDOnTwoCalendars is the issue #756 contract. Google
+// Calendar (and CalDAV) reuse one UID when the same meeting lives on more
+// than one collection. A pull of the second calendar must insert a second
+// row. It must not move or overwrite the first calendar's copy.
+func TestUpsertByUID_SameUIDOnTwoCalendars(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	otherID := insertCalendar(t, svc, "Other")
+
+	start := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	p := UpsertParams{
+		UID: "shared-meeting", CalendarID: 1, Title: "Standup",
+		StartTime: start, EndTime: end,
+	}
+	first, err := svc.UpsertByUID(ctx, p)
+	if err != nil {
+		t.Fatalf("upsert calendar 1: %v", err)
+	}
+
+	p.CalendarID = otherID
+	p.Title = "Standup (other)"
+	second, err := svc.UpsertByUID(ctx, p)
+	if err != nil {
+		t.Fatalf("upsert calendar 2: %v", err)
+	}
+
+	if first.ID == second.ID {
+		t.Fatalf("upsert reused id %d; each calendar must keep its own copy", first.ID)
+	}
+	if first.CalendarID != 1 {
+		t.Errorf("first.CalendarID = %d, want 1", first.CalendarID)
+	}
+	if second.CalendarID != otherID {
+		t.Errorf("second.CalendarID = %d, want %d", second.CalendarID, otherID)
+	}
+
+	got1, err := svc.Get(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("Get first: %v", err)
+	}
+	if got1.CalendarID != 1 || got1.Title != "Standup" {
+		t.Errorf("first copy: calendar %d title %q, want calendar 1 title Standup",
+			got1.CalendarID, got1.Title)
+	}
+	got2, err := svc.Get(ctx, second.ID)
+	if err != nil {
+		t.Fatalf("Get second: %v", err)
+	}
+	if got2.CalendarID != otherID || got2.Title != "Standup (other)" {
+		t.Errorf("second copy: calendar %d title %q, want calendar %d title Standup (other)",
+			got2.CalendarID, got2.Title, otherID)
+	}
+
+	listed, err := svc.ListByDateRange(ctx, start.Add(-time.Minute), end.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("ListByDateRange: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("ListByDateRange returned %d events, want 2 (one per calendar)", len(listed))
+	}
+}
+
+func TestUpsertByUID_SameCalendarStillUpdates(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	start := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	p := UpsertParams{
+		UID: "same-cal", CalendarID: 1, Title: "Original",
+		StartTime: start, EndTime: start.Add(time.Hour),
+	}
+	first, err := svc.UpsertByUID(ctx, p)
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	p.Title = "Updated"
+	second, err := svc.UpsertByUID(ctx, p)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Errorf("same-calendar upsert created id %d, want %d", second.ID, first.ID)
+	}
+	if second.Title != "Updated" {
+		t.Errorf("Title = %q, want Updated", second.Title)
+	}
+}

--- a/internal/event/query.go
+++ b/internal/event/query.go
@@ -117,8 +117,35 @@ func (s *Service) GetByUID(ctx context.Context, uid string) (Event, error) {
 	return e, nil
 }
 
+func (s *Service) GetByCalendarUID(ctx context.Context, calendarID int64, uid string) (Event, error) {
+	r, err := s.q.GetEventByCalendarUID(ctx, storage.GetEventByCalendarUIDParams{
+		CalendarID: calendarID,
+		Uid:        uid,
+	})
+	if err != nil {
+		return Event{}, err
+	}
+	e := FromStorage(r)
+	s.populateSingleCategories(ctx, &e)
+	return e, nil
+}
+
 func (s *Service) GetByUIDAndRecurrenceID(ctx context.Context, uid, recurrenceID string) (Event, error) {
 	r, err := s.q.GetEventByUIDAndRecurrenceID(ctx, storage.GetEventByUIDAndRecurrenceIDParams{
+		Uid:          uid,
+		RecurrenceID: recurrenceID,
+	})
+	if err != nil {
+		return Event{}, err
+	}
+	e := FromStorage(r)
+	s.populateSingleCategories(ctx, &e)
+	return e, nil
+}
+
+func (s *Service) GetByCalendarUIDAndRecurrenceID(ctx context.Context, calendarID int64, uid, recurrenceID string) (Event, error) {
+	r, err := s.q.GetEventByCalendarUIDAndRecurrenceID(ctx, storage.GetEventByCalendarUIDAndRecurrenceIDParams{
+		CalendarID:   calendarID,
 		Uid:          uid,
 		RecurrenceID: recurrenceID,
 	})

--- a/internal/icaltransfer/transfer.go
+++ b/internal/icaltransfer/transfer.go
@@ -96,12 +96,12 @@ func ParseFile(path string) (Preview, error) {
 	return preview, nil
 }
 
-// ValidateDestination validates every present component family and every
-// cross-calendar UID source row before the first write. This blocks both
-// partial mixed imports and UID upserts that would move data out of a
-// read-only remote collection. Each present family must be writable at the
-// destination. Any row already matched by UID must live in a calendar the
-// caller can write to.
+// ValidateDestination validates every present component family before the
+// first write. Each present family must be writable at the destination.
+// Event UIDs are unique per calendar (issue #756), so an event that already
+// lives on another calendar does not move. Todos and journals still use a
+// global UID. A todo or journal UID that already lives in another calendar
+// must live in a calendar the caller can write to.
 func ValidateDestination(ctx context.Context, a *app.App, calendarID int64, preview Preview) error {
 	result := preview.Result
 
@@ -135,18 +135,6 @@ func ValidateDestination(ctx context.Context, a *app.App, calendarID int64, prev
 			return fmt.Errorf("import %s UID %q from calendar %d: %w", component, uid, sourceID, err)
 		}
 		return nil
-	}
-	for _, imported := range result.Events {
-		existing, err := a.Queries.GetEventByUIDAndRecurrenceID(ctx, storage.GetEventByUIDAndRecurrenceIDParams{
-			Uid: imported.UID, RecurrenceID: imported.RecurrenceID,
-		})
-		if err == nil {
-			if err := checkSource(existing.CalendarID, FamilyEvent, imported.UID); err != nil {
-				return err
-			}
-		} else if !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("check existing %s UID %q: %w", FamilyEvent, imported.UID, err)
-		}
 	}
 	for _, imported := range result.Todos {
 		existing, err := a.Queries.GetTodoByUIDAndRecurrenceID(ctx, storage.GetTodoByUIDAndRecurrenceIDParams{
@@ -199,7 +187,7 @@ func Import(ctx context.Context, a *app.App, calendarID int64, result *ical.Impo
 
 	// Import events.
 	for _, e := range result.Events {
-		_, lookupErr := lookupEvent(ctx, a.Events, e.UID, e.RecurrenceID)
+		_, lookupErr := lookupEvent(ctx, a.Events, calendarID, e.UID, e.RecurrenceID)
 		saved, err := a.Events.UpsertByUID(ctx, event.UpsertParams{
 			UID: e.UID, CalendarID: calendarID,
 			Title: e.Title, Description: e.Description, Location: e.Location,
@@ -440,11 +428,11 @@ func ExportCalendarFile(ctx context.Context, a *app.App, calendarID int64, calen
 // lookupEvent reports whether an imported event row already exists. An
 // override (a non-empty recurrence_id) must match its own row, not the
 // master, so the summary counts a first-time override as new.
-func lookupEvent(ctx context.Context, svc *event.Service, uid, recurrenceID string) (event.Event, error) {
+func lookupEvent(ctx context.Context, svc *event.Service, calendarID int64, uid, recurrenceID string) (event.Event, error) {
 	if recurrenceID != "" {
-		return svc.GetByUIDAndRecurrenceID(ctx, uid, recurrenceID)
+		return svc.GetByCalendarUIDAndRecurrenceID(ctx, calendarID, uid, recurrenceID)
 	}
-	return svc.GetByUID(ctx, uid)
+	return svc.GetByCalendarUID(ctx, calendarID, uid)
 }
 
 // lookupTodo reports whether an imported todo row already exists.

--- a/internal/icaltransfer/transfer_test.go
+++ b/internal/icaltransfer/transfer_test.go
@@ -325,12 +325,11 @@ func TestImport_ReimportRemovesStaleChildren(t *testing.T) {
 	}
 }
 
-// TestValidateDestination_CrossCalendarReadOnlyUIDRejectedBeforeWrite locks
-// in the cross-calendar UID guard. An import of a UID that already lives in a
-// read-only remote collection into a different calendar must be rejected
-// before any write occurs. The upsert then cannot move data out of the
-// read-only source.
-func TestValidateDestination_CrossCalendarReadOnlyUIDRejectedBeforeWrite(t *testing.T) {
+// TestValidateDestination_CrossCalendarEventUIDAllowed locks in issue #756.
+// An event UID that already lives on a read-only calendar can still import
+// into a different writable calendar. The upsert inserts a second copy. It
+// does not move the source row.
+func TestValidateDestination_CrossCalendarEventUIDAllowed(t *testing.T) {
 	ctx := context.Background()
 	a := newTestApp(t)
 
@@ -372,20 +371,27 @@ func TestValidateDestination_CrossCalendarReadOnlyUIDRejectedBeforeWrite(t *test
 	preview := icaltransfer.Preview{Result: ical.ImportResult{Events: []event.Event{sourceEvt}}}
 	preview.Events = 1
 
-	if err := icaltransfer.ValidateDestination(ctx, a, target.ID, preview); err == nil ||
-		!strings.Contains(err.Error(), "read-only") {
-		t.Fatalf("cross-calendar error = %v, want read-only source rejection", err)
+	if err := icaltransfer.ValidateDestination(ctx, a, target.ID, preview); err != nil {
+		t.Fatalf("ValidateDestination: %v", err)
 	}
-
-	// Validation must have rejected before Import could write, so the row
-	// still belongs to the source calendar.
-	got, err := a.Events.GetByUID(ctx, "uid-cross-cal")
+	summary := icaltransfer.Import(ctx, a, target.ID, &preview.Result)
+	if summary.Failed != 0 || summary.NewEvents != 1 {
+		t.Fatalf("import Failed=%d NewEvents=%d, want Failed=0 NewEvents=1",
+			summary.Failed, summary.NewEvents)
+	}
+	src, err := a.Events.GetByCalendarUID(ctx, source.ID, "uid-cross-cal")
 	if err != nil {
-		t.Fatalf("GetByUID: %v", err)
+		t.Fatalf("source copy: %v", err)
 	}
-	if got.CalendarID != source.ID {
-		t.Errorf("event.CalendarID = %d, want %d (no write should have happened)",
-			got.CalendarID, source.ID)
+	if src.Title != "Existing" {
+		t.Errorf("source title = %q, want Existing", src.Title)
+	}
+	dst, err := a.Events.GetByCalendarUID(ctx, target.ID, "uid-cross-cal")
+	if err != nil {
+		t.Fatalf("destination copy: %v", err)
+	}
+	if dst.ID == src.ID {
+		t.Fatalf("import reused id %d; each calendar must keep its own copy", src.ID)
 	}
 }
 

--- a/internal/recurrence/cross_calendar_uid_test.go
+++ b/internal/recurrence/cross_calendar_uid_test.go
@@ -1,0 +1,95 @@
+package recurrence
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/testutil"
+)
+
+// TestListExpandedEvents_SameUIDOnTwoCalendars is the issue #756 expansion
+// contract. Two calendars can store the same UID. An override on one calendar
+// must not hide the other calendar's occurrence.
+func TestListExpandedEvents_SameUIDOnTwoCalendars(t *testing.T) {
+	db, q := testutil.NewTestDB(t)
+	eventsSvc := event.NewService(db, q)
+	recurSvc := NewService(db, q)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO calendars (name) VALUES ('Other')`)
+	if err != nil {
+		t.Fatalf("insert calendar: %v", err)
+	}
+	otherID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("calendar id: %v", err)
+	}
+
+	start := time.Date(2026, 4, 6, 9, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	master, err := eventsSvc.Create(ctx, event.CreateParams{
+		CalendarID:     1,
+		Title:          "Standup",
+		StartTime:      start,
+		EndTime:        end,
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=MO",
+	})
+	if err != nil {
+		t.Fatalf("create calendar 1 master: %v", err)
+	}
+	if _, err := eventsSvc.UpsertByUID(ctx, event.UpsertParams{
+		UID:          master.UID,
+		CalendarID:   1,
+		Title:        "Standup (moved)",
+		StartTime:    time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 4, 8, 15, 0, 0, 0, time.UTC),
+		RecurrenceID: "2026-04-06T09:00:00Z",
+	}); err != nil {
+		t.Fatalf("create calendar 1 override: %v", err)
+	}
+
+	if _, err := eventsSvc.UpsertByUID(ctx, event.UpsertParams{
+		UID:            master.UID,
+		CalendarID:     otherID,
+		Title:          "Standup",
+		StartTime:      start,
+		EndTime:        end,
+		RecurrenceRule: "FREQ=WEEKLY;BYDAY=MO",
+	}); err != nil {
+		t.Fatalf("create calendar 2 master: %v", err)
+	}
+
+	from := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 13, 0, 0, 0, 0, time.UTC)
+	got, err := recurSvc.ListExpandedEvents(ctx, from, to)
+	if err != nil {
+		t.Fatalf("ListExpandedEvents: %v", err)
+	}
+
+	var cal1, cal2 []ExpandedEvent
+	for _, ev := range got {
+		switch ev.CalendarID {
+		case 1:
+			cal1 = append(cal1, ev)
+		case otherID:
+			cal2 = append(cal2, ev)
+		}
+	}
+	if len(cal1) != 1 {
+		t.Fatalf("calendar 1 instances = %d, want 1 (the moved override)", len(cal1))
+	}
+	if cal1[0].Title != "Standup (moved)" {
+		t.Errorf("calendar 1 title = %q, want Standup (moved)", cal1[0].Title)
+	}
+	if len(cal2) != 1 {
+		t.Fatalf("calendar 2 instances = %d, want 1 (the un-overridden Monday)", len(cal2))
+	}
+	if cal2[0].Title != "Standup" {
+		t.Errorf("calendar 2 title = %q, want Standup", cal2[0].Title)
+	}
+	if !cal2[0].InstanceTime.Equal(start) {
+		t.Errorf("calendar 2 instance = %s, want %s", cal2[0].InstanceTime, start)
+	}
+}

--- a/internal/recurrence/list_events.go
+++ b/internal/recurrence/list_events.go
@@ -30,7 +30,8 @@ func (s *Service) eventOverridesByUID(ctx context.Context, masters []storage.Eve
 	}
 	byUID := make(map[string][]storage.Event, len(rows))
 	for _, r := range rows {
-		byUID[r.Uid] = append(byUID[r.Uid], r)
+		key := seriesKey(r.CalendarID, r.Uid)
+		byUID[key] = append(byUID[key], r)
 	}
 	return byUID, nil
 }
@@ -245,7 +246,7 @@ func expandedEventKind(s *Service) recurringKind[storage.Event, ExpandedEvent, E
 		},
 		instTime:       func(i ExpandedEvent) time.Time { return i.InstanceTime },
 		applyInstance:  func(i ExpandedEvent) ExpandedEvent { return i },
-		uid:            func(r storage.Event) string { return r.Uid },
+		uid:            func(r storage.Event) string { return seriesKey(r.CalendarID, r.Uid) },
 		status:         func(r storage.Event) string { return r.Status },
 		recurrenceID:   func(r storage.Event) string { return r.RecurrenceID },
 		overridesByUID: s.eventOverridesByUID,
@@ -272,7 +273,7 @@ func (s *Service) expandRecurringRows(ctx context.Context, rows []storage.Event,
 			e.EndTime = i.InstanceTime.Add(dur)
 			return e
 		},
-		uid:            func(r storage.Event) string { return r.Uid },
+		uid:            func(r storage.Event) string { return seriesKey(r.CalendarID, r.Uid) },
 		status:         func(r storage.Event) string { return r.Status },
 		recurrenceID:   func(r storage.Event) string { return r.RecurrenceID },
 		overridesByUID: s.eventOverridesByUID,

--- a/internal/recurrence/list_journals.go
+++ b/internal/recurrence/list_journals.go
@@ -25,7 +25,8 @@ func (s *Service) journalOverridesByUID(ctx context.Context, masters []storage.J
 	}
 	byUID := make(map[string][]storage.Journal, len(rows))
 	for _, r := range rows {
-		byUID[r.Uid] = append(byUID[r.Uid], r)
+		key := seriesKey(r.CalendarID, r.Uid)
+		byUID[key] = append(byUID[key], r)
 	}
 	return byUID, nil
 }
@@ -150,7 +151,7 @@ func (s *Service) expandRecurringJournalRows(ctx context.Context, rows []storage
 			}
 			return jj
 		},
-		uid:            func(r storage.Journal) string { return r.Uid },
+		uid:            func(r storage.Journal) string { return seriesKey(r.CalendarID, r.Uid) },
 		status:         func(r storage.Journal) string { return r.Status },
 		recurrenceID:   func(r storage.Journal) string { return r.RecurrenceID },
 		overridesByUID: s.journalOverridesByUID,

--- a/internal/recurrence/list_todos.go
+++ b/internal/recurrence/list_todos.go
@@ -25,7 +25,8 @@ func (s *Service) todoOverridesByUID(ctx context.Context, masters []storage.Todo
 	}
 	byUID := make(map[string][]storage.Todo, len(rows))
 	for _, r := range rows {
-		byUID[r.Uid] = append(byUID[r.Uid], r)
+		key := seriesKey(r.CalendarID, r.Uid)
+		byUID[key] = append(byUID[key], r)
 	}
 	return byUID, nil
 }
@@ -166,7 +167,7 @@ func (s *Service) expandRecurringTodoRows(ctx context.Context, rows []storage.To
 			}
 			return t
 		},
-		uid:            func(r storage.Todo) string { return r.Uid },
+		uid:            func(r storage.Todo) string { return seriesKey(r.CalendarID, r.Uid) },
 		status:         func(r storage.Todo) string { return r.Status },
 		recurrenceID:   func(r storage.Todo) string { return r.RecurrenceID },
 		overridesByUID: s.todoOverridesByUID,

--- a/internal/recurrence/service.go
+++ b/internal/recurrence/service.go
@@ -3,6 +3,7 @@ package recurrence
 import (
 	"context"
 	"database/sql"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +21,12 @@ type Service struct {
 
 func NewService(db *sql.DB, q *storage.Queries) *Service {
 	return &Service{db: db, q: q}
+}
+
+// seriesKey identifies a recurring series. UID is unique per calendar
+// (issue #756), so the key includes calendar_id.
+func seriesKey(calendarID int64, uid string) string {
+	return strconv.FormatInt(calendarID, 10) + "\x00" + uid
 }
 
 // tzForExpansion returns the *time.Location to use for rrule expansion.

--- a/internal/storage/events.sql.go
+++ b/internal/storage/events.sql.go
@@ -169,6 +169,95 @@ func (q *Queries) GetEvent(ctx context.Context, id int64) (Event, error) {
 	return i, err
 }
 
+const getEventByCalendarUID = `-- name: GetEventByCalendarUID :one
+SELECT id, uid, calendar_id, title, description, location, start_time, end_time, all_day, recurrence_rule, timezone, status, transp, sequence, priority, class, url, exdates, rdates, recurrence_id, geo, created_at, updated_at, duration, dtstamp, conference_uri, deleted_at FROM events WHERE calendar_id = ? AND uid = ? AND recurrence_id = '' AND deleted_at IS NULL
+`
+
+type GetEventByCalendarUIDParams struct {
+	CalendarID int64
+	Uid        string
+}
+
+func (q *Queries) GetEventByCalendarUID(ctx context.Context, arg GetEventByCalendarUIDParams) (Event, error) {
+	row := q.db.QueryRowContext(ctx, getEventByCalendarUID, arg.CalendarID, arg.Uid)
+	var i Event
+	err := row.Scan(
+		&i.ID,
+		&i.Uid,
+		&i.CalendarID,
+		&i.Title,
+		&i.Description,
+		&i.Location,
+		&i.StartTime,
+		&i.EndTime,
+		&i.AllDay,
+		&i.RecurrenceRule,
+		&i.Timezone,
+		&i.Status,
+		&i.Transp,
+		&i.Sequence,
+		&i.Priority,
+		&i.Class,
+		&i.Url,
+		&i.Exdates,
+		&i.Rdates,
+		&i.RecurrenceID,
+		&i.Geo,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Duration,
+		&i.Dtstamp,
+		&i.ConferenceUri,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
+const getEventByCalendarUIDAndRecurrenceID = `-- name: GetEventByCalendarUIDAndRecurrenceID :one
+SELECT id, uid, calendar_id, title, description, location, start_time, end_time, all_day, recurrence_rule, timezone, status, transp, sequence, priority, class, url, exdates, rdates, recurrence_id, geo, created_at, updated_at, duration, dtstamp, conference_uri, deleted_at FROM events WHERE calendar_id = ? AND uid = ? AND recurrence_id = ? AND deleted_at IS NULL
+`
+
+type GetEventByCalendarUIDAndRecurrenceIDParams struct {
+	CalendarID   int64
+	Uid          string
+	RecurrenceID string
+}
+
+func (q *Queries) GetEventByCalendarUIDAndRecurrenceID(ctx context.Context, arg GetEventByCalendarUIDAndRecurrenceIDParams) (Event, error) {
+	row := q.db.QueryRowContext(ctx, getEventByCalendarUIDAndRecurrenceID, arg.CalendarID, arg.Uid, arg.RecurrenceID)
+	var i Event
+	err := row.Scan(
+		&i.ID,
+		&i.Uid,
+		&i.CalendarID,
+		&i.Title,
+		&i.Description,
+		&i.Location,
+		&i.StartTime,
+		&i.EndTime,
+		&i.AllDay,
+		&i.RecurrenceRule,
+		&i.Timezone,
+		&i.Status,
+		&i.Transp,
+		&i.Sequence,
+		&i.Priority,
+		&i.Class,
+		&i.Url,
+		&i.Exdates,
+		&i.Rdates,
+		&i.RecurrenceID,
+		&i.Geo,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Duration,
+		&i.Dtstamp,
+		&i.ConferenceUri,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
 const getEventByUID = `-- name: GetEventByUID :one
 SELECT id, uid, calendar_id, title, description, location, start_time, end_time, all_day, recurrence_rule, timezone, status, transp, sequence, priority, class, url, exdates, rdates, recurrence_id, geo, created_at, updated_at, duration, dtstamp, conference_uri, deleted_at FROM events WHERE uid = ? AND recurrence_id = '' AND deleted_at IS NULL
 `
@@ -1015,8 +1104,7 @@ INSERT INTO events (
     class, url, exdates, rdates, recurrence_id, geo, duration, dtstamp,
     conference_uri
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-ON CONFLICT(uid, recurrence_id) DO UPDATE SET
-    calendar_id = excluded.calendar_id,
+ON CONFLICT(calendar_id, uid, recurrence_id) DO UPDATE SET
     title = excluded.title, description = excluded.description,
     location = excluded.location, start_time = excluded.start_time,
     end_time = excluded.end_time, all_day = excluded.all_day,

--- a/internal/sync/engine_persist.go
+++ b/internal/sync/engine_persist.go
@@ -253,7 +253,19 @@ func (e *Engine) persistImported(ctx context.Context, calendarID int64, result i
 	// Prune overrides the server dropped (e.g. a deleted instance that became
 	// an EXDATE on the master); see pruneStaleOverrides for the safety gates.
 	if err := pruneStaleOverrides(ctx, e, calendarID, eventKeep, dirtyBefore, revs,
-		e.q.ListOverridesByUID,
+		func(ctx context.Context, uid string) ([]storage.Event, error) {
+			rows, err := e.q.ListOverridesByUID(ctx, uid)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]storage.Event, 0, len(rows))
+			for _, r := range rows {
+				if r.CalendarID == calendarID {
+					out = append(out, r)
+				}
+			}
+			return out, nil
+		},
 		func(v storage.Event) int64 { return v.ID },
 		func(v storage.Event) string { return v.RecurrenceID },
 		(*storage.Queries).SoftDeleteEvent,


### PR DESCRIPTION
Fixes #756.

## Problem

Google Calendar (and CalDAV) reuse one UID when the same meeting lives on more than one collection. The events table used `UNIQUE(uid, recurrence_id)`, so a pull of the second calendar overwrote the first row. Only one calendar showed the meeting.

## Change

- Rebuild the events unique key as `(calendar_id, uid, recurrence_id)`.
- Upsert on that key, so a second calendar inserts a second copy.
- Key recurrence expansion and override prune by calendar as well as UID.
- Allow an ICS import of that UID into a different writable calendar.

`GetByUID` still exists for a UID that lives on one calendar. Use `GetByCalendarUID` when the calendar is known.

## Tests

`go test ./...` passes.