### PR TITLE
fix(nix): do not run the Go tests in the build sandbox

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,11 +42,16 @@
             "-X main.date=${self.lastModifiedDate or "unknown"}"
           ];
 
-          checkPhase = ''
-            runHook preCheck
-            HOME="$TMPDIR" GOFLAGS="" go test ./...
-            runHook postCheck
-          '';
+          # Do not run the Go test suite in the Nix sandbox. The sandbox has
+          # no OS keyring, so the credential tests fail with exit status 195.
+          # The passwd home directory of the build user is /var/empty, so the
+          # account lock root is not writable. The lock root comes from the
+          # passwd entry on purpose, because every process of one OS user must
+          # resolve the same root. See issue #761.
+          # The CI workflow .github/workflows/ci.yml runs the full suite with
+          # the race detector on Linux and macOS for every push and every pull
+          # request.
+          doCheck = false;
 
           meta = {
             description = "Terminal-first calendar, todo, and journal manager";

--- a/internal/sync/engine_6_test.go
+++ b/internal/sync/engine_6_test.go
@@ -762,7 +762,16 @@ func TestEngineSyncCalendarSerializesWholeCycle(t *testing.T) {
 		_, err := engine.SyncCalendar(ctx, calendarID, ConflictServerWins)
 		results <- err
 	}()
-	<-firstEntered
+	// Do not wait for firstEntered alone. A sync that stops before the server
+	// call never closes that channel, and the test then hangs for the whole
+	// package timeout (issue #761).
+	select {
+	case <-firstEntered:
+	case err := <-results:
+		t.Fatalf("first sync stopped before the server call: %v", err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("first sync did not reach the server")
+	}
 	go func() {
 		_, err := engine.SyncCalendar(ctx, calendarID, ConflictServerWins)
 		results <- err


### PR DESCRIPTION
Fixes #761.

`nix run github:DouglasdeMoura/chroncal` fails during the build, because the Nix sandbox runs the test suite and the sandbox has no OS keyring and no writable home directory.

Two changes:

- **flake.nix** — `doCheck = false`, so the build no longer runs the tests. CI already runs the full suite with the race detector on Linux and macOS for every push and PR, and the `nix` job still builds the package, so a stale `vendorHash` is still caught.
- **internal/sync/engine_6_test.go** — `TestEngineSyncCalendarSerializesWholeCycle` waited on a channel that only the HTTP handler closes. When the sync failed before reaching the server, the test hung for the full 10-minute timeout instead of reporting the error. It now waits on the channel, the result, or a 30-second deadline.

I left `accountLockRoot` alone on purpose. It reads the home directory from the passwd entry, because every process of one user has to agree on the lock root — otherwise two processes take different lock files for the same database. Adding a `$HOME` override just to satisfy the sandbox would break that.

### Verified

Built with real Nix (nix-portable, sandbox on): the package builds and `nix run` works.

One caveat worth knowing: on Linux the *old* check phase passed fine — all 32 packages, inside the sandbox. The reported failure is macOS-only, where the build user's home is `/var/empty` and the keyring is the Keychain. So this fixes a macOS build failure I could not reproduce locally. The test hang fix applies everywhere.

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint reports no issues (`make lint`)
- [ ] Add new tests for new functions
- [ ] Update the documentation when the change needs it
