### PR TITLE
fix(nix): drop the custom Go source override

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784007870,
-        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
+        "lastModified": 1788881743,
+        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
+        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,16 +19,12 @@
         # Single source of truth for the released version; the release
         # workflow refuses to run if VERSION does not match the tag.
         version = pkgs.lib.trim (builtins.readFile ./VERSION);
-        # nixos-unstable still carries an older Go 1.26 patch.
-        # Pin Nix-built binaries to 1.26.6 until the nixpkgs input catches up.
-        go = pkgs.go_1_26.overrideAttrs (_: {
-          version = "1.26.6";
-          src = pkgs.fetchurl {
-            url = "https://go.dev/dl/go1.26.6.src.tar.gz";
-            hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
-          };
-        });
-        chroncal = pkgs.buildGoModule {
+        # One source of truth for the Go toolchain. The package build and the
+        # devShell both use this value. go.mod asks for a 1.26 toolchain, so
+        # the flake selects go_1_26 from nixpkgs. The binary cache holds that
+        # package, so a build does not compile Go from the source.
+        go = pkgs.go_1_26;
+        chroncal = (pkgs.buildGoModule.override { inherit go; }) {
           pname = "chroncal";
           inherit version;
 
@@ -36,7 +32,6 @@
           subPackages = [ "cmd/chroncal" ];
           vendorHash = "sha256-6i48BSXh1gRvrU9Hd0myPDLf783Rl4k3n6DwcAO1Y2Y=";
 
-          nativeBuildInputs = [ go ];
           env.CGO_ENABLED = "0";
 
           ldflags = [


### PR DESCRIPTION
Fixes #760.

The flake replaced the source of `pkgs.go_1_26` with the go 1.26.6 tarball from go.dev. Nothing in the binary cache matches that derivation, so every `nix run github:DouglasdeMoura/chroncal` compiled Go from source first.

Three changes:

1. `go = pkgs.go_1_26;` replaces the `overrideAttrs` block.
2. The flake passes that `go` to `pkgs.buildGoModule.override { inherit go; }` and drops `nativeBuildInputs = [ go ]`. This matters: `buildGoModule` puts its own Go first on PATH, so the old override never actually selected the Go used for the build — it only dragged an extra source build into the closure.
3. `flake.lock` moves nixpkgs to `nixos-unstable` rev `d6524aaca2ff07876657ae2b323f24be4874944b` (2026-09-08).

### Why the lock had to move

The old pin (2026-07-14) carried only go 1.26.4, and `go.mod` asks for `toolchain go1.26.6`. The new revision carries go 1.26.7. `go.mod` is untouched.

I could not run `nix flake update`, so I wrote the lock entry by hand and checked every field: the rev is the head of `nixos-unstable`, `1.26.nix` at that rev declares 1.26.7, `all-packages.nix` maps `go_1_26` to it, `lastModified` matches the commit date, and the `narHash` matches three independent repos that pin the same rev.

### Verified

Built with real Nix (nix-portable, sandbox on). Go comes from cache.nixos.org — the derivation uses `go-1.26.7` and the log shows no Go source build. `nix run .#chroncal -- --version` prints `chroncal 0.9.1`. CI agrees: both Nix jobs finish in about 2m20s.

**Heads up:** the lock bump also moves `golangci-lint`, `goreleaser`, `govulncheck`, and `sqlc` in the devShell to newer versions. Same effect as the monthly `update-flake-lock` run. It will also conflict with #757, which touches the same file.

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint reports no issues (`make lint`)
- [ ] Add new tests for new functions
- [ ] Update the documentation when the change needs it
