### PR TITLE
feat(nix): add a home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,57 @@ Build the package from a clone:
 nix build .#chroncal
 ```
 
-The flake exposes `packages.default`, `packages.chroncal`, `apps.default`, and a developer shell with Go, GoReleaser, golangci-lint, govulncheck, and sqlc.
+The flake exposes `packages.default`, `packages.chroncal`, `apps.default`, `homeModules.chroncal`, `homeModules.default`, and a developer shell with Go, GoReleaser, golangci-lint, govulncheck, and sqlc.
+
+### home-manager
+
+The flake also exposes a [home-manager](https://github.com/nix-community/home-manager) module. The module installs the program and writes `$XDG_CONFIG_HOME/chroncal/config.toml`.
+
+Add the input to your `flake.nix`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    chroncal.url = "github:DouglasdeMoura/chroncal";
+  };
+}
+```
+
+Then import the module in your home-manager configuration:
+
+```nix
+{ inputs, ... }:
+{
+  imports = [ inputs.chroncal.homeModules.default ];
+
+  programs.chroncal = {
+    enable = true;
+    settings = {
+      product_id = "-//example//chroncal//EN";
+      ui = {
+        theme = "default";
+        week_start = "monday";
+      };
+      soft_delete.purge_days = 30;
+      sync.conflict_strategy = "prompt";
+    };
+  };
+}
+```
+
+The module has three options:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `programs.chroncal.enable` | boolean | Installs the package and writes the config file. |
+| `programs.chroncal.package` | package or null | The package to install. The default is the package of this flake for the system of the host. Set it to `null` to install the program with another method. |
+| `programs.chroncal.settings` | attribute set | The content of `config.toml`. See [Config keys](#config-keys) for each key. |
+
+Do not put a secret in `settings`. The Nix store is readable for every user of the machine. Pass a secret through an environment variable, for example `CHRONCAL_SMTP_PASSWORD`.
+
+On macOS the module writes the file to `~/Library/Application Support/chroncal/config.toml`, because the program reads that directory. With `xdg.enable = true` the module writes the file to `xdg.configHome` instead.
 
 ### Scoop (Windows)
 

--- a/flake.nix
+++ b/flake.nix
@@ -82,5 +82,11 @@
           ];
         };
       }
-    );
+    )
+    // {
+      # The home-manager module is not per-system. It reads the pkgs of the
+      # host configuration, so it stays outside eachDefaultSystem.
+      homeModules.chroncal = import ./nix/hm-module.nix self;
+      homeModules.default = self.homeModules.chroncal;
+    };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,97 @@
+# home-manager module for chroncal.
+#
+# The flake applies this file to itself. The module then reads the package
+# that the flake builds for the system of the host configuration.
+self:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.chroncal;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  # The flake builds a package for each default system. On another system the
+  # module falls back to the nixpkgs package, and then to null. A null package
+  # installs nothing, so the user can supply the program with another method.
+  flakePackage = self.packages.${pkgs.stdenv.hostPlatform.system}.chroncal or null;
+  nixpkgsPackage = pkgs.chroncal or null;
+  defaultPackage = if flakePackage != null then flakePackage else nixpkgsPackage;
+
+  # chroncal reads $XDG_CONFIG_HOME/chroncal/config.toml. macOS has no XDG
+  # variable by default, so the program reads the user configuration
+  # directory. home-manager exports XDG_CONFIG_HOME when xdg.enable is true.
+  configHome =
+    if pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable then
+      "${config.home.homeDirectory}/Library/Application Support"
+    else
+      config.xdg.configHome;
+in
+{
+  options.programs.chroncal = {
+    enable = lib.mkEnableOption "chroncal, a terminal-first calendar, todo, and journal manager";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "chroncal.packages.\${pkgs.stdenv.hostPlatform.system}.chroncal";
+      description = ''
+        The chroncal package to install. Set the option to `null` to install
+        the program with another method.
+      '';
+    };
+
+    settings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          product_id = "-//example//chroncal//EN";
+          ui = {
+            theme = "default";
+            week_start = "monday";
+          };
+          soft_delete.purge_days = 30;
+          sync = {
+            interval = "15m";
+            conflict_strategy = "prompt";
+          };
+        }
+      '';
+      description = ''
+        The configuration for chroncal. home-manager writes the attribute set
+        to {file}`$XDG_CONFIG_HOME/chroncal/config.toml` in the TOML format.
+
+        The program reads these keys:
+
+        - `db`: the path to the SQLite database file.
+        - `product_id`: the iCal PRODID for an export.
+        - `[smtp]`: `host`, `port`, `username`, `password`, `from`, and `tls`
+          for an EMAIL alarm.
+        - `[sync]`: `interval` and `conflict_strategy` for a CalDAV sync.
+        - `[security]`: `allow_unsafe_alarm_audio_attach`,
+          `allow_unsafe_alarm_email_attendees`, and `allow_plaintext`.
+        - `[soft_delete]`: `purge_days` for the retention of a deleted row.
+        - `[ui]`: `theme` and `week_start` for the TUI.
+
+        Do not put a secret in this attribute set. The Nix store is readable
+        for every user of the machine. Use an environment variable, for
+        example `CHRONCAL_SMTP_PASSWORD`, for a secret.
+
+        See <https://github.com/DouglasdeMoura/chroncal#configuration> for the
+        description and the default of each key.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file."${configHome}/chroncal/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "chroncal-config.toml" cfg.settings;
+    };
+  };
+}


### PR DESCRIPTION
Refs #627.

Issue #627 asks for two things. This PR does the first one: a home-manager module. The second (`password_cmd`) is in #773, and the issue also asks for arrow-key navigation in modals, so it stays open.

**What it adds**

- `nix/hm-module.nix` — the module. The flake applies it to `self`, so it uses the package the flake builds for the host system.
- `flake.nix` — `homeModules.chroncal` and `homeModules.default`, appended after `eachDefaultSystem`. They have to sit outside it: a home-manager module is not per-system, it takes the `pkgs` of the host configuration.
- `README.md` — an install example and an option table.

**Options**

| Option | Type | What it does |
|--------|------|--------------|
| `programs.chroncal.enable` | bool | Installs the package and writes the config file. |
| `programs.chroncal.package` | package or null | Defaults to the flake's package for your system, then `pkgs.chroncal`, then `null`. `null` installs nothing, so you can manage `settings` while installing the binary some other way. |
| `programs.chroncal.settings` | `pkgs.formats.toml` | Rendered to `config.toml`. |

`settings` is free-form on purpose. A hand-written mirror of every key would drift from what viper actually reads in `internal/config/config.go`; the option description names the real keys instead.

**Config file path**

`$XDG_CONFIG_HOME/chroncal/config.toml`, except on macOS without an XDG variable, where the program reads `~/Library/Application Support`. The module writes there when `xdg.enable` is false, matching `configDir()` in `internal/config/config.go`.

### Verified

Built with real Nix (nix-portable) against home-manager. Four configurations build:

| Case | Result |
|---|---|
| `enable = false` | no file, no package |
| `enable`, no `settings` | package installed, no config file |
| `xdg.enable = true` | `~/.config/chroncal/config.toml` |
| `xdg.enable = false` (Linux) | `~/.config/chroncal/config.toml` |
| `xdg.enable = false` (aarch64-darwin, evaluated) | `~/Library/Application Support/chroncal/config.toml` |

The generated TOML matches the real schema, and chroncal reads it end to end: pointed at the generated file, `chroncal calendar list` worked and created the database at the configured `db` path. `nix flake check` passes and `homeModules` exposes `[ "chroncal" "default" ]`.

No Go code changes.

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint reports no issues (`make lint`)
- [ ] Add new tests for new functions
- [x] Update the documentation when the change needs it
