### PR TITLE
fix(sync): raise the CalDAV request timeout and store any RELTYPE token

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,7 @@ Configuration loads in this order of precedence:
 | `soft_delete.purge_days` | Days to keep soft-deleted rows before the background purge. `0` disables automatic purge. | `30` |
 | `sync.interval` | Minimum interval between background CalDAV syncs that `chroncal service run` performs. `service install` defaults to `15m` when this is unset. | (unset — no sync unless the installed service sets `CHRONCAL_SYNC_INTERVAL`) |
 | `sync.conflict_strategy` | Default conflict-resolution mode when you do not pass `sync run --conflict` | `prompt` |
+| `sync.http_timeout` | Time limit for one CalDAV request, as a Go duration (for example `10m`). Raise it for a server that answers a large multiget slowly. Lower it to fail faster against a hung server. | `5m` |
 | `security.allow_unsafe_alarm_audio_attach` | Allow AUDIO alarms to attach arbitrary URIs. Off by default. | `false` |
 | `security.allow_unsafe_alarm_email_attendees` | Allow EMAIL alarms to send to unverified attendee addresses. Off by default. | `false` |
 

--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ Configuration loads in this order of precedence:
 | `soft_delete.purge_days` | Days to keep soft-deleted rows before the background purge. `0` disables automatic purge. | `30` |
 | `sync.interval` | Minimum interval between background CalDAV syncs that `chroncal service run` performs. `service install` defaults to `15m` when this is unset. | (unset — no sync unless the installed service sets `CHRONCAL_SYNC_INTERVAL`) |
 | `sync.conflict_strategy` | Default conflict-resolution mode when you do not pass `sync run --conflict` | `prompt` |
-| `sync.http_timeout` | Time limit for one CalDAV request, as a Go duration (for example `10m`). Raise it for a server that answers a large multiget slowly. Lower it to fail faster against a hung server. | `5m` |
+| `sync.http_timeout` | Time limit for one CalDAV request, as a Go duration (for example `10m`). Raise it for a server that answers a large multiget slowly. Lower it to fail faster against a hung server. Each sync deadline derives from this value, so a larger value also gives each sync pass more time. An unusable value gives a warning, and chroncal keeps the default. | `5m` |
 | `security.allow_unsafe_alarm_audio_attach` | Allow AUDIO alarms to attach arbitrary URIs. Off by default. | `false` |
 | `security.allow_unsafe_alarm_email_attendees` | Allow EMAIL alarms to send to unverified attendee addresses. Off by default. | `false` |
 

--- a/cmd/chroncal/calendar_remote.go
+++ b/cmd/chroncal/calendar_remote.go
@@ -97,9 +97,18 @@ func connectCalendarRemote(ctx context.Context, a *app.App, cal calendarpkg.Cale
 			metaPassword = resolved
 		}
 	}
-	metaCtx, metaCancel := context.WithTimeout(ctx, 10*time.Second)
-	meta, _ := caldav.FetchCalendarMetadata(metaCtx, flags.RemoteURL, flags.Username, metaPassword, flags.AuthType, flags.AllowInsecure)
+	// The metadata fetch is best effort: it seeds the color, the access mode,
+	// and the component set. A failure must not stop the link. The budget
+	// stays short because the user waits at the shell, but it tracks the
+	// configured request timeout so a slow server can still answer.
+	metaCtx, metaCancel := context.WithTimeout(ctx, calendarMetadataBudget())
+	meta, metaErr := caldav.FetchCalendarMetadata(metaCtx, flags.RemoteURL, flags.Username, metaPassword, flags.AuthType, flags.AllowInsecure)
 	metaCancel()
+	if metaErr != nil {
+		// Tell the user why the color and the access mode stay unset. A
+		// silent skip looks like a server with no color.
+		fmt.Fprintf(os.Stderr, "chroncal: warning: could not read the calendar metadata (%v); the color and the access mode stay unset\n", metaErr)
+	}
 
 	return a.Calendars.Connect(ctx, cal, calendarpkg.RemoteLink{
 		RemoteURL:        flags.RemoteURL,
@@ -110,6 +119,18 @@ func connectCalendarRemote(ctx context.Context, a *app.App, cal calendarpkg.Cale
 		RemoteAccess:     string(meta.Access),
 		RemoteComponents: meta.SupportedComponents,
 	}, cred, credStore)
+}
+
+// calendarMetadataBudget bounds the metadata PROPFIND that runs when a
+// calendar links to a server. The fetch is best effort and the user waits at
+// the shell, so the budget stays far below a sync budget. It still tracks the
+// configured request timeout, so a slow server can answer.
+func calendarMetadataBudget() time.Duration {
+	const ceiling = 30 * time.Second
+	if d := caldav.HTTPTimeout(); d < ceiling {
+		return d
+	}
+	return ceiling
 }
 
 func disconnectCalendarRemote(ctx context.Context, a *app.App, cal calendarpkg.Calendar) error {

--- a/cmd/chroncal/event_parse.go
+++ b/cmd/chroncal/event_parse.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -164,10 +165,22 @@ func parseOrganizerFlag(val string) model.Attendee {
 	}
 }
 
+// relationXTokenPattern matches an RFC 5545 x-name, for example
+// "X-APPLE-SOMETHING". A server may send a RELTYPE outside the three named
+// values, and the database stores the token as it arrives. The flag parser
+// accepts an x-name so a user can write that relation back. Without it, a
+// --related-to edit drops a stored x-name relation and the next push sends
+// the shortened body to the server.
+var relationXTokenPattern = regexp.MustCompile(`^X-[A-Z0-9-]+$`)
+
 // parseRelationFlags parses --related-to flag values into Relation models.
 // Each value can be:
 //   - A UID: "some-event-uid" (defaults to RELTYPE=PARENT)
 //   - "RELTYPE:uid": "PARENT:uid", "CHILD:uid", "SIBLING:uid"
+//   - "X-NAME:uid": an x-name RELTYPE, for example "X-APPLE-THING:uid"
+//
+// A prefix outside those values stays part of the UID. A URN UID such as
+// "urn:uuid:1234" therefore keeps its scheme.
 func parseRelationFlags(flags []string) ([]model.Relation, error) {
 	validTypes := map[string]bool{"PARENT": true, "CHILD": true, "SIBLING": true}
 	var out []model.Relation
@@ -176,7 +189,7 @@ func parseRelationFlags(flags []string) ([]model.Relation, error) {
 		uid := val
 		if idx := strings.Index(val, ":"); idx > 0 {
 			prefix := strings.ToUpper(val[:idx])
-			if validTypes[prefix] {
+			if validTypes[prefix] || relationXTokenPattern.MatchString(prefix) {
 				relType = prefix
 				uid = val[idx+1:]
 			}

--- a/cmd/chroncal/http_timeout_test.go
+++ b/cmd/chroncal/http_timeout_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/caldav"
+)
+
+// sync.http_timeout tunes the CalDAV request ceiling. A slow server, for
+// example iCloud, needs a long ceiling. A hung server needs a short one
+// (issue #768).
+func TestApplyCalDAVHTTPTimeout(t *testing.T) {
+	previous := caldav.HTTPTimeout()
+	t.Cleanup(func() { caldav.SetHTTPTimeout(previous) })
+
+	if err := applyCalDAVHTTPTimeout("90s"); err != nil {
+		t.Fatalf("applyCalDAVHTTPTimeout: %v", err)
+	}
+	if got := caldav.HTTPTimeout(); got != 90*time.Second {
+		t.Errorf("caldav.HTTPTimeout() = %s, want 1m30s", got)
+	}
+
+	// An empty value keeps whatever the package already uses.
+	if err := applyCalDAVHTTPTimeout(""); err != nil {
+		t.Fatalf("applyCalDAVHTTPTimeout with an empty value: %v", err)
+	}
+	if got := caldav.HTTPTimeout(); got != 90*time.Second {
+		t.Errorf("caldav.HTTPTimeout() after an empty value = %s, want 1m30s", got)
+	}
+}
+
+func TestApplyCalDAVHTTPTimeoutRejectsBadValues(t *testing.T) {
+	previous := caldav.HTTPTimeout()
+	t.Cleanup(func() { caldav.SetHTTPTimeout(previous) })
+
+	for _, raw := range []string{"soon", "5", "0s", "-1m"} {
+		if err := applyCalDAVHTTPTimeout(raw); err == nil {
+			t.Errorf("applyCalDAVHTTPTimeout(%q) = nil, want an error", raw)
+		}
+	}
+	if got := caldav.HTTPTimeout(); got != previous {
+		t.Errorf("caldav.HTTPTimeout() = %s, want the unchanged %s", got, previous)
+	}
+}
+
+// A parent context must outlive one CalDAV request. A short parent deadline
+// cut a slow first pull before the server answered (issue #768).
+func TestSyncRunTimeoutOutlivesOneRequest(t *testing.T) {
+	if syncRunTimeout <= caldav.HTTPTimeout() {
+		t.Errorf("syncRunTimeout = %s, want more than the CalDAV request ceiling %s",
+			syncRunTimeout, caldav.HTTPTimeout())
+	}
+}

--- a/cmd/chroncal/http_timeout_test.go
+++ b/cmd/chroncal/http_timeout_test.go
@@ -14,41 +14,45 @@ func TestApplyCalDAVHTTPTimeout(t *testing.T) {
 	previous := caldav.HTTPTimeout()
 	t.Cleanup(func() { caldav.SetHTTPTimeout(previous) })
 
-	if err := applyCalDAVHTTPTimeout("90s"); err != nil {
-		t.Fatalf("applyCalDAVHTTPTimeout: %v", err)
-	}
+	applyCalDAVHTTPTimeout("90s")
 	if got := caldav.HTTPTimeout(); got != 90*time.Second {
 		t.Errorf("caldav.HTTPTimeout() = %s, want 1m30s", got)
 	}
 
 	// An empty value keeps whatever the package already uses.
-	if err := applyCalDAVHTTPTimeout(""); err != nil {
-		t.Fatalf("applyCalDAVHTTPTimeout with an empty value: %v", err)
-	}
+	applyCalDAVHTTPTimeout("")
 	if got := caldav.HTTPTimeout(); got != 90*time.Second {
 		t.Errorf("caldav.HTTPTimeout() after an empty value = %s, want 1m30s", got)
 	}
 }
 
-func TestApplyCalDAVHTTPTimeoutRejectsBadValues(t *testing.T) {
+// An unusable value keeps the built-in default. It does not stop the command.
+// This key affects the CalDAV requests only, and the root command applies it
+// for every command, including a local one such as `chroncal event list`.
+func TestApplyCalDAVHTTPTimeoutKeepsDefaultForBadValues(t *testing.T) {
 	previous := caldav.HTTPTimeout()
 	t.Cleanup(func() { caldav.SetHTTPTimeout(previous) })
 
 	for _, raw := range []string{"soon", "5", "0s", "-1m"} {
-		if err := applyCalDAVHTTPTimeout(raw); err == nil {
-			t.Errorf("applyCalDAVHTTPTimeout(%q) = nil, want an error", raw)
+		applyCalDAVHTTPTimeout(raw)
+		if got := caldav.HTTPTimeout(); got != previous {
+			t.Errorf("caldav.HTTPTimeout() after %q = %s, want the unchanged %s", raw, got, previous)
 		}
-	}
-	if got := caldav.HTTPTimeout(); got != previous {
-		t.Errorf("caldav.HTTPTimeout() = %s, want the unchanged %s", got, previous)
 	}
 }
 
 // A parent context must outlive one CalDAV request. A short parent deadline
-// cut a slow first pull before the server answered (issue #768).
-func TestSyncRunTimeoutOutlivesOneRequest(t *testing.T) {
-	if syncRunTimeout <= caldav.HTTPTimeout() {
-		t.Errorf("syncRunTimeout = %s, want more than the CalDAV request ceiling %s",
-			syncRunTimeout, caldav.HTTPTimeout())
+// cut a slow first pull before the server answered (issue #768). The budget
+// derives from the request timeout, so the rule must hold for a configured
+// timeout too, not only for the default.
+func TestSyncRunBudgetOutlivesOneRequest(t *testing.T) {
+	previous := caldav.HTTPTimeout()
+	t.Cleanup(func() { caldav.SetHTTPTimeout(previous) })
+
+	for _, request := range []time.Duration{30 * time.Second, 5 * time.Minute, 45 * time.Minute} {
+		caldav.SetHTTPTimeout(request)
+		if got := syncRunBudget(); got <= request {
+			t.Errorf("syncRunBudget() = %s at a request ceiling of %s, want more", got, request)
+		}
 	}
 }

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -235,9 +235,7 @@ Helpful conventions:
 		if cfg.ProductID != "" {
 			ical.ProductID = cfg.ProductID
 		}
-		if err := applyCalDAVHTTPTimeout(cfg.Sync.HTTPTimeout); err != nil {
-			return err
-		}
+		applyCalDAVHTTPTimeout(cfg.Sync.HTTPTimeout)
 		switch outputFmt {
 		case "text", "json":
 			return nil
@@ -281,21 +279,35 @@ Helpful conventions:
 
 // applyCalDAVHTTPTimeout sets the CalDAV request timeout from the config
 // key sync.http_timeout. An empty value keeps the built-in default. The
-// value is a Go duration string, for example "5m". A malformed or
-// non-positive value is a config error, not a silent fallback.
-func applyCalDAVHTTPTimeout(raw string) error {
+// value is a Go duration string, for example "5m".
+//
+// A malformed or non-positive value gives a warning, and the program keeps
+// the built-in default. It does not give an error. This key affects the
+// CalDAV requests only, and this function runs for every command. An error
+// here would stop a local command such as `chroncal event list`, which never
+// opens a network connection.
+func applyCalDAVHTTPTimeout(raw string) {
 	if raw == "" {
-		return nil
+		return
 	}
 	d, err := time.ParseDuration(raw)
 	if err != nil {
-		return errInvalidInputf("invalid sync.http_timeout %q: %v", raw, err)
+		warnBadHTTPTimeout(raw, err.Error())
+		return
 	}
 	if d <= 0 {
-		return errInvalidInputf("invalid sync.http_timeout %q: the timeout must be positive", raw)
+		warnBadHTTPTimeout(raw, "the timeout must be positive")
+		return
 	}
 	caldav.SetHTTPTimeout(d)
-	return nil
+}
+
+// warnBadHTTPTimeout reports an unusable sync.http_timeout value. The
+// program continues with the built-in default.
+func warnBadHTTPTimeout(raw, reason string) {
+	fmt.Fprintf(os.Stderr,
+		"chroncal: warning: invalid sync.http_timeout %q (%s); chroncal uses the default of %s\n",
+		raw, reason, caldav.HTTPTimeout())
 }
 
 func initApp() (*app.App, error) {

--- a/cmd/chroncal/main.go
+++ b/cmd/chroncal/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/douglasdemoura/chroncal/internal/app"
+	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/config"
 	"github.com/douglasdemoura/chroncal/internal/event"
 	"github.com/douglasdemoura/chroncal/internal/ical"
@@ -234,6 +235,9 @@ Helpful conventions:
 		if cfg.ProductID != "" {
 			ical.ProductID = cfg.ProductID
 		}
+		if err := applyCalDAVHTTPTimeout(cfg.Sync.HTTPTimeout); err != nil {
+			return err
+		}
 		switch outputFmt {
 		case "text", "json":
 			return nil
@@ -273,6 +277,25 @@ Helpful conventions:
 		}
 		return tui.Run(a, cfg.UI.Theme, tui.RunOptions{Event: openEvent, WeekStart: weekStart, SyncConflictStrategy: cfg.Sync.ConflictStrategy})
 	},
+}
+
+// applyCalDAVHTTPTimeout sets the CalDAV request timeout from the config
+// key sync.http_timeout. An empty value keeps the built-in default. The
+// value is a Go duration string, for example "5m". A malformed or
+// non-positive value is a config error, not a silent fallback.
+func applyCalDAVHTTPTimeout(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return errInvalidInputf("invalid sync.http_timeout %q: %v", raw, err)
+	}
+	if d <= 0 {
+		return errInvalidInputf("invalid sync.http_timeout %q: the timeout must be positive", raw)
+	}
+	caldav.SetHTTPTimeout(d)
+	return nil
 }
 
 func initApp() (*app.App, error) {

--- a/cmd/chroncal/push.go
+++ b/cmd/chroncal/push.go
@@ -13,6 +13,11 @@ import (
 	syncPkg "github.com/douglasdemoura/chroncal/internal/sync"
 )
 
+// opportunisticPushTimeout bounds the best-effort push after a CLI write.
+// The budget stays short on purpose, and it is independent of the CalDAV
+// request ceiling. The user waits at the shell for the command to return,
+// and a push carries one small resource per dirty edit. A push that runs out
+// of time keeps the dirty flag. The next sync retries it.
 const opportunisticPushTimeout = 30 * time.Second
 
 // opportunisticPush is what every write path calls. It derives the two

--- a/cmd/chroncal/relation_flag_test.go
+++ b/cmd/chroncal/relation_flag_test.go
@@ -1,0 +1,44 @@
+package main
+
+import "testing"
+
+// The database stores any RELTYPE token that a server sends. The flag parser
+// must accept an x-name, or a --related-to edit drops a stored x-name
+// relation and the next push sends the shortened body to the server.
+func TestParseRelationFlagsAcceptsXNameToken(t *testing.T) {
+	rels, err := parseRelationFlags([]string{"X-APPLE-SOMETHING:apple-uid"})
+	if err != nil {
+		t.Fatalf("parseRelationFlags: %v", err)
+	}
+	if len(rels) != 1 {
+		t.Fatalf("got %d relations, want 1", len(rels))
+	}
+	if rels[0].RelType != "X-APPLE-SOMETHING" || rels[0].RelUID != "apple-uid" {
+		t.Errorf("relation = %+v, want RelType X-APPLE-SOMETHING and RelUID apple-uid", rels[0])
+	}
+}
+
+// A URN UID keeps its scheme. The parser must not read "urn" as a RELTYPE.
+func TestParseRelationFlagsKeepsURNUID(t *testing.T) {
+	rels, err := parseRelationFlags([]string{"urn:uuid:1234"})
+	if err != nil {
+		t.Fatalf("parseRelationFlags: %v", err)
+	}
+	if rels[0].RelType != "PARENT" || rels[0].RelUID != "urn:uuid:1234" {
+		t.Errorf("relation = %+v, want RelType PARENT and the whole URN as the UID", rels[0])
+	}
+}
+
+// The three named values still work, and the parser folds the case.
+func TestParseRelationFlagsAcceptsNamedTypes(t *testing.T) {
+	rels, err := parseRelationFlags([]string{"child:a", "SIBLING:b", "c"})
+	if err != nil {
+		t.Fatalf("parseRelationFlags: %v", err)
+	}
+	want := []struct{ relType, uid string }{{"CHILD", "a"}, {"SIBLING", "b"}, {"PARENT", "c"}}
+	for i, w := range want {
+		if rels[i].RelType != w.relType || rels[i].RelUID != w.uid {
+			t.Errorf("relation %d = %+v, want %s:%s", i, rels[i], w.relType, w.uid)
+		}
+	}
+}

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/douglasdemoura/chroncal/internal/app"
 	"github.com/douglasdemoura/chroncal/internal/auth"
+	"github.com/douglasdemoura/chroncal/internal/caldav"
 	syncPkg "github.com/douglasdemoura/chroncal/internal/sync"
 )
 
@@ -76,7 +77,7 @@ func syncNewCalendars(
 	if len(calendarIDs) == 0 {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(ctx, syncRunTimeout)
+	ctx, cancel := context.WithTimeout(ctx, syncRunBudget())
 	defer cancel()
 	svc := syncPkg.NewService(
 		a.DB, a.Queries, store, a.Calendars, a.Events, a.Todos, a.Journals, nil,
@@ -99,11 +100,13 @@ func syncNewCalendars(
 	return errors.Join(syncErrs...)
 }
 
-// syncRunTimeout bounds one whole sync run. The run covers every selected
-// calendar. One CalDAV request can take up to caldav.HTTPTimeout, and the
-// retry helper repeats a transient failure. A short parent deadline cut a
-// slow first pull before the server answered (issue #768).
-const syncRunTimeout = 30 * time.Minute
+// syncRunBudget bounds one whole sync run. The run covers every selected
+// calendar, so it wraps the per-calendar budget of the engine and needs a
+// larger factor. The budget derives from the configured request timeout, so
+// a user who raises sync.http_timeout raises this budget with it.
+func syncRunBudget() time.Duration {
+	return caldav.RequestBudget(6)
+}
 
 func syncCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -159,7 +162,7 @@ linked to one CalDAV account. The two flags are mutually exclusive.`,
 				return err
 			}
 			defer a.Close()
-			ctx, cancel := context.WithTimeout(context.Background(), syncRunTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), syncRunBudget())
 			defer cancel()
 
 			// Look up names for every calendar up front so both the JSON and

--- a/cmd/chroncal/sync.go
+++ b/cmd/chroncal/sync.go
@@ -99,7 +99,11 @@ func syncNewCalendars(
 	return errors.Join(syncErrs...)
 }
 
-const syncRunTimeout = 5 * time.Minute
+// syncRunTimeout bounds one whole sync run. The run covers every selected
+// calendar. One CalDAV request can take up to caldav.HTTPTimeout, and the
+// retry helper repeats a transient failure. A short parent deadline cut a
+// slow first pull before the server answered (issue #768).
+const syncRunTimeout = 30 * time.Minute
 
 func syncCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/db/migrations/051_relation_type_token.sql
+++ b/db/migrations/051_relation_type_token.sql
@@ -1,0 +1,115 @@
+-- +goose Up
+-- RFC 5545 makes RELTYPE an extensible token. PARENT, CHILD, and SIBLING are
+-- the three values the standard names, but a server can send any other token.
+-- iCloud does. The old CHECK(rel_type IN ('PARENT','CHILD','SIBLING')) then
+-- failed the insert, the pull withheld the sync-token, and the calendar
+-- re-pulled everything on every sync (issue #768).
+--
+-- Widen the constraint to any non-empty token. SQLite cannot alter a CHECK,
+-- so rebuild each of the three relation tables. Each table is a leaf: no
+-- other table references it, and no trigger reads it. The rebuild copies the
+-- rows with their ids, then recreates the index.
+
+CREATE TABLE event_relations_new (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    rel_type TEXT    NOT NULL DEFAULT 'PARENT'
+        CHECK(rel_type <> ''),
+    rel_uid  TEXT    NOT NULL
+);
+
+INSERT INTO event_relations_new (id, event_id, rel_type, rel_uid)
+SELECT id, event_id, rel_type, rel_uid FROM event_relations;
+
+DROP TABLE event_relations;
+ALTER TABLE event_relations_new RENAME TO event_relations;
+
+CREATE INDEX idx_event_relations_event_id ON event_relations(event_id);
+
+CREATE TABLE todo_relations_new (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    todo_id  INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
+    rel_type TEXT    NOT NULL DEFAULT 'PARENT'
+        CHECK(rel_type <> ''),
+    rel_uid  TEXT    NOT NULL
+);
+
+INSERT INTO todo_relations_new (id, todo_id, rel_type, rel_uid)
+SELECT id, todo_id, rel_type, rel_uid FROM todo_relations;
+
+DROP TABLE todo_relations;
+ALTER TABLE todo_relations_new RENAME TO todo_relations;
+
+CREATE INDEX idx_todo_relations_todo_id ON todo_relations(todo_id);
+
+CREATE TABLE journal_relations_new (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    journal_id INTEGER NOT NULL REFERENCES journals(id) ON DELETE CASCADE,
+    rel_type   TEXT    NOT NULL DEFAULT 'PARENT'
+        CHECK(rel_type <> ''),
+    rel_uid    TEXT    NOT NULL
+);
+
+INSERT INTO journal_relations_new (id, journal_id, rel_type, rel_uid)
+SELECT id, journal_id, rel_type, rel_uid FROM journal_relations;
+
+DROP TABLE journal_relations;
+ALTER TABLE journal_relations_new RENAME TO journal_relations;
+
+CREATE INDEX idx_journal_relations_journal_id ON journal_relations(journal_id);
+
+-- +goose Down
+-- The narrow CHECK cannot hold a token outside the three named values. The
+-- Down step therefore drops each row that carries another token. This matches
+-- migration 044, which also drops the rows that the old CHECK refuses.
+
+CREATE TABLE event_relations_old (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    rel_type TEXT    NOT NULL DEFAULT 'PARENT'
+        CHECK(rel_type IN ('PARENT','CHILD','SIBLING')),
+    rel_uid  TEXT    NOT NULL
+);
+
+INSERT INTO event_relations_old (id, event_id, rel_type, rel_uid)
+SELECT id, event_id, rel_type, rel_uid FROM event_relations
+WHERE rel_type IN ('PARENT','CHILD','SIBLING');
+
+DROP TABLE event_relations;
+ALTER TABLE event_relations_old RENAME TO event_relations;
+
+CREATE INDEX idx_event_relations_event_id ON event_relations(event_id);
+
+CREATE TABLE todo_relations_old (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    todo_id  INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
+    rel_type TEXT    NOT NULL DEFAULT 'PARENT'
+        CHECK(rel_type IN ('PARENT','CHILD','SIBLING')),
+    rel_uid  TEXT    NOT NULL
+);
+
+INSERT INTO todo_relations_old (id, todo_id, rel_type, rel_uid)
+SELECT id, todo_id, rel_type, rel_uid FROM todo_relations
+WHERE rel_type IN ('PARENT','CHILD','SIBLING');
+
+DROP TABLE todo_relations;
+ALTER TABLE todo_relations_old RENAME TO todo_relations;
+
+CREATE INDEX idx_todo_relations_todo_id ON todo_relations(todo_id);
+
+CREATE TABLE journal_relations_old (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    journal_id INTEGER NOT NULL REFERENCES journals(id) ON DELETE CASCADE,
+    rel_type   TEXT    NOT NULL DEFAULT 'PARENT'
+        CHECK(rel_type IN ('PARENT','CHILD','SIBLING')),
+    rel_uid    TEXT    NOT NULL
+);
+
+INSERT INTO journal_relations_old (id, journal_id, rel_type, rel_uid)
+SELECT id, journal_id, rel_type, rel_uid FROM journal_relations
+WHERE rel_type IN ('PARENT','CHILD','SIBLING');
+
+DROP TABLE journal_relations;
+ALTER TABLE journal_relations_old RENAME TO journal_relations;
+
+CREATE INDEX idx_journal_relations_journal_id ON journal_relations(journal_id);

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -44,7 +44,16 @@ type Change struct {
 	Deleted bool
 }
 
-const defaultHTTPTimeout = 30 * time.Second
+// defaultHTTPTimeout bounds one CalDAV request, from the dial to the last
+// byte of the body. A large server needs a long time for one full-calendar
+// multiget. iCloud answers such a report in 30 to 35 seconds for a calendar
+// with a few hundred resources. The former 30-second ceiling killed every
+// pull before the headers arrived (issue #768).
+//
+// Five minutes is a ceiling for a hung server, not an expectation. A healthy
+// server answers in under one second. Set sync.http_timeout in config.toml,
+// or CHRONCAL_SYNC_HTTP_TIMEOUT, to change it.
+const defaultHTTPTimeout = 5 * time.Minute
 const maxHTTPResponseBytes = 8 << 20
 const maxRedirects = 10
 
@@ -52,6 +61,24 @@ var defaultHTTPClient = &http.Client{
 	Timeout:       defaultHTTPTimeout,
 	CheckRedirect: checkRedirect,
 }
+
+// SetHTTPTimeout replaces the request timeout of the shared CalDAV HTTP
+// client. A value of zero or less keeps the current timeout.
+//
+// Call it once at startup, before the first CalDAV request. The client is a
+// package-level value, so a later call races with a request in flight.
+func SetHTTPTimeout(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	defaultHTTPClient.Timeout = d
+}
+
+// HTTPTimeout reports the request timeout of the shared CalDAV HTTP client.
+func HTTPTimeout() time.Duration {
+	return defaultHTTPClient.Timeout
+}
+
 var errResponseTooLarge = errors.New("caldav response exceeds configured limits")
 
 // checkRedirect governs redirects for defaultHTTPClient. It rejects any

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -79,6 +79,25 @@ func HTTPTimeout() time.Duration {
 	return defaultHTTPClient.Timeout
 }
 
+// RequestBudget returns a parent deadline that holds n sequential CalDAV
+// requests at the current request timeout.
+//
+// Every context that wraps a CalDAV call must take its deadline from this
+// function. The request timeout is configurable (sync.http_timeout), so a
+// fixed parent constant can become shorter than one request. The parent
+// deadline then expires first and the pull dies again, which is the failure
+// of issue #768. A derived budget grows with the configured timeout.
+//
+// Pick n from the number of requests that the operation sends in sequence.
+// A caller that wraps another budgeted operation must use a larger n than
+// the operation it wraps, or the inner budget never binds.
+func RequestBudget(n int) time.Duration {
+	if n < 1 {
+		n = 1
+	}
+	return time.Duration(n) * HTTPTimeout()
+}
+
 var errResponseTooLarge = errors.New("caldav response exceeds configured limits")
 
 // checkRedirect governs redirects for defaultHTTPClient. It rejects any

--- a/internal/caldav/timeout_test.go
+++ b/internal/caldav/timeout_test.go
@@ -1,0 +1,54 @@
+package caldav
+
+import (
+	"testing"
+	"time"
+)
+
+// iCloud takes 30 to 35 seconds to answer a full-calendar multiget. The
+// former 30-second ceiling killed every pull before the headers arrived
+// (issue #768). The default must stay well above that observed time.
+func TestDefaultHTTPTimeoutCoversASlowMultiget(t *testing.T) {
+	if defaultHTTPTimeout < time.Minute {
+		t.Errorf("defaultHTTPTimeout = %s, want at least 1m", defaultHTTPTimeout)
+	}
+	if got := HTTPTimeout(); got != defaultHTTPTimeout {
+		t.Errorf("HTTPTimeout() = %s, want %s", got, defaultHTTPTimeout)
+	}
+}
+
+func TestSetHTTPTimeout(t *testing.T) {
+	previous := HTTPTimeout()
+	t.Cleanup(func() { defaultHTTPClient.Timeout = previous })
+
+	SetHTTPTimeout(90 * time.Second)
+	if got := HTTPTimeout(); got != 90*time.Second {
+		t.Errorf("HTTPTimeout() = %s, want 1m30s", got)
+	}
+
+	// A zero or negative value keeps the current timeout. The caller then
+	// cannot turn the ceiling off by accident.
+	SetHTTPTimeout(0)
+	if got := HTTPTimeout(); got != 90*time.Second {
+		t.Errorf("HTTPTimeout() after a zero value = %s, want 1m30s", got)
+	}
+	SetHTTPTimeout(-time.Second)
+	if got := HTTPTimeout(); got != 90*time.Second {
+		t.Errorf("HTTPTimeout() after a negative value = %s, want 1m30s", got)
+	}
+}
+
+// The clients share one *http.Client, so a startup change of the timeout
+// reaches a client that a constructor already built.
+func TestSetHTTPTimeoutReachesABuiltClient(t *testing.T) {
+	previous := HTTPTimeout()
+	t.Cleanup(func() { defaultHTTPClient.Timeout = previous })
+
+	if _, err := NewBasicAuthClient("https://example.com", "user", "pass"); err != nil {
+		t.Fatalf("NewBasicAuthClient: %v", err)
+	}
+	SetHTTPTimeout(2 * time.Minute)
+	if got := defaultHTTPClient.Timeout; got != 2*time.Minute {
+		t.Errorf("shared client timeout = %s, want 2m", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,11 @@ type SMTPConfig struct {
 type SyncConfig struct {
 	Interval         string `mapstructure:"interval"`
 	ConflictStrategy string `mapstructure:"conflict_strategy"`
+	// HTTPTimeout bounds one CalDAV request, as a Go duration string (for
+	// example "5m"). An empty value keeps the built-in default of the caldav
+	// package. Raise it for a server that answers a large multiget slowly.
+	// Lower it to fail faster against a hung server.
+	HTTPTimeout string `mapstructure:"http_timeout"`
 }
 
 type SecurityConfig struct {
@@ -186,6 +191,7 @@ func newViper() *viper.Viper {
 	v.SetDefault("sync.conflict_strategy", "prompt")
 	v.BindEnv("sync.interval")
 	v.BindEnv("sync.conflict_strategy")
+	v.BindEnv("sync.http_timeout")
 	v.BindEnv("security.allow_unsafe_alarm_audio_attach")
 	v.BindEnv("security.allow_unsafe_alarm_email_attendees")
 	v.BindEnv("security.allow_plaintext")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -138,6 +138,7 @@ port = 25
 func TestLoad_SyncFromEnv(t *testing.T) {
 	t.Setenv("CHRONCAL_SYNC_INTERVAL", "15m")
 	t.Setenv("CHRONCAL_SYNC_CONFLICT_STRATEGY", "prompt")
+	t.Setenv("CHRONCAL_SYNC_HTTP_TIMEOUT", "10m")
 
 	cfg := mustLoad(t)
 
@@ -146,6 +147,17 @@ func TestLoad_SyncFromEnv(t *testing.T) {
 	}
 	if cfg.Sync.ConflictStrategy != "prompt" {
 		t.Fatalf("Sync.ConflictStrategy = %q, want prompt", cfg.Sync.ConflictStrategy)
+	}
+	if cfg.Sync.HTTPTimeout != "10m" {
+		t.Fatalf("Sync.HTTPTimeout = %q, want 10m", cfg.Sync.HTTPTimeout)
+	}
+}
+
+// An unset sync.http_timeout keeps the built-in default of the caldav
+// package. Load must not invent a value here (issue #768).
+func TestLoad_SyncHTTPTimeoutUnset(t *testing.T) {
+	if cfg := mustLoad(t); cfg.Sync.HTTPTimeout != "" {
+		t.Fatalf("Sync.HTTPTimeout = %q, want empty", cfg.Sync.HTTPTimeout)
 	}
 }
 

--- a/internal/event/relation_reltype_test.go
+++ b/internal/event/relation_reltype_test.go
@@ -1,0 +1,52 @@
+package event
+
+import (
+	"context"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+// RELTYPE is an extensible token in RFC 5545. iCloud sends tokens outside
+// PARENT, CHILD, and SIBLING. The old CHECK on event_relations refused them.
+// The pull then withheld the sync-token and the calendar re-pulled every
+// resource on every sync (issue #768).
+func TestEventService_ReplaceRelations_AcceptsUnknownRelType(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	e := createEvent(t, svc)
+
+	want := []model.Relation{
+		{RelType: "PARENT", RelUID: "parent-uid"},
+		{RelType: "X-APPLE-SOMETHING", RelUID: "apple-uid"},
+	}
+	if err := svc.ReplaceRelations(ctx, e.ID, want); err != nil {
+		t.Fatalf("ReplaceRelations: %v", err)
+	}
+
+	got, err := svc.ListRelations(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("ListRelations: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("relations = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].RelType != want[i].RelType || got[i].RelUID != want[i].RelUID {
+			t.Errorf("relation[%d] = %q:%q, want %q:%q",
+				i, got[i].RelType, got[i].RelUID, want[i].RelType, want[i].RelUID)
+		}
+	}
+}
+
+// An empty RELTYPE is not a token. The schema must still refuse it.
+func TestEventService_ReplaceRelations_RefusesEmptyRelType(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	e := createEvent(t, svc)
+
+	err := svc.ReplaceRelations(ctx, e.ID, []model.Relation{{RelUID: "no-type-uid"}})
+	if err == nil {
+		t.Fatal("ReplaceRelations accepted an empty rel_type")
+	}
+}

--- a/internal/ical/export.go
+++ b/internal/ical/export.go
@@ -383,8 +383,10 @@ func emitResources(props ical.Props, resources []string) {
 	}
 }
 
-// emitRelations appends one RELATED-TO property per relation. The RELTYPE
-// parameter is omitted for the default PARENT type.
+// emitRelations appends one RELATED-TO property per relation. The function
+// leaves out the RELTYPE parameter for the default PARENT type. Any other
+// token goes out as it is stored, which keeps the round-trip exact for a
+// server-specific token such as X-APPLE-SOMETHING (issue #768).
 func emitRelations(props ical.Props, relations []model.Relation) {
 	for _, r := range relations {
 		p := &ical.Prop{Name: ical.PropRelatedTo, Params: make(ical.Params)}

--- a/internal/ical/import.go
+++ b/internal/ical/import.go
@@ -596,10 +596,16 @@ func parseResourcesFromProps(props ical.Props) []string {
 	return out
 }
 
+// parseRelationsFromProps reads every RELATED-TO property. RELTYPE is an
+// extensible token in RFC 5545, so the function keeps the token that the
+// file carries. It does not map an unknown token onto PARENT, CHILD, or
+// SIBLING: that mapping would lose the value on export (issue #768). The
+// only change is the case fold to upper case. A token compares without
+// regard to case, so the fold keeps the meaning.
 func parseRelationsFromProps(props ical.Props) []model.Relation {
 	var out []model.Relation
 	for _, prop := range props.Values(ical.PropRelatedTo) {
-		relType := prop.Params.Get("RELTYPE")
+		relType := strings.TrimSpace(prop.Params.Get("RELTYPE"))
 		if relType == "" {
 			relType = "PARENT" // default per RFC 5545
 		}

--- a/internal/ical/relation_reltype_test.go
+++ b/internal/ical/relation_reltype_test.go
@@ -1,0 +1,137 @@
+package ical
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/event"
+	"github.com/douglasdemoura/chroncal/internal/journal"
+	"github.com/douglasdemoura/chroncal/internal/model"
+	"github.com/douglasdemoura/chroncal/internal/todo"
+)
+
+// RELTYPE is an extensible token in RFC 5545. iCloud sends tokens outside
+// PARENT, CHILD, and SIBLING. The import must keep the token as it arrives.
+// A map onto a standard token would lose the value on export (issue #768).
+const appleRelType = "X-APPLE-SOMETHING"
+
+func TestImport_RelatedToKeepsUnknownRelType(t *testing.T) {
+	t.Parallel()
+	ics := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//test//test//EN\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:reltype-event\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T140000Z\r\n" +
+		"DTEND:20260401T150000Z\r\n" +
+		"SUMMARY:Event\r\n" +
+		"RELATED-TO;RELTYPE=" + appleRelType + ":related-event-uid\r\n" +
+		"END:VEVENT\r\n" +
+		"BEGIN:VTODO\r\n" +
+		"UID:reltype-todo\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"SUMMARY:Todo\r\n" +
+		"RELATED-TO;RELTYPE=" + appleRelType + ":related-todo-uid\r\n" +
+		"END:VTODO\r\n" +
+		"BEGIN:VJOURNAL\r\n" +
+		"UID:reltype-journal\r\n" +
+		"DTSTAMP:20260401T100000Z\r\n" +
+		"DTSTART:20260401T090000Z\r\n" +
+		"SUMMARY:Journal\r\n" +
+		"RELATED-TO;RELTYPE=" + appleRelType + ":related-journal-uid\r\n" +
+		"END:VJOURNAL\r\n" +
+		"END:VCALENDAR\r\n"
+
+	result, err := ImportFile(strings.NewReader(ics))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Todos) != 1 || len(result.Journals) != 1 {
+		t.Fatalf("imported %d events, %d todos, %d journals; want 1 of each",
+			len(result.Events), len(result.Todos), len(result.Journals))
+	}
+
+	checks := []struct {
+		kind      string
+		relations []model.Relation
+		wantUID   string
+	}{
+		{"event", result.Events[0].Relations, "related-event-uid"},
+		{"todo", result.Todos[0].Relations, "related-todo-uid"},
+		{"journal", result.Journals[0].Relations, "related-journal-uid"},
+	}
+	for _, c := range checks {
+		if len(c.relations) != 1 {
+			t.Errorf("%s relations = %d, want 1", c.kind, len(c.relations))
+			continue
+		}
+		if c.relations[0].RelType != appleRelType {
+			t.Errorf("%s RelType = %q, want %q", c.kind, c.relations[0].RelType, appleRelType)
+		}
+		if c.relations[0].RelUID != c.wantUID {
+			t.Errorf("%s RelUID = %q, want %q", c.kind, c.relations[0].RelUID, c.wantUID)
+		}
+	}
+}
+
+// The export must give the token back unchanged, so a pull and a later push
+// carry the same RELATED-TO property.
+func TestRoundtrip_UnknownRelTypeSurvivesExport(t *testing.T) {
+	t.Parallel()
+	relations := []model.Relation{{RelType: appleRelType, RelUID: "related-uid"}}
+	want := "RELATED-TO;RELTYPE=" + appleRelType + ":related-uid"
+
+	evtICS, err := ExportEvents([]event.Event{{
+		UID:       "reltype-event",
+		Title:     "Event",
+		StartTime: time.Date(2026, 4, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 4, 1, 15, 0, 0, 0, time.UTC),
+		Status:    "CONFIRMED",
+		Transp:    "OPAQUE",
+		Relations: relations,
+	}}, "")
+	if err != nil {
+		t.Fatalf("export events: %v", err)
+	}
+	todoICS, err := ExportTodos([]todo.Todo{{
+		UID:       "reltype-todo",
+		Summary:   "Todo",
+		Status:    "NEEDS-ACTION",
+		Relations: relations,
+	}}, "")
+	if err != nil {
+		t.Fatalf("export todos: %v", err)
+	}
+	journalICS, err := ExportJournals([]journal.Journal{{
+		UID:       "reltype-journal",
+		Summary:   "Journal",
+		StartDate: "2026-04-01",
+		Status:    "FINAL",
+		Relations: relations,
+	}}, "")
+	if err != nil {
+		t.Fatalf("export journals: %v", err)
+	}
+
+	for kind, data := range map[string][]byte{
+		"event":   evtICS,
+		"todo":    todoICS,
+		"journal": journalICS,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("%s export missing %q:\n%s", kind, want, data)
+		}
+	}
+
+	// One full round trip: export, import, and compare the token.
+	result, err := ImportFile(strings.NewReader(string(evtICS)))
+	if err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+	if len(result.Events) != 1 || len(result.Events[0].Relations) != 1 {
+		t.Fatalf("re-imported %d events", len(result.Events))
+	}
+	if got := result.Events[0].Relations[0].RelType; got != appleRelType {
+		t.Errorf("RelType after the round trip = %q, want %q", got, appleRelType)
+	}
+}

--- a/internal/journal/relation_reltype_test.go
+++ b/internal/journal/relation_reltype_test.go
@@ -1,0 +1,30 @@
+package journal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+// The journal_relations CHECK must accept any RELTYPE token, like the event
+// table. RELTYPE is extensible in RFC 5545 (issue #768).
+func TestJournalService_ReplaceRelations_AcceptsUnknownRelType(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	j := createJournal(t, svc)
+
+	if err := svc.ReplaceRelations(ctx, j.ID, []model.Relation{
+		{RelType: "X-APPLE-SOMETHING", RelUID: "apple-uid"},
+	}); err != nil {
+		t.Fatalf("ReplaceRelations: %v", err)
+	}
+
+	got, err := svc.ListRelations(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("ListRelations: %v", err)
+	}
+	if len(got) != 1 || got[0].RelType != "X-APPLE-SOMETHING" || got[0].RelUID != "apple-uid" {
+		t.Fatalf("relations = %+v, want one X-APPLE-SOMETHING:apple-uid", got)
+	}
+}

--- a/internal/model/relation.go
+++ b/internal/model/relation.go
@@ -1,7 +1,12 @@
 package model
 
 type Relation struct {
-	ID      int64
-	RelType string // PARENT, CHILD, SIBLING
+	ID int64
+	// RelType holds the RFC 5545 RELTYPE parameter. The standard names
+	// PARENT, CHILD, and SIBLING, but RELTYPE is an extensible token. A
+	// server can send another token, for example X-APPLE-SOMETHING. The
+	// database keeps the token as it arrives, so an export gives it back
+	// unchanged. Only an empty token is invalid.
+	RelType string
 	RelUID  string // UID of related component
 }

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -556,3 +556,84 @@ func TestMigration045PatternMatchesTokenRule(t *testing.T) {
 		}
 	}
 }
+
+// Verifies migration 051 (the wide RELTYPE CHECK) rolls back and re-applies
+// cleanly with live rows in the three relation tables. RELTYPE is an
+// extensible token in RFC 5545, so the widened CHECK must accept a
+// server-specific token such as X-APPLE-SOMETHING (issue #768). The Down step
+// restores the narrow CHECK and drops each row that carries another token.
+func TestMigration051UpDown(t *testing.T) {
+	conn, _, err := Open(t.TempDir() + "/mig051.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := context.Background()
+	mustExec, count := migHelpers(t, ctx, conn)
+
+	mustExec(`INSERT INTO events (id, uid, calendar_id, title, start_time, end_time)
+		VALUES (1, 'mig051-evt', 1, 'Mig', '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z')`)
+	mustExec(`INSERT INTO todos (id, uid, calendar_id, summary) VALUES (1, 'mig051-todo', 1, 'Mig')`)
+	mustExec(`INSERT INTO journals (id, uid, calendar_id, summary, start_date)
+		VALUES (1, 'mig051-jnl', 1, 'Mig', '2026-01-01')`)
+
+	// One standard token and one server-specific token per table. The
+	// widened CHECK must accept both.
+	mustExec(`INSERT INTO event_relations (id, event_id, rel_type, rel_uid)
+		VALUES (5, 1, 'CHILD', 'evt-child')`)
+	mustExec(`INSERT INTO event_relations (id, event_id, rel_type, rel_uid)
+		VALUES (6, 1, 'X-APPLE-SOMETHING', 'evt-apple')`)
+	mustExec(`INSERT INTO todo_relations (id, todo_id, rel_type, rel_uid)
+		VALUES (5, 1, 'SIBLING', 'todo-sibling')`)
+	mustExec(`INSERT INTO todo_relations (id, todo_id, rel_type, rel_uid)
+		VALUES (6, 1, 'X-APPLE-SOMETHING', 'todo-apple')`)
+	mustExec(`INSERT INTO journal_relations (id, journal_id, rel_type, rel_uid)
+		VALUES (5, 1, 'PARENT', 'jnl-parent')`)
+	mustExec(`INSERT INTO journal_relations (id, journal_id, rel_type, rel_uid)
+		VALUES (6, 1, 'X-APPLE-SOMETHING', 'jnl-apple')`)
+
+	// The widened CHECK still refuses an empty token.
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO event_relations (event_id, rel_type, rel_uid) VALUES (1, '', 'evt-empty')`,
+	); err == nil {
+		t.Errorf("wide CHECK accepted an empty rel_type")
+	}
+
+	provider := migProvider(t, conn)
+	if _, err := provider.DownTo(ctx, 50); err != nil {
+		t.Fatalf("down to 50: %v", err)
+	}
+
+	for _, table := range []string{"event_relations", "todo_relations", "journal_relations"} {
+		if n := count(`SELECT COUNT(*) FROM ` + table); n != 1 {
+			t.Errorf("%s rows after Down = %d, want 1 (the unknown token is dropped)", table, n)
+		}
+		if n := count(`SELECT COUNT(*) FROM ` + table + ` WHERE id = 5`); n != 1 {
+			t.Errorf("%s row id 5 after Down = %d, want 1 (id-intact restore)", table, n)
+		}
+	}
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO event_relations (event_id, rel_type, rel_uid) VALUES (1, 'X-APPLE-SOMETHING', 'evt-again')`,
+	); err == nil {
+		t.Errorf("narrow CHECK accepted an unknown rel_type after Down")
+	}
+
+	if _, err := provider.Up(ctx); err != nil {
+		t.Fatalf("re-up: %v", err)
+	}
+
+	for _, table := range []string{"event_relations", "todo_relations", "journal_relations"} {
+		if n := count(`SELECT COUNT(*) FROM ` + table + ` WHERE id = 5`); n != 1 {
+			t.Errorf("%s row id 5 after re-Up = %d, want 1 (id-intact restore)", table, n)
+		}
+	}
+	// The widened CHECK accepts a server-specific token again, and the
+	// recreated foreign key still cascades a delete of the owner row.
+	mustExec(`INSERT INTO event_relations (id, event_id, rel_type, rel_uid)
+		VALUES (9, 1, 'X-CALENDARSERVER-LINK', 'evt-link')`)
+	mustExec(`DELETE FROM events WHERE id = 1`)
+	if n := count(`SELECT COUNT(*) FROM event_relations`); n != 0 {
+		t.Errorf("event_relations after the owner delete = %d, want 0 (cascade recreated)", n)
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -635,11 +635,17 @@ func (e *Engine) resolveMootConflicts(ctx context.Context, calendarID int64) (in
 	return resolved, nil
 }
 
-// accountCalendarSyncTimeout bounds the sync of one calendar inside an
+// accountCalendarSyncBudget bounds the sync of one calendar inside an
 // account pass. A full first pull of a large calendar needs many multiget
-// requests. Each request can take up to caldav.HTTPTimeout. Keep this
-// budget well above that ceiling (issue #768).
-const accountCalendarSyncTimeout = 30 * time.Minute
+// requests, so the factor is above one request.
+//
+// The factor stays below the factor of every caller that wraps a whole
+// account pass. A per-calendar budget equal to the budget of the run never
+// binds: one wedged calendar would consume the whole run budget and each
+// remaining calendar would fail at once.
+func accountCalendarSyncBudget() time.Duration {
+	return caldav.RequestBudget(3)
+}
 
 // SyncAccount syncs every calendar linked to one account serially. Calendars
 // that share a credential must not refresh or persist that credential
@@ -654,7 +660,7 @@ func (e *Engine) SyncAccount(ctx context.Context, accountID int64, strategy Conf
 		if err := ctx.Err(); err != nil {
 			return results, err
 		}
-		calendarCtx, cancel := context.WithTimeout(ctx, accountCalendarSyncTimeout)
+		calendarCtx, cancel := context.WithTimeout(ctx, accountCalendarSyncBudget())
 		result, err := e.SyncCalendar(calendarCtx, cal.ID, strategy)
 		cancel()
 		if err != nil {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -635,7 +635,11 @@ func (e *Engine) resolveMootConflicts(ctx context.Context, calendarID int64) (in
 	return resolved, nil
 }
 
-const accountCalendarSyncTimeout = 5 * time.Minute
+// accountCalendarSyncTimeout bounds the sync of one calendar inside an
+// account pass. A full first pull of a large calendar needs many multiget
+// requests. Each request can take up to caldav.HTTPTimeout. Keep this
+// budget well above that ceiling (issue #768).
+const accountCalendarSyncTimeout = 30 * time.Minute
 
 // SyncAccount syncs every calendar linked to one account serially. Calendars
 // that share a credential must not refresh or persist that credential

--- a/internal/sync/timeout_test.go
+++ b/internal/sync/timeout_test.go
@@ -1,0 +1,17 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/caldav"
+)
+
+// SyncAccount gives each calendar its own deadline. That deadline must
+// outlive one CalDAV request, or it cuts a slow first pull before the server
+// answers (issue #768).
+func TestAccountCalendarSyncTimeoutOutlivesOneRequest(t *testing.T) {
+	if accountCalendarSyncTimeout <= caldav.HTTPTimeout() {
+		t.Errorf("accountCalendarSyncTimeout = %s, want more than the CalDAV request ceiling %s",
+			accountCalendarSyncTimeout, caldav.HTTPTimeout())
+	}
+}

--- a/internal/sync/timeout_test.go
+++ b/internal/sync/timeout_test.go
@@ -2,16 +2,23 @@ package sync
 
 import (
 	"testing"
+	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 )
 
 // SyncAccount gives each calendar its own deadline. That deadline must
 // outlive one CalDAV request, or it cuts a slow first pull before the server
-// answers (issue #768).
-func TestAccountCalendarSyncTimeoutOutlivesOneRequest(t *testing.T) {
-	if accountCalendarSyncTimeout <= caldav.HTTPTimeout() {
-		t.Errorf("accountCalendarSyncTimeout = %s, want more than the CalDAV request ceiling %s",
-			accountCalendarSyncTimeout, caldav.HTTPTimeout())
+// answers (issue #768). The budget derives from the request timeout, so the
+// rule must hold for a configured timeout too, not only for the default.
+func TestAccountCalendarSyncBudgetOutlivesOneRequest(t *testing.T) {
+	previous := caldav.HTTPTimeout()
+	t.Cleanup(func() { caldav.SetHTTPTimeout(previous) })
+
+	for _, request := range []time.Duration{30 * time.Second, 5 * time.Minute, 45 * time.Minute} {
+		caldav.SetHTTPTimeout(request)
+		if got := accountCalendarSyncBudget(); got <= request {
+			t.Errorf("accountCalendarSyncBudget() = %s at a request ceiling of %s, want more", got, request)
+		}
 	}
 }

--- a/internal/todo/relation_reltype_test.go
+++ b/internal/todo/relation_reltype_test.go
@@ -1,0 +1,30 @@
+package todo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/model"
+)
+
+// The todo_relations CHECK must accept any RELTYPE token, like the event
+// table. RELTYPE is extensible in RFC 5545 (issue #768).
+func TestTodoService_ReplaceRelations_AcceptsUnknownRelType(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestService(t)
+	td := createTodo(t, svc)
+
+	if err := svc.ReplaceRelations(ctx, td.ID, []model.Relation{
+		{RelType: "X-APPLE-SOMETHING", RelUID: "apple-uid"},
+	}); err != nil {
+		t.Fatalf("ReplaceRelations: %v", err)
+	}
+
+	got, err := svc.ListRelations(ctx, td.ID)
+	if err != nil {
+		t.Fatalf("ListRelations: %v", err)
+	}
+	if len(got) != 1 || got[0].RelType != "X-APPLE-SOMETHING" || got[0].RelUID != "apple-uid" {
+		t.Fatalf("relations = %+v, want one X-APPLE-SOMETHING:apple-uid", got)
+	}
+}

--- a/internal/tui/app_account.go
+++ b/internal/tui/app_account.go
@@ -389,9 +389,15 @@ func existingCalendarDiscoveryAccount(accounts []account.Account, req CalendarDi
 	return account.Account{}, false
 }
 
+// accountDiscoveryTimeout bounds one account discovery. Discovery sends a
+// PROPFIND to the CalDAV server. One request can take up to
+// caldav.HTTPTimeout, and the retry helper repeats a transient failure. Keep
+// this budget above that ceiling (issue #768).
+const accountDiscoveryTimeout = 10 * time.Minute
+
 func (m Model) connectAndDiscoverCalendar(req CalendarDiscoveryRequestedMsg, cred auth.Credential) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryTimeout)
 		defer cancel()
 		store, err := m.openCredentialStore()
 		if err != nil {
@@ -450,7 +456,7 @@ func (m Model) importAndSyncAccountCalendars(paths []string) tea.Cmd {
 	}
 	discovery := m.calendarManager.DiscoveryPicker().discovery
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), syncOperationTimeout)
 		defer cancel()
 		result, err := m.app.Accounts.Import(ctx, discovery, paths)
 		if err != nil {
@@ -481,7 +487,7 @@ func (m Model) reconcileAndSyncAccountCalendars(selection *accountCalendarSelect
 	discovery := selection.discovery
 	params := selection.params
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), syncOperationTimeout)
 		defer cancel()
 		store, err := m.openCredentialStore()
 		if err != nil {
@@ -664,7 +670,7 @@ func (m Model) discoverAccountCalendars(accountID int64, generation uint64) tea.
 		}
 	}
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryTimeout)
 		defer cancel()
 		store, err := m.openCredentialStore()
 		if err != nil {

--- a/internal/tui/app_account.go
+++ b/internal/tui/app_account.go
@@ -389,15 +389,20 @@ func existingCalendarDiscoveryAccount(accounts []account.Account, req CalendarDi
 	return account.Account{}, false
 }
 
-// accountDiscoveryTimeout bounds one account discovery. Discovery sends a
-// PROPFIND to the CalDAV server. One request can take up to
-// caldav.HTTPTimeout, and the retry helper repeats a transient failure. Keep
-// this budget above that ceiling (issue #768).
-const accountDiscoveryTimeout = 10 * time.Minute
+// accountDiscoveryBudget bounds one account discovery. Discovery sends a
+// small number of sequential PROPFIND requests, and the retry helper repeats
+// a transient failure. The budget derives from the configured request
+// timeout (sync.http_timeout), so it cannot become shorter than one request.
+//
+// The TUI blocks while discovery runs, so this budget is also the time that
+// a hung server can hold the screen.
+func accountDiscoveryBudget() time.Duration {
+	return caldav.RequestBudget(2)
+}
 
 func (m Model) connectAndDiscoverCalendar(req CalendarDiscoveryRequestedMsg, cred auth.Credential) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryBudget())
 		defer cancel()
 		store, err := m.openCredentialStore()
 		if err != nil {
@@ -456,7 +461,7 @@ func (m Model) importAndSyncAccountCalendars(paths []string) tea.Cmd {
 	}
 	discovery := m.calendarManager.DiscoveryPicker().discovery
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), syncOperationTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), syncAccountBudget())
 		defer cancel()
 		result, err := m.app.Accounts.Import(ctx, discovery, paths)
 		if err != nil {
@@ -487,7 +492,7 @@ func (m Model) reconcileAndSyncAccountCalendars(selection *accountCalendarSelect
 	discovery := selection.discovery
 	params := selection.params
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), syncOperationTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), syncAccountBudget())
 		defer cancel()
 		store, err := m.openCredentialStore()
 		if err != nil {
@@ -670,7 +675,7 @@ func (m Model) discoverAccountCalendars(accountID int64, generation uint64) tea.
 		}
 	}
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryBudget())
 		defer cancel()
 		store, err := m.openCredentialStore()
 		if err != nil {

--- a/internal/tui/app_sync.go
+++ b/internal/tui/app_sync.go
@@ -8,15 +8,29 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/config"
 	syncpkg "github.com/douglasdemoura/chroncal/internal/sync"
 )
 
-// syncOperationTimeout bounds one sync of one calendar from the TUI. A full
-// first pull of a large calendar needs many CalDAV requests. Each request
-// can take up to caldav.HTTPTimeout. A short budget cut the pull before the
-// server answered (issue #768).
-const syncOperationTimeout = 30 * time.Minute
+// syncCalendarBudget bounds one sync of one calendar from the TUI. A full
+// first pull of a large calendar needs many CalDAV requests, so the factor
+// is above one request. The budget derives from the configured request
+// timeout (sync.http_timeout), so it cannot become shorter than one
+// request.
+//
+// The TUI blocks the calendar list and the account manager while the sync
+// runs, so this budget is also the time that a hung server can hold the
+// screen. Keep the factor as small as a real first pull allows.
+func syncCalendarBudget() time.Duration {
+	return caldav.RequestBudget(3)
+}
+
+// syncAccountBudget bounds a sync that covers every calendar of one account.
+// It wraps the per-calendar budget of the engine, so the factor is larger.
+func syncAccountBudget() time.Duration {
+	return caldav.RequestBudget(6)
+}
 
 // caldavPushTimeout bounds one opportunistic push after a save. The push is
 // best-effort, and this budget stays short on purpose. The user waits for
@@ -62,7 +76,7 @@ func (m Model) runSyncOne(target syncTarget, index, total int) tea.Cmd {
 		if err != nil {
 			return syncCalendarFinishedMsg{index: index, total: total, name: target.Name, err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), syncOperationTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), syncCalendarBudget())
 		defer cancel()
 		result, err := svc.SyncCalendar(ctx, target.ID, m.fullSyncStrategy)
 		return syncCalendarFinishedMsg{index: index, total: total, name: target.Name, result: result, err: err}
@@ -75,7 +89,7 @@ func (m Model) runSyncCalendar(id int64, name string) tea.Cmd {
 		if err != nil {
 			return syncFinishedMsg{err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), syncOperationTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), syncCalendarBudget())
 		defer cancel()
 		result, err := svc.SyncCalendar(ctx, id, m.fullSyncStrategy)
 		if err != nil {

--- a/internal/tui/app_sync.go
+++ b/internal/tui/app_sync.go
@@ -12,6 +12,18 @@ import (
 	syncpkg "github.com/douglasdemoura/chroncal/internal/sync"
 )
 
+// syncOperationTimeout bounds one sync of one calendar from the TUI. A full
+// first pull of a large calendar needs many CalDAV requests. Each request
+// can take up to caldav.HTTPTimeout. A short budget cut the pull before the
+// server answered (issue #768).
+const syncOperationTimeout = 30 * time.Minute
+
+// caldavPushTimeout bounds one opportunistic push after a save. The push is
+// best-effort, and this budget stays short on purpose. The user waits for
+// the next screen, and a push carries one small resource per dirty edit. A
+// push that runs out of time keeps the dirty flag. The next sync retries it.
+const caldavPushTimeout = 30 * time.Second
+
 func (m Model) newSyncService() (*syncpkg.Service, error) {
 	credStore, err := m.openCredentialStore()
 	if err != nil {
@@ -50,7 +62,7 @@ func (m Model) runSyncOne(target syncTarget, index, total int) tea.Cmd {
 		if err != nil {
 			return syncCalendarFinishedMsg{index: index, total: total, name: target.Name, err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), syncOperationTimeout)
 		defer cancel()
 		result, err := svc.SyncCalendar(ctx, target.ID, m.fullSyncStrategy)
 		return syncCalendarFinishedMsg{index: index, total: total, name: target.Name, result: result, err: err}
@@ -63,7 +75,7 @@ func (m Model) runSyncCalendar(id int64, name string) tea.Cmd {
 		if err != nil {
 			return syncFinishedMsg{err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), syncOperationTimeout)
 		defer cancel()
 		result, err := svc.SyncCalendar(ctx, id, m.fullSyncStrategy)
 		if err != nil {
@@ -193,7 +205,7 @@ func (m Model) runOpportunisticPush(calendarID int64) tea.Cmd {
 		if err != nil {
 			return opportunisticPushFinishedMsg{err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), caldavPushTimeout)
 		defer cancel()
 		result, err := svc.PushLocalEdits(ctx, calendarID)
 		if err != nil {

--- a/internal/tui/app_update_calendar.go
+++ b/internal/tui/app_update_calendar.go
@@ -398,10 +398,26 @@ func (m Model) handleCalendarSetDefaultRequested(msg CalendarSetDefaultRequested
 	}
 }
 
+// calendarProbeBudget bounds the "Test connection" probe. The probe sends
+// one PROPFIND, and the user waits in front of the dialog, so the budget
+// stays far below a sync budget.
+//
+// It still tracks the configured request timeout. A fixed short budget made
+// the probe fail against a slow server while the later sync succeeded, which
+// is confusing at the moment of setup. The probe therefore takes the smaller
+// of one request timeout and one minute.
+func calendarProbeBudget() time.Duration {
+	const ceiling = time.Minute
+	if d := caldav.HTTPTimeout(); d < ceiling {
+		return d
+	}
+	return ceiling
+}
+
 func (m Model) handleCalendarTestRequested(msg CalendarTestRequestedMsg) (tea.Model, tea.Cmd) {
 	req := msg
 	return m, func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), calendarProbeBudget())
 		defer cancel()
 
 		password := req.Password

--- a/internal/tui/calendar_move.go
+++ b/internal/tui/calendar_move.go
@@ -82,7 +82,7 @@ func (m Model) beginCalendarMove(msg CalendarMoveToAccountRequestedMsg) (Model, 
 
 func (m Model) discoverCalendarMove(state calendarMoveState) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryBudget())
 		defer cancel()
 		store, err := m.openCredentialStore()
 		if err != nil {

--- a/internal/tui/calendar_move.go
+++ b/internal/tui/calendar_move.go
@@ -82,7 +82,7 @@ func (m Model) beginCalendarMove(msg CalendarMoveToAccountRequestedMsg) (Model, 
 
 func (m Model) discoverCalendarMove(state calendarMoveState) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), accountDiscoveryTimeout)
 		defer cancel()
 		store, err := m.openCredentialStore()
 		if err != nil {

--- a/internal/tui/sync_timeout_test.go
+++ b/internal/tui/sync_timeout_test.go
@@ -2,28 +2,44 @@ package tui
 
 import (
 	"testing"
+	"time"
 
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 )
 
 // A TUI sync and a TUI account discovery must outlive one CalDAV request. A
 // short deadline cut a slow first pull before the server answered
-// (issue #768).
-func TestTUITimeoutsOutliveOneRequest(t *testing.T) {
-	ceiling := caldav.HTTPTimeout()
-	if syncOperationTimeout <= ceiling {
-		t.Errorf("syncOperationTimeout = %s, want more than the CalDAV request ceiling %s",
-			syncOperationTimeout, ceiling)
-	}
-	if accountDiscoveryTimeout <= ceiling {
-		t.Errorf("accountDiscoveryTimeout = %s, want more than the CalDAV request ceiling %s",
-			accountDiscoveryTimeout, ceiling)
-	}
-	// caldavPushTimeout stays short on purpose. The opportunistic push is
-	// best-effort, and the user waits for the next screen. A push that runs
-	// out of time keeps the dirty flag, and the next sync retries it.
-	if caldavPushTimeout >= syncOperationTimeout {
-		t.Errorf("caldavPushTimeout = %s, want less than syncOperationTimeout %s",
-			caldavPushTimeout, syncOperationTimeout)
+// (issue #768). Each budget derives from the request timeout, so the rule
+// must hold for a configured timeout too, not only for the default.
+func TestTUIBudgetsOutliveOneRequest(t *testing.T) {
+	previous := caldav.HTTPTimeout()
+	t.Cleanup(func() { caldav.SetHTTPTimeout(previous) })
+
+	for _, request := range []time.Duration{30 * time.Second, 5 * time.Minute, 45 * time.Minute} {
+		caldav.SetHTTPTimeout(request)
+		if got := syncCalendarBudget(); got <= request {
+			t.Errorf("syncCalendarBudget() = %s at a request ceiling of %s, want more", got, request)
+		}
+		if got := accountDiscoveryBudget(); got <= request {
+			t.Errorf("accountDiscoveryBudget() = %s at a request ceiling of %s, want more", got, request)
+		}
+		// An account pass wraps the per-calendar budget of the engine, so it
+		// must be larger. Equal budgets let one wedged calendar consume the
+		// whole pass.
+		if syncAccountBudget() <= syncCalendarBudget() {
+			t.Errorf("syncAccountBudget() = %s, want more than syncCalendarBudget() %s",
+				syncAccountBudget(), syncCalendarBudget())
+		}
+		// caldavPushTimeout stays short on purpose. The opportunistic push is
+		// best-effort, and the user waits for the next screen. A push that runs
+		// out of time keeps the dirty flag, and the next sync retries it.
+		if caldavPushTimeout >= syncCalendarBudget() {
+			t.Errorf("caldavPushTimeout = %s, want less than syncCalendarBudget() %s",
+				caldavPushTimeout, syncCalendarBudget())
+		}
+		// The interactive probe stays short, and it never exceeds one request.
+		if got := calendarProbeBudget(); got > request {
+			t.Errorf("calendarProbeBudget() = %s at a request ceiling of %s, want no more", got, request)
+		}
 	}
 }

--- a/internal/tui/sync_timeout_test.go
+++ b/internal/tui/sync_timeout_test.go
@@ -1,0 +1,29 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/caldav"
+)
+
+// A TUI sync and a TUI account discovery must outlive one CalDAV request. A
+// short deadline cut a slow first pull before the server answered
+// (issue #768).
+func TestTUITimeoutsOutliveOneRequest(t *testing.T) {
+	ceiling := caldav.HTTPTimeout()
+	if syncOperationTimeout <= ceiling {
+		t.Errorf("syncOperationTimeout = %s, want more than the CalDAV request ceiling %s",
+			syncOperationTimeout, ceiling)
+	}
+	if accountDiscoveryTimeout <= ceiling {
+		t.Errorf("accountDiscoveryTimeout = %s, want more than the CalDAV request ceiling %s",
+			accountDiscoveryTimeout, ceiling)
+	}
+	// caldavPushTimeout stays short on purpose. The opportunistic push is
+	// best-effort, and the user waits for the next screen. A push that runs
+	// out of time keeps the dirty flag, and the next sync retries it.
+	if caldavPushTimeout >= syncOperationTimeout {
+		t.Errorf("caldavPushTimeout = %s, want less than syncOperationTimeout %s",
+			caldavPushTimeout, syncOperationTimeout)
+	}
+}


### PR DESCRIPTION
Fixes #768. Two unrelated bugs stopped every iCloud import.

### 1. The CalDAV request timeout was too short

iCloud takes 30 to 35 seconds to answer a full-calendar multiget, and the ceiling in `internal/caldav/client.go` was exactly 30 seconds, so every pull died before the headers arrived.

- `defaultHTTPTimeout` is now 5 minutes — a ceiling for a hung server, not an expectation.
- New `sync.http_timeout` config key and `CHRONCAL_SYNC_HTTP_TIMEOUT`, taking a Go duration string. An unusable value gives a warning and keeps the default; it does not stop a local command such as `chroncal event list`.
- **Every parent deadline now derives from the request timeout** via `caldav.RequestBudget(n)`, instead of being a fixed constant. A sync run and a TUI account pass hold 6 requests, one calendar holds 3, an account discovery holds 2. This matters: with fixed constants, raising `sync.http_timeout` past a parent constant made the parent expire first and reproduced the original bug.
- The two interactive probes ("Test connection", and the metadata fetch on connect) stay short, but they also track the request timeout, so they no longer fail against exactly the slow servers this PR targets. Each now carries a comment explaining the short budget, and the connect path reports a failed metadata fetch instead of skipping in silence.

### 2. An unknown `RELATED-TO;RELTYPE` token failed the schema CHECK

I took option 2 from the report and widened the constraint. Option 1 maps unknown tokens onto `SIBLING`, which loses the value on export, and this repo cares about iCal round-trip fidelity.

- Migration `051_relation_type_token.sql` rebuilds `event_relations`, `todo_relations`, and `journal_relations` with `CHECK(rel_type <> '')`, since SQLite cannot alter a CHECK. Each table is a leaf — nothing references it, no trigger reads it — so the rebuild copies the rows and recreates the index.
- Down restores the narrow CHECK and drops rows carrying other tokens, since they cannot be represented. Migration 044 set that precedent.
- `parseRelationsFromProps` keeps whatever token the file carries, and `emitRelations` already wrote every non-default token as stored, so the round trip is exact.
- `--related-to` now accepts an x-name such as `X-APPLE-SOMETHING:uid`. Without that, storing arbitrary tokens created a new data-loss path: a `--related-to` edit replaces all relations, so an event pulled from iCloud with an x-name relation lost it, and the user had no way to write it back. A prefix outside the named values and the x-name pattern still stays part of the UID, so a URN UID keeps its scheme.

### Tests

Import, export, and a full round trip of `RELTYPE=X-APPLE-SOMETHING` for VEVENT, VTODO and VJOURNAL; all three services; the Up and Down paths of migration 051 against a database with live rows; the flag parser for x-names, named types and URN UIDs; and the budget invariants — now checked at 30s, 5m and 45m request ceilings rather than only at the default.

### Review follow-up

A `/code-review` pass raised seven findings. Six are fixed above. The seventh is not, and it is worth stating plainly: the TUI still cannot cancel a sync or a discovery. Both derive from `context.Background()`, and `m.syncing` gates the calendar and account manager, so a hung server holds the screen for the whole budget. This PR shortens the worst case (a single-calendar TUI sync now holds 3 request timeouts rather than a flat 30 minutes) but a cancel key is a separate change.

### Notes

- I have no iCloud account, so the live behavior is unverified. The reporter verified both original fixes against a live account.

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint reports no issues (`make lint`)
- [x] Add new tests for new functions
- [x] Update the documentation when the change needs it
