### PR TITLE
feat(auth): retrieve a password from a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ An account stores one credential. It discovers every CalDAV calendar collection 
 
 If you select none, the command also removes the empty account and credential. `account remove` deletes the credential and remote links. It keeps downloaded calendars as local copies.
 
-`account credentials` rotates the stored secret of a basic or bearer account. It reads the new value from `CHRONCAL_PASSWORD` (basic) or `CHRONCAL_BEARER_TOKEN` (bearer). `account reauth` repeats the Google OAuth consent flow for an oauth2 account; the client secret comes from `GOOGLE_CLIENT_SECRET` or the stored value, and `--oauth-client-id` replaces the stored client ID. Neither command accepts a secret as a CLI flag.
+`account credentials` rotates the stored secret of a basic or bearer account. It reads the new value from `CHRONCAL_PASSWORD` (basic) or `CHRONCAL_BEARER_TOKEN` (bearer). For a basic account, `--password-cmd` stores a command instead of a password. See [Command-retrieved passwords](#command-retrieved-passwords). `account reauth` repeats the Google OAuth consent flow for an oauth2 account; the client secret comes from `GOOGLE_CLIENT_SECRET` or the stored value, and `--oauth-client-id` replaces the stored client ID. Neither command accepts a secret as a CLI flag.
 
 You can open read-only collections locally and sync them pull-only. Chroncal does not send metadata changes, resources, or tombstones to them.
 
@@ -467,6 +467,8 @@ You can still use remote flags with `create` or `update` to attach one local cal
 ```
 
 For script setup, the commands read credentials from environment variables, not from prompts: `CHRONCAL_PASSWORD` (basic), `CHRONCAL_BEARER_TOKEN` (bearer), and `GOOGLE_CLIENT_SECRET` (oauth2). The commands do not accept these values as CLI flags.
+
+A basic account also accepts `--password-cmd` or `CHRONCAL_PASSWORD_CMD`. The value is a command, not a secret, so a flag is safe. See [Command-retrieved passwords](#command-retrieved-passwords).
 
 Pass `--disconnect-remote` on `update` to remove the remote link of a calendar.
 
@@ -770,6 +772,55 @@ from = "you@example.com"
 ```
 
 Or via environment: `CHRONCAL_SMTP_HOST`, `CHRONCAL_SMTP_PORT`, `CHRONCAL_SMTP_USERNAME`, `CHRONCAL_SMTP_PASSWORD`, `CHRONCAL_SMTP_FROM`.
+
+To keep the SMTP password out of the config file, set `smtp.password_cmd` or `CHRONCAL_SMTP_PASSWORD_CMD`:
+
+```toml
+[smtp]
+host = "smtp.example.com"
+password_cmd = "pass show smtp/example"
+```
+
+`smtp.password` and `smtp.password_cmd` are mutually exclusive. Chroncal rejects a config file that sets both.
+
+### Command-retrieved passwords
+
+Chroncal can read a password from a command at the time of use. The password stays in your password manager. Chroncal stores the command only.
+
+Two settings use this feature:
+
+- `--password-cmd` or `CHRONCAL_PASSWORD_CMD` for a CalDAV basic-auth password
+- `smtp.password_cmd` or `CHRONCAL_SMTP_PASSWORD_CMD` for the SMTP password
+
+```bash
+chroncal account add "Work server" \
+    --server https://cal.example.com/dav/ --username alice --auth basic \
+    --password-cmd "pass show caldav/work"
+
+chroncal account credentials "Work server" --password-cmd "pass show caldav/work"
+```
+
+The rules for a password command are:
+
+- Chroncal runs the command through the system shell.
+- The secret is the first line of the standard output. Chroncal discards each later line, because `pass` prints metadata after the password.
+- Chroncal discards the standard error. A noisy command cannot damage the TUI display.
+- The deadline is 30 seconds. A command that is too slow gives an error.
+- An empty first line gives an error.
+- The keyring holds the command, not the secret. Chroncal runs the command at discovery and at each sync.
+
+A password and a password command are mutually exclusive. Every write path rejects the pair.
+
+Chroncal reads a basic-auth secret from these sources, in this order:
+
+1. The `--password-cmd` flag
+2. The `CHRONCAL_PASSWORD_CMD` variable
+3. The `CHRONCAL_PASSWORD` variable
+4. The interactive prompt
+
+A command source plus `CHRONCAL_PASSWORD` is an error.
+
+In the TUI, the Add Account form and the Update Credentials dialog show a Password cmd field next to Password. Fill one field, not both. Bearer auth and OAuth ignore the command field.
 
 ### Desktop notification backends
 

--- a/cmd/chroncal/account.go
+++ b/cmd/chroncal/account.go
@@ -44,11 +44,12 @@ account share one stored credential.`,
 
 func accountAddCmd() *cobra.Command {
 	var (
-		serverURL     string
-		username      string
-		authType      string
-		oauthClientID string
-		allowInsecure bool
+		serverURL       string
+		username        string
+		authType        string
+		passwordCommand string
+		oauthClientID   string
+		allowInsecure   bool
 	)
 	cmd := &cobra.Command{
 		Use:   "add <name>",
@@ -69,7 +70,8 @@ exposes, import every usable collection, and complete their initial sync.`,
 				return fmt.Errorf("credential store: %w", err)
 			}
 			cred, err := buildCalendarCredential(ctx, calendarRemoteFlags{
-				Username: username, AuthType: authType, OAuthClientID: oauthClientID,
+				Username: username, AuthType: authType,
+				PasswordCommand: passwordCommand, OAuthClientID: oauthClientID,
 			})
 			if err != nil {
 				return err
@@ -122,6 +124,7 @@ exposes, import every usable collection, and complete their initial sync.`,
 	cmd.Flags().StringVar(&serverURL, "server", "", "CalDAV discovery endpoint (required)")
 	cmd.Flags().StringVar(&username, "username", "", "username or account email (required)")
 	cmd.Flags().StringVar(&authType, "auth", "basic", "authentication type: basic, bearer, oauth2")
+	cmd.Flags().StringVar(&passwordCommand, "password-cmd", "", "shell command that prints the basic-auth password on its first line")
 	cmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "Google OAuth desktop client ID")
 	cmd.Flags().BoolVar(&allowInsecure, "allow-insecure", false, "allow an HTTP endpoint for local development")
 	_ = cmd.MarkFlagRequired("server")
@@ -230,6 +233,7 @@ authentication type, or stored credential.`,
 }
 
 func accountCredentialsCmd() *cobra.Command {
+	var passwordCommand string
 	cmd := &cobra.Command{
 		Use:   "credentials <name|id>",
 		Short: "Rotate a basic or bearer account secret",
@@ -242,9 +246,19 @@ Secrets come from the environment, never from flags:
   basic   CHRONCAL_PASSWORD
   bearer  CHRONCAL_BEARER_TOKEN
 
+For basic auth, --password-cmd or CHRONCAL_PASSWORD_CMD stores a shell
+command instead of a password. Chroncal runs the command at each
+connection and reads the password from the first output line. The
+command is not a secret, so a flag can carry it. A password command
+and CHRONCAL_PASSWORD are mutually exclusive.
+
+The rotation clears the source you do not use. You can therefore
+switch a stored password to a password command, and back.
+
 A missing or identity-mismatched keyring entry is repaired. Other
 backend failures leave the previous secret unchanged.`,
 		Example: `  CHRONCAL_PASSWORD=... chroncal account credentials Work --output json
+  chroncal account credentials Work --password-cmd "pass show caldav/work"
   CHRONCAL_BEARER_TOKEN=... chroncal account credentials 3 --output json`,
 		Args: exactOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -260,7 +274,7 @@ backend failures leave the previous secret unchanged.`,
 			}
 
 			authType := strings.ToLower(strings.TrimSpace(configured.AuthType))
-			var secret string
+			var secret basicSecret
 			switch authType {
 			case "oauth2":
 				return errInvalidInputf(
@@ -268,9 +282,15 @@ backend failures leave the previous secret unchanged.`,
 					configured.DisplayName,
 				)
 			case "bearer":
-				secret, err = readBearerToken()
+				if strings.TrimSpace(passwordCommand) != "" {
+					return errInvalidInputf(
+						"account %q uses bearer auth; --password-cmd applies to basic auth only",
+						configured.DisplayName,
+					)
+				}
+				secret.Password, err = readBearerToken()
 			case "basic", "":
-				secret, err = readBasicPassword()
+				secret, err = readBasicSecret(passwordCommand)
 			default:
 				return errInvalidInputf("unsupported auth type %q", configured.AuthType)
 			}
@@ -291,9 +311,12 @@ backend failures leave the previous secret unchanged.`,
 				return err
 			}
 			if authType == "bearer" {
-				cred.AccessToken = secret
+				cred.AccessToken = secret.Password
 			} else {
-				cred.Password = secret
+				// Clear the source the user does not use. A stale value in
+				// the other field would conflict with the new one.
+				cred.Password = secret.Password
+				cred.PasswordCommand = secret.Command
 			}
 			if err := a.Accounts.StoreCredential(ctx, configured.ID, fingerprint, cred, store); err != nil {
 				return err
@@ -307,6 +330,7 @@ backend failures leave the previous secret unchanged.`,
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&passwordCommand, "password-cmd", "", "shell command that prints the basic-auth password on its first line")
 	return cmd
 }
 

--- a/cmd/chroncal/account_cli_test.go
+++ b/cmd/chroncal/account_cli_test.go
@@ -873,6 +873,112 @@ func TestAccountCredentialsMissingEnvLeavesPreviousSecret(t *testing.T) {
 	}
 }
 
+// A rotation to --password-cmd stores the command and clears the password.
+// The credential store must never hold the resolved secret.
+func TestAccountCredentialsStoresThePasswordCommand(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/dav/",
+		Username: "alice", AuthType: "basic",
+	}, auth.Credential{Password: "old-password"}, store)
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	a.Close()
+
+	t.Setenv("CHRONCAL_PASSWORD", "")
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "")
+	stdout, _, err := runChroncalCommand(t,
+		"account", "credentials", "Work",
+		"--password-cmd", "echo resolved-secret",
+		"--output", "json", "--allow-plaintext",
+	)
+	if err != nil {
+		t.Fatalf("account credentials with a password command: %v", err)
+	}
+	if strings.Contains(stdout, "resolved-secret") || strings.Contains(stdout, "old-password") {
+		t.Fatalf("json leaked a secret: %s", stdout)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load credential: %v", err)
+	}
+	if got.PasswordCommand != "echo resolved-secret" {
+		t.Fatalf("PasswordCommand = %q, want %q", got.PasswordCommand, "echo resolved-secret")
+	}
+	if got.Password != "" {
+		t.Fatalf("Password = %q, want empty after the rotation", got.Password)
+	}
+}
+
+// A rotation back to a password clears the stored command. Without the
+// clear, the two sources would conflict and every connection would fail.
+func TestAccountCredentialsRotationClearsThePasswordCommand(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	created, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "Work", ServerURL: "https://cal.example.test/dav/",
+		Username: "alice", AuthType: "basic",
+	}, auth.Credential{PasswordCommand: "echo resolved-secret"}, store)
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	a.Close()
+
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "")
+	t.Setenv("CHRONCAL_PASSWORD", "new-password")
+	if _, _, err := runChroncalCommand(t,
+		"account", "credentials", "Work",
+		"--output", "json", "--allow-plaintext",
+	); err != nil {
+		t.Fatalf("account credentials with a password: %v", err)
+	}
+
+	a = openPlaintextApp(t, dbPath)
+	defer a.Close()
+	got, err := a.Accounts.LoadCredential(ctx, created.ID, openPlaintextStore(t, a))
+	if err != nil {
+		t.Fatalf("load credential: %v", err)
+	}
+	if got.Password != "new-password" {
+		t.Fatalf("Password = %q, want new-password", got.Password)
+	}
+	if got.PasswordCommand != "" {
+		t.Fatalf("PasswordCommand = %q, want empty after the rotation", got.PasswordCommand)
+	}
+}
+
+func TestAccountCredentialsRejectsAPasswordCommandForBearer(t *testing.T) {
+	dbPath := setupCalendarCLITestEnv(t)
+	ctx := context.Background()
+	a := openPlaintextApp(t, dbPath)
+	store := openPlaintextStore(t, a)
+	if _, err := a.Accounts.Create(ctx, account.CreateParams{
+		Name: "API Token", ServerURL: "https://cal.example.test/dav/",
+		Username: "alice", AuthType: "bearer",
+	}, auth.Credential{AccessToken: "old-token"}, store); err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	a.Close()
+
+	t.Setenv("CHRONCAL_BEARER_TOKEN", "new-token")
+	if _, _, err := runChroncalCommand(t,
+		"account", "credentials", "API Token",
+		"--password-cmd", "echo resolved-secret",
+		"--output", "json", "--allow-plaintext",
+	); err == nil {
+		t.Fatal("a password command on a bearer account should fail")
+	}
+}
+
 func TestAccountCredentialsRepairsBrokenKeyring(t *testing.T) {
 	dbPath := setupCalendarCLITestEnv(t)
 	ctx := context.Background()

--- a/cmd/chroncal/calendar.go
+++ b/cmd/chroncal/calendar.go
@@ -287,14 +287,15 @@ func calendarGetCmd() *cobra.Command {
 
 func calendarCreateCmd() *cobra.Command {
 	var (
-		color         string
-		description   string
-		email         string
-		remoteURL     string
-		username      string
-		authType      string
-		oauthClientID string
-		allowInsecure bool
+		color           string
+		description     string
+		email           string
+		remoteURL       string
+		username        string
+		authType        string
+		passwordCommand string
+		oauthClientID   string
+		allowInsecure   bool
 	)
 	cmd := &cobra.Command{
 		Use:   `create "<name>"`,
@@ -334,11 +335,12 @@ behavior.`,
 
 			if strings.TrimSpace(remoteURL) != "" {
 				if err := connectCalendarRemote(cmd.Context(), a, c, calendarRemoteFlags{
-					RemoteURL:     remoteURL,
-					Username:      username,
-					AuthType:      authType,
-					OAuthClientID: oauthClientID,
-					AllowInsecure: allowInsecure,
+					RemoteURL:       remoteURL,
+					Username:        username,
+					AuthType:        authType,
+					PasswordCommand: passwordCommand,
+					OAuthClientID:   oauthClientID,
+					AllowInsecure:   allowInsecure,
 				}); err != nil {
 					return err
 				}
@@ -367,6 +369,7 @@ behavior.`,
 	cmd.Flags().StringVar(&remoteURL, "remote-url", "", "remote CalDAV calendar URL")
 	cmd.Flags().StringVar(&username, "username", "", "Username for remote authentication")
 	cmd.Flags().StringVar(&authType, "auth", "basic", "Auth type: basic, bearer, oauth2")
+	cmd.Flags().StringVar(&passwordCommand, "password-cmd", "", "shell command that prints the basic-auth password on its first line")
 	cmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "OAuth 2.0 client ID")
 	cmd.Flags().BoolVar(&allowInsecure, "allow-insecure", false, "Allow HTTP (non-HTTPS) remote URLs")
 	return cmd
@@ -381,6 +384,7 @@ func calendarUpdateCmd() *cobra.Command {
 		remoteURL        string
 		username         string
 		authType         string
+		passwordCommand  string
 		oauthClientID    string
 		allowInsecure    bool
 		disconnectRemote bool
@@ -466,11 +470,12 @@ Only the flags you pass are changed.`,
 				}
 			} else if strings.TrimSpace(remoteURL) != "" {
 				if err := connectCalendarRemote(ctx, a, c, calendarRemoteFlags{
-					RemoteURL:     remoteURL,
-					Username:      username,
-					AuthType:      authType,
-					OAuthClientID: oauthClientID,
-					AllowInsecure: allowInsecure,
+					RemoteURL:       remoteURL,
+					Username:        username,
+					AuthType:        authType,
+					PasswordCommand: passwordCommand,
+					OAuthClientID:   oauthClientID,
+					AllowInsecure:   allowInsecure,
 				}); err != nil {
 					return err
 				}
@@ -499,6 +504,7 @@ Only the flags you pass are changed.`,
 	cmd.Flags().StringVar(&remoteURL, "remote-url", "", "remote CalDAV calendar URL")
 	cmd.Flags().StringVar(&username, "username", "", "Username for remote authentication")
 	cmd.Flags().StringVar(&authType, "auth", "basic", "Auth type: basic, bearer, oauth2")
+	cmd.Flags().StringVar(&passwordCommand, "password-cmd", "", "shell command that prints the basic-auth password on its first line")
 	cmd.Flags().StringVar(&oauthClientID, "oauth-client-id", "", "OAuth 2.0 client ID")
 	cmd.Flags().BoolVar(&allowInsecure, "allow-insecure", false, "Allow HTTP (non-HTTPS) remote URLs")
 	cmd.Flags().BoolVar(&disconnectRemote, "disconnect-remote", false, "Remove the remote CalDAV link from this calendar")

--- a/cmd/chroncal/calendar_remote.go
+++ b/cmd/chroncal/calendar_remote.go
@@ -23,11 +23,15 @@ var newCalendarCredentialStore = auth.NewCredentialStore
 var runGoogleOAuthFlow = auth.GoogleOAuthFlow
 
 type calendarRemoteFlags struct {
-	RemoteURL     string
-	Username      string
-	AuthType      string
-	OAuthClientID string
-	AllowInsecure bool
+	RemoteURL string
+	Username  string
+	AuthType  string
+	// PasswordCommand holds the --password-cmd value. It is a shell command
+	// that prints the basic-auth password. The command is not a secret, so a
+	// flag can carry it.
+	PasswordCommand string
+	OAuthClientID   string
+	AllowInsecure   bool
 }
 
 func validateCalendarRemoteFlags(remoteURL, username, authType, oauthClientID string, allowInsecure, disconnectRemote bool) error {
@@ -83,8 +87,15 @@ func connectCalendarRemote(ctx context.Context, a *app.App, cal calendarpkg.Cale
 	// fetch is whichever secret matches the auth type — basic password,
 	// bearer token, or OAuth access token.
 	metaPassword := cred.Password
-	if cred.AccessToken != "" {
+	switch {
+	case cred.AccessToken != "":
 		metaPassword = cred.AccessToken
+	case cred.HasPasswordCommand():
+		// The metadata fetch stays best effort. A password command that
+		// fails leaves the color unset. The next sync reports the failure.
+		if resolved, resolveErr := cred.ResolvePassword(ctx); resolveErr == nil {
+			metaPassword = resolved
+		}
 	}
 	metaCtx, metaCancel := context.WithTimeout(ctx, 10*time.Second)
 	meta, _ := caldav.FetchCalendarMetadata(metaCtx, flags.RemoteURL, flags.Username, metaPassword, flags.AuthType, flags.AllowInsecure)
@@ -122,11 +133,15 @@ func buildCalendarCredential(ctx context.Context, flags calendarRemoteFlags) (au
 		}
 		return auth.Credential{Username: flags.Username, AccessToken: token}, nil
 	case "basic":
-		password, err := readBasicPassword()
+		secret, err := readBasicSecret(flags.PasswordCommand)
 		if err != nil {
 			return auth.Credential{}, err
 		}
-		return auth.Credential{Username: flags.Username, Password: password}, nil
+		return auth.Credential{
+			Username:        flags.Username,
+			Password:        secret.Password,
+			PasswordCommand: secret.Command,
+		}, nil
 	case "oauth2":
 		clientSecret, err := readGoogleClientSecret()
 		if err != nil {
@@ -153,6 +168,45 @@ func normalizeAuthType(authType string) string {
 	return calendarpkg.NormalizeAuthType(authType)
 }
 
+// basicSecret carries one resolved source for a basic-auth secret. At most
+// one field has a value. Command holds a shell command that prints the
+// password. Password holds the password itself.
+type basicSecret struct {
+	Password string
+	Command  string
+}
+
+// readBasicSecret obtains the basic-auth secret source. A password command is
+// not a secret, so a flag can carry it. A password never comes from a flag.
+// That keeps the password out of /proc/<pid>/cmdline and the shell history.
+// Sources, in order:
+//
+//  1. The --password-cmd flag.
+//  2. The CHRONCAL_PASSWORD_CMD env var.
+//  3. The CHRONCAL_PASSWORD env var.
+//  4. The interactive prompt.
+//
+// A command source plus CHRONCAL_PASSWORD is an error. Two sources hide which
+// secret the program sends.
+func readBasicSecret(passwordCommand string) (basicSecret, error) {
+	command := strings.TrimSpace(passwordCommand)
+	if command == "" {
+		command = strings.TrimSpace(os.Getenv("CHRONCAL_PASSWORD_CMD"))
+	}
+	if command != "" {
+		if os.Getenv("CHRONCAL_PASSWORD") != "" {
+			return basicSecret{}, errInvalidInputf(
+				"a password command and CHRONCAL_PASSWORD are mutually exclusive; set only one")
+		}
+		return basicSecret{Command: command}, nil
+	}
+	password, err := readBasicPassword()
+	if err != nil {
+		return basicSecret{}, err
+	}
+	return basicSecret{Password: password}, nil
+}
+
 // readBasicPassword obtains the password for --auth basic. We never accept it
 // as a CLI flag. That keeps secrets out of /proc/<pid>/cmdline and shell
 // history. Sources, in order:
@@ -164,7 +218,7 @@ func readBasicPassword() (string, error) {
 		return s, nil
 	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return "", fmt.Errorf("a password is required: set CHRONCAL_PASSWORD or run interactively")
+		return "", fmt.Errorf("a password is required: set --password-cmd, CHRONCAL_PASSWORD_CMD, or CHRONCAL_PASSWORD, or run interactively")
 	}
 	fmt.Fprint(os.Stderr, "Password: ")
 	passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/cmd/chroncal/calendar_remote_test.go
+++ b/cmd/chroncal/calendar_remote_test.go
@@ -21,3 +21,81 @@ func TestReadBasicPasswordRequiresEnvWhenNonInteractive(t *testing.T) {
 		t.Fatal("expected error when stdin is not a terminal and env is unset")
 	}
 }
+
+// The flag wins over every other source. The env command is next. The env
+// password comes last before the interactive prompt.
+func TestReadBasicSecretSourceOrder(t *testing.T) {
+	tests := []struct {
+		name        string
+		flag        string
+		envCommand  string
+		envPassword string
+		want        basicSecret
+	}{
+		{
+			name:        "the flag wins over the env command",
+			flag:        "flag-command",
+			envCommand:  "env-command",
+			envPassword: "",
+			want:        basicSecret{Command: "flag-command"},
+		},
+		{
+			name:        "the env command wins over the env password",
+			flag:        "",
+			envCommand:  "env-command",
+			envPassword: "",
+			want:        basicSecret{Command: "env-command"},
+		},
+		{
+			name:        "the env password applies when no command exists",
+			flag:        "",
+			envCommand:  "",
+			envPassword: "lab-secret",
+			want:        basicSecret{Password: "lab-secret"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CHRONCAL_PASSWORD_CMD", tc.envCommand)
+			t.Setenv("CHRONCAL_PASSWORD", tc.envPassword)
+			got, err := readBasicSecret(tc.flag)
+			if err != nil {
+				t.Fatalf("readBasicSecret: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("readBasicSecret = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadBasicSecretRejectsACommandWithAnEnvPassword(t *testing.T) {
+	t.Setenv("CHRONCAL_PASSWORD", "lab-secret")
+
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "")
+	if _, err := readBasicSecret("flag-command"); err == nil {
+		t.Fatal("the flag command plus CHRONCAL_PASSWORD should fail")
+	}
+
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "env-command")
+	if _, err := readBasicSecret(""); err == nil {
+		t.Fatal("CHRONCAL_PASSWORD_CMD plus CHRONCAL_PASSWORD should fail")
+	}
+}
+
+func TestBuildCalendarCredentialCarriesThePasswordCommand(t *testing.T) {
+	t.Setenv("CHRONCAL_PASSWORD", "")
+	t.Setenv("CHRONCAL_PASSWORD_CMD", "")
+	cred, err := buildCalendarCredential(t.Context(), calendarRemoteFlags{
+		Username: "alice", AuthType: "basic", PasswordCommand: "pass show caldav",
+	})
+	if err != nil {
+		t.Fatalf("buildCalendarCredential: %v", err)
+	}
+	if cred.PasswordCommand != "pass show caldav" {
+		t.Fatalf("PasswordCommand = %q, want %q", cred.PasswordCommand, "pass show caldav")
+	}
+	if cred.Password != "" {
+		t.Fatalf("Password = %q, want empty", cred.Password)
+	}
+}

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -18,9 +18,14 @@ import (
 
 // Credential holds authentication secrets for an account.
 type Credential struct {
-	AccountID          int64  `json:"account_id"`
-	Username           string `json:"username,omitempty"`
-	Password           string `json:"password,omitempty"`
+	AccountID int64  `json:"account_id"`
+	Username  string `json:"username,omitempty"`
+	Password  string `json:"password,omitempty"`
+	// PasswordCommand holds a shell command that prints the basic-auth
+	// password on its first standard-output line. The credential store keeps
+	// the command, never the password. Password and PasswordCommand are
+	// mutually exclusive.
+	PasswordCommand    string `json:"password_cmd,omitempty"`
 	AccessToken        string `json:"access_token,omitempty"`
 	RefreshToken       string `json:"refresh_token,omitempty"`
 	TokenExpiry        string `json:"token_expiry,omitempty"` // RFC 3339
@@ -193,6 +198,9 @@ func (s *KeyringStore) Get(accountID int64, accountFingerprint string) (Credenti
 }
 
 func (s *KeyringStore) Set(cred Credential) error {
+	if err := cred.ValidatePasswordSources(); err != nil {
+		return err
+	}
 	data, err := json.Marshal(cred)
 	if err != nil {
 		return fmt.Errorf("marshal credential: %w", err)
@@ -249,6 +257,9 @@ func (s *PlaintextFileStore) Get(accountID int64, accountFingerprint string) (Cr
 }
 
 func (s *PlaintextFileStore) Set(cred Credential) error {
+	if err := cred.ValidatePasswordSources(); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(s.path(cred.AccountID)), 0o700); err != nil {
 		return fmt.Errorf("create credential dir: %w", err)
 	}

--- a/internal/auth/password_command.go
+++ b/internal/auth/password_command.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/douglasdemoura/chroncal/internal/secretcmd"
+)
+
+// ErrPasswordSourceConflict reports a credential that holds both a password
+// and a password command. Two sources hide which secret the program sends,
+// so every write path rejects the pair.
+var ErrPasswordSourceConflict = errors.New(
+	"a password and a password command are mutually exclusive; set only one")
+
+// HasPasswordCommand reports whether the credential resolves its basic-auth
+// password from a command.
+func (c Credential) HasPasswordCommand() bool {
+	return strings.TrimSpace(c.PasswordCommand) != ""
+}
+
+// ValidatePasswordSources reports a conflict between the two basic-auth
+// password sources. Call it before a write to the credential store.
+func (c Credential) ValidatePasswordSources() error {
+	if strings.TrimSpace(c.Password) != "" && c.HasPasswordCommand() {
+		return ErrPasswordSourceConflict
+	}
+	return nil
+}
+
+// ResolvePassword returns the basic-auth password of the credential. It runs
+// the password command when the credential holds one. The caller must not
+// log, print, or store the result.
+//
+// An access-token credential stays on the OAuth path. ResolvePassword does
+// not read AccessToken.
+func (c Credential) ResolvePassword(ctx context.Context) (string, error) {
+	if err := c.ValidatePasswordSources(); err != nil {
+		return "", err
+	}
+	if !c.HasPasswordCommand() {
+		return c.Password, nil
+	}
+	secret, err := secretcmd.Run(ctx, c.PasswordCommand)
+	if err != nil {
+		return "", fmt.Errorf("resolve the password command: %w", err)
+	}
+	return secret, nil
+}

--- a/internal/auth/password_command_test.go
+++ b/internal/auth/password_command_test.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the test uses a POSIX shell")
+	}
+}
+
+func TestResolvePasswordReturnsTheStoredPassword(t *testing.T) {
+	cred := Credential{Username: "alice", Password: "secret123"}
+	got, err := cred.ResolvePassword(t.Context())
+	if err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	if got != "secret123" {
+		t.Errorf("ResolvePassword() = %q, want %q", got, "secret123")
+	}
+}
+
+func TestResolvePasswordRunsTheCommand(t *testing.T) {
+	skipOnWindows(t)
+	cred := Credential{Username: "alice", PasswordCommand: `printf 'from-command\nlogin: alice\n'`}
+	got, err := cred.ResolvePassword(t.Context())
+	if err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	if got != "from-command" {
+		t.Errorf("ResolvePassword() = %q, want %q", got, "from-command")
+	}
+}
+
+func TestResolvePasswordRejectsBothSources(t *testing.T) {
+	cred := Credential{Password: "secret123", PasswordCommand: "true"}
+	if _, err := cred.ResolvePassword(t.Context()); !errors.Is(err, ErrPasswordSourceConflict) {
+		t.Fatalf("ResolvePassword() error = %v, want ErrPasswordSourceConflict", err)
+	}
+	if err := cred.ValidatePasswordSources(); !errors.Is(err, ErrPasswordSourceConflict) {
+		t.Fatalf("ValidatePasswordSources() error = %v, want ErrPasswordSourceConflict", err)
+	}
+}
+
+func TestResolvePasswordReportsACommandFailure(t *testing.T) {
+	skipOnWindows(t)
+	cred := Credential{PasswordCommand: "echo leaked-secret; exit 1"}
+	_, err := cred.ResolvePassword(t.Context())
+	if err == nil {
+		t.Fatal("ResolvePassword() returned no error for a failed command")
+	}
+	if strings.Contains(err.Error(), "leaked-secret") {
+		t.Fatalf("ResolvePassword() error leaks the output: %q", err)
+	}
+}
+
+// The credential store keeps the command. It must never keep the resolved
+// secret, so the marshalled JSON holds password_cmd and no password.
+func TestCredentialJSONKeepsTheCommandOnly(t *testing.T) {
+	skipOnWindows(t)
+	cred := Credential{AccountID: 1, Username: "alice", PasswordCommand: "echo secret123"}
+	if _, err := cred.ResolvePassword(t.Context()); err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	data, err := json.Marshal(cred)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"password_cmd":"echo secret123"`) {
+		t.Errorf("credential JSON = %s, want a password_cmd field", text)
+	}
+	if strings.Contains(text, `"password"`) {
+		t.Errorf("credential JSON = %s, want no password field", text)
+	}
+}
+
+// Every credential store refuses a credential that holds both sources. The
+// check lives in Set, so no write path can store the conflicting pair.
+func TestPlaintextStoreSetRejectsBothPasswordSources(t *testing.T) {
+	store := &PlaintextFileStore{dir: t.TempDir(), namespace: "test", warn: io.Discard}
+	err := store.Set(Credential{AccountID: 1, Password: "secret123", PasswordCommand: "true"})
+	if !errors.Is(err, ErrPasswordSourceConflict) {
+		t.Fatalf("Set() error = %v, want ErrPasswordSourceConflict", err)
+	}
+}
+
+func TestHasPasswordCommandIgnoresBlankSpace(t *testing.T) {
+	if (Credential{PasswordCommand: "   "}).HasPasswordCommand() {
+		t.Error("HasPasswordCommand() = true for a blank command, want false")
+	}
+	if !(Credential{PasswordCommand: "true"}).HasPasswordCommand() {
+		t.Error("HasPasswordCommand() = false for a real command, want true")
+	}
+}

--- a/internal/caldav/auth.go
+++ b/internal/caldav/auth.go
@@ -56,8 +56,14 @@ func httpClientFromCredential(cred auth.Credential, persist func(auth.Credential
 			}
 		}
 		return httpClient, nil
-	case cred.Password != "":
-		return webdav.HTTPClientWithBasicAuth(defaultHTTPClient, cred.Username, cred.Password), nil
+	case cred.Password != "" || cred.HasPasswordCommand():
+		// Resolve the password here. A password command keeps the secret out
+		// of the keyring, so it exists only in this client.
+		password, err := cred.ResolvePassword(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		return webdav.HTTPClientWithBasicAuth(defaultHTTPClient, cred.Username, password), nil
 	default:
 		return nil, fmt.Errorf("credential has no password or access token")
 	}

--- a/internal/caldav/auth_test.go
+++ b/internal/caldav/auth_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -217,5 +219,71 @@ func TestNewClientFromCredential_UsesBoundedHTTPClient(t *testing.T) {
 	}
 	if oauthClient.inner.Timeout != defaultHTTPTimeout {
 		t.Fatalf("inner timeout = %s, want %s", oauthClient.inner.Timeout, defaultHTTPTimeout)
+	}
+}
+
+// A basic-auth credential with a password command sends the first stdout
+// line of the command as the password.
+func TestHTTPClientFromCredential_RunsThePasswordCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the test uses a POSIX shell")
+	}
+	httpClient, err := httpClientFromCredential(auth.Credential{
+		Username:        "alice",
+		PasswordCommand: `printf 'from-command\nlogin: alice\n'`,
+	}, nil)
+	if err != nil {
+		t.Fatalf("httpClientFromCredential: %v", err)
+	}
+
+	var gotUser, gotPassword string
+	var ok bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPassword, ok = r.BasicAuth()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+
+	if !ok {
+		t.Fatal("the request carried no basic-auth header")
+	}
+	if gotUser != "alice" || gotPassword != "from-command" {
+		t.Fatalf("basic auth = %q/%q, want alice/from-command", gotUser, gotPassword)
+	}
+}
+
+func TestHTTPClientFromCredential_RejectsBothPasswordSources(t *testing.T) {
+	_, err := httpClientFromCredential(auth.Credential{
+		Username:        "alice",
+		Password:        "secret123",
+		PasswordCommand: "true",
+	}, nil)
+	if !errors.Is(err, auth.ErrPasswordSourceConflict) {
+		t.Fatalf("httpClientFromCredential error = %v, want ErrPasswordSourceConflict", err)
+	}
+}
+
+// An access-token credential stays on the OAuth path. A stray password
+// command must not divert it to basic auth.
+func TestHTTPClientFromCredential_AccessTokenIgnoresThePasswordCommand(t *testing.T) {
+	httpClient, err := httpClientFromCredential(auth.Credential{
+		AccessToken:     "token",
+		PasswordCommand: "exit 1",
+	}, nil)
+	if err != nil {
+		t.Fatalf("httpClientFromCredential: %v", err)
+	}
+	if _, ok := httpClient.(*oauth2HTTPClient); !ok {
+		t.Fatalf("client type = %T, want *oauth2HTTPClient", httpClient)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,12 +1,14 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
 	"strings"
 
+	"github.com/douglasdemoura/chroncal/internal/secretcmd"
 	"github.com/spf13/viper"
 )
 
@@ -16,7 +18,11 @@ type SMTPConfig struct {
 	Port     int    `mapstructure:"port"`
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
-	From     string `mapstructure:"from"`
+	// PasswordCommand holds a shell command that prints the SMTP password
+	// on its first standard-output line. It keeps the password out of the
+	// config file. Password and PasswordCommand are mutually exclusive.
+	PasswordCommand string `mapstructure:"password_cmd"`
+	From            string `mapstructure:"from"`
 	// TLSMode controls how TLS is established for the SMTP connection.
 	// Valid values:
 	//   ""           – auto-detect: port 465 uses implicit TLS (SMTPS), all
@@ -118,7 +124,41 @@ func Load() (Config, error) {
 	if !v.IsSet("soft_delete.purge_days") {
 		cfg.SoftDelete.PurgeDays = DefaultSoftDeletePurgeDays
 	}
+	if err := cfg.SMTP.Validate(); err != nil {
+		return Config{}, err
+	}
 	return cfg, nil
+}
+
+// ErrSMTPPasswordSourceConflict reports a config that sets both an SMTP
+// password and an SMTP password command. Two sources hide which secret the
+// program sends, so Load rejects the pair.
+var ErrSMTPPasswordSourceConflict = errors.New(
+	"smtp.password and smtp.password_cmd are mutually exclusive; set only one")
+
+// Validate reports a conflict between the two SMTP password sources.
+func (c SMTPConfig) Validate() error {
+	if strings.TrimSpace(c.Password) != "" && strings.TrimSpace(c.PasswordCommand) != "" {
+		return ErrSMTPPasswordSourceConflict
+	}
+	return nil
+}
+
+// ResolvePassword returns the SMTP password. It runs smtp.password_cmd when
+// that key has a value. The caller must not log or print the result.
+func (c SMTPConfig) ResolvePassword(ctx context.Context) (string, error) {
+	if err := c.Validate(); err != nil {
+		return "", err
+	}
+	command := strings.TrimSpace(c.PasswordCommand)
+	if command == "" {
+		return c.Password, nil
+	}
+	secret, err := secretcmd.Run(ctx, command)
+	if err != nil {
+		return "", fmt.Errorf("resolve smtp.password_cmd: %w", err)
+	}
+	return secret, nil
 }
 
 // newViper creates a pre-configured Viper instance with CHRONCAL_ env prefix
@@ -138,6 +178,7 @@ func newViper() *viper.Viper {
 	v.BindEnv("smtp.port")
 	v.BindEnv("smtp.username")
 	v.BindEnv("smtp.password")
+	v.BindEnv("smtp.password_cmd")
 	v.BindEnv("smtp.from")
 	v.BindEnv("smtp.tls")
 	// An unset conflict strategy must mean the safe mode: record the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -295,5 +298,112 @@ func TestLoad_ConflictStrategyDefaultsToPrompt(t *testing.T) {
 
 	if cfg.Sync.ConflictStrategy != "prompt" {
 		t.Fatalf("Sync.ConflictStrategy = %q, want prompt", cfg.Sync.ConflictStrategy)
+	}
+}
+
+func TestLoad_SMTPPasswordCommandFromFile(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "chroncal")
+	os.MkdirAll(configDir, 0o755)
+
+	content := `[smtp]
+host = "smtp.example.com"
+username = "user@example.com"
+password_cmd = "secret-tool lookup smtp"
+`
+	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(content), 0o644)
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_SMTP_PASSWORD", "")
+	t.Setenv("CHRONCAL_SMTP_PASSWORD_CMD", "")
+
+	cfg := mustLoad(t)
+
+	if cfg.SMTP.PasswordCommand != "secret-tool lookup smtp" {
+		t.Errorf("SMTP.PasswordCommand = %q, want %q", cfg.SMTP.PasswordCommand, "secret-tool lookup smtp")
+	}
+	if cfg.SMTP.Password != "" {
+		t.Errorf("SMTP.Password = %q, want empty", cfg.SMTP.Password)
+	}
+}
+
+func TestLoad_SMTPPasswordCommandFromEnv(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "chroncal"), 0o755)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_SMTP_PASSWORD", "")
+	t.Setenv("CHRONCAL_SMTP_PASSWORD_CMD", "secret-tool lookup smtp")
+
+	cfg := mustLoad(t)
+
+	if cfg.SMTP.PasswordCommand != "secret-tool lookup smtp" {
+		t.Errorf("SMTP.PasswordCommand = %q, want %q", cfg.SMTP.PasswordCommand, "secret-tool lookup smtp")
+	}
+}
+
+func TestLoad_RejectsBothSMTPPasswordSources(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "chroncal")
+	os.MkdirAll(configDir, 0o755)
+
+	content := `[smtp]
+host = "smtp.example.com"
+password = "secret123"
+password_cmd = "secret-tool lookup smtp"
+`
+	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(content), 0o644)
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CHRONCAL_SMTP_PASSWORD", "")
+	t.Setenv("CHRONCAL_SMTP_PASSWORD_CMD", "")
+
+	if _, err := Load(); !errors.Is(err, ErrSMTPPasswordSourceConflict) {
+		t.Fatalf("Load() error = %v, want ErrSMTPPasswordSourceConflict", err)
+	}
+}
+
+func TestSMTPResolvePasswordReturnsTheLiteralPassword(t *testing.T) {
+	cfg := SMTPConfig{Password: "secret123"}
+	got, err := cfg.ResolvePassword(t.Context())
+	if err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	if got != "secret123" {
+		t.Errorf("ResolvePassword() = %q, want %q", got, "secret123")
+	}
+}
+
+func TestSMTPResolvePasswordRunsTheCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the test uses a POSIX shell")
+	}
+	cfg := SMTPConfig{PasswordCommand: `printf 'from-command\nmetadata\n'`}
+	got, err := cfg.ResolvePassword(t.Context())
+	if err != nil {
+		t.Fatalf("ResolvePassword() error = %v", err)
+	}
+	if got != "from-command" {
+		t.Errorf("ResolvePassword() = %q, want %q", got, "from-command")
+	}
+}
+
+func TestSMTPResolvePasswordRejectsBothSources(t *testing.T) {
+	cfg := SMTPConfig{Password: "secret123", PasswordCommand: "true"}
+	if _, err := cfg.ResolvePassword(t.Context()); !errors.Is(err, ErrSMTPPasswordSourceConflict) {
+		t.Fatalf("ResolvePassword() error = %v, want ErrSMTPPasswordSourceConflict", err)
+	}
+}
+
+func TestSMTPResolvePasswordReportsACommandFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the test uses a POSIX shell")
+	}
+	cfg := SMTPConfig{PasswordCommand: "echo leaked-secret; exit 1"}
+	_, err := cfg.ResolvePassword(t.Context())
+	if err == nil {
+		t.Fatal("ResolvePassword() returned no error for a failed command")
+	}
+	if strings.Contains(err.Error(), "leaked-secret") {
+		t.Fatalf("ResolvePassword() error leaks the output: %q", err)
 	}
 }

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -271,7 +271,14 @@ func Email(da alarm.DueAlarm, smtpCfg config.SMTPConfig, policy ExecutionPolicy)
 
 	var auth smtp.Auth
 	if smtpCfg.Username != "" {
-		auth = smtp.PlainAuth("", smtpCfg.Username, smtpCfg.Password, smtpCfg.Host)
+		// Resolve the password at send time. A password command keeps the
+		// secret out of the config file, so it exists only here and in the
+		// SMTP handshake.
+		password, err := smtpCfg.ResolvePassword(context.Background())
+		if err != nil {
+			return fmt.Errorf("smtp password: %w", err)
+		}
+		auth = smtp.PlainAuth("", smtpCfg.Username, password, smtpCfg.Host)
 	}
 
 	if useImplicitTLS(smtpCfg) {

--- a/internal/secretcmd/secretcmd.go
+++ b/internal/secretcmd/secretcmd.go
@@ -1,0 +1,99 @@
+// Package secretcmd runs a user-supplied command and reads one secret from
+// its standard output. It lets a user keep a password in a password manager
+// instead of the config file or the OS keyring.
+//
+// The runner never writes the secret to a log, to an error message, or to a
+// terminal. Only the command string is persistent.
+package secretcmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Timeout is the deadline for one command. A hung command must not wedge a
+// sync pass or an alarm delivery.
+const Timeout = 30 * time.Second
+
+// waitDelay is the grace period after the deadline. The runner then kills
+// the process group and stops the read of the pipes.
+const waitDelay = time.Second
+
+// ErrEmptyCommand reports an empty command string.
+var ErrEmptyCommand = errors.New("the password command is empty")
+
+// ErrEmptyOutput reports a command that wrote no usable first line.
+var ErrEmptyOutput = errors.New("the password command returned no secret")
+
+// Run executes command through the system shell and returns the secret.
+//
+// The secret is the first line of the standard output. The runner discards
+// every later line, because a password manager such as pass prints metadata
+// after the password. The runner also discards the standard error, so a
+// noisy command cannot corrupt the TUI display.
+//
+// Run applies a 30-second deadline on top of the deadline of ctx. It returns
+// an error for an empty command, for a non-zero exit status, for a timeout,
+// and for an empty first line. No error message holds the command output.
+func Run(ctx context.Context, command string) (string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return "", ErrEmptyCommand
+	}
+	runCtx, cancel := context.WithTimeout(ctx, Timeout)
+	defer cancel()
+
+	name, args := shellInvocation(runtime.GOOS, command)
+	cmd := exec.CommandContext(runCtx, name, args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	// A nil Stderr sends the standard error to the null device. Keep it nil.
+	// The TUI owns the terminal, and a write to the standard error prints
+	// over the display.
+	cmd.Stderr = nil
+	// WaitDelay bounds the wait after the deadline. Without it, a grandchild
+	// process that holds the pipe open blocks Wait forever.
+	cmd.WaitDelay = waitDelay
+
+	err := cmd.Run()
+	if err != nil {
+		if runCtx.Err() != nil {
+			return "", fmt.Errorf("the password command did not finish in %s", Timeout)
+		}
+		// The error text holds the exit status only. The command output
+		// stays out of it.
+		return "", fmt.Errorf("the password command failed: %w", err)
+	}
+
+	secret := firstLine(stdout.String())
+	if strings.TrimSpace(secret) == "" {
+		return "", ErrEmptyOutput
+	}
+	return secret, nil
+}
+
+// firstLine returns the first line of out without the line terminator. A
+// carriage return at the end of the line is also removed, so a command that
+// writes CRLF gives the same secret as a command that writes LF.
+func firstLine(out string) string {
+	if i := strings.IndexByte(out, '\n'); i >= 0 {
+		out = out[:i]
+	}
+	return strings.TrimSuffix(out, "\r")
+}
+
+// shellInvocation returns the shell program and its arguments for one goos.
+// The command runs through a shell on purpose. A user writes a pipeline or a
+// path with arguments, for example "pass show caldav_password".
+func shellInvocation(goos, command string) (string, []string) {
+	if goos == "windows" {
+		return "cmd", []string{"/c", command}
+	}
+	return "sh", []string{"-c", command}
+}

--- a/internal/secretcmd/secretcmd_test.go
+++ b/internal/secretcmd/secretcmd_test.go
@@ -1,0 +1,122 @@
+package secretcmd
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the test uses a POSIX shell")
+	}
+}
+
+func TestRunReturnsFirstStdoutLine(t *testing.T) {
+	skipOnWindows(t)
+	got, err := Run(t.Context(), "printf 'hunter2\\nlogin: alice\\nurl: example.com\\n'")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got != "hunter2" {
+		t.Fatalf("Run = %q, want %q", got, "hunter2")
+	}
+}
+
+func TestRunAcceptsOutputWithNoTrailingNewline(t *testing.T) {
+	skipOnWindows(t)
+	got, err := Run(t.Context(), "printf 'hunter2'")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got != "hunter2" {
+		t.Fatalf("Run = %q, want %q", got, "hunter2")
+	}
+}
+
+func TestRunStripsCarriageReturn(t *testing.T) {
+	skipOnWindows(t)
+	got, err := Run(t.Context(), "printf 'hunter2\\r\\n'")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got != "hunter2" {
+		t.Fatalf("Run = %q, want %q", got, "hunter2")
+	}
+}
+
+func TestRunRejectsAnEmptyCommand(t *testing.T) {
+	if _, err := Run(t.Context(), "   "); !errors.Is(err, ErrEmptyCommand) {
+		t.Fatalf("Run error = %v, want ErrEmptyCommand", err)
+	}
+}
+
+func TestRunRejectsEmptyOutput(t *testing.T) {
+	skipOnWindows(t)
+	if _, err := Run(t.Context(), "true"); !errors.Is(err, ErrEmptyOutput) {
+		t.Fatalf("Run error = %v, want ErrEmptyOutput", err)
+	}
+}
+
+func TestRunRejectsABlankFirstLine(t *testing.T) {
+	skipOnWindows(t)
+	if _, err := Run(t.Context(), "printf '   \\nhunter2\\n'"); !errors.Is(err, ErrEmptyOutput) {
+		t.Fatalf("Run error = %v, want ErrEmptyOutput", err)
+	}
+}
+
+func TestRunReportsANonZeroExit(t *testing.T) {
+	skipOnWindows(t)
+	_, err := Run(t.Context(), "exit 3")
+	if err == nil {
+		t.Fatal("Run returned no error for a non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "the password command failed") {
+		t.Fatalf("Run error = %q, want a command-failed message", err)
+	}
+}
+
+// The error must not carry the command output. A command that prints the
+// secret and then fails must not leak the secret through the error text.
+func TestRunKeepsTheOutputOutOfTheError(t *testing.T) {
+	skipOnWindows(t)
+	_, err := Run(t.Context(), "echo hunter2; echo oops >&2; exit 1")
+	if err == nil {
+		t.Fatal("Run returned no error for a non-zero exit")
+	}
+	if strings.Contains(err.Error(), "hunter2") || strings.Contains(err.Error(), "oops") {
+		t.Fatalf("Run error leaks output: %q", err)
+	}
+}
+
+func TestRunStopsAtTheDeadline(t *testing.T) {
+	skipOnWindows(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := Run(ctx, "sleep 30")
+	if err == nil {
+		t.Fatal("Run returned no error for a slow command")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Run took %s, want a fast stop", elapsed)
+	}
+	if !strings.Contains(err.Error(), "did not finish") {
+		t.Fatalf("Run error = %q, want a timeout message", err)
+	}
+}
+
+func TestShellInvocation(t *testing.T) {
+	name, args := shellInvocation("linux", "pass show caldav")
+	if name != "sh" || len(args) != 2 || args[0] != "-c" || args[1] != "pass show caldav" {
+		t.Fatalf("shellInvocation(linux) = %q %q", name, args)
+	}
+	name, args = shellInvocation("windows", "pass show caldav")
+	if name != "cmd" || len(args) != 2 || args[0] != "/c" || args[1] != "pass show caldav" {
+		t.Fatalf("shellInvocation(windows) = %q %q", name, args)
+	}
+}

--- a/internal/tui/account_settings_dialog.go
+++ b/internal/tui/account_settings_dialog.go
@@ -375,11 +375,22 @@ func (m AccountOAuthConfigDialogModel) View() string {
 type AccountCredentialsUpdateSubmittedMsg struct {
 	AccountID int64
 	Secret    string
+	// SecretCommand holds a shell command that prints the basic-auth
+	// password. Secret and SecretCommand are mutually exclusive. Bearer auth
+	// ignores this field.
+	SecretCommand string
 }
 
 // AccountCredentialsUpdateClosedMsg reports a cancel from the credential
 // update dialog; no credential was changed.
 type AccountCredentialsUpdateClosedMsg struct{ AccountID int64 }
+
+// Form field indices for the credential-rotation form. Bearer auth shows the
+// Token row only. Basic auth adds the Password cmd row after it.
+const (
+	credentialsIdxSecret = iota
+	credentialsIdxSecretCommand
+)
 
 // AccountCredentialsDialogModel collects the single secret needed to rotate a
 // basic (password) or bearer (token) account credential in place. It is the
@@ -404,25 +415,47 @@ func NewAccountCredentialsDialogModel(
 	accountName, authType, username string,
 	theme Theme,
 ) AccountCredentialsDialogModel {
-	var fieldLabel string
+	bearer := accountAuthIsBearer(authType)
 	secret := newPasswordField()
-	if accountAuthIsBearer(authType) {
-		fieldLabel = "Token"
-		secret.SetPlaceholder("paste your API token")
-	} else {
-		fieldLabel = "Password"
-	}
 	styles := DefaultFormStyles()
 	styles.LabelLayout = LabelTop
-	form := NewForm(
-		"Update",
-		styles,
-		FormItem{Label: fieldLabel, Field: secret, Required: true},
-	)
+	var form Form
+	if bearer {
+		// Bearer auth has no password command. Command retrieval covers the
+		// basic-auth password only.
+		secret.SetPlaceholder("paste your API token")
+		form = NewForm(
+			"Update",
+			styles,
+			FormItem{Label: "Token", Field: secret, Required: true},
+		)
+	} else {
+		// Basic auth accepts a password or a password command. Neither row
+		// is required on its own, so OnSubmit checks the pair instead.
+		form = NewForm(
+			"Update",
+			styles,
+			FormItem{Label: "Password", Field: secret},
+			FormItem{Label: "Password cmd", Field: newPasswordCommandField("")},
+		)
+	}
 	form.OnSubmit(func(f *Form) tea.Cmd {
 		msg := AccountCredentialsUpdateSubmittedMsg{
 			AccountID: accountID,
-			Secret:    strings.TrimSpace(f.Field(0).(*TextField).Value()),
+			Secret:    strings.TrimSpace(f.Field(credentialsIdxSecret).(*TextField).Value()),
+		}
+		if !bearer {
+			msg.SecretCommand = strings.TrimSpace(
+				f.Field(credentialsIdxSecretCommand).(*TextField).Value())
+			if msg.Secret != "" && msg.SecretCommand != "" {
+				f.SetError(credentialsIdxSecretCommand,
+					"Enter a password or a password command, not both")
+				return nil
+			}
+			if msg.Secret == "" && msg.SecretCommand == "" {
+				f.SetError(credentialsIdxSecret, "Enter a password or a password command")
+				return nil
+			}
 		}
 		return func() tea.Msg { return msg }
 	})
@@ -474,7 +507,7 @@ func (m AccountCredentialsDialogModel) View() string {
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "update")),
 		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel")),
 	}))
-	noun := "password"
+	noun := "password or password command"
 	if accountAuthIsBearer(m.authType) {
 		noun = "token"
 	}

--- a/internal/tui/account_settings_dialog_test.go
+++ b/internal/tui/account_settings_dialog_test.go
@@ -203,10 +203,13 @@ func TestAccountCredentialsDialogBasicCollectsPassword(t *testing.T) {
 	m := NewAccountCredentialsDialogModel(7, "Work", "basic", "alice@example.com", NewTheme(true)).
 		SetSize(80, 30)
 	view := stripANSI(m.View())
-	if !strings.Contains(view, "Password") || !strings.Contains(view, "New password for Work") {
+	if !strings.Contains(view, "Password") || !strings.Contains(view, "New password or password command for Work") {
 		t.Fatalf("basic dialog missing Password field/context:\n%s", view)
 	}
-	m.form.Field(0).(*TextField).SetValue("hunter2")
+	if !strings.Contains(view, "Password cmd") {
+		t.Fatalf("basic dialog missing Password cmd field:\n%s", view)
+	}
+	m.form.Field(credentialsIdxSecret).(*TextField).SetValue("hunter2")
 	form, cmd := m.form.Submit()
 	m.form = form
 	if cmd == nil {
@@ -215,6 +218,49 @@ func TestAccountCredentialsDialogBasicCollectsPassword(t *testing.T) {
 	msg, ok := cmd().(AccountCredentialsUpdateSubmittedMsg)
 	if !ok || msg.AccountID != 7 || msg.Secret != "hunter2" {
 		t.Fatalf("basic submission = %#v, want account 7 secret hunter2", cmd())
+	}
+}
+
+// TestAccountCredentialsDialogBasicCollectsPasswordCommand checks the command
+// path. An empty password plus a command is a valid rotation.
+func TestAccountCredentialsDialogBasicCollectsPasswordCommand(t *testing.T) {
+	m := NewAccountCredentialsDialogModel(7, "Work", "basic", "alice@example.com", NewTheme(true)).
+		SetSize(80, 30)
+	m.form.Field(credentialsIdxSecretCommand).(*TextField).SetValue("pass show caldav/work")
+	form, cmd := m.form.Submit()
+	m.form = form
+	if cmd == nil {
+		t.Fatal("command-only credential form did not submit")
+	}
+	msg, ok := cmd().(AccountCredentialsUpdateSubmittedMsg)
+	if !ok || msg.Secret != "" || msg.SecretCommand != "pass show caldav/work" {
+		t.Fatalf("command submission = %#v, want an empty secret and the command", cmd())
+	}
+}
+
+// TestAccountCredentialsDialogBasicRejectsBothSources checks the pair. A
+// password plus a command hides which secret the program sends.
+func TestAccountCredentialsDialogBasicRejectsBothSources(t *testing.T) {
+	m := NewAccountCredentialsDialogModel(7, "Work", "basic", "alice@example.com", NewTheme(true)).
+		SetSize(80, 30)
+	m.form.Field(credentialsIdxSecret).(*TextField).SetValue("hunter2")
+	m.form.Field(credentialsIdxSecretCommand).(*TextField).SetValue("pass show caldav/work")
+	form, cmd := m.form.Submit()
+	m.form = form
+	if cmd != nil {
+		t.Fatalf("form submitted with both sources set: %#v", cmd())
+	}
+}
+
+// TestAccountCredentialsDialogBasicRejectsEmptySources checks that the form
+// needs one source. Neither row is required on its own.
+func TestAccountCredentialsDialogBasicRejectsEmptySources(t *testing.T) {
+	m := NewAccountCredentialsDialogModel(7, "Work", "basic", "alice@example.com", NewTheme(true)).
+		SetSize(80, 30)
+	form, cmd := m.form.Submit()
+	m.form = form
+	if cmd != nil {
+		t.Fatalf("empty form submitted: %#v", cmd())
 	}
 }
 

--- a/internal/tui/app_update_account.go
+++ b/internal/tui/app_update_account.go
@@ -303,10 +303,11 @@ func (m Model) handleCalendarDiscoveryRequested(msg CalendarDiscoveryRequestedMs
 		return m.startOAuthFlow(msg.OAuthClientID, msg.OAuthClientSecret)
 	}
 	cred := auth.Credential{Username: msg.Username}
-	if msg.AuthType == "bearer" {
+	if accountAuthIsBearer(msg.AuthType) {
 		cred.AccessToken = msg.Secret
 	} else {
 		cred.Password = msg.Secret
+		cred.PasswordCommand = msg.SecretCommand
 	}
 	m.syncing = true
 	m.syncStatus = "Adding account…"

--- a/internal/tui/app_update_calendar.go
+++ b/internal/tui/app_update_calendar.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/douglasdemoura/chroncal/internal/auth"
 	"github.com/douglasdemoura/chroncal/internal/caldav"
 	"github.com/douglasdemoura/chroncal/internal/calendar"
 	"github.com/douglasdemoura/chroncal/internal/icaltransfer"
@@ -402,7 +404,19 @@ func (m Model) handleCalendarTestRequested(msg CalendarTestRequestedMsg) (tea.Mo
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 
-		meta, err := caldav.VerifyCalendarURL(ctx, req.URL, req.Username, req.Password, req.AuthType, req.AllowInsecure)
+		password := req.Password
+		if strings.TrimSpace(req.PasswordCommand) != "" {
+			// Run the command here so the ping uses the same secret a later
+			// sync uses. The resolved secret never leaves this function.
+			resolved, err := auth.Credential{PasswordCommand: req.PasswordCommand}.
+				ResolvePassword(ctx)
+			if err != nil {
+				return CalendarTestResultMsg{Message: err.Error()}
+			}
+			password = resolved
+		}
+
+		meta, err := caldav.VerifyCalendarURL(ctx, req.URL, req.Username, password, req.AuthType, req.AllowInsecure)
 		if err != nil {
 			return CalendarTestResultMsg{Message: err.Error()}
 		}

--- a/internal/tui/calendar_dialog.go
+++ b/internal/tui/calendar_dialog.go
@@ -73,10 +73,14 @@ type CalendarSavedMsg struct {
 // CalendarDiscoveryRequestedMsg starts discovery from the Add Account flow.
 // Remote collection metadata supplies the local calendars after sign-in.
 type CalendarDiscoveryRequestedMsg struct {
-	ServerURL         string
-	Username          string
-	AuthType          string
-	Secret            string
+	ServerURL string
+	Username  string
+	AuthType  string
+	Secret    string
+	// SecretCommand holds a shell command that prints the basic-auth
+	// password. Secret and SecretCommand are mutually exclusive. Bearer and
+	// OAuth ignore this field.
+	SecretCommand     string
 	OAuthClientID     string
 	OAuthClientSecret string
 	AllowInsecure     bool
@@ -122,11 +126,14 @@ type CalendarKeepLocalRequestedMsg struct {
 // CalendarTestRequestedMsg is emitted when the user presses Test. The parent
 // runs a CalDAV authenticated ping and replies with CalendarTestResultMsg.
 type CalendarTestRequestedMsg struct {
-	URL           string
-	Username      string
-	AuthType      string
-	Password      string
-	AllowInsecure bool
+	URL      string
+	Username string
+	AuthType string
+	Password string
+	// PasswordCommand holds a shell command that prints the basic-auth
+	// password. The parent runs it before the ping.
+	PasswordCommand string
+	AllowInsecure   bool
 }
 
 // CalendarTestResultMsg is the outcome of a CalendarTestRequestedMsg.
@@ -161,19 +168,65 @@ const (
 	cdIdxEmail       = 3
 )
 
+// Form field indices for the Add Account form. The first three rows never
+// move. The tail after them depends on the auth type:
+//
+//   - basic:  Password, Password cmd, HTTP
+//   - bearer: Token, HTTP
+//   - oauth2: Client ID, Client secret, HTTP
+//
+// calDAVInsecureIdx returns the HTTP row for the active tail.
 const (
 	calDAVIdxServer = iota
 	calDAVIdxUsername
 	calDAVIdxAuth
 	calDAVIdxSecret
+	calDAVIdxSecretCommand
 	calDAVIdxAllowInsecure
 )
 
 const (
 	calDAVIdxOAuthClientID      = calDAVIdxSecret
-	calDAVIdxOAuthClientSecret  = calDAVIdxAllowInsecure
-	calDAVIdxOAuthAllowInsecure = calDAVIdxAllowInsecure + 1
+	calDAVIdxOAuthClientSecret  = calDAVIdxSecret + 1
+	calDAVIdxOAuthAllowInsecure = calDAVIdxSecret + 2
 )
+
+// calDAVIdxBearerAllowInsecure is the HTTP row of the bearer tail. Bearer
+// auth has no password command, so its tail is one row shorter.
+const calDAVIdxBearerAllowInsecure = calDAVIdxSecret + 1
+
+// calDAVTailLayout names the tail the Add Account form shows.
+type calDAVTailLayout int
+
+const (
+	calDAVTailBasic calDAVTailLayout = iota
+	calDAVTailBearer
+	calDAVTailOAuth
+)
+
+// calDAVTailFor maps an auth-type string to the tail layout it needs.
+func calDAVTailFor(authType string) calDAVTailLayout {
+	switch {
+	case calendarAuthIsOAuth(authType):
+		return calDAVTailOAuth
+	case accountAuthIsBearer(authType):
+		return calDAVTailBearer
+	default:
+		return calDAVTailBasic
+	}
+}
+
+// calDAVInsecureIdx returns the index of the HTTP checkbox for one tail.
+func calDAVInsecureIdx(layout calDAVTailLayout) int {
+	switch layout {
+	case calDAVTailOAuth:
+		return calDAVIdxOAuthAllowInsecure
+	case calDAVTailBearer:
+		return calDAVIdxBearerAllowInsecure
+	default:
+		return calDAVIdxAllowInsecure
+	}
+}
 
 var authOptions = []SelectOption{
 	{Label: "Basic", Value: "basic"},
@@ -348,6 +401,16 @@ func newPasswordField() *TextField {
 	f := NewTextField("your password")
 	f.SetCharLimit(256)
 	f.SetEchoPassword(true)
+	return f
+}
+
+// newPasswordCommandField builds the Password cmd input. The value is a
+// shell command, not a secret, so the field does not mask what the user
+// types. Chroncal stores the command and runs it at each connection.
+func newPasswordCommandField(value string) *TextField {
+	f := NewTextField("pass show caldav/work")
+	f.SetValue(value)
+	f.SetCharLimit(512)
 	return f
 }
 

--- a/internal/tui/calendar_dialog_new.go
+++ b/internal/tui/calendar_dialog_new.go
@@ -285,11 +285,14 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 
 	insecure := NewCheckboxField("", false)
 	insecure.SetContent("allow plain HTTP")
+	// Basic auth accepts a password or a password command. Neither row is
+	// required on its own, so OnSubmit checks the pair instead.
 	form := NewForm("Sign In", styles,
 		FormItem{Label: "Server URL", Field: newRemoteURLField(""), Required: true},
 		FormItem{Label: "Username", Field: newUsernameField(usernamePrefill), Required: true},
 		FormItem{Label: "Auth", Field: newAuthField("basic"), Required: true},
-		FormItem{Label: "Password", Field: newPasswordField(), Required: true},
+		FormItem{Label: "Password", Field: newPasswordField()},
+		FormItem{Label: "Password cmd", Field: newPasswordCommandField("")},
 		FormItem{Label: "HTTP", Field: insecure},
 	)
 	form.SetActionButton("Test", Button, func() tea.Msg {
@@ -300,24 +303,30 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 	})
 
 	var snapshot struct {
-		secret, clientID, clientSecret string
-		allowInsecure                  bool
+		secret, secretCommand, clientID, clientSecret string
+		allowInsecure                                 bool
 	}
-	oauthLayout := new(bool)
+	layout := new(calDAVTailLayout)
 	snapshotTail := func(f *Form) {
-		if *oauthLayout {
+		snapshot.allowInsecure = f.Field(calDAVInsecureIdx(*layout)).(*CheckboxField).Checked()
+		switch *layout {
+		case calDAVTailOAuth:
 			snapshot.clientID = f.Field(calDAVIdxOAuthClientID).(*TextField).Value()
 			snapshot.clientSecret = f.Field(calDAVIdxOAuthClientSecret).(*TextField).Value()
-			snapshot.allowInsecure = f.Field(calDAVIdxOAuthAllowInsecure).(*CheckboxField).Checked()
-			return
+		case calDAVTailBasic:
+			snapshot.secret = f.Field(calDAVIdxSecret).(*TextField).Value()
+			snapshot.secretCommand = f.Field(calDAVIdxSecretCommand).(*TextField).Value()
+		case calDAVTailBearer:
+			snapshot.secret = f.Field(calDAVIdxSecret).(*TextField).Value()
 		}
-		snapshot.secret = f.Field(calDAVIdxSecret).(*TextField).Value()
-		snapshot.allowInsecure = f.Field(calDAVIdxAllowInsecure).(*CheckboxField).Checked()
 	}
-	appendTail := func(f *Form, authType string) {
+	appendTail := func(f *Form, next calDAVTailLayout) {
 		allow := NewCheckboxField("", snapshot.allowInsecure)
 		allow.SetContent("allow plain HTTP")
-		if calendarAuthIsOAuth(authType) {
+		secret := newPasswordField()
+		secret.SetValue(snapshot.secret)
+		switch next {
+		case calDAVTailOAuth:
 			clientSecret := newOAuthClientSecretField()
 			clientSecret.SetValue(snapshot.clientSecret)
 			f.AppendItems(
@@ -325,41 +334,33 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 				FormItem{Label: "Client secret", Field: clientSecret, Required: true},
 				FormItem{Label: "HTTP", Field: allow},
 			)
-			*oauthLayout = true
-			return
+		case calDAVTailBearer:
+			// Bearer auth has no password command. Command retrieval covers
+			// the basic-auth password only.
+			secret.SetPlaceholder("paste your API token")
+			f.AppendItems(
+				FormItem{Label: "Token", Field: secret, Required: true},
+				FormItem{Label: "HTTP", Field: allow},
+			)
+		case calDAVTailBasic:
+			f.AppendItems(
+				FormItem{Label: "Password", Field: secret},
+				FormItem{Label: "Password cmd", Field: newPasswordCommandField(snapshot.secretCommand)},
+				FormItem{Label: "HTTP", Field: allow},
+			)
 		}
-		secret := newPasswordField()
-		secret.SetValue(snapshot.secret)
-		f.AppendItems(
-			FormItem{Label: "Password", Field: secret, Required: true},
-			FormItem{Label: "HTTP", Field: allow},
-		)
-		*oauthLayout = false
+		*layout = next
 	}
 	form.OnRebuild(func(f *Form) {
 		authType := f.Field(calDAVIdxAuth).(*SelectField).Value()
-		if calendarAuthIsOAuth(authType) != *oauthLayout {
+		if next := calDAVTailFor(authType); next != *layout {
 			snapshotTail(f)
 			f.RemoveItems(calDAVIdxSecret)
 			f.ClearError()
-			appendTail(f, authType)
-		}
-		if !*oauthLayout {
-			secret := f.Field(calDAVIdxSecret).(*TextField)
-			if authType == "bearer" {
-				f.SetItemLabel(calDAVIdxSecret, "Token")
-				secret.SetPlaceholder("paste your API token")
-			} else {
-				f.SetItemLabel(calDAVIdxSecret, "Password")
-				secret.SetPlaceholder("your password")
-			}
+			appendTail(f, next)
 		}
 
-		insecureIdx := calDAVIdxAllowInsecure
-		if *oauthLayout {
-			insecureIdx = calDAVIdxOAuthAllowInsecure
-		}
-		allow := f.Field(insecureIdx).(*CheckboxField)
+		allow := f.Field(calDAVInsecureIdx(*layout)).(*CheckboxField)
 		wasAuto := allow.AutoChecked()
 		if isLocalhostHTTP(f.Field(calDAVIdxServer).(*TextField).Value()) {
 			allow.SetChecked(true)
@@ -408,12 +409,28 @@ func newCalDAVConnectionForm(theme Theme, usernamePrefill string) Form {
 				f.SetError(calDAVIdxOAuthClientSecret, "Client secret is required")
 				return nil
 			}
-		} else {
+		} else if accountAuthIsBearer(msg.AuthType) {
 			msg.Secret = f.Field(calDAVIdxSecret).(*TextField).Value()
-			msg.AllowInsecure = f.Field(calDAVIdxAllowInsecure).(*CheckboxField).Checked()
+			msg.AllowInsecure = f.Field(calDAVIdxBearerAllowInsecure).(*CheckboxField).Checked()
 			if strings.TrimSpace(msg.Secret) == "" {
 				f.SetError(calDAVIdxSecret, "Credential is required")
 				return nil
+			}
+		} else {
+			msg.Secret = f.Field(calDAVIdxSecret).(*TextField).Value()
+			msg.SecretCommand = strings.TrimSpace(f.Field(calDAVIdxSecretCommand).(*TextField).Value())
+			msg.AllowInsecure = f.Field(calDAVIdxAllowInsecure).(*CheckboxField).Checked()
+			hasPassword := strings.TrimSpace(msg.Secret) != ""
+			if hasPassword && msg.SecretCommand != "" {
+				f.SetError(calDAVIdxSecretCommand, "Enter a password or a password command, not both")
+				return nil
+			}
+			if !hasPassword && msg.SecretCommand == "" {
+				f.SetError(calDAVIdxSecret, "Enter a password or a password command")
+				return nil
+			}
+			if msg.SecretCommand != "" {
+				msg.Secret = ""
 			}
 		}
 		return func() tea.Msg { return msg }

--- a/internal/tui/calendar_dialog_update.go
+++ b/internal/tui/calendar_dialog_update.go
@@ -138,9 +138,20 @@ func (m CalendarDialogModel) handleTestPressed() (CalendarDialogModel, tea.Cmd) 
 	user := strings.TrimSpace(m.form.Field(calDAVIdxUsername).(*TextField).Value())
 	auth := m.form.Field(calDAVIdxAuth).(*SelectField).Value()
 	pass := m.form.Field(calDAVIdxSecret).(*TextField).Value()
-	ins := m.form.Field(calDAVIdxAllowInsecure).(*CheckboxField).Checked()
 
-	if url == "" || user == "" || pass == "" {
+	layout := calDAVTailFor(auth)
+	var passCommand string
+	if layout == calDAVTailBasic {
+		passCommand = strings.TrimSpace(m.form.Field(calDAVIdxSecretCommand).(*TextField).Value())
+	}
+	ins := m.form.Field(calDAVInsecureIdx(layout)).(*CheckboxField).Checked()
+
+	if pass != "" && passCommand != "" {
+		m.testStatus = lipgloss.NewStyle().Foreground(m.theme.Error).
+			Render("✗ Enter a password or a password command, not both")
+		return m, nil
+	}
+	if url == "" || user == "" || (pass == "" && passCommand == "") {
 		m.testStatus = lipgloss.NewStyle().Foreground(m.theme.Error).
 			Render("✗ Fill URL, Username, and Password first")
 		return m, nil
@@ -150,11 +161,12 @@ func (m CalendarDialogModel) handleTestPressed() (CalendarDialogModel, tea.Cmd) 
 		Render("Testing…")
 	return m, func() tea.Msg {
 		return CalendarTestRequestedMsg{
-			URL:           url,
-			Username:      user,
-			AuthType:      auth,
-			Password:      pass,
-			AllowInsecure: ins,
+			URL:             url,
+			Username:        user,
+			AuthType:        auth,
+			Password:        pass,
+			PasswordCommand: passCommand,
+			AllowInsecure:   ins,
 		}
 	}
 }


### PR DESCRIPTION
Refs #627 — the second request in that issue. The first one (the home-manager module) is #771, and the issue also asks for arrow-key navigation in modals, so it stays open.

You can now keep a password in a password manager instead of handing it to chroncal. Chroncal stores the *command* and runs it when it needs the secret. The keyring holds the command, never the password.

```bash
chroncal account add "Work server" \
    --server https://cal.example.com/dav/ --username alice --auth basic \
    --password-cmd "pass show caldav/work"
```

Two settings use it:

- `--password-cmd` or `CHRONCAL_PASSWORD_CMD` for a CalDAV basic-auth password
- `smtp.password_cmd` or `CHRONCAL_SMTP_PASSWORD_CMD` for the SMTP password

### How the runner behaves

`internal/secretcmd` runs the command through the shell (`sh -c`, or `cmd /c` on Windows).

- The secret is the **first line** of stdout. Later lines are ignored, because `pass` prints metadata after the password.
- stderr is discarded, so a noisy command cannot scribble over the TUI.
- 30-second deadline with a 1-second `WaitDelay`, so a hung command cannot wedge a sync.
- An empty command, a non-zero exit, or an empty first line is an error. No error message contains the command output.

### Where it is wired

- `internal/config` — `smtp.password_cmd`. `Load` rejects a file that sets both `smtp.password` and `smtp.password_cmd`. `notify.Email` resolves it.
- `internal/auth` — `Credential.PasswordCommand`. A password and a command are mutually exclusive on every write path.
- `internal/caldav` — `httpClientFromCredential` resolves the password when it builds a basic-auth client.
- `cmd/chroncal` — the flag on `account add`, `account credentials`, and calendar remote connect. Order: flag, `CHRONCAL_PASSWORD_CMD`, `CHRONCAL_PASSWORD`, then the interactive prompt. A command source plus `CHRONCAL_PASSWORD` is an error.
- `internal/tui` — a "Password cmd" field beside "Password" in the Add Account form and the Update Credentials dialog. Both set is an error, neither set is an error. Bearer and OAuth ignore it.
- `README.md` — a new "Command-retrieved passwords" section.

OAuth and bearer secrets keep their own path.

### Note for the reviewer

`internal/tui/account_settings_dialog_test.go` asserted the old prompt text ("New password for Work"); the dialog now says "New password or password command for Work", so that assertion is updated. Three tests are added: a command-only rotation, both-sources rejection, and empty-form rejection.

The home-manager example in #771 could use a `password_cmd` line once that PR merges. This branch is off `master`, so that section is not here yet.

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint reports no issues (`make lint`)
- [x] Add new tests for new functions
- [x] Update the documentation when the change needs it
