### PR TITLE
style(tui): apply gofmt and check the format in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ jobs:
         with:
           go-version: "1.26.6"
 
+      - name: gofmt
+        # The Makefile check runs locally only. Without this step, an
+        # unformatted file reaches master and `make check` then fails for
+        # every contributor.
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files need gofmt:"
+            echo "$unformatted"
+            exit 1
+          fi
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/internal/tui/glyphs.go
+++ b/internal/tui/glyphs.go
@@ -5,14 +5,14 @@ package tui
 // vs plain Unicode) from a single place.
 var Glyphs = map[string]string{
 	// Focus / navigation
-	"focus":    ">",
+	"focus": ">",
 
 	// Checkbox
 	"checkbox.on":  "[x]",
 	"checkbox.off": "[ ]",
 
 	// Status
-	"status.ok":     "✓",
+	"status.ok": "✓",
 
 	// Select
 	"select.prev": "◀",


### PR DESCRIPTION
Two small repairs to the format checks.

### `internal/tui/glyphs.go` was not gofmt-clean

Two map entries kept the alignment padding of a group that has since shrunk:

```
-	"focus":    ">",
+	"focus": ">",
-	"status.ok":     "✓",
+	"status.ok": "✓",
```

Whitespace only — the glyph values do not change. Before this, `make fmt-check` and `make check` failed on `master` for everyone.

### CI never checked the format

`make fmt-check` only runs on a developer machine. No CI job ran `gofmt`, which is how the file above reached `master` and stayed. The lint job now has a `gofmt` step that fails and prints the offending files.

### About the lint

There is nothing to fix. An earlier note in this batch of PRs claimed `make lint` failed on `master` with 6 staticcheck SA5011 findings. That was wrong: it came from a poisoned local `golangci-lint` cache, which reused results for content-identical packages and reported the path of the first copy it had analyzed — a path inside a sibling git worktree.

After `golangci-lint cache clean`, version 2.12.2 reports `0 issues` on `master`, on each feature branch, and on a tree with all open PRs merged. CI's pinned v2.11.4 agrees.

## Checklist

- [x] Tests pass (`make test`)
- [x] Lint reports no issues (`make lint`)
- [ ] Add new tests for new functions
- [x] Update the documentation when the change needs it
