### PR TITLE
feat(ical): import a directory of .ics files

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,9 @@ chroncal event list --from 2026-04-01 --to 2026-04-30
 # Search
 chroncal event search "standup"
 
-# Import from iCal
+# Import from iCal (one file, or a directory of .ics files)
 chroncal ical import calendar.ics --calendar Work
+chroncal ical import ~/.calendars/work --calendar Work
 
 # Export to iCal
 chroncal ical export --calendar Work -f work.ics
@@ -475,11 +476,31 @@ Pass `--disconnect-remote` on `update` to remove the remote link of a calendar.
 ### iCal import/export
 
 ```
-chroncal ical import  <file.ics> [--calendar NAME]
+chroncal ical import  <file.ics|directory> [--calendar NAME]
 chroncal ical export  [--calendar NAME] [--from DATE] [--to DATE] [--category TEXT] [--status TEXT] [-f FILE] [--events] [--todos] [--journals] [--skip-unreadable]
 ```
 
-Imports have size limits to reduce resource exhaustion from untrusted calendar data. `chroncal ical import` rejects `.ics` payloads larger than 8 MiB. It also rejects inline base64 attachments larger than 1 MiB decoded.
+The import path is one `.ics` file or one directory. For a directory, chroncal reads every `.ics` file in that directory and in its subdirectories, and imports them into one calendar. A tool such as [vdirsyncer](https://vdirsyncer.pimutils.org/) writes one `.ics` file for each event, so point the import at the collection directory:
+
+```bash
+# One collection
+chroncal ical import ~/.calendars/work --calendar Work
+
+# Every collection below one parent directory, merged into one calendar
+chroncal ical import ~/.calendars --calendar Personal
+```
+
+Directory rules:
+
+- chroncal skips every file and directory whose name starts with a dot. A version-control directory and a partial file from a sync tool stay out of the import.
+- chroncal skips every file without an `.ics` extension, for example the `displayname` and `color` files that vdirsyncer writes.
+- A file that fails to parse becomes a warning. The rest of the directory still lands.
+- chroncal reads at most 10000 `.ics` files in one run.
+- The import does not follow a symbolic link.
+
+Entries are matched by UID, so a second import of the same path updates the existing items.
+
+Imports have size limits to reduce resource exhaustion from untrusted calendar data. `chroncal ical import` rejects `.ics` payloads larger than 8 MiB. It also rejects inline base64 attachments larger than 1 MiB decoded. The limit applies to each file, not to a whole directory.
 
 The export aborts when one relation read fails. It writes no file, so no incomplete backup exists. Pass `--skip-unreadable` to continue past records with unreadable relations. The file then carries a comment header that names each incomplete record. The command also lists those records on stderr.
 
@@ -720,7 +741,7 @@ Hidden state and scroll apply to calendar rows, not to group headings. Read-only
 
 Account headings collapse with Left/Right. Enter opens account settings. The root inspector keeps a calendar **Edit…** action or an account **Account Settings…** action at the bottom. Enter or a click on a calendar-row body opens metadata, export, default-calendar, and delete controls. The hierarchy stays mounted. Linked calendar details open account settings without a loss of unsaved calendar edits.
 
-The source list has a bottom **+ Add** action. It opens an anchored menu for **New Calendar…**, **Add Account…**, and **Import Calendar File…**. Account connection signs in once and adds every usable remote calendar. iCal import keeps its preview and the selection of a compatible destination. Todo and journal management live in the CLI for now.
+The source list has a bottom **+ Add** action. It opens an anchored menu for **New Calendar…**, **Add Account…**, and **Import Calendar File or Directory…**. Account connection signs in once and adds every usable remote calendar. iCal import accepts one `.ics` file or one directory of `.ics` files. It keeps its preview and the selection of a compatible destination. Todo and journal management live in the CLI for now.
 
 A calendar whose last sync failed shows a `⚠` next to it in the sidebar. Open it to see why and to get a fix. See [Google Calendar via CalDAV](#google-calendar-via-caldav) for the OAuth flow.
 

--- a/cmd/chroncal/ical.go
+++ b/cmd/chroncal/ical.go
@@ -28,6 +28,7 @@ func icalCmd() *cobra.Command {
 Import accepts VEVENT, VTODO, and VJOURNAL components. Export can emit
 any combination of those resource types.`,
 		Example: `  chroncal ical import ./calendar.ics
+  chroncal ical import ~/.calendars/work
   chroncal ical export --calendar Work --file work.ics`,
 		Args: rejectUnknownSubcommand,
 		RunE: groupRunE,
@@ -41,15 +42,23 @@ func icalImportCmd() *cobra.Command {
 		calendarName string
 	)
 	cmd := &cobra.Command{
-		Use:   "import <file.ics>",
-		Short: "Import events, todos, and journal entries from an iCal (.ics) file",
+		Use:   "import <path>",
+		Short: "Import events, todos, and journal entries from an iCal (.ics) file or directory",
 		Long: `Read an .ics file and upsert its events, todos, and journal entries
 into a local calendar.
 
-Entries are matched by UID when possible, so importing the same file
+The path can also be a directory. chroncal then reads every .ics file in
+that directory and in its subdirectories, and imports them together. A
+tool such as vdirsyncer writes one .ics file for each event, so point the
+import at the collection directory. chroncal skips every name that starts
+with a dot. A file that fails to parse becomes a warning, and the rest of
+the directory still lands.
+
+Entries are matched by UID when possible, so importing the same path
 again updates existing items instead of blindly duplicating them.`,
 		Example: `  chroncal ical import ./calendar.ics
-  chroncal ical import ./team.ics --calendar Work
+  chroncal ical import ~/.calendars/work --calendar Work
+  chroncal ical import ~/.calendars --calendar Personal
   chroncal ical import ./dump.ics --output json`,
 		Args: exactOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -61,7 +70,7 @@ again updates existing items instead of blindly duplicating them.`,
 			ctx, cancel := context.WithTimeout(context.Background(), icalImportTimeout)
 			defer cancel()
 
-			preview, err := icaltransfer.ParseFile(args[0])
+			preview, err := icaltransfer.ParsePath(args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/icaltransfer/parse_dir.go
+++ b/internal/icaltransfer/parse_dir.go
@@ -27,16 +27,24 @@ var ErrTooManyICSFiles = fmt.Errorf("the directory holds more than %d .ics files
 //
 // A directory is read one level deep and deeper. A tool such as vdirsyncer
 // keeps one directory for each collection, so a parent directory holds many
-// collections. The parse merges every collection into one preview.
+// collections. The parse merges every collection into one preview. A
+// symbolic link at the path is an error. The walk skips a symbolic link
+// and any other non-regular entry.
 func ParsePath(path string) (Preview, error) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return Preview{}, fmt.Errorf("open file: %w", err)
 	}
-	if !info.IsDir() {
-		return ParseFile(path)
+	if info.Mode()&os.ModeSymlink != 0 {
+		return Preview{}, fmt.Errorf("open file: the import does not follow a symbolic link")
 	}
-	return ParseDir(path)
+	if info.IsDir() {
+		return ParseDir(path)
+	}
+	if !info.Mode().IsRegular() {
+		return Preview{}, fmt.Errorf("open file: %s is not a regular file or directory", path)
+	}
+	return ParseFile(path)
 }
 
 // ParseDir parses every .ics file in the tree below dir and merges the
@@ -104,6 +112,13 @@ func collectICSFiles(dir string) ([]string, error) {
 			return nil
 		}
 		if !strings.EqualFold(filepath.Ext(entry.Name()), ".ics") {
+			return nil
+		}
+		info, statErr := entry.Info()
+		if statErr != nil {
+			return statErr
+		}
+		if !info.Mode().IsRegular() {
 			return nil
 		}
 		if len(files) >= MaxDirFiles {

--- a/internal/icaltransfer/parse_dir.go
+++ b/internal/icaltransfer/parse_dir.go
@@ -1,0 +1,154 @@
+package icaltransfer
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MaxDirFiles bounds one directory import. A tool such as vdirsyncer writes
+// one .ics file for each event, so a real collection holds many files. The
+// bound stops a run that points at a very large tree, for example a home
+// directory.
+const MaxDirFiles = 10000
+
+// ErrNoICSFiles reports a directory that holds no .ics file.
+var ErrNoICSFiles = errors.New("the directory holds no .ics file")
+
+// ErrTooManyICSFiles reports a directory tree above the MaxDirFiles bound.
+var ErrTooManyICSFiles = fmt.Errorf("the directory holds more than %d .ics files", MaxDirFiles)
+
+// ParsePath parses one .ics file or one directory of .ics files. It is the
+// entry point for every import caller. Use it in place of ParseFile when the
+// path comes from a user.
+//
+// A directory is read one level deep and deeper. A tool such as vdirsyncer
+// keeps one directory for each collection, so a parent directory holds many
+// collections. The parse merges every collection into one preview.
+func ParsePath(path string) (Preview, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Preview{}, fmt.Errorf("open file: %w", err)
+	}
+	if !info.IsDir() {
+		return ParseFile(path)
+	}
+	return ParseDir(path)
+}
+
+// ParseDir parses every .ics file in the tree below dir and merges the
+// results into one preview.
+//
+// The walk skips an entry whose name starts with a dot. That excludes a
+// version-control directory and a partial file that a sync tool writes.
+// The walk does not follow a symbolic link, so a link loop cannot hang it.
+//
+// A file that fails to parse becomes a warning. The parse then continues.
+// One bad file does not discard a whole collection. ParseDir returns an
+// error only when it finds no .ics file, when the tree is above MaxDirFiles,
+// or when the walk itself fails.
+func ParseDir(dir string) (Preview, error) {
+	files, err := collectICSFiles(dir)
+	if err != nil {
+		return Preview{}, err
+	}
+	if len(files) == 0 {
+		return Preview{}, fmt.Errorf("import %s: %w", dir, ErrNoICSFiles)
+	}
+
+	var (
+		preview Preview
+		seenTZ  = map[string]bool{}
+	)
+	for _, path := range files {
+		label := displayLabel(dir, path)
+		one, parseErr := ParseFile(path)
+		if parseErr != nil {
+			preview.Result.Warnings = append(preview.Result.Warnings,
+				fmt.Sprintf("%s: %v", label, parseErr))
+			continue
+		}
+		mergeInto(&preview, one, label, seenTZ)
+	}
+
+	preview.Events = len(preview.Result.Events)
+	preview.Todos = len(preview.Result.Todos)
+	preview.Journals = len(preview.Result.Journals)
+	preview.FreeBusy = len(preview.Result.FreeBusy)
+	preview.Warnings = append([]string(nil), preview.Result.Warnings...)
+	return preview, nil
+}
+
+// collectICSFiles returns the .ics files in the tree below dir. WalkDir
+// reads each directory in lexical order, so the result is repeatable: two
+// files that carry the same UID always land in the same order.
+func collectICSFiles(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// Keep the root even when the user names a dot-directory. Skip
+		// every other dot-entry: a version-control directory, and the
+		// partial file that a sync tool writes.
+		if path != dir && strings.HasPrefix(entry.Name(), ".") {
+			if entry.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".ics") {
+			return nil
+		}
+		if len(files) >= MaxDirFiles {
+			return ErrTooManyICSFiles
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, ErrTooManyICSFiles) {
+			return nil, fmt.Errorf("import %s: %w", dir, ErrTooManyICSFiles)
+		}
+		return nil, fmt.Errorf("read directory %s: %w", dir, err)
+	}
+	return files, nil
+}
+
+// displayLabel returns the path of one file relative to the imported
+// directory. A warning then names the file the user can open.
+func displayLabel(dir, path string) string {
+	relative, err := filepath.Rel(dir, path)
+	if err != nil {
+		return filepath.Base(path)
+	}
+	return relative
+}
+
+// mergeInto appends one file's parse to the merged preview. A timezone is
+// stored once for each TZID: a per-event file layout repeats the same
+// VTIMEZONE in every file, and the import writes one row for each copy.
+func mergeInto(preview *Preview, one Preview, label string, seenTZ map[string]bool) {
+	result := one.Result
+	preview.Result.Events = append(preview.Result.Events, result.Events...)
+	preview.Result.Todos = append(preview.Result.Todos, result.Todos...)
+	preview.Result.Journals = append(preview.Result.Journals, result.Journals...)
+	preview.Result.FreeBusy = append(preview.Result.FreeBusy, result.FreeBusy...)
+	preview.Result.SkippedComponents += result.SkippedComponents
+	for _, tz := range result.Timezones {
+		if seenTZ[tz.TZID] {
+			continue
+		}
+		seenTZ[tz.TZID] = true
+		preview.Result.Timezones = append(preview.Result.Timezones, tz)
+	}
+	for _, warning := range result.Warnings {
+		preview.Result.Warnings = append(preview.Result.Warnings, label+": "+warning)
+	}
+}

--- a/internal/icaltransfer/parse_dir_test.go
+++ b/internal/icaltransfer/parse_dir_test.go
@@ -154,3 +154,61 @@ func TestParsePath_MissingPathIsWrapped(t *testing.T) {
 		t.Fatalf("err = %v, want an open file wrap", err)
 	}
 }
+
+func mustSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, target, err)
+	}
+}
+
+// TestParsePath_RootSymlinkFileIsAnError confirms a symbolic-link file is
+// not resolved to its target.
+func TestParsePath_RootSymlinkFileIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "one.ics")
+	writeFile(t, target, eventICS("link-root-file", "Link"))
+	link := filepath.Join(dir, "alias.ics")
+	mustSymlink(t, target, link)
+
+	_, err := icaltransfer.ParsePath(link)
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("err = %v, want a symbolic link error", err)
+	}
+}
+
+// TestParsePath_RootSymlinkDirectoryIsAnError confirms a symbolic-link
+// directory is not walked as its target.
+func TestParsePath_RootSymlinkDirectoryIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	collection := filepath.Join(dir, "work")
+	writeFile(t, filepath.Join(collection, "a.ics"), eventICS("link-root-dir", "Work"))
+	link := filepath.Join(dir, "alias")
+	mustSymlink(t, collection, link)
+
+	_, err := icaltransfer.ParsePath(link)
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("err = %v, want a symbolic link error", err)
+	}
+}
+
+// TestParsePath_DirectorySkipsChildSymlink confirms a symbolic-link .ics
+// file inside the tree is skipped, so the import cannot leave the tree.
+func TestParsePath_DirectorySkipsChildSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(root, "good.ics"), eventICS("link-good", "Good"))
+	writeFile(t, filepath.Join(outside, "secret.ics"), eventICS("link-secret", "Secret"))
+	mustSymlink(t, filepath.Join(outside, "secret.ics"), filepath.Join(root, "alias.ics"))
+
+	preview, err := icaltransfer.ParsePath(root)
+	if err != nil {
+		t.Fatalf("ParsePath: %v", err)
+	}
+	if preview.Events != 1 {
+		t.Fatalf("events = %d, want 1", preview.Events)
+	}
+	if preview.Result.Events[0].UID != "link-good" {
+		t.Fatalf("UID = %q, want link-good", preview.Result.Events[0].UID)
+	}
+}

--- a/internal/icaltransfer/parse_dir_test.go
+++ b/internal/icaltransfer/parse_dir_test.go
@@ -1,0 +1,156 @@
+package icaltransfer_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/douglasdemoura/chroncal/internal/icaltransfer"
+)
+
+// eventICS builds a one-event calendar with the given UID and summary. The
+// tests below write one such file for each event, the layout that vdirsyncer
+// produces.
+func eventICS(uid, summary string) string {
+	return "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//chroncal//test//EN\r\n" +
+		"BEGIN:VTIMEZONE\r\nTZID:Europe/Lisbon\r\n" +
+		"BEGIN:STANDARD\r\nDTSTART:19701025T020000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\n" +
+		"TZNAME:WET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\n" +
+		"BEGIN:VEVENT\r\nUID:" + uid + "\r\nSUMMARY:" + summary + "\r\n" +
+		"DTSTART:20260421T090000Z\r\nDTEND:20260421T100000Z\r\nEND:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestParsePath_DirectoryTreeMergesEveryCollection covers the vdirsyncer
+// layout of issue #776: a parent directory of collection directories, one
+// .ics file for each event. Every event lands, and the repeated VTIMEZONE is
+// stored once.
+func TestParsePath_DirectoryTreeMergesEveryCollection(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "work", "a.ics"), eventICS("dir-a", "Work A"))
+	writeFile(t, filepath.Join(root, "work", "b.ics"), eventICS("dir-b", "Work B"))
+	writeFile(t, filepath.Join(root, "family", "c.ICS"), eventICS("dir-c", "Family C"))
+	// vdirsyncer keeps plain metadata files beside the .ics files.
+	writeFile(t, filepath.Join(root, "work", "displayname"), "Work")
+	// A dot-directory and a dot-file are both skipped.
+	writeFile(t, filepath.Join(root, ".git", "hook.ics"), eventICS("dir-hidden", "Hidden"))
+	writeFile(t, filepath.Join(root, "work", ".partial.ics"), eventICS("dir-partial", "Partial"))
+
+	preview, err := icaltransfer.ParsePath(root)
+	if err != nil {
+		t.Fatalf("ParsePath: %v", err)
+	}
+	if preview.Events != 3 {
+		t.Fatalf("events = %d, want 3", preview.Events)
+	}
+	if len(preview.Result.Timezones) != 1 {
+		t.Fatalf("timezones = %d, want 1 (deduplicated by TZID)", len(preview.Result.Timezones))
+	}
+	got := map[string]bool{}
+	for _, e := range preview.Result.Events {
+		got[e.UID] = true
+	}
+	for _, uid := range []string{"dir-a", "dir-b", "dir-c"} {
+		if !got[uid] {
+			t.Fatalf("UID %q missing from %v", uid, got)
+		}
+	}
+	for _, uid := range []string{"dir-hidden", "dir-partial"} {
+		if got[uid] {
+			t.Fatalf("UID %q came from a dot-entry and must be skipped", uid)
+		}
+	}
+}
+
+// TestParsePath_SingleFileStillWorks confirms ParsePath keeps the ParseFile
+// behavior for a plain file argument.
+func TestParsePath_SingleFileStillWorks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "one.ics")
+	writeFile(t, path, eventICS("single-1", "Single"))
+
+	preview, err := icaltransfer.ParsePath(path)
+	if err != nil {
+		t.Fatalf("ParsePath: %v", err)
+	}
+	if preview.Events != 1 {
+		t.Fatalf("events = %d, want 1", preview.Events)
+	}
+}
+
+// TestParsePath_UnreadableFileBecomesWarning confirms one bad file does not
+// discard the rest of the directory. The warning names the file.
+func TestParsePath_UnreadableFileBecomesWarning(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "good.ics"), eventICS("warn-good", "Good"))
+	writeFile(t, filepath.Join(root, "bad.ics"), "not an icalendar stream at all")
+
+	preview, err := icaltransfer.ParsePath(root)
+	if err != nil {
+		t.Fatalf("ParsePath: %v", err)
+	}
+	if preview.Events != 1 {
+		t.Fatalf("events = %d, want 1", preview.Events)
+	}
+	if !containsSubstring(preview.Warnings, "bad.ics") {
+		t.Fatalf("warnings do not name the bad file: %v", preview.Warnings)
+	}
+}
+
+// TestParseDir_ComponentWarningNamesItsFile confirms a per-component warning
+// keeps the file name, so the user can open the file that produced it.
+func TestParseDir_ComponentWarningNamesItsFile(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "venue.ics"),
+		"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//chroncal//test//EN\r\n"+
+			"BEGIN:VVENUE\r\nUID:venue-1\r\nEND:VVENUE\r\n"+
+			"BEGIN:VEVENT\r\nUID:venue-event\r\nSUMMARY:Kept\r\n"+
+			"DTSTART:20260421T090000Z\r\nDTEND:20260421T100000Z\r\nEND:VEVENT\r\n"+
+			"END:VCALENDAR\r\n")
+
+	preview, err := icaltransfer.ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if preview.Events != 1 {
+		t.Fatalf("events = %d, want 1", preview.Events)
+	}
+	if !containsSubstring(preview.Warnings, "venue.ics: ") {
+		t.Fatalf("component warning does not name its file: %v", preview.Warnings)
+	}
+}
+
+// TestParseDir_EmptyDirectoryIsAnError confirms a directory with no .ics file
+// reports a named error rather than an empty, silent import.
+func TestParseDir_EmptyDirectoryIsAnError(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "displayname"), "Work")
+
+	_, err := icaltransfer.ParsePath(root)
+	if !errors.Is(err, icaltransfer.ErrNoICSFiles) {
+		t.Fatalf("err = %v, want ErrNoICSFiles", err)
+	}
+	if !strings.Contains(err.Error(), root) {
+		t.Fatalf("error does not name the directory: %v", err)
+	}
+}
+
+// TestParsePath_MissingPathIsWrapped confirms a missing path keeps the
+// existing "open file" wrap of the file path.
+func TestParsePath_MissingPathIsWrapped(t *testing.T) {
+	_, err := icaltransfer.ParsePath(filepath.Join(t.TempDir(), "absent.ics"))
+	if err == nil || !strings.Contains(err.Error(), "open file") {
+		t.Fatalf("err = %v, want an open file wrap", err)
+	}
+}

--- a/internal/icaltransfer/parse_dir_unix_test.go
+++ b/internal/icaltransfer/parse_dir_unix_test.go
@@ -1,0 +1,68 @@
+//go:build unix
+
+package icaltransfer_test
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/douglasdemoura/chroncal/internal/icaltransfer"
+)
+
+func parsePathWithTimeout(t *testing.T, path string) (icaltransfer.Preview, error) {
+	t.Helper()
+	type outcome struct {
+		preview icaltransfer.Preview
+		err     error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		preview, err := icaltransfer.ParsePath(path)
+		done <- outcome{preview, err}
+	}()
+	select {
+	case got := <-done:
+		return got.preview, got.err
+	case <-time.After(2 * time.Second):
+		t.Fatal("ParsePath blocked on a FIFO")
+		return icaltransfer.Preview{}, nil
+	}
+}
+
+func mustMkfifo(t *testing.T, path string) {
+	t.Helper()
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", path, err)
+	}
+}
+
+// TestParsePath_DirectorySkipsFIFO confirms a FIFO named .ics is skipped,
+// so the import cannot block on a pipe.
+func TestParsePath_DirectorySkipsFIFO(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "good.ics"), eventICS("fifo-good", "Good"))
+	mustMkfifo(t, filepath.Join(root, "pipe.ics"))
+
+	preview, err := parsePathWithTimeout(t, root)
+	if err != nil {
+		t.Fatalf("ParsePath: %v", err)
+	}
+	if preview.Events != 1 {
+		t.Fatalf("events = %d, want 1", preview.Events)
+	}
+}
+
+// TestParsePath_RootFIFOIsAnError confirms a FIFO at the import path is an
+// error, so the import cannot block on a pipe.
+func TestParsePath_RootFIFOIsAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipe.ics")
+	mustMkfifo(t, path)
+
+	_, err := parsePathWithTimeout(t, path)
+	if err == nil || !strings.Contains(err.Error(), "not a regular file or directory") {
+		t.Fatalf("err = %v, want a non-regular-file error", err)
+	}
+}

--- a/internal/tui/app_update_calendar.go
+++ b/internal/tui/app_update_calendar.go
@@ -148,7 +148,7 @@ func (m Model) handleCalendarImportPreviewRequested(msg CalendarImportPreviewReq
 	m.syncStatus = "Reading iCal file…"
 	path := msg.Path
 	return m, func() tea.Msg {
-		preview, err := icaltransfer.ParseFile(path)
+		preview, err := icaltransfer.ParsePath(path)
 		return calendarImportPreviewReadyMsg{Generation: msg.Generation, Path: path, Preview: preview, Err: err}
 	}
 }

--- a/internal/tui/calendar_manager_2_test.go
+++ b/internal/tui/calendar_manager_2_test.go
@@ -917,7 +917,7 @@ func TestCalendarManagerWideImportKeepsHierarchyMounted(t *testing.T) {
 	if !strings.Contains(view, "Local") || !strings.Contains(view, "Primary") {
 		t.Fatalf("wide import did not keep hierarchy mounted:\n%s", view)
 	}
-	if !strings.Contains(view, "Import iCal file") || !strings.Contains(view, "Path") {
+	if !strings.Contains(view, "Import iCal file") || !strings.Contains(view, "File or directory") {
 		t.Fatalf("wide import missing inline form:\n%s", view)
 	}
 }

--- a/internal/tui/calendar_manager_add_menu.go
+++ b/internal/tui/calendar_manager_add_menu.go
@@ -24,7 +24,7 @@ type calendarManagerAddItem struct {
 var calendarManagerAddItems = [...]calendarManagerAddItem{
 	{label: "New Calendar…", target: CalendarManagerTargetLocalCreate},
 	{label: "Add Account…", target: CalendarManagerTargetAccountConnect},
-	{label: "Import Calendar File…", target: CalendarManagerTargetImport},
+	{label: "Import Calendar File or Directory…", target: CalendarManagerTargetImport},
 }
 
 // calendarManagerMenuTrailing is the blank padding reserved after the longest

--- a/internal/tui/calendar_manager_test.go
+++ b/internal/tui/calendar_manager_test.go
@@ -469,7 +469,7 @@ func TestCalendarManagerAddMenuRowsAndNoCancel(t *testing.T) {
 	m.list.selectIdentity(calendarRowIdentity{kind: accountHeaderRow, id: 0})
 	m = m.openAddMenu()
 	view := stripANSI(m.View())
-	for _, want := range []string{"New Calendar…", "Add Account…", "Import Calendar File…"} {
+	for _, want := range []string{"New Calendar…", "Add Account…", "Import Calendar File or Directory…"} {
 		if !strings.Contains(view, want) {
 			t.Errorf("menu missing row %q\n%s", want, view)
 		}

--- a/internal/tui/calendar_transfer_dialog.go
+++ b/internal/tui/calendar_transfer_dialog.go
@@ -14,6 +14,10 @@ import (
 	"github.com/douglasdemoura/chroncal/internal/icaltransfer"
 )
 
+// calendarImportTitle names the import dialog. The path it reads is one
+// .ics file or one directory of .ics files.
+const calendarImportTitle = "Import iCal file or directory"
+
 type CalendarTransferClosedMsg struct{}
 
 type CalendarImportPreviewRequestedMsg struct {
@@ -97,7 +101,7 @@ type CalendarTransferDialogModel struct {
 func NewCalendarImportDialogModel(theme Theme, generation ...uint64) CalendarTransferDialogModel {
 	gen := firstGeneration(generation)
 	m := CalendarTransferDialogModel{
-		dialog:     NewDialog("Import iCal file", DefaultDialogStyles()),
+		dialog:     NewDialog(calendarImportTitle, DefaultDialogStyles()),
 		help:       newThemedHelp(theme),
 		theme:      theme,
 		mode:       calendarTransferImport,
@@ -105,7 +109,7 @@ func NewCalendarImportDialogModel(theme Theme, generation ...uint64) CalendarTra
 		generation: gen,
 	}
 	m.dialog.SetWidth(68)
-	m.form = m.pathForm("Preview", "Path", "", func(path string) tea.Msg {
+	m.form = m.pathForm("Preview", "File or directory", "", func(path string) tea.Msg {
 		return CalendarImportPreviewRequestedMsg{Generation: gen, Path: path}
 	})
 	return m
@@ -166,7 +170,7 @@ func (m CalendarTransferDialogModel) WithPreview(path string, preview icaltransf
 	m.preview = preview
 	m.phase = calendarTransferDestination
 	m.errText = ""
-	m.dialog = NewDialog("Import iCal file", DefaultDialogStyles())
+	m.dialog = NewDialog(calendarImportTitle, DefaultDialogStyles())
 	m.dialog.SetWidth(68)
 
 	styles := DefaultFormStyles()
@@ -292,10 +296,15 @@ func (m CalendarTransferDialogModel) View() string {
 	return mouseSweep(m.dialog.Box(strings.Join(parts, "\n")))
 }
 
+// icalCalendarName proposes the new-calendar name for an imported path. It
+// removes an .ics suffix only. A directory keeps its full name, so a
+// collection directory such as "2026.work" does not lose its last segment.
 func icalCalendarName(path string) string {
 	base := filepath.Base(strings.TrimSpace(path))
-	ext := filepath.Ext(base)
-	name := strings.TrimSpace(strings.TrimSuffix(base, ext))
+	if strings.EqualFold(filepath.Ext(base), ".ics") {
+		base = base[:len(base)-len(".ics")]
+	}
+	name := strings.TrimSpace(base)
 	if name == "" || name == "." {
 		return "Imported calendar"
 	}


### PR DESCRIPTION
Closes #776.

## Problem

vdirsyncer (and vdir-format tools in general) keep a calendar as a directory tree of `.ics` files, one file for each event:

```
calendars/
├── work/
│   ├── 3f2a….ics
│   ├── 8b71….ics
│   ├── displayname
│   └── color
└── family/
    └── …
```

`chroncal ical import` accepted a single file, so the only way in was to concatenate the tree by hand.

## What this does

`icaltransfer.ParsePath` now accepts one `.ics` file **or** one directory. For a directory, the new `ParseDir` walks the tree, parses every `.ics` file, and merges the results into one preview. Both the CLI and the TUI go through it, so the two surfaces stay identical.

Rules, all covered by tests:

| Case | Behavior |
| --- | --- |
| Nested collection directories | Walked and merged into one import |
| `displayname`, `color`, other non-`.ics` files | Skipped |
| Dot-entries (`.git/`, `.partial.ics`) | Skipped |
| Repeated `VTIMEZONE` in every file | Stored once for each TZID |
| One unparseable file | A warning that names the file; the rest still lands |
| Directory with no `.ics` file | `ErrNoICSFiles`, so the import cannot report a silent success |
| More than 10000 `.ics` files | `ErrTooManyICSFiles` |
| Symbolic link | Not followed (no link loop) |

UID upsert is unchanged, so a second import of the same directory updates instead of duplicating.

## TUI

- Add menu: **Import Calendar File…** → **Import Calendar File or Directory…**
- Import dialog: the title and the path label name a directory too.
- `icalCalendarName` now strips only an `.ics` suffix, so a directory named `2026.work` keeps its full name as the proposed calendar name.

## Try it

```bash
chroncal ical import ~/.calendars/work --calendar Work
chroncal ical import ~/.calendars --calendar Personal
```

## Notes for the reviewer

- The 8 MiB import cap still applies to each file, not to the whole directory. The 10000-file bound is what keeps a mistaken `chroncal ical import ~` from reading a home directory.
- Warnings from a directory import are prefixed with the file path relative to the imported directory, so the user can open the file that produced one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import iCalendar data from either a single `.ics` file or a directory.
  * Directory imports search recursively, skip hidden and non-`.ics` files, and combine supported calendar data.
  * Import previews display per-file parse warnings and retain UID-based updates.
  * The terminal interface now clearly labels imports as “File or directory.”

* **Documentation**
  * Updated quick-start examples and CLI reference with directory import behavior, limits, and exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->